### PR TITLE
Implement sort command, essential options and test

### DIFF
--- a/cmds/sort/sort.go
+++ b/cmds/sort/sort.go
@@ -1,0 +1,93 @@
+// Copyright 2016 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+Sort copies lines from the input to the output, sorting them in the process.
+This does nothing fancy (no multi-threading, compression, tables, ...); it
+simply uses Go's sort.Sort function.
+
+sort [OPTION]... [FILE]...
+
+The options are:
+	-r		reverse
+	-o string	output file
+*/
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"sort"
+	"strings"
+)
+
+var (
+	reverse    = flag.Bool("r", false, "Reverse")
+	outputFile = flag.String("o", "", "Output file")
+)
+
+// Sort from file a to file b.
+func sortFiles(from []*os.File, to *os.File) {
+	// Read unicode string from input
+	fileContents := []string{}
+	for _, f := range from {
+		bytes, err := ioutil.ReadAll(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fileContents = append(fileContents, string(bytes))
+	}
+	s := strings.Join(fileContents, "")
+
+	// Sorting algorithm
+	if len(s) > 0 && s[len(s)-1] == '\n' {
+		s = s[:len(s)-1] // remove terminating newline
+	}
+	lines := strings.Split(string(s), "\n")
+	if *reverse {
+		sort.Sort(sort.Reverse(sort.StringSlice(lines)))
+	} else {
+		sort.Strings(lines)
+	}
+	s = strings.Join(lines, "\n") + "\n" // append newline terminated
+
+	// Write to output
+	to.Write([]byte(s))
+}
+
+func main() {
+	flag.Parse()
+
+	// Input files
+	from := []*os.File{}
+	if flag.NArg() > 0 {
+		for _, v := range flag.Args() {
+			if f, err := os.Open(v); err == nil {
+				from = append(from, f)
+				defer f.Close()
+			} else {
+				log.Fatal(err)
+			}
+		}
+	} else {
+		from = []*os.File{os.Stdin}
+	}
+
+	// Output file
+	var to *os.File = os.Stdout
+	if *outputFile != "" {
+		log.Println(*outputFile)
+		if f, err := os.Create(*outputFile); err == nil {
+			to = f
+			defer f.Close()
+		} else {
+			log.Fatal(err)
+		}
+	}
+
+	sortFiles(from, to)
+}

--- a/cmds/sort/sort_test.go
+++ b/cmds/sort/sort_test.go
@@ -1,0 +1,102 @@
+// Copyright 2016 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// TODO: test multi-file input
+
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+type Test struct {
+	flag string
+	in   string
+	out  string
+}
+
+var sortTests = []Test{
+	// already sorted, in == out
+	{"", "a\nb\nc\n", "a\nb\nc\n"},
+	// sort letters
+	{"", "c\na\nb\n", "a\nb\nc\n"},
+	// sort lexicographic
+	{"", "abc \nab\na bc\n", "a bc\nab\nabc \n"},
+	// sort without terminating newline
+	{"", "a\nb\nc", "a\nb\nc\n"},
+	// sort with utf-8 characters
+	{"", "γ\nα\nβ\n", "α\nβ\nγ\n"},
+	// reverse sort
+	{"-r", "c\na\nb\n", "c\nb\na\n"},
+	// reverse sort without terminating newline
+	{"-r", "a\nb\nc", "c\nb\na\n"},
+}
+
+func TestSort(t *testing.T) {
+	// Create temp directory
+	tmpDir, err := ioutil.TempDir("", "TestSort")
+	if err != nil {
+		t.Fatal("TempDir failed: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Compile sort program
+	sortPath := filepath.Join(tmpDir, "sort")
+	out, err := exec.Command("go", "build", "-o", sortPath, "sort.go").CombinedOutput()
+	if err != nil {
+		t.Fatalf("go build -o %v cmds/sort: %v\n%s", sortPath, err, string(out))
+	}
+
+	// Table-driven testing
+	for _, test := range sortTests {
+		// Two ways to test:
+		pipes(t, test, tmpDir, sortPath)
+		files(t, test, tmpDir, sortPath)
+	}
+}
+
+func pipes(t *testing.T, test Test, tmpDir string, sortPath string) {
+	cmd := fmt.Sprintf("printf %#v | %s %s", test.in, sortPath, test.flag)
+	out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
+	if err != nil {
+		t.Errorf("%s: %v", cmd, err)
+		return
+	}
+	if string(out) != test.out {
+		t.Errorf("%s = %#v; want %#v", cmd, string(out), test.out)
+	}
+}
+
+func files(t *testing.T, test Test, tmpDir string, sortPath string) {
+	inFile := filepath.Join(tmpDir, "in")
+	outFile := filepath.Join(tmpDir, "out")
+	if err := ioutil.WriteFile(inFile, []byte(test.in), 0600); err != nil {
+		t.Error(err)
+		return
+	}
+	cmd := []string{sortPath, "-o", outFile, inFile}
+	if test.flag != "" {
+		cmd = []string{sortPath, test.flag, "-o", outFile, inFile}
+	}
+	out, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
+	if err != nil {
+		t.Errorf("%s: %v\n%s", strings.Join(cmd, " "), err, out)
+		return
+	}
+	out, err = ioutil.ReadFile(outFile)
+	if err != nil {
+		t.Errorf("Cannot open out file: %v", err)
+		return
+	}
+	if string(out) != test.out {
+		t.Errorf("%s = %#v; want %#v", strings.Join(cmd, " "),
+			string(out), test.out)
+	}
+}

--- a/cmds/sort/sort_test.go
+++ b/cmds/sort/sort_test.go
@@ -2,12 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// TODO: test multi-file input
-
 package main
 
 import (
-	"fmt"
+	"bytes"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -16,87 +14,140 @@ import (
 	"testing"
 )
 
-type Test struct {
-	flag string
-	in   string
-	out  string
+type test struct {
+	flags []string
+	in    string
+	out   string
 }
 
-var sortTests = []Test{
+var sortTests = []test{
+	// empty
+	{[]string{}, "", ""},
 	// already sorted, in == out
-	{"", "a\nb\nc\n", "a\nb\nc\n"},
+	{[]string{}, "a\nb\nc\n", "a\nb\nc\n"},
 	// sort letters
-	{"", "c\na\nb\n", "a\nb\nc\n"},
+	{[]string{}, "c\na\nb\n", "a\nb\nc\n"},
 	// sort lexicographic
-	{"", "abc \nab\na bc\n", "a bc\nab\nabc \n"},
+	{[]string{}, "abc \nab\na bc\n", "a bc\nab\nabc \n"},
 	// sort without terminating newline
-	{"", "a\nb\nc", "a\nb\nc\n"},
+	{[]string{}, "a\nb\nc", "a\nb\nc\n"},
 	// sort with utf-8 characters
-	{"", "γ\nα\nβ\n", "α\nβ\nγ\n"},
+	{[]string{}, "γ\nα\nβ\n", "α\nβ\nγ\n"},
 	// reverse sort
-	{"-r", "c\na\nb\n", "c\nb\na\n"},
+	{[]string{"-r"}, "c\na\nb\n", "c\nb\na\n"},
 	// reverse sort without terminating newline
-	{"-r", "a\nb\nc", "c\nb\na\n"},
+	{[]string{"-r"}, "a\nb\nc", "c\nb\na\n"},
 }
 
-func TestSort(t *testing.T) {
+// Helper function to create a temp directory and compile the sort program.
+// Remember to delete the directory after the test.
+func compileInTempDir(t *testing.T) (tmpDir string, sortPath string) {
 	// Create temp directory
 	tmpDir, err := ioutil.TempDir("", "TestSort")
 	if err != nil {
 		t.Fatal("TempDir failed: ", err)
 	}
-	defer os.RemoveAll(tmpDir)
 
 	// Compile sort program
-	sortPath := filepath.Join(tmpDir, "sort")
-	out, err := exec.Command("go", "build", "-o", sortPath, "sort.go").CombinedOutput()
+	sortPath = filepath.Join(tmpDir, "sort")
+	out, err := exec.Command("go", "build", "-o", sortPath,
+		"sort.go").CombinedOutput()
 	if err != nil {
 		t.Fatalf("go build -o %v cmds/sort: %v\n%s", sortPath, err, string(out))
 	}
+	return
+}
+
+// sort < in > out
+func TestSortWithPipes(t *testing.T) {
+	tmpDir, sortPath := compileInTempDir(t)
+	defer os.RemoveAll(tmpDir)
 
 	// Table-driven testing
-	for _, test := range sortTests {
-		// Two ways to test:
-		pipes(t, test, tmpDir, sortPath)
-		files(t, test, tmpDir, sortPath)
+	for _, tt := range sortTests {
+		cmd := exec.Command(sortPath, tt.flags...)
+		cmd.Stdin = strings.NewReader(tt.in)
+		var out bytes.Buffer
+		cmd.Stdout = &out
+		if err := cmd.Run(); err != nil {
+			t.Errorf("sort(%#v): %v", tt.in, err)
+		}
+		if out.String() != tt.out {
+			t.Errorf("sort(%#v) = %#v; want %#v", tt.in,
+				out.String(), tt.out)
+		}
 	}
 }
 
-func pipes(t *testing.T, test Test, tmpDir string, sortPath string) {
-	cmd := fmt.Sprintf("printf %#v | %s %s", test.in, sortPath, test.flag)
-	out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
-	if err != nil {
-		t.Errorf("%s: %v", cmd, err)
-		return
+// Helper function to create input files, run sort and compare the output.
+func sortWithFiles(t *testing.T, tt test, tmpDir string, sortPath string,
+	inFiles []string, outFile string) {
+	// Create input files
+	inPaths := make([]string, len(inFiles))
+	for i, inFile := range inFiles {
+		inPaths[i] = filepath.Join(tmpDir, inFile)
+		if err := ioutil.WriteFile(inPaths[i], []byte(tt.in), 0600); err != nil {
+			t.Error(err)
+			return
+		}
 	}
-	if string(out) != test.out {
-		t.Errorf("%s = %#v; want %#v", cmd, string(out), test.out)
-	}
-}
+	outPath := filepath.Join(tmpDir, outFile)
 
-func files(t *testing.T, test Test, tmpDir string, sortPath string) {
-	inFile := filepath.Join(tmpDir, "in")
-	outFile := filepath.Join(tmpDir, "out")
-	if err := ioutil.WriteFile(inFile, []byte(test.in), 0600); err != nil {
-		t.Error(err)
-		return
-	}
-	cmd := []string{sortPath, "-o", outFile, inFile}
-	if test.flag != "" {
-		cmd = []string{sortPath, test.flag, "-o", outFile, inFile}
-	}
-	out, err := exec.Command(cmd[0], cmd[1:]...).CombinedOutput()
+	args := append(append(append([]string{}, tt.flags...), "-o",
+		outPath), inPaths...)
+	out, err := exec.Command(sortPath, args...).CombinedOutput()
 	if err != nil {
-		t.Errorf("%s: %v\n%s", strings.Join(cmd, " "), err, out)
+		t.Errorf("sort %s: %v\n%s", strings.Join(args, " "),
+			err, out)
 		return
 	}
-	out, err = ioutil.ReadFile(outFile)
+
+	out, err = ioutil.ReadFile(outPath)
 	if err != nil {
 		t.Errorf("Cannot open out file: %v", err)
 		return
 	}
-	if string(out) != test.out {
-		t.Errorf("%s = %#v; want %#v", strings.Join(cmd, " "),
-			string(out), test.out)
+	if string(out) != tt.out {
+		t.Errorf("sort %s = %#v; want %#v", strings.Join(args, " "),
+			string(out), tt.out)
 	}
+}
+
+// sort -o in out
+func TestSortWithFiles(t *testing.T) {
+	tmpDir, sortPath := compileInTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	// Table-driven testing
+	for _, tt := range sortTests {
+		sortWithFiles(t, tt, tmpDir, sortPath, []string{"in"}, "out")
+	}
+}
+
+// sort -o file file
+func TestInplaceSort(t *testing.T) {
+	tmpDir, sortPath := compileInTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	// Table-driven testing
+	for _, tt := range sortTests {
+		sortWithFiles(t, tt, tmpDir, sortPath, []string{"file"}, "file")
+	}
+}
+
+// sort -o out in1 in2 in3 in4
+func TestMultipleFileInputs(t *testing.T) {
+	tmpDir, sortPath := compileInTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	tt := test{[]string{}, "a\nb\nc\n",
+		"a\na\na\na\nb\nb\nb\nb\nc\nc\nc\nc\n"}
+	sortWithFiles(t, tt, tmpDir, sortPath,
+		[]string{"in1", "in2", "in3", "in4"}, "out")
+
+	// Run the test again without newline terminators.
+	tt = test{[]string{}, "a\nb\nc",
+		"a\na\na\na\nb\nb\nb\nb\nc\nc\nc\nc\n"}
+	sortWithFiles(t, tt, tmpDir, sortPath,
+		[]string{"in1", "in2", "in3", "in4"}, "out")
 }


### PR DESCRIPTION
"Essential options" includes reverse (-r) and output file (-o). This
implementation is nowhere near the sophistication of coreutil's 4500+
line implementation. I did not implement any parallelization,
compression, etc... Also, the entire dataset to sort must be loaded into
memory at once.

Testing does not include inputting multiple files and a few edge cases
(such as concatenating files which do not end with a newline character).

Examples usages:

sort < a.in > b.out
sort -r < a.in > b.out
sort a.in -o b.out

This is my first u-root contribution, so be diligent! Also, is there anything manual to be done for the following?

- busybox sort command
- add sort_test.go to travis CI