### PR TITLE
Add command ln full POSIX compliant + tests

### DIFF
--- a/cmds/ln/ln.go
+++ b/cmds/ln/ln.go
@@ -1,0 +1,219 @@
+// Copyright 2016 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// created by Manoel Vilela <manoel_vilela@engineer.com>
+
+// Ln make links between files
+// the actual implementations supports that flags: [-rsvfLPti]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+type config struct {
+	symlink  bool
+	verbose  bool
+	force    bool
+	nondir   bool
+	prompt   bool
+	logical  bool
+	physical bool
+	relative bool
+	dirtgt   string
+}
+
+// promptOverwrite ask for overwrite destination
+func promptOverwrite(fname string) bool {
+	fmt.Printf("ln: overwrite '%v'? ", fname)
+	var txt string
+	if fmt.Scanln(&txt); txt != "y" {
+		return false
+	}
+	return true
+}
+
+// exists verify if a fname exists
+// the IsExists don't works fine, sorry for messy
+func exists(fname string) bool {
+	_, err := os.Lstat(fname)
+	return !os.IsNotExist(err)
+}
+
+// evalArgs based of the four type of uses describe at ln
+// get the targets and linknames operands
+// attention: linkName can be "", which latter will be inferred (see inferLinkName function)
+func (conf *config) evalArgs(args []string) (targets []string, linkName string) {
+	if conf.dirtgt != "" || len(args) <= 1 {
+		return args, ""
+	}
+
+	targets = args[:len(args)-1]
+	lastArg := args[len(args)-1]
+
+	if lf, err := os.Stat(lastArg); !conf.nondir && err == nil && lf.IsDir() {
+		conf.dirtgt = lastArg
+	} else {
+		linkName = lastArg
+	}
+
+	return targets, linkName
+}
+
+// relLink get the relative link path between
+// a target and linkName fpath
+// between a linkName operand and the target
+// HMM, i don't have sure if that works well...
+func relLink(target, linkName string) (string, error) {
+	base := filepath.Dir(linkName)
+	if newTarget, err := filepath.Rel(base, target); err == nil {
+		return newTarget, nil
+	} else if absLink, err := filepath.Abs(linkName); err == nil {
+		return filepath.Rel(absLink, target)
+	}
+
+	return "", nil
+}
+
+// inferLinkname infers the linkName if don't passed ("")
+// otherwhise preserves the linkName
+// e.g.:
+// $ ln -s -v /usr/bin/cp
+// cp -> /usr/bin/cp
+func inferLinkName(target, linkName string) string {
+	if linkName == "" {
+		linkName = filepath.Base(target)
+	}
+	return linkName
+}
+
+// dereferTarget treat symlinks according the flags -P and -L
+// if conf.logical or conf.physical follow the links
+// if conf.physical create a hard link instead symbolink
+func (conf config) dereferTarget(target string, linkFunc *func(string, string) error) (string, error) {
+	if conf.logical || conf.physical {
+		if newTarget, err := filepath.EvalSymlinks(target); err != nil {
+			return "", err
+		} else if newTarget != target {
+			target = newTarget
+			if conf.physical {
+				*linkFunc = os.Symlink
+			}
+		}
+	}
+	return target, nil
+}
+
+// ln is a general procedure for controlling the
+// flow of links creation, handling the flags and other stuffs.
+func (conf config) ln(args []string) error {
+	var remove bool
+
+	linkFunc := os.Link
+	if conf.symlink {
+		linkFunc = os.Symlink
+	}
+
+	originalPath, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	targets, linkName := conf.evalArgs(args)
+	for _, target := range targets {
+		linkFunc := linkFunc // back-overwrite possibilty
+
+		// dereference symlinks
+		t, err := conf.dereferTarget(target, &linkFunc)
+		if err != nil {
+			return err
+		}
+		target = t
+
+		linkName := inferLinkName(target, linkName)
+		if conf.dirtgt != "" {
+			linkName = filepath.Join(conf.dirtgt, linkName)
+		}
+
+		if exists(linkName) {
+			if conf.prompt && !conf.force {
+				remove = promptOverwrite(linkName)
+				if !remove {
+					continue
+				}
+			}
+
+			if conf.force || remove {
+				if err := os.Remove(linkName); err != nil {
+					return err
+				}
+			}
+		}
+
+		if conf.relative && !conf.symlink {
+			return fmt.Errorf("cannot do -r without -s")
+		}
+
+		// make relative paths with symlinks
+		if conf.relative {
+			if relTarget, err := relLink(target, linkName); err != nil {
+				return err
+			} else {
+				target = relTarget
+			}
+
+			if dir := filepath.Dir(linkName); dir != "" {
+				linkName = filepath.Base(linkName)
+				if err := os.Chdir(dir); err != nil {
+					return err
+				}
+			}
+
+		}
+
+		if err := linkFunc(target, linkName); err != nil {
+			return err
+		}
+
+		if conf.relative {
+			if err := os.Chdir(originalPath); err != nil {
+				return err
+			}
+		}
+
+		if conf.verbose {
+			fmt.Printf("%q -> %q\n", linkName, target)
+		}
+	}
+
+	return nil
+}
+
+func main() {
+	var conf config
+	flag.BoolVar(&conf.symlink, "s", false, "make symbolic links instead of hard links")
+	flag.BoolVar(&conf.verbose, "v", false, "print name of each linked file")
+	flag.BoolVar(&conf.force, "f", false, "remove destination files")
+	flag.BoolVar(&conf.nondir, "T", false, "treat linkname operand as a non-dir always")
+	flag.BoolVar(&conf.prompt, "i", false, "prompt if the user wants overwrite")
+	flag.BoolVar(&conf.logical, "L", false, "dereference targets if are symbolic links")
+	flag.BoolVar(&conf.physical, "P", false, "make hard links directly to symbolic links")
+	flag.BoolVar(&conf.relative, "r", false, "create symlinks relative to link location")
+	flag.StringVar(&conf.dirtgt, "t", "", "specify the directory to put the links")
+	flag.Parse()
+
+	args := flag.Args()
+	if len(args) == 0 {
+		log.Printf("ln: missing file operand")
+		flag.Usage()
+	}
+
+	if err := conf.ln(args); err != nil {
+		log.Fatalf("ln: link creation failed: %v", err)
+	}
+}

--- a/cmds/ln/ln_test.go
+++ b/cmds/ln/ln_test.go
@@ -1,0 +1,282 @@
+// Copyright 2016 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// created by Manoel Vilela <manoel_vilela@engineer.com>
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testPath   = "."
+	removeTest = true
+)
+
+type create struct {
+	name string
+	dir  bool
+}
+
+type result struct {
+	symlink       bool
+	name, linksTo string
+}
+
+type test struct {
+	conf    config   // conf with flags
+	args    []string // to pass for ln
+	results []result // expected results
+	files   []create // previous files for testing
+	cmdline string   // cmdline ln equivalent
+}
+
+// prepareTestName prepares a custom testname for creating file/folder
+// using a cmdline, for that remove chars  whose conflicts with unix paths
+func prepareTestName(cmdline string) string {
+	d := strings.Replace(cmdline, " ", "_", -1)
+	return strings.Replace(d, "/", "|", -1)
+}
+
+// loadTests loads the main table driven tests
+// for ln command tests
+func loadTests() []test {
+	return []test{
+		{
+			// covers usage:
+			// ln [OPTIONS]... [-T] TARGET LINK_NAME   (1st form) (posix)
+			config{},
+			[]string{"a", "b"},
+			[]result{{name: "b", linksTo: "a"}},
+			[]create{{name: "a"}},
+			"ln a b",
+		},
+		{
+			config{symlink: true},
+			[]string{"a", "b"},
+			[]result{{symlink: true, name: "b", linksTo: "a"}},
+			[]create{{name: "a"}},
+			"ln -s a b",
+		},
+		{
+			// covers usage:
+			// ln [OPTIONS]... TARGET   (2nd form) (gnu)
+			config{symlink: true},
+			[]string{"bin/cp"},
+			[]result{
+				{symlink: true, name: "cp", linksTo: "bin/cp"},
+			},
+			[]create{
+				{name: "bin", dir: true},
+				{name: "bin/cp"},
+			},
+			"ln -s bin/cp",
+		},
+		{
+			// covers usage:
+			// ln [OPTIONS]... TARGET... DIRECTORY  (3rd form) (posix)
+			config{symlink: true},
+			[]string{"bin/cp", "bin/ls", "bin/ln", "."},
+			[]result{
+				{symlink: true, name: "cp", linksTo: "bin/cp"},
+				{symlink: true, name: "ls", linksTo: "bin/ls"},
+				{symlink: true, name: "ln", linksTo: "bin/ln"},
+			},
+			[]create{
+				{name: "bin", dir: true},
+				{name: "bin/cp"},
+				{name: "bin/ls"},
+				{name: "bin/ln"},
+			},
+			"ln -s bin/cp bin/ls bin/ln .",
+		},
+		{
+			// covers usage:
+			// ln [OPTIONS]... -t DIRECTORY TARGET...  (4th form) (gnu)
+			config{symlink: true, dirtgt: "."},
+			[]string{"bin/cp", "bin/ls", "bin/ln"},
+			[]result{
+				{symlink: true, name: "cp", linksTo: "bin/cp"},
+				{symlink: true, name: "ls", linksTo: "bin/ls"},
+				{symlink: true, name: "ln", linksTo: "bin/ln"},
+			},
+			[]create{
+				{name: "bin", dir: true},
+				{name: "bin/cp"},
+				{name: "bin/ls"},
+				{name: "bin/ln"},
+			},
+			"ln -s bin/cp bin/ls bin/ln -t .",
+		},
+		{
+			// covers usage:
+			// ln [OPTIONS]... -t DIRECTORY TARGET...  (4th form) (gnu)
+			config{symlink: true, dirtgt: "folder", relative: true},
+			[]string{"cp", "ls", "ln"},
+			[]result{
+				{symlink: true, name: "folder/cp", linksTo: "../cp"},
+				{symlink: true, name: "folder/ls", linksTo: "../ls"},
+				{symlink: true, name: "folder/ln", linksTo: "../ln"},
+			},
+			[]create{
+				{name: "folder", dir: true},
+				{name: "cp"},
+				{name: "ls"},
+				{name: "ln"},
+			},
+			"ln -s -v -r -t folder cp ls ln",
+		},
+		{
+			// -i -f mutually exclusive (f overwrite evers)
+			config{force: true, prompt: true},
+			[]string{"a", "overwrite"},
+			[]result{
+				{name: "overwrite", linksTo: "a"},
+			},
+			[]create{
+				{name: "overwrite"},
+				{name: "a"},
+			},
+			"ln -i -f a overwrite",
+		},
+	}
+}
+
+// newDir create a temp dir
+func newDir(testName string, t *testing.T) (name string) {
+	name, err := ioutil.TempDir(testPath, "Go_"+testName)
+	if err != nil {
+		t.Errorf("TempDir %s: %s", testName, err)
+	}
+	return
+}
+
+// testHardLink test if hardlink creation was sucessful
+// 'target' and 'linkName' must exists
+// linkName -> target
+func testHardLink(linkName, target string, t *testing.T) {
+	linkStat, err := os.Stat(linkName)
+	if err != nil {
+		t.Errorf("stat %q failed: %v", linkName, err)
+	}
+	targetStat, err := os.Stat(target)
+	if err != nil {
+		t.Errorf("stat %q failed: %v", target, err)
+	}
+	if !os.SameFile(linkStat, targetStat) {
+		t.Errorf("link %q, %q did not create hard link", linkName, target)
+	}
+}
+
+// testSymllink test if symlink creation was sucessful
+// 'target' and 'linkName' must exists
+// linkName -> target
+func testSymlink(linkName, linksTo string, t *testing.T) {
+	target := linksTo
+	if !filepath.IsAbs(target) {
+		target = filepath.Base(target)
+	}
+
+	linkStat, err := os.Stat(linkName)
+	if err != nil {
+		t.Errorf("stat %q failed: %v", linkName, err)
+	}
+	targetStat, err := os.Stat(target)
+	if err != nil {
+		t.Errorf("stat %q failed: %v", target, err)
+	}
+	if !os.SameFile(linkStat, targetStat) {
+		t.Errorf("symlink %q, %q did not create symlink", linkName, target)
+	}
+	targetStat, err = os.Stat(target)
+	if err != nil {
+		t.Errorf("lstat %q failed: %v", target, err)
+	}
+
+	if targetStat.Mode()&os.ModeSymlink == os.ModeSymlink {
+		t.Errorf("symlink %q, %q did not create symlink", linkName, target)
+	}
+
+	targetStat, err = os.Stat(target)
+	if err != nil {
+		t.Errorf("stat %q failed: %v", target, err)
+	}
+	if targetStat.Mode()&os.ModeSymlink != 0 {
+		t.Errorf("stat %q did not follow symlink", target)
+	}
+	s, err := os.Readlink(linkName)
+	if err != nil {
+		t.Errorf("readlink %q failed: %v", target, err)
+	}
+	if s != linksTo {
+		t.Errorf("after symlink %q != %q", s, target)
+	}
+	file, err := os.Open(target)
+	if err != nil {
+		t.Errorf("open %q failed: %v", target, err)
+	}
+	file.Close()
+}
+
+// TestLn make a general tests based on
+// tabDriven tests (see loadTests())
+func TestLn(t *testing.T) {
+	tabDriven := loadTests()
+	testDir := newDir("TestLnGeneric", t)
+	if removeTest {
+		defer os.RemoveAll(testDir)
+	}
+	// executing ln on isolated testDir
+	if err := os.Chdir(testDir); err != nil {
+		t.Fatalf("Changing directory for %q fails: %v", testDir, err)
+	}
+	defer os.Chdir("..") // after defer to go back to the original root
+
+	for caseNum, testCase := range tabDriven {
+		d := newDir(prepareTestName(testCase.cmdline), t)
+		if err := os.Chdir(d); err != nil {
+			t.Fatalf("Changing directory for %q fails: %v", t, err)
+		}
+
+		for _, f := range testCase.files {
+			t.Logf("Creating: %v (dir: %v)", f.name, f.dir)
+			p := filepath.Join(f.name)
+			if f.dir {
+				if err := os.Mkdir(p, 0750); err != nil && err == os.ErrExist {
+					t.Skipf("Creation of dir %q fails: %v", p, err)
+				}
+			} else {
+				if err := ioutil.WriteFile(p, []byte{'.'}, 0640); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+		}
+
+		if err := testCase.conf.ln(testCase.args); err != nil {
+			t.Errorf("Fails: test [%d]. %v", caseNum+1, err)
+			continue
+		}
+
+		t.Logf("Testing cmdline: %q", testCase.cmdline)
+		for _, expected := range testCase.results {
+			if expected.symlink {
+				t.Logf("%q -> %q (symlink)", expected.name, expected.linksTo)
+				testSymlink(expected.name, expected.linksTo, t)
+			} else {
+				t.Logf("%q -> %q (hardlink)", expected.name, expected.linksTo)
+				testHardLink(expected.name, expected.linksTo, t)
+			}
+
+		}
+
+		// backing to testDir folder
+		os.Chdir("..")
+	}
+}


### PR DESCRIPTION
I added some common treatment at GNU implementation of ln.

The command in that moment works that way:
```
SYNOPSIS:
       ln [OPTIONS]... [-T] TARGET LINK_NAME   (1st form) (posix)
       ln [OPTIONS]... TARGET                  (2nd form) (gnu)
       ln [OPTIONS]... TARGET... DIRECTORY     (3rd form) (posix)
       ln [OPTIONS]... -t DIRECTORY TARGET...  (4th form) (gnu)

OPTIONS:
	-t [string] receive a directory to put the links (gnu)
	-i interactive mode to ask for overwrite (gnu)
	-f force the last flag and don't ask about overwrite (posix)
	-s create symbolic links instead hard links (gnu)
	-v verbose mode to print each link created (gnu)
	-T treat LINK_NAME operand as a normal file always (gnu)
	-r create symbolic links relative to link location (gnu)
	-P make hard links directly to symbolic links (posix)
	-L dereference TARGETs that are symbolic links (posix)
```
> TESTS:
* We have 6 tests on table driven tests.
* The tests covers the four usages, at example:

```bash
$ ln TARGET LINK_NAME
$ ln -f TARGET
$ ln -s TARGET1 TARGET2... folder/
$ ln -t folder/ TARGET1 TARGET2 TARGET3...
$ ln -s -r -t folder/ TARGET1 TARGET2 TARGET3...
```
But need tests yet flags like -P, -L, -i, -T.