### PR TITLE
Remove the exec bit from builtin.go

### DIFF
--- a/cmds/builtin/builtin.go
+++ b/cmds/builtin/builtin.go
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Script takes the arg list, does minimal rewriting, builds it and runs it
 package main
 
 import (


### PR DESCRIPTION
In github, you can see where it says "100755 → 100644" on the file. That means the exec bit is removed.

The go source file does not require exec bits. Correct me if I'm wrong and I will add a comment explaining why this file requires an exec bit.

Additionally, this commit removes the misleading docstring on the package. I think it was a copy-paste error. I will come up with a man-page for it when I do another run-through on the man pages.