### PR TITLE
ps.go: remove terminal stuff and fixed error when process disappears

### DIFF
--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -49,7 +49,7 @@ type ProcessTable struct {
 	headers  []string // each column to print
 	fields   []string // which fields of process to print, on order
 	fstring  []string // formated strings
-	maxwidth int      // max width
+	maxwidth int      // DEPRECATED: reason -> remove terminal stuff
 }
 
 // to use on sort.Sort
@@ -112,10 +112,6 @@ func (pT ProcessTable) PrintHeader() {
 		row += fmt.Sprintf(formated, field)
 	}
 
-	if len(row) > pT.maxwidth {
-		row = row[:pT.maxwidth]
-	}
-
 	fmt.Printf("%v\n", row)
 }
 
@@ -129,10 +125,6 @@ func (pT ProcessTable) PrintProcess(index int) {
 		formated := pT.fstring[index]
 		row += fmt.Sprintf(formated, field)
 
-	}
-
-	if len(row) > pT.maxwidth {
-		row = row[:pT.maxwidth]
 	}
 
 	fmt.Printf("%v\n", row)

--- a/cmds/ps/ps_test.go
+++ b/cmds/ps/ps_test.go
@@ -13,7 +13,6 @@ import (
 // Simple Test trying execute the ps
 // If no errors returns, it's okay
 func TestPsExecution(t *testing.T) {
-	t.Skipf("ps is broken; if a process disappears the test fails.")
 	pT := ProcessTable{}
 	if err := pT.LoadTable(); err != nil {
 		t.Fatalf("Loading Table fails on some point; %v", err)


### PR DESCRIPTION
We have a problem here, the -x implies the long command line expansion
at executing ps. However, if we don't put a limit, at example erlier
I assumpt the the width size of terminal, unfortunally the
visual table will break. For that, i disabled the long command line
expansion @ line 118 on ps_linux.go file.

Probably now the build at travis will works. Because I did can't
reply the 'process dissapears error' I only try a fix here.
Let's see what travis-ci will say.