### PR TITLE
initramfs: clean things.

### DIFF
--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -50,7 +50,7 @@ func main() {
 	envs := uroot.Envs
 	log.Printf("envs %v", envs)
 	os.Setenv("GOBIN", "/buildbin")
-	cmd := exec.Command("go", "install", "-x", path.Join(uroot.CmdsPath, "installcommand"))
+	cmd := exec.Command("go", "build", "-x", "-o", "/buildbin/installcommand", path.Join(uroot.CmdsPath, "installcommand"))
 	installenvs := envs
 	installenvs = append(envs, "GOBIN=/buildbin")
 	cmd.Env = installenvs
@@ -76,6 +76,18 @@ func main() {
 		n := path.Join("/env", nv[0])
 		if err := ioutil.WriteFile(n, []byte(nv[1]), 0666); err != nil {
 			log.Printf("%v: %v", n, err)
+		}
+	}
+
+	// Now here's some good fun. We've set environment variables we want to see used.
+	// But on some systems the environment variable we create is completely ignored.
+	// Oh, is that you again, tinycore? Well.
+	// So we can save the day by writing the uroot.profile string to /etc/profile.d/uroot.sh
+	// mode, usually, 644.
+	// Only bother doing this is /etc/profile.d exists and is a directory.
+	if fi, err := os.Stat("/etc/profile.d"); err == nil && fi.IsDir() {
+		if err := ioutil.WriteFile("/etc/profile.d/uroot.sh", []byte(uroot.Profile), 0644); err != nil {
+			log.Printf("Trying to write uroot profile failed: %v", err)
 		}
 	}
 

--- a/cmds/tcz/tcz.go
+++ b/cmds/tcz/tcz.go
@@ -88,7 +88,7 @@ func clonetree(tree string) error {
 	err := filepath.Walk(tree, func(path string, fi os.FileInfo, err error) error {
 		if fi.IsDir() {
 			l.Printf("walking, dir %v\n", path)
-			os.MkdirAll(path[lt:], 0600)
+			os.MkdirAll(path[lt:], 0700)
 			return nil
 		}
 		// all else gets a symlink.
@@ -192,7 +192,7 @@ func setupPackages(tczName string, deps map[string]bool) error {
 	for v := range deps {
 		cmdName := strings.Split(v, ".")[0]
 		packagePath := path.Join("/tmp/tcloop", cmdName)
-		if err := os.MkdirAll(packagePath, 0600); err != nil {
+		if err := os.MkdirAll(packagePath, 0700); err != nil {
 			l.Fatal(err)
 		}
 
@@ -238,11 +238,11 @@ func main() {
 	cmdName := flag.Args()[0]
 	tczName := cmdName + ".tcz"
 
-	if err := os.MkdirAll(tcz, 0600); err != nil {
+	if err := os.MkdirAll(tcz, 0700); err != nil {
 		l.Fatal(err)
 	}
 
-	if err := os.MkdirAll("/tmp/tcloop", 0600); err != nil {
+	if err := os.MkdirAll("/tmp/tcloop", 0700); err != nil {
 		l.Fatal(err)
 	}
 


### PR DESCRIPTION
We're very, very close. Here is how I build an initramfs with a combined tinycore cpio:
go run ramfs.go -cpio ~/projects/u-root/tinycore64-6.4/boot/corepure64

This gets all the way to an ash prompt. You can then run ordinary commands.

If you want a uniquely u-root command you can just type, e.g.
rush

and the right things happen. If you want a command that is also in /bin, e.g. date,
/buildbin/date

If you're in a stupid shell that wants to be smart and remember things, like ash, you'll have to do this:
hash -r
to clear its hash.

rush has no such problem but it has lots of limits too.

Tinycore package fetching is not quite right yet in the combined initramfs. I'm not sure why.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>