### PR TITLE
validate: check binary signatures, handle missing libraries

### DIFF
--- a/cmds/validate/validate.go
+++ b/cmds/validate/validate.go
@@ -15,15 +15,15 @@ import (
 	"os"
 	"strings"
 
-	// TODO _ "golang.org/x/crypto/openpgp"
-	// TODO _ "golang.org/x/crypto/md4"
+	_ "golang.org/x/crypto/openpgp"
+	_ "golang.org/x/crypto/md4"
 	_ "crypto/md5"
 	_ "crypto/sha1"
 	_ "crypto/sha256"
 	_ "crypto/sha512"
 
-	//	_ "golang.org/x/crypto/ripemd160"
-	//	_ "golang.org/x/crypto/sha3"
+	_ "golang.org/x/crypto/ripemd160"
+	_ "golang.org/x/crypto/sha3"
 	_ "crypto/sha512"
 )
 

--- a/cmds/validate/validate.go
+++ b/cmds/validate/validate.go
@@ -91,9 +91,7 @@ func main() {
 		debug = log.Printf
 	}
 
-	// TODO: read in the file with the validation.
-	// The second args will be flag.Args()[1], of course!
-	f, v := flag.Args()[0], flag.Args()[1]
+	v, f := flag.Args()[0], flag.Args()[1]
 
 	sigData, err := ioutil.ReadFile(v)
 	if err != nil {

--- a/cmds/validate/validate.go
+++ b/cmds/validate/validate.go
@@ -43,18 +43,50 @@ var (
 		"SHA3_512":  crypto.SHA3_512,
 	}
 
-	armored = flag.Bool("a", false, "signature is ASCII armored")
-	sumfile = flag.String("i", "", "checksum file")
-	alg     = flag.String("alg", "MD5", "md5sum")
-	verbose = flag.Bool("v", false, "verbose")
-	debug   = func(string, ...interface{}) {}
+	armored    = flag.Bool("a", false, "signature is ASCII armored")
+	sumfile    = flag.String("i", "", "checksum file")
+	alg        = flag.String("alg", "", "algorithms to check")
+	verbose    = flag.Bool("v", false, "verbose")
+	debug      = func(string, ...interface{}) {}
+	try, tried []string
 )
+
+func init() {
+	for v := range algs {
+		try = append(try, v)
+	}
+}
+
+func one(n string, b []byte, sig string) bool {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("Hash %v did not get linked in: ", n, r)
+		}
+	}()
+	debug("Check alg %v", n)
+	checker := algs[n].New()
+	checker.Write(b)
+	r := checker.Sum([]byte{})
+	tried = append(tried, n)
+
+	// There has to be a better way.
+	sumText := ""
+	for _, v := range r {
+		sumText += fmt.Sprintf("%02x", v)
+	}
+	debug("Compare to %v", sumText)
+	if sumText == sig {
+		return true
+	}
+	return false
+}
 
 func main() {
 	flag.Parse()
 	if flag.NArg() < 2 {
 		log.Fatalf("Need at least a file to be validated and one public key")
 	}
+
 	if *verbose {
 		debug = log.Printf
 	}
@@ -68,35 +100,36 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 
+	if *alg != "" {
+		try = []string{}
+		for _, v := range strings.Split(*alg, ",") {
+			try = append(try, v)
+		}
+	}
+
+	log.Printf("Try %v", try)
+
 	sig := strings.Split(string(sigData), " ")
+
 	debug("Signature is %v len %v", sig[0], len(sig[0]))
 
 	b, err := ioutil.ReadFile(f)
 	if err != nil {
 		log.Fatalf("%s: %v", f, err)
 	}
-	for _, h := range strings.Split(*alg, ",") {
-		debug("Check %v", h)
-		h, ok := algs[h]
-		if !ok {
-			debug("%s is not in %v", h, algs)
+	for i := range try {
+		debug("Check %v", try[i])
+		if one(try[i], b, sig[0]) {
+			debug("ok")
+			os.Exit(0)
 		}
-
-		checker := h.New()
-		checker.Write(b)
-		r := checker.Sum([]byte{})
-
-		// There has to be a better way.
-		sumText := ""
-		for _, v := range r {
-			sumText += fmt.Sprintf("%02x", v)
-		}
-		debug("Compare to %v", sumText)
-		if sumText == sig[0] {
+		// Sometimes it's not a file in the standard format, but some binary thing.
+		// Check that too.
+		if one(try[i], b, string(sigData)) {
 			debug("ok")
 			os.Exit(0)
 		}
 		debug("not ok")
 	}
-	log.Fatalf("No matches found for *alg")
+	log.Fatalf("No matches found for %v", tried)
 }

--- a/cmds/validate/validate.go
+++ b/cmds/validate/validate.go
@@ -60,7 +60,7 @@ func init() {
 func one(n string, b []byte, sig string) bool {
 	defer func() {
 		if r := recover(); r != nil {
-			log.Printf("Hash %v did not get linked in: ", n, r)
+			log.Printf("Hash %v did not get linked in: %v", n, r)
 		}
 	}()
 	debug("Check alg %v", n)
@@ -120,13 +120,13 @@ func main() {
 	for i := range try {
 		debug("Check %v", try[i])
 		if one(try[i], b, sig[0]) {
-			debug("ok")
+			fmt.Printf("%v\n", try[i])
 			os.Exit(0)
 		}
 		// Sometimes it's not a file in the standard format, but some binary thing.
 		// Check that too.
 		if one(try[i], b, string(sigData)) {
-			debug("ok")
+			fmt.Printf("%v\n", try[i])
 			os.Exit(0)
 		}
 		debug("not ok")

--- a/cmds/validate/validate_test.go
+++ b/cmds/validate/validate_test.go
@@ -1,0 +1,108 @@
+// Copyright 2016 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+type file struct {
+	name string
+	a string
+	val []byte
+	o string
+	e string
+	x int // XXX wrong for Plan 9 and Harvey
+}
+
+func TestValidate(t *testing.T) {
+	var data = []byte(`127.0.0.1	localhost
+127.0.1.1	akaros
+192.168.28.16	ak
+192.168.28.131	uroot
+
+# The following lines are desirable for IPv6 capable hosts
+::1     localhost ip6-localhost ip6-loopback
+ff02::1 ip6-allnodes
+ff02::2 ip6-allrouters
+`)
+	var tests           = []file {
+		{name: "hosts.sha1", val: []byte("3f397a3b3a7450075da91b078afa35b794cf6088  hosts"), o: "SHA1\n"},
+	}
+
+	tmpDir, err := ioutil.TempDir("", "validatetest")
+	if err != nil {
+		t.Fatal("TempDir failed: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	if err := ioutil.WriteFile(path.Join(tmpDir, "hosts"), data, 0444); err != nil {
+		t.Fatalf("Can't set up data file: %v", err)
+	}
+
+	validatetestpath := filepath.Join(tmpDir, "validatetest.exe")
+	out, err := exec.Command("go", "build", "-o", validatetestpath, ".").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build -o %v cmds/validate: %v\n%s", validatetestpath, err, string(out))
+	}
+
+	t.Logf("Built %v for test", validatetestpath)
+	for _, v := range tests {
+		if err := ioutil.WriteFile(path.Join(tmpDir, v.name), v.val, 0444); err != nil {
+			t.Fatalf("Can't set up hash file: %v", err)
+		}
+
+		c := exec.Command(validatetestpath, path.Join(tmpDir, "hosts"), path.Join(tmpDir, v.name))
+		ep, err := c.StderrPipe()
+		if err != nil {
+			t.Fatalf("Can't start StderrPipe: %v", err)
+		}
+		op, err := c.StdoutPipe()
+		if err != nil {
+			t.Fatalf("Can't start StdoutPipe: %v", err)
+		}
+
+		if err := c.Start(); err != nil {
+			t.Fatalf("Can't start %v: %v", c, err)
+		}
+		e, err := ioutil.ReadAll(ep)
+		if err != nil {
+			t.Fatalf("Can't get stderr of %v: %v", c, err)
+		}
+		o, err := ioutil.ReadAll(op)
+		if err != nil {
+			t.Fatalf("Can't get sdout of %v: %v", c, err)
+		}
+
+		if err = c.Wait(); err != nil {
+			t.Fatalf("Can's Wait %v: %v", c, err)
+		}
+
+		// TODO: fix this for Plan 9/Harvey
+		s := c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+
+		if s != v.x {
+			t.Errorf("Validate %v hosts %v (%v): want (exit: %v), got (exit %v), output %v", v.a, v.name, string(v.val), v.x, s, string(o))
+			continue
+		}
+
+		if err != nil && string(e) != v.e {
+			t.Errorf("Validate %v hosts %v (%v): want stderr: %v, got %v)", v.a, v.name, string(v.val), v.e, string(o))
+			continue
+		}
+
+		if string(o) != v.o {
+			t.Errorf("Validate %v hosts %v (%v): want stdout: %v, got %v)", v.a, v.name, string(v.val), v.o, string(o))
+			continue
+		}
+
+		t.Logf("Validate %v hosts %v: %v", v.a, v.name, string(o))
+	}
+}

--- a/cmds/validate/validate_test.go
+++ b/cmds/validate/validate_test.go
@@ -59,7 +59,7 @@ ff02::2 ip6-allrouters
 			t.Fatalf("Can't set up hash file: %v", err)
 		}
 
-		c := exec.Command(validatetestpath, path.Join(tmpDir, "hosts"), path.Join(tmpDir, v.name))
+		c := exec.Command(validatetestpath, path.Join(tmpDir, v.name), path.Join(tmpDir, "hosts"))
 		ep, err := c.StderrPipe()
 		if err != nil {
 			t.Fatalf("Can't start StderrPipe: %v", err)


### PR DESCRIPTION
move the individual validates into a function.

h.New() panics if the function is not compiled in, have the function
recover from that

Keep track of what hashes could be tried and what were tried. Print out the
ones we actually tried at the end.

The signature file might be binary; if the signature fails, try its contents
as a binary signature.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>