### PR TITLE
Add man pages for all the commands

### DIFF
--- a/cmds/ansi/ansi.go
+++ b/cmds/ansi/ansi.go
@@ -1,9 +1,18 @@
-// Copyright 2015 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// By Manoel Vilela <manoel_vilela@engineer.com>
-
+// Print ansi escape sequences.
+//
+// Synopsis:
+//     ansi COMMAND
+//
+// Options:
+//     COMMAND must be one of:
+//         - clear: clear the screen and reset the cursor position
+//
+// Author:
+//     Manoel Vilela <manoel_vilela@engineer.com>
 package main
 
 import (
@@ -39,5 +48,4 @@ func main() {
 	if err := ansi(os.Stdout, os.Args[1:]); err != nil {
 		log.Fatalf("%v", err)
 	}
-
 }

--- a/cmds/archive/archive.go
+++ b/cmds/archive/archive.go
@@ -1,11 +1,23 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Archive archives files. The VTOC is at the front; we're not modeling tape drives or
-// streams as in tar and cpio. This will greatly speed up listing the archive,
-// modifying it, and so on. We think.
-// Why a new tool?
+// Archive archives files.
+//
+//
+// Synopsis:
+//     archive d|e|t [-d] [args...]
+//
+// Description:
+//     The VTOC is at the front; we're not modeling tape drives or streams as
+//     in tar and cpio. This will greatly speed up listing the archive,
+//     modifying it, and so on. We think. Why a new tool?
+//
+// Options:
+//     d: decode
+//     e: toc (table of contents)
+//     t: toc (table of contents)
+//     -d: debug prints
 package main
 
 import (

--- a/cmds/builtin/builtin.go
+++ b/cmds/builtin/builtin.go
@@ -1,4 +1,4 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/cat/cat.go
+++ b/cmds/cat/cat.go
@@ -1,9 +1,17 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Cat reads each file from its arguments in sequence and writes it on the standard output.
-
+// Cat concatenates files and prints to stdout.
+//
+// Synopsis:
+//     cp [-u] [FILES]...
+//
+// Description:
+//     If no files are specified, read from stdin.
+//
+// Options:
+//     -u: ignored flag
 package main
 
 import (

--- a/cmds/chmod/chmod.go
+++ b/cmds/chmod/chmod.go
@@ -1,8 +1,14 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// chmod command in Go.
+// Change modifier bits of a file.
+//
+// Synopsis:
+//     chmod MODE FILE...
+//
+// Desription:
+//     MODE is a three character octal value.
 package main
 
 import (

--- a/cmds/cmp/cmp.go
+++ b/cmds/cmp/cmp.go
@@ -1,21 +1,24 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Cmp compares the two files and prints a message if the contents differ.
-
-cmp [ –lLs ] file1 file2 [ offset1 [ offset2 ] ]
-
-The options are:
-	–l    Print the byte number (decimal) and the differing bytes (octal) for each difference.
-	–L    Print the line number of the first differing byte.
-	–s    Print nothing for differing files, but set the exit status.
-
--If offsets are given, comparison starts at the designated byte position of the corresponding file.
--Offsets that begin with 0x are hexadecimal; with 0, octal; with anything else, decimal.
-*/
-
+// Cmp compares two files and prints a message if their contents differ.
+//
+// Synopsis:
+//     cmp [–lLs] FILE1 FILE2 [OFFSET1 [OFFSET2]]
+//
+// Description:
+//     If offsets are given, comparison starts at the designated byte position
+//     of the corresponding file.
+//
+//     Offsets that begin with 0x are hexadecimal; with 0, octal; with anything
+//     else, decimal.
+//
+// Options:
+//     –l: Print the byte number (decimal) and the differing bytes (octal) for
+//         each difference.
+//     –L: Print the line number of the first differing byte.
+//     –s: Print nothing for differing files, but set the exit status.
 package main
 
 import (

--- a/cmds/comm/comm.go
+++ b/cmds/comm/comm.go
@@ -1,11 +1,24 @@
-// Copyright 2013-2016 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style license
 // that can be found in the LICENSE file.
 
-//Comm reads file1 and file2, which are in lexicographical order, and
-//produces a three column output: lines only in file1; lines only in
-//file2; and lines in both files. The file name – means the standard
-//input.
+// Perform a set comparision over two files.
+//
+// Synopsis:
+//     comm [-123hi] FILE1 FILE2
+//
+// Descrption:
+//     Comm reads file1 and file2, which are in lexicographical order, and
+//     produces a three column output: lines only in file1; lines only in
+//     file2; and lines in both files. The file name – means the standard
+//     input.
+//
+// Options:
+//     -1: suppress printing of column 1
+//     -2: suppress printing of column 2
+//     -3: suppress printing of column 3
+//     -h: print this help message and exit
+//     -i: case insensitive comparison of lines
 package main
 
 import (

--- a/cmds/cp/cp.go
+++ b/cmds/cp/cp.go
@@ -1,10 +1,20 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// The cp command is an userland program for copy files with that usage:
-// $ cp [FLAGS] from to
-// whose FLAGS := -rRfivwP
+// Copy files.
+//
+// Synopsis:
+//     cp [-rRfivwP] FROM... TO
+//
+// Options:
+//     -w n: number of worker goroutines
+//     -R: copy file hierarchies
+//     -r: alias to -R recursive mode
+//     -i: prompt about overwriting file
+//     -f: force overwrite files
+//     -v: verbose copy mode
+//     -P: don't follow symlinks
 package main
 
 import (
@@ -47,7 +57,6 @@ func init() {
 	flag.BoolVar(&symlink, "P", false, "don't follow symlinks")
 	flag.Parse()
 	go nextOff()
-
 }
 
 // promptOverwrite ask if the user wants overwrite file

--- a/cmds/date/date.go
+++ b/cmds/date/date.go
@@ -1,7 +1,11 @@
-// Copyright 2015 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Print the date.
+//
+// Synopsis:
+//     date [-u] [+format] | date [-u] [MMDDhhmm[CC]YY[.ss]]
 package main
 
 import (

--- a/cmds/dd/dd.go
+++ b/cmds/dd/dd.go
@@ -1,14 +1,30 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// Convert and copy a file.
+//
+// Synopsis:
+//     dd [OPTIONS...] [-inName FILE] [-outName FILE]
+//
+// Description:
+//     dd is modeled after dd. Each step in the chain is a goroutine that reads
+//     a block and writes a block. There are always two goroutines, in and out.
+//     They're actually the same thing save they have, maybe, different block
+//     sizes.
+//
+// Options:
+//     -ibs n:   input block size (default=1)
+//     -obs n:   output block size (default=1)
+//     -bs n:    input and output block size (default=0)
+//     -skip n:  skip n bytes before reading (default=0)
+//     -seek n:  seek output when writing (default=0)
+//     -conv s:  Convert the file on a specific way, like notrunc
+//     -count n: max output of data to copy
+//     -inName:  defaults to stdin
+//     -outName: defaults to stdout
 package main
 
-/*
-dd is modeled after dd. Each step in the chain is a goroutine that
-reads a block and writes a block.
-There are two always-the goroutines, in and out. They're actually
-the same thing save they have, maybe, different block sizes.
-*/
 import (
 	"flag"
 	"fmt"

--- a/cmds/dmesg/dmesg.go
+++ b/cmds/dmesg/dmesg.go
@@ -1,8 +1,14 @@
-// Copyright 2012,2016 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//dmesg reads the system log.
+// Read the system log.
+//
+// Synopsis:
+//     dmesg [-c]
+//
+// Options:
+//     -c: clear the log
 package main
 
 import (

--- a/cmds/echo/echo.go
+++ b/cmds/echo/echo.go
@@ -1,8 +1,12 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//Echo writes its arguments separated by blanks and terminated by a newline on the standard output.
+// Echo writes its arguments separated by blanks and terminated by a newline on
+// the standard output.
+//
+// Synopsis:
+//     echo [STRING]...
 package main
 
 import (
@@ -16,7 +20,6 @@ import (
 var nonewline = flag.Bool("n", false, "suppress newline")
 
 func echo(w io.Writer, s ...string) error {
-
 	_, err := fmt.Fprintf(w, "%s", strings.Join(s, " "))
 
 	if !*nonewline {
@@ -24,13 +27,9 @@ func echo(w io.Writer, s ...string) error {
 	}
 
 	return err
-
 }
 
 func main() {
-
 	flag.Parse()
-
 	echo(os.Stdout, flag.Args()...)
-
 }

--- a/cmds/freq/freq.go
+++ b/cmds/freq/freq.go
@@ -1,25 +1,26 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Freq reads the given files (default standard input) and prints histograms of the
-character frequencies. By default, freq counts each byte as a character; under
-the –r option it instead counts UTF sequences, that is, runes.
-
-Each non–zero entry of the table is printed preceded by the byte value, in decimal,
-octal, hex, and Unicode character (if printable). If any options are given, the
-–d, –x, –o, –c flags specify a subset of value formats: decimal, hex, octal, and
-character, respectively.
-
-The options are:
-	–r    	treat input as UTF-8.
-	–d		print decimal value
-	–x		print hex value
-	–o		print octal value
-	–c		print charanter/UTF value
-*/
-
+// Freq reads the given files (default standard input) and prints histograms of the
+// character frequencies. By default, freq counts each byte as a character; under
+// the –r option it instead counts UTF sequences, that is, runes.
+//
+// Synopsis:
+//     freq [-rdxoc] [FILES]...
+//
+// Description:
+//     Each non–zero entry of the table is printed preceded by the byte value,
+//     in decimal, octal, hex, and Unicode character (if printable). If any
+//     options are given, the –d, –x, –o, –c flags specify a subset of value
+//     formats: decimal, hex, octal, and character, respectively.
+//
+// Options:
+//     –r: treat input as UTF-8
+//     –d: print decimal value
+//     –x: print hex value
+//     –o: print octal value
+//     –c: print character/UTF value
 package main
 
 import (

--- a/cmds/gitclone/gitclone.go
+++ b/cmds/gitclone/gitclone.go
@@ -1,11 +1,8 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Wget reads one file from the argument and writes it on the standard output.
-*/
-
+// gitclone does not work!
 package main
 
 import (

--- a/cmds/gopxe/gopxe.go
+++ b/cmds/gopxe/gopxe.go
@@ -1,16 +1,15 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 // gopxe is a pxe program written in Go.
-// It includes the functionality of the the PXE loader
-// and pxelinux.
-// It is incomplete but anyone with interest in filling it out
-// should find this pretty easy.
-// You can extend it to fetch a file following the rules
-// of pxe file name formation, then fetch the files, then use
-// the kexec system call (see kexec.go) to exec it.
-
+//
+// Description:
+//     It includes the functionality of the the PXE loader and pxelinux. It is
+//     incomplete but anyone with interest in filling it out should find this
+//     pretty easy. You can extend it to fetch a file following the rules of
+//     pxe file name formation, then fetch the files, then use the kexec system
+//     call (see kexec.go) to exec it.
 package main
 
 import (
@@ -40,5 +39,4 @@ func main() {
 
 	data, err := ioutil.ReadAll(f)
 	fmt.Printf("len(data) %v, err %v", len(data), err)
-
 }

--- a/cmds/gpgv/gpgv.go
+++ b/cmds/gpgv/gpgv.go
@@ -1,17 +1,25 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 // gpgv validates a signature against a file.
-// It prints "OK\n" to stdout if the check succeeds and exits with 0.
-// It prints an error message and exits with non-0 otherwise.
 //
-// The openpgp package ReadKeyRing function does not completely
-// implement RFC4880 in that it can't use a PublicSigningKey with
-// 0 signatures. We use one from Eric Grosse instead.
+// Synopsis:
+//     gpgv [-v] KEY SIG CONTENT
 //
-// Redistribute freely. Report bugs to grosse@gmail.com.  2016-11-05
-
+// Description:
+//     It prints "OK\n" to stdout if the check succeeds and exits with 0. It
+//     prints an error message and exits with non-0 otherwise.
+//
+//     The openpgp package ReadKeyRing function does not completely implement
+//     RFC4880 in that it can't use a PublicSigningKey with 0 signatures. We
+//     use one from Eric Grosse instead.
+//
+// Options:
+//     -v: verbose
+//
+// Author:
+//     grosse@gmail.com.
 package main
 
 import (

--- a/cmds/grep/grep.go
+++ b/cmds/grep/grep.go
@@ -1,17 +1,27 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 // Concurrent, parallel grep.
-// It has to deal with the EMFILE limit.
-// To do so we have one chan that is bounded.
-// From args, we use filepath.Walk to generate a chan of names.
-// From that, we create a chan of grepCommands.
-// From that, we create a chan of grepResults.
-// The grepResults contain matches or not-matches only.
-// if we are in -l mode, the goprocs handling the grep bail out as soon as the condition is met.
-// This grep is about 2x faster than GNU grep for simple non-recursive greps and slower
-// as soon as filepath.Walk enters the picture. Let's fix this.
+//
+// Synopsis:
+//     grep [-vrlq] [FILE]...
+//
+// Description:
+//     It has to deal with the EMFILE limit. To do so we have one chan that is
+//     bounded. From args, we use filepath.Walk to generate a chan of names.
+//     From that, we create a chan of grepCommands. From that, we create a chan
+//     of grepResults. The grepResults contain matches or not-matches only. If
+//     we are in -l mode, the goprocs handling the grep bail out as soon as the
+//     condition is met. This grep is about 2x faster than GNU grep for simple
+//     non-recursive greps and slower as soon as filepath. Walk enters the
+//     picture. Let's fix this.
+//
+// Options:
+//     -v: print only non-matching lines
+//     -r: recursive
+//     -l: list only files
+//     -q: don't print matches; exit on first match
 package main
 
 import (

--- a/cmds/hostname/hostname.go
+++ b/cmds/hostname/hostname.go
@@ -1,9 +1,14 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//show the system's hostname
-//created by Beletti (rhiguita@gmail.com)
+// Print the system's hostname.
+//
+// Synopsis:
+//     hostname
+//
+// Author:
+//     Beletti <rhiguita@gmail.com>
 package main
 
 import (
@@ -13,16 +18,12 @@ import (
 )
 
 func hostname(w io.Writer) error {
-
 	hostname, error := os.Hostname()
-
 	fmt.Fprintf(w, "%v", hostname)
 	return error
 }
 
 func main() {
-
 	hostname(os.Stdout)
 	fmt.Println()
-
 }

--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -1,4 +1,4 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -1,5 +1,19 @@
 package main
 
+// Install command from a go source file.
+//
+// Synopsis:
+//     installcommand [-v] [-ludicrous]
+//
+// Description:
+//     u-root commands are lazily compiled. Uncompiled commands in the /bin
+//     directory are symbolic links to installcommand. When executed through
+//     the symbolic link, installcommand will build the command from source and
+//     exec it.
+//
+// Options:
+//     -v: print all build commands
+//     -ludicrous: print out ALL the output from the go build commands
 import (
 	"flag"
 	"log"

--- a/cmds/ip/ip.go
+++ b/cmds/ip/ip.go
@@ -1,4 +1,4 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/kexec/kexec.go
+++ b/cmds/kexec/kexec.go
@@ -1,9 +1,20 @@
-// Copyright 2015 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// kexec command in Go.
-// This is only intended to be used with kexec_load_files, not the older kexec.
+// kexec executes a new kernel over the running kernel (u-root).
+//
+// Synopsis:
+//     kexec [--dryrun] [--cmdline=] [--i=] [FILES...]
+//
+// Description:
+//     This is only intended to be used with kexec_load_files, not the older
+//     kexec.
+//
+// Options:
+//     -dryrun:   do not do kexec system calls
+//     --cmdline: command line for kernel
+//     --i:       initramfs
 package main
 
 // N.B. /**/ comments are verbatim from uapi/linux/kexec.h.

--- a/cmds/kill/kill.go
+++ b/cmds/kill/kill.go
@@ -1,15 +1,20 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 // Kill kills processes.
-// -l lists the signal names.
-// -name, --signal name, or -s name is the message to send.
-// On some systems this is a string,
-// on others a number. It is optional and an OS-dependent value will
-// be used if it is not set.
-// pid is a list of at least one pid.
-
+//
+// Synopsis:
+//     kill -l
+//     kill [<-s | --signal | -> <isgname|signum>] pid [pid...]
+//
+// Options:
+//     -l:                       list the signal names
+//     -name, --signal name, -s: name is the message to send. On some systems
+//                               this is a string, on others a number. It is
+//                               optional and an OS-dependent value will be
+//                               used if it is not set. pid is a list of at
+//                               least one pid.
 package main
 
 import (

--- a/cmds/ldd/ldd.go
+++ b/cmds/ldd/ldd.go
@@ -1,12 +1,14 @@
-// Copyright 2009 The Go Authors.  All rights reserved.
+// Copyright 2009-2017 The Go Authors.  All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 // ldd prints the full path of dependencies.
-// unlike the standard one, you can use it in a script, e.g.
-// i=`ldd whatever`
-// leaves you with a list of files you can usefully copy.
-// You can also feed it a long list of files (/bin/*) and get
-// a short list of libraries; further, it will read stdin.
+//
+// Description:
+//     Unlike the standard one, you can use it in a script,
+//     e.g. i=`ldd whatever` leaves you with a list of files you can usefully
+//     copy. You can also feed it a long list of files (/bin/*) and get a
+//     short list of libraries; further, it will read stdin.
 package main
 
 import (
@@ -19,7 +21,6 @@ import (
 var list map[string]bool
 
 func process(file *os.File, name string) error {
-
 	if f, err := elf.NewFile(file); err != nil {
 		return err
 	} else {

--- a/cmds/ln/ln.go
+++ b/cmds/ln/ln.go
@@ -1,11 +1,25 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// created by Manoel Vilela <manoel_vilela@engineer.com>
-
-// Ln make links between files
-// the actual implementations supports that flags: [-rsvfLPti]
+// Ln makes links to files.
+//
+// Synopsis:
+//     ln [-svfTiLPrt] TARGET LINK
+//
+// Options:
+//     -s: make symbolic links instead of hard links
+//     -v: print name of each linked file
+//     -f: remove destination files
+//     -T: treat linkname operand as a non-dir always
+//     -i: prompt if the user wants overwrite
+//     -L: dereference targets if are symbolic links
+//     -P: make hard links directly to symbolic links
+//     -r: create symlinks relative to link location
+//     -t: specify the directory to put the links
+//
+// Author:
+//     Manoel Vilela <manoel_vilela@engineer.com>
 package main
 
 import (

--- a/cmds/losetup/losetup.go
+++ b/cmds/losetup/losetup.go
@@ -1,7 +1,16 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Setup loop devices.
+//
+// Synopsis:
+//     losetup [-Ad] FILE
+//     losetup [-Ad] DEV FILE
+//
+// Options:
+//     -A: pick any device
+//     -d: detach the device
 package main
 
 import (

--- a/cmds/ls/ls.go
+++ b/cmds/ls/ls.go
@@ -1,16 +1,16 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Ls reads the directories in the command line and prints out the names.
-
-The options are:
-	-l		Long form.
-	-r		raw (%v) form
-	-R		recurse
-*/
-
+// Ls prints the contents of a directory.
+//
+// Synopsis:
+//     ls [OPTIONS] [DIRS]...
+//
+// Options:
+//     -l: Long form.
+//     -r: raw (%v) form
+//     -R: recurse
 package main
 
 import (

--- a/cmds/mkdir/mkdir.go
+++ b/cmds/mkdir/mkdir.go
@@ -1,11 +1,16 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Cat reads each file from its arguments in sequence and writes it on the standard output.
-*/
-
+// Mkdir makes a new directory.
+//
+// Synopsis:
+//     mkdir [-m mode] [-v] [-p] DIRECTORY...
+//
+// Options:
+//     -m: make all needed directories in the path
+//     -v: directory mode (ex: 666)
+//     -p: print each directory as it is made
 package main
 
 import (

--- a/cmds/mount/mount.go
+++ b/cmds/mount/mount.go
@@ -1,6 +1,14 @@
-// Copyright 2012-2016 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// Mount a filesystem at the specified path.
+//
+// Synopsis:
+//     mount [-r] [-t FSTYPE] DEV PATH
+//
+// Options:
+//     -r: read only
 package main
 
 import (

--- a/cmds/mv/mv.go
+++ b/cmds/mv/mv.go
@@ -1,9 +1,15 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+// Mv renames files and directories.
 //
-//  move (rename) files
-// created by Beletti (rhiguita@gmail.com)
+// Synopsis:
+//     mv SOURCE TARGET
+//     mv SOURCE... DIRECTORY
+//
+// Author:
+//     Beletti (rhiguita@gmail.com)
 package main
 
 import (

--- a/cmds/netcat/netcat.go
+++ b/cmds/netcat/netcat.go
@@ -1,11 +1,8 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-netcat connects to a place and sends data to it and from it.
-*/
-
+// Netcat pipes over the network.
 package main
 
 import (

--- a/cmds/ping/ping.go
+++ b/cmds/ping/ping.go
@@ -2,6 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Send icmp packets to a server to test network connectivity.
+//
+// Synopsis:
+//     ping [-hV] [-c COUNT] [-i INTERVAL] [-s PACKETSIZE] [-w DEADLINE] DESTINATION
+//
+// Options:
+//     -6: use ipv6 (ip6:ipv6-icmp)
+//     -s: data size (default: 64)
+//     -c: # iterations, 0 to run forever (default)
+//     -i: interval in milliseconds (default: 1000)
+//     -V: version
+//     -w: wait time in milliseconds (default: 100)
+//     -h: help
 package main
 
 import (
@@ -24,7 +37,7 @@ var (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stdout, "ping [-hV] [-c count] [-i interval] [-s packetsize [-w deadline] destination\n")
+	fmt.Fprintf(os.Stdout, "ping [-hV] [-c count] [-i interval] [-s packetsize] [-w deadline] destination\n")
 	os.Exit(0)
 }
 

--- a/cmds/printenv/printenv.go
+++ b/cmds/printenv/printenv.go
@@ -1,3 +1,7 @@
+// Print environment variables.
+//
+// Synopsis:
+//     printenv
 package main
 
 import (

--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -1,10 +1,22 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// ps reads the /proc and prints out nice things about what it finds.
-// /proc in linux has grown by a process of Evilution, so it's messy.
-
+// Print process information.
+//
+// Synopsis:
+//     ps [-Aaex]
+//
+// Description:
+//     ps reads the /proc filesystem and prints nice things about what it
+//     finds.  /proc in linux has grown by a process of Evilution, so it's
+//     messy.
+//
+// Options:
+//     -A: select all processes. Identical to -e.
+//     -e: select all processes. Identical to -A.
+//     -x: BSD-Like style, with STAT Column and long CommandLine
+//     -a: print all process except whose are session leaders or unlinked with terminal
 package main
 
 import (

--- a/cmds/pwd/pwd.go
+++ b/cmds/pwd/pwd.go
@@ -1,12 +1,18 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
- print name of current/working directory
- created by Beletti (rhiguita@gmail.com)
-*/
-
+// Print name of current directory.
+//
+// Synopsis:
+//     pwd [-LP]
+//
+// Options:
+//     -L: follow symlinks (default)
+//     -P: don't follow symlinks
+//
+// Author:
+//     created by Beletti (rhiguita@gmail.com)
 package main
 
 import (

--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -1,7 +1,17 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Delete files.
+//
+// Synopsis:
+//     rm [-Rrvi] FILE...
+//
+// Options:
+//     -i: interactive mode
+//     -v: verbose mode
+//     -R: remove file hierarchies
+//     -r: equivalent to -R
 package main
 
 import (

--- a/cmds/rush/rush.go
+++ b/cmds/rush/rush.go
@@ -1,12 +1,11 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-sh reads in a line at a time and runs it.
-prompt is '% '
-*/
-
+// Rush is an interactive shell similar to sh.
+//
+// Description:
+//     Prompt is '% '.
 package main
 
 import (
@@ -123,6 +122,7 @@ func OpenRead(c *Command, r io.Reader, fd int) (io.Reader, error) {
 	}
 	return r, nil
 }
+
 func OpenWrite(c *Command, w io.Writer, fd int) (io.Writer, error) {
 	if c.fdmap[fd] != "" {
 		f, err := os.Create(c.fdmap[fd])

--- a/cmds/script/script.go
+++ b/cmds/script/script.go
@@ -1,8 +1,17 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Script takes the arg list, does minimal rewriting, builds it and runs it
+// Script executes its arguments as a Go program.
+//
+// Synopsis:
+//     script [-v] GO_CODE..
+//
+// Examples:
+//     script {fmt.Println("hello")}
+//
+// Options:
+//     -v: verbose display of processing
 package main
 
 import (

--- a/cmds/seq/seq.go
+++ b/cmds/seq/seq.go
@@ -1,7 +1,24 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Print a sequence of numbers.
+//
+// Synopsis:
+//     seq [-f FORMAT] [-w] [-s SEPARATOR] [START [STEP [END]]]
+//
+// Examples:
+//    % seq -s=' ' 3
+//    1 2 3
+//    % seq -s=' ' 2 4
+//    2 3 4
+//    % seq -s=' ' 3 2 7
+//    3 5 7
+//
+// Options:
+//     -f: use printf style floating-point FORMAT (default: %v)
+//     -s: use STRING to separate numbers (default: \n)
+//     -w: equalize width by padding with leading zeroes (default: false)
 package main
 
 import (
@@ -20,7 +37,7 @@ var (
 		separator  string
 		widthEqual bool
 	}
-	cmd = "seq [-f format] [-w] [-s separator] [start] [step] <end>"
+	cmd = "seq [-f format] [-w] [-s separator] [start [step [end]]]"
 )
 
 func usage() {

--- a/cmds/sort/sort.go
+++ b/cmds/sort/sort.go
@@ -1,19 +1,20 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Sort copies lines from the input to the output, sorting them in the process.
-This does nothing fancy (no multi-threading, compression, optiminzations, ...);
-it simply uses Go's sort.Sort function.
-
-sort [OPTION]... [FILE]...
-
-The options are:
-	-r		reverse
-	-o string	output file
-*/
-
+// Sort lines.
+//
+// Synopsis:
+//     sort [OPTIONS]... [INPUT]...
+//
+// Description:
+//     Sort copies lines from the input to the output, sorting them in the
+//     process. This does nothing fancy (no multi-threading, compression,
+//     optiminzations, ...); it simply uses Go's sort.Sort function.
+//
+// Options:
+//     -r:      reverse
+//     -o FILE: output file
 package main
 
 import (

--- a/cmds/srvfiles/srvfiles.go
+++ b/cmds/srvfiles/srvfiles.go
@@ -1,3 +1,12 @@
+// Serve files on the network.
+//
+// Synopsis:
+//     srvfiles [--h=HOST] [--p=PORT] [--d=DIR]
+//
+// Options:
+//     --h: hostname (default: 127.0.0.1)
+//     --p: port number (default: 8080)
+//     --d: directory to serve (default: .)
 package main
 
 import (
@@ -7,9 +16,9 @@ import (
 )
 
 var (
-	host = flag.String("h", "127.0.0.1", "IP")
-	port = flag.String("p", "8080", "port")
-	dir  = flag.String("d", ".", "dir")
+	host = flag.String("h", "127.0.0.1", "hostname")
+	port = flag.String("p", "8080", "port number")
+	dir  = flag.String("d", ".", "directory to serve")
 )
 
 func main() {

--- a/cmds/sync/sync.go
+++ b/cmds/sync/sync.go
@@ -1,4 +1,4 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,5 @@ package main
 import "syscall"
 
 func main() {
-
 	syscall.Sync()
-
 }

--- a/cmds/tee/tee.go
+++ b/cmds/tee/tee.go
@@ -1,8 +1,16 @@
-// Copyright 2013-2016 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//Tee transcribes the standard input to the standard output and makes copies in the files.
+// Tee transcribes the standard input to the standard output and makes copies
+// in the files.
+//
+// Synopsis:
+//     tee [-ai] FILES...
+//
+// Options:
+//     -a: append the output to the files rather than rewriting them
+//     -i: ignore the SIGINT signal
 package main
 
 import (
@@ -19,9 +27,8 @@ var (
 	ignore = flag.Bool("i", false, "ignore the SIGINT signal")
 )
 
-//Copy any input from buffer to Stdout and files
+// Copy any input from buffer to Stdout and files
 func copyinput(files []io.Writer, buf []byte) error {
-
 	for _, v := range files {
 		if _, err := v.Write(buf); err != nil {
 			return err
@@ -30,9 +37,8 @@ func copyinput(files []io.Writer, buf []byte) error {
 	return nil
 }
 
-//Parses all the flags and sets variables accordingly
+// Parses all the flags and sets variables accordingly
 func handleflags() int {
-
 	flag.Parse()
 
 	oflags := os.O_WRONLY | os.O_CREATE
@@ -49,7 +55,6 @@ func handleflags() int {
 }
 
 func main() {
-
 	oflags := handleflags()
 
 	files := make([]io.Writer, flag.NArg())

--- a/cmds/uname/uname.go
+++ b/cmds/uname/uname.go
@@ -1,3 +1,16 @@
+// Print build information about the kernel and machine.
+//
+// Synopsis:
+//     uname [-asnrvmd]
+//
+// Options:
+//     -a: print everything
+//     -s: print the kernel name
+//     -n: print the network node name
+//     -r: print the kernel release
+//     -v: print the kernel version
+//     -m: print the machine hardware name
+//     -d: print your domain name
 package main
 
 import (

--- a/cmds/uniq/uniq.go
+++ b/cmds/uniq/uniq.go
@@ -1,27 +1,33 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Uniq copies the input file, or the standard input, to the standard output,
-comparing adjacent lines. In the normal case, the second and succeeding
-copies of repeated lines are removed. Repeated lines must be adjacent in
-order to be found.
-
-	–u    Print unique lines.
-	–d    Print (one copy of) duplicated lines.
-	–c    Prefix a repetition count and a tab to each output line. Implies –u and –d.
-	–f num	The first num fields together with any blanks before each are ignored.
-			A field is defined as a string of non–space, non–tab characters separated
-			by tabs and spaces from its neighbors.
-	-c num	The first num characters are ignored. Fields are skipped before characters.
-*/
+// Uniq removes repeated lines.
+//
+// Synopsis:
+//     uniq [OPTIONS...] [FILES]...
+//
+// Description:
+//     Uniq copies the input file, or the standard input, to the standard
+//     output, comparing adjacent lines. In the normal case, the second and
+//     succeeding copies of repeated lines are removed. Repeated lines must be
+//     adjacent in order to be found.
+//
+// Options:
+//     –u:      Print unique lines.
+//     –d:      Print (one copy of) duplicated lines.
+//     –c:      Prefix a repetition count and a tab to each output line.
+//              Implies –u and –d.
+//     –f num:  The first num fields together with any blanks before each are
+//              ignored. A field is defined as a string of non–space, non–tab
+//              characters separated by tabs and spaces from its neighbors.
+//     -cn num: The first num characters are ignored. Fields are skipped before
+//              characters.
+package main
 
 // TODO(aam): -num and +num are not implemented. they're easy to do, just not exactly the
 // way that the plan9 uniq does them as we want to avoid polluting the flag parsing libs with
 // outdated flags.
-
-package main
 
 import (
 	"bufio"

--- a/cmds/unshare/unshare.go
+++ b/cmds/unshare/unshare.go
@@ -1,16 +1,35 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 // Disassociate parts of the process execution context.
-// Go applications use multiple processes, and the Go user level scheduler schedules goroutines onto those processes.
-// For this reason, it is not possible to use syscall.Unshare. A goroutine can call syscall.Unshare from process m
-// and the scheduler can resume that goroutine in process n, which has not had the unshare operation!
-// This is a known problem with any system call that modifies the name space or file system context
-// of only one process as opposed to the entire Go application, i.e. all of its processes.
-// Examples include chroot and unshare. There has been lively discussion of this problem
-// but no resolution as of yet. In sum: it is not possible to use syscall.Unshare from Go with any reasonable expectation
-// of success.
+//
+// Synopsis:
+//     unshare [OPTIONS] [PROGRAM [ARGS]...]
+//
+// Description:
+//     Go applications use multiple processes, and the Go user level scheduler
+//     schedules goroutines onto those processes. For this reason, it is not
+//     possible to use syscall.Unshare. A goroutine can call `syscall.Unshare`
+//     from process m and the scheduler can resume that goroutine in process n,
+//     which has not had the unshare operation! This is a known problem with
+//     any system call that modifies the name space or file system context of
+//     only one process as opposed to the entire Go application, i.e. all of
+//     its processes. Examples include chroot and unshare. There has been
+//     lively discussion of this problem but no resolution as of yet. In sum:
+//     it is not possible to use `syscall.Unshare` from Go with any reasonable
+//     expectation of success.
+//
+//     If PROGRAM is not specified, unshare defaults to /ubin/rush.
+//
+// Options:
+//     -ipc:           Unshare the IPC namespace
+//     -mount:         Unshare the mount namespace
+//     -pid:           Unshare the pid namespace
+//     -net:           Unshare the net namespace
+//     -uts:           Unshare the uts namespace
+//     -user:          Unshare the user namespace
+//     -map-root-user: Map current uid to root. Not working
 package main
 
 import (

--- a/cmds/validate/validate.go
+++ b/cmds/validate/validate.go
@@ -1,9 +1,20 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//This program validates a file by verifying a checksum file and a signature file
-//Exit status: 0-OK, 1-Any error, 2-Bad signature, 3-Bad checksum
+// This program validates a file by verifying a checksum and a signature file.
+//
+// Synopsis:
+//     validate [OPTIONS...] FILE PUBLIC_KEY_FILE
+//
+// Description:
+//     Return code: 0-OK, 1-Any error, 2-Bad signature, 3-Bad checksum
+//
+// Options:
+//     -a:        signature is ASCII armored
+//     -i FILE:   checksum file
+//     -alg FILE: algorithms to check
+//     -v:        verbose
 package main
 
 import (

--- a/cmds/wc/wc.go
+++ b/cmds/wc/wc.go
@@ -1,46 +1,45 @@
-// Copyright 2013 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-/*
-Wc counts lines, words, runes, syntactically–invalid UTF codes and
-bytes in the named files, or in the standard input if no file is
-named. A word is a maximal string of characters delimited by spaces,
-tabs or newlines. The count of runes includes invalid codes.  If
-the optional argument is present, just the specified counts (lines,
-words, runes, broken UTF codes or bytes) are selected by the letters
-l, w, r, b, or c. Otherwise, lines, words and bytes (–lwc) are
-reported.
-
-	–l		Count lines.
-	–w		Count words.
-	–r		Count runes.
-	–b		Count broken UTF codes.
-	-c		Count bytes.
-*/
-
-/* Bugs:
-
-   This wc differs from Plan 9's wc somewhat in word count (BSD's wc differs
-   even more significantly):
-
-	$ unicode 0x0-0x10ffff | 9 wc -w
-	2228221
-	$ unicode 0x0-0x10ffff | gowc -w
-	2228198
-	$ unicode 0x0-0x10ffff | bsdwc -w
-	 2293628
-
-
-   This wc differs from Plan 9's wc significantly in bad rune count:
-
-	$ unicode 0x0-0x10ffff | gowc -b
-	6144
-	$ unicode 0x0-0x10ffff | 9 wc -b
-	1966080
-
-*/
-
+// Wc counts lines, words, runes, syntactically–invalid UTF codes.
+//
+// Synopsis:
+//     wc [OPTIONS...] [FILES]...
+//
+// Description:
+//     Wc counts lines, words, runes, syntactically–invalid UTF codes and bytes
+//     in the named files, or in the standard input if no file is named. A word
+//     is a maximal string of characters delimited by spaces, tabs or newlines.
+//     The count of runes includes invalid codes. If the optional argument is
+//     present, just the specified counts (lines, words, runes, broken UTF
+//     codes or bytes) are selected by the letters l, w, r, b, or c. Otherwise,
+//     lines, words and bytes (–lwc) are reported.
+//
+// Options:
+//     –l: count lines
+//     –w: count words
+//     –r: count runes
+//     –b: count broken UTF codes
+//     -c: count bytes
+//
+// Bugs:
+//     This wc differs from Plan 9's wc somewhat in word count (BSD's wc differs
+//     even more significantly):
+//
+//     $ unicode 0x0-0x10ffff | 9 wc -w
+//     2228221
+//     $ unicode 0x0-0x10ffff | gowc -w
+//     2228198
+//     $ unicode 0x0-0x10ffff | bsdwc -w
+//     2293628
+//
+//     This wc differs from Plan 9's wc significantly in bad rune count:
+//
+//     $ unicode 0x0-0x10ffff | gowc -b
+//     6144
+//     $ unicode 0x0-0x10ffff | 9 wc -b
+//     1966080
 package main
 
 import (

--- a/cmds/wget/wget.go
+++ b/cmds/wget/wget.go
@@ -1,8 +1,14 @@
-// Copyright 2012 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//Wget reads one file from the argument and writes it on the standard output.
+// Wget reads one file from a url and writes to stdout.
+//
+// Synopsis:
+//     wget URL
+//
+// Example:
+//     wget http://google.com/ | tee e100.html
 package main
 
 import (
@@ -24,6 +30,7 @@ func wget(arg string, w io.Writer) error {
 }
 
 func main() {
+	// TODO: use flags library
 	if len(os.Args) < 2 {
 		os.Exit(1)
 	}

--- a/cmds/which/which.go
+++ b/cmds/which/which.go
@@ -1,8 +1,14 @@
-// Copyright 2016 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 // Which locates a command.
+//
+// Synopsis:
+//     which [-a] [COMMAND]...
+//
+// Options:
+//     -a: print all matching pathnames of each argument
 package main
 
 import (


### PR DESCRIPTION
This comments are placed directly above `package main`, so they are
parsed by godoc and show up in
https://godoc.org/github.com/u-root/u-root

This is a first pass through all the commands, so all the man pages may
not be 100% complete, accurate and consistent. Anyhow, it is a great
start and I learned a lot in the process!