### PR TITLE
ramfs.go: add netlink to keep at src, solve the dhcp import problem

### DIFF
--- a/scripts/ramfs.go
+++ b/scripts/ramfs.go
@@ -43,6 +43,7 @@ pkg/tool/{{.Goos}}_{{.Arch}}/old6a`
 	urootList = `{{.Gopath}}
 
 src/github.com/u-root/u-root/cmds
+src/github.com/u-root/u-root/netlink
 src/github.com/u-root/u-root/uroot
 src/github.com/u-root/u-root/vendor`
 )


### PR DESCRIPTION
However, the dhcp doesn't compiling yet. Now we have some
trouble about deadlock goroutines.