### PR TITLE
Dmesg test

### DIFF
--- a/cmds/dmesg/dmesg_test.go
+++ b/cmds/dmesg/dmesg_test.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestDmesg(t *testing.T) {
+	
+	out, err := exec.Command("go", "run", "dmesg.go", "-c").Output()
+	if err != nil {
+		t.Fatalf("can't run dmesg: %v", err)
+	}
+
+	out, err = exec.Command("go", "run", "dmesg.go").Output()
+	if err != nil {
+		t.Fatalf("can't run dmesg: %v", err)
+	}
+
+	if len(out) > 0 {
+		t.Fatalf("The log wasn't cleared, got %v", out)
+	}
+}

--- a/cmds/dmesg/dmesg_test.go
+++ b/cmds/dmesg/dmesg_test.go
@@ -6,47 +6,18 @@ package main
 
 import (
 	"os/exec"
-	"os/user"
 	"testing"
 )
 
 // Test reading from the buffer.
 // dmesg
 func TestDmesg(t *testing.T) {
-	_, err := exec.Command("go", "run", "dmesg.go").Output()
+	out, err := exec.Command("go", "run", "dmesg.go").Output()
 	if err != nil {
 		t.Fatalf("Error running dmesg: %v", err)
 	}
-	// FIXME: How can the test verify the output is correct?
-}
-
-// Test clearing the buffer.
-// dmesg -c
-func TestClearDmesg(t *testing.T) {
-	// Test requies root priviledges or CAP_SYSLOG capability.
-	// FIXME: preferably unit tests do not require root priviledges
-	if u, err := user.Current(); err != nil {
-		t.Fatal("Cannot get current user", err)
-	} else if u.Uid != "0" {
-		t.Skipf("Test requires root priviledges (uid == 0), uid = %s", u.Uid)
-	}
-
-	// Clear
-	out, err := exec.Command("go", "run", "dmesg.go", "-c").Output()
-	if err != nil {
-		t.Fatalf("Error running dmesg -c: %v", err)
-	}
-
-	// Read
-	out, err = exec.Command("go", "run", "dmesg.go").Output()
-	if err != nil {
-		t.Fatalf("Error running dmesg: %v", err)
-	}
-
-	// Second run of dmesg.go should be cleared.
-	// FIXME: This is actually non-determinstic as the system is free (but
-	// unlikely) to write more messages inbetween the syscalls.
-	if len(out) > 0 {
-		t.Fatalf("The log was not cleared, got %v", out)
+	// Test passes if anything is read.
+	if len(out) == 0 {
+		t.Fatalf("Nothing read from dmesg")
 	}
 }

--- a/cmds/dmesg/dmesg_test.go
+++ b/cmds/dmesg/dmesg_test.go
@@ -1,23 +1,52 @@
+// Copyright 2016-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (
 	"os/exec"
+	"os/user"
 	"testing"
 )
 
+// Test reading from the buffer.
+// dmesg
 func TestDmesg(t *testing.T) {
-	
+	_, err := exec.Command("go", "run", "dmesg.go").Output()
+	if err != nil {
+		t.Fatalf("Error running dmesg: %v", err)
+	}
+	// FIXME: How can the test verify the output is correct?
+}
+
+// Test clearing the buffer.
+// dmesg -c
+func TestClearDmesg(t *testing.T) {
+	// Test requies root priviledges or CAP_SYSLOG capability.
+	// FIXME: preferably unit tests do not require root priviledges
+	if u, err := user.Current(); err != nil {
+		t.Fatal("Cannot get current user", err)
+	} else if u.Uid != "0" {
+		t.Skipf("Test requires root priviledges (uid == 0), uid = %s", u.Uid)
+	}
+
+	// Clear
 	out, err := exec.Command("go", "run", "dmesg.go", "-c").Output()
 	if err != nil {
-		t.Fatalf("can't run dmesg: %v", err)
+		t.Fatalf("Error running dmesg -c: %v", err)
 	}
 
+	// Read
 	out, err = exec.Command("go", "run", "dmesg.go").Output()
 	if err != nil {
-		t.Fatalf("can't run dmesg: %v", err)
+		t.Fatalf("Error running dmesg: %v", err)
 	}
 
+	// Second run of dmesg.go should be cleared.
+	// FIXME: This is actually non-determinstic as the system is free (but
+	// unlikely) to write more messages inbetween the syscalls.
 	if len(out) > 0 {
-		t.Fatalf("The log wasn't cleared, got %v", out)
+		t.Fatalf("The log was not cleared, got %v", out)
 	}
 }


### PR DESCRIPTION
As they stand, these tests are really bad for the following reasons:

- Tests are non-deterministic (cannot predict the contents of dmesg)
- The second test requires root permissions to run. When uid != 0, the
  second test is skipped to allow the build to pass in travis.

These issues result from the inability to mock the syscall.

I'm brainstorming a way to place syscall in an interface so that it can
be mocked in the test. It is a teensy bit tricky because the executable
and test code are in separate binaries.