### PR TITLE
travis.yml: add slack notifications -> #build-notices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,6 @@ script:
   - echo "Did it blend"
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" ]; then ghr --username u-root --token $GITHUB_TOKEN --replace --prerelease --debug `git describe --always`  dist/; fi
+
+notifications:
+  slack: u-root:S74GnNB8ekAiqNYTjwbEhkQE


### PR DESCRIPTION
I setup at slack of u-root an integration with travis CI
https://slack.com/apps/A0F81FP4N-travis-ci

I think is nice receive the build status of PR and commits
to easily see if something is broken.