### PR TITLE
Add a link to a generated html godocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 u-root
 ======
 
-[![Build Status](https://travis-ci.org/u-root/u-root.svg?branch=master)](https://travis-ci.org/u-root/u-root)
-
-[![Go Report Card](https://goreportcard.com/badge/github.com/u-root/u-root)](https://goreportcard.com/report/github.com/u-root/u-root)
+[![Build Status](https://travis-ci.org/u-root/u-root.svg?branch=master)](https://travis-ci.org/u-root/u-root) [![Go Report Card](https://goreportcard.com/badge/github.com/u-root/u-root)](https://goreportcard.com/report/github.com/u-root/u-root) [![GoDoc](https://godoc.org/github.com/u-root/u-root?status.svg)](https://godoc.org/github.com/u-root/u-root)
 
 # Description
 


### PR DESCRIPTION
This creates a link to https://godoc.org/github.com/u-root/u-root which is an HTML page generated from the comments in our go source code.

It looks really nice and looks almost like a man page. I'll try to add more comments in the proper format to make the page more complete.

Also, all the badges are now on the same line.