### PR TITLE
Delete CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-u-root.tk


### PR DESCRIPTION
We have some troubles to use CNAME because the host itself need folding like: u-root.github.io/u-root

The website now should be on, but this is annoying.

I can't get the directly ip for u-root.github.io/u-root to setup the CNAME on DNS servers... unfortunately