### PR TITLE
initramfs: set $IFS to `hash -r` so newly build u-root commands are found

### DIFF
--- a/uroot/root.go
+++ b/uroot/root.go
@@ -127,6 +127,9 @@ func Rootfs() {
 	for k, v := range env {
 		Profile += "export " +k+"="+v+"\n"
 	}
+	// The IFS lets us force a rehash every time we type a command, so that when we
+	// build uroot commands we don't keep rebuilding them.
+	Profile += "IFS=`hash -r`\n"
 	// IF the profile is used, THEN when the user logs in they will need a private
 	// tmpfs. There's no good way to do this on linux. The closest we can get for now
 	// is to mount a tmpfs of /go/pkg/%s_%s :-(


### PR DESCRIPTION
This way, when a u-root command in /buildbin is built into /ubin, it will
be found in /ubin.

With this change, tinycore integration works very smoothly. To install a new command,
e.g. bash, one simply does
sudo -E tcz bash

and bash is ready to use.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>