### PR TITLE
rush: fix dangling open files from > and <

### DIFF
--- a/cmds/rush/parse.go
+++ b/cmds/rush/parse.go
@@ -27,6 +27,7 @@ type Command struct {
 	// These are filled in by the parser.
 	args  []arg
 	fdmap map[int]string
+	files map[int]io.Closer
 	link  string
 	bg    bool
 
@@ -219,7 +220,7 @@ func parse(b *bufio.Reader) (*Command, string) {
 }
 
 func newCommand() *Command {
-	return &Command{fdmap: make(map[int]string)}
+	return &Command{fdmap: make(map[int]string), files: make(map[int]io.Closer)}
 }
 
 // Just eat it up until you have all the commands you need.


### PR DESCRIPTION
Rush was not properly closing redirection files. This was a
result of our not having fork/exec; things just have to be done
differently.

Add a map of io.Closers to the Command struct, called files, and have
OpenRead and OpenWrite add opened files to it.

In runit, add a defer() to close all files in the files map.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>