### PR TITLE
Add licenses to u-root files without licenses

### DIFF
--- a/bb/bb.go
+++ b/bb/bb.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // bb converts standalone u-root tools to shell builtins.
 // It copies and converts a set of u-root utilities into a directory called bbsh.
 // It assumes nothing; all files it needs are always copied, no matter what

--- a/bb/bb.go
+++ b/bb/bb.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/bb/buildinit.go
+++ b/bb/buildinit.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/bb/buildinit.go
+++ b/bb/buildinit.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/bb/config.go
+++ b/bb/config.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/bb/config.go
+++ b/bb/config.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // bbramfs builds a simple initramfs given an existing built bb; see bb.go
 // You have to run bb first, which creates cmds/bb/bbsh. cd to that directory,
 // and run bbramfs, and you have a single binary which does all u-root commands.

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/bbnofork/bb.go
+++ b/bbnofork/bb.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // bb converts standalone u-root tools to shell builtins.
 // It copies and converts a set of u-root utilities into a directory called bbsh.
 // It assumes nothing; all files it needs are always copied, no matter what

--- a/bbnofork/bb.go
+++ b/bbnofork/bb.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/bbnofork/buildinit.go
+++ b/bbnofork/buildinit.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/bbnofork/buildinit.go
+++ b/bbnofork/buildinit.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/bbnofork/config.go
+++ b/bbnofork/config.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/bbnofork/config.go
+++ b/bbnofork/config.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/bbnofork/ramfs.go
+++ b/bbnofork/ramfs.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/bbnofork/ramfs.go
+++ b/bbnofork/ramfs.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // bbramfs builds a simple initramfs given an existing built bb; see src/bb.go
 // You have to run bb first, which creates src/cmds/bb/bbsh. cd to that directory,
 // and run bbramfs, and you have a single binary which does all u-root commands.

--- a/cmds/chmod/chmod_test.go
+++ b/cmds/chmod/chmod_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/chmod/chmod_test.go
+++ b/cmds/chmod/chmod_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/cmp/cmp_test.go
+++ b/cmds/cmp/cmp_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/cmp/cmp_test.go
+++ b/cmds/cmp/cmp_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/comm/comm.go
+++ b/cmds/comm/comm.go
@@ -1,6 +1,6 @@
 // Copyright 2013-2017 the u-root Authors. All rights reserved
-// Use of this source code is governed by a BSD-style license
-// that can be found in the LICENSE file.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 
 // Perform a set comparision over two files.
 //

--- a/cmds/cp/cp_plan9.go
+++ b/cmds/cp/cp_plan9.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/cp/cp_plan9.go
+++ b/cmds/cp/cp_plan9.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 func sameFile(sys1, sys2 interface{}) bool {

--- a/cmds/cp/cp_unix.go
+++ b/cmds/cp/cp_unix.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // +build darwin freebsd linux netbsd openbsd
 
 package main

--- a/cmds/cp/cp_unix.go
+++ b/cmds/cp/cp_unix.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2013-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/echo/echo_test.go
+++ b/cmds/echo/echo_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/echo/echo_test.go
+++ b/cmds/echo/echo_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/grep/grep_test.go
+++ b/cmds/grep/grep_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/grep/grep_test.go
+++ b/cmds/grep/grep_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/hostname/hostname_test.go
+++ b/cmds/hostname/hostname_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/hostname/hostname_test.go
+++ b/cmds/hostname/hostname_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 // Install command from a go source file.

--- a/cmds/kexec/kexec_test.go
+++ b/cmds/kexec/kexec_test.go
@@ -1,1 +1,5 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main

--- a/cmds/kexec/kexec_test.go
+++ b/cmds/kexec/kexec_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/kill/list_linux_amd64.go
+++ b/cmds/kill/list_linux_amd64.go
@@ -1,6 +1,7 @@
-// Copyright "2016" the u-root Authors. All rights reserved
+// Copyright 2016 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/kill/signaler_unix.go
+++ b/cmds/kill/signaler_unix.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/kill/signaler_unix.go
+++ b/cmds/kill/signaler_unix.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/mv/mv_test.go
+++ b/cmds/mv/mv_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/mv/mv_test.go
+++ b/cmds/mv/mv_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/pflask/pflask.go
+++ b/cmds/pflask/pflask.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/pflask/pflask.go
+++ b/cmds/pflask/pflask.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/pflask/termios.go
+++ b/cmds/pflask/termios.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/pflask/termios.go
+++ b/cmds/pflask/termios.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/printenv/printenv.go
+++ b/cmds/printenv/printenv.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // Print environment variables.
 //
 // Synopsis:

--- a/cmds/printenv/printenv.go
+++ b/cmds/printenv/printenv.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2014-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/printenv/printenv_test.go
+++ b/cmds/printenv/printenv_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/printenv/printenv_test.go
+++ b/cmds/printenv/printenv_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/rush/parse.go
+++ b/cmds/rush/parse.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // The u-root shell is intended to be very simple, since builtins and extensions
 // are written in Go. It should not need YACC. As in the JSON parser, we hope this
 // simple state machine will do the job.

--- a/cmds/rush/parse.go
+++ b/cmds/rush/parse.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2014-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/script/tempfile.go
+++ b/cmds/script/tempfile.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2014-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/script/tempfile.go
+++ b/cmds/script/tempfile.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 // ah well, the tempfile in go has a bad limitation. So let's do better.

--- a/cmds/srvfiles/srvfiles.go
+++ b/cmds/srvfiles/srvfiles.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2014-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/srvfiles/srvfiles.go
+++ b/cmds/srvfiles/srvfiles.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // Serve files on the network.
 //
 // Synopsis:

--- a/cmds/sync/sync_test.go
+++ b/cmds/sync/sync_test.go
@@ -1,1 +1,5 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main

--- a/cmds/sync/sync_test.go
+++ b/cmds/sync/sync_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/uname/uname.go
+++ b/cmds/uname/uname.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/uname/uname.go
+++ b/cmds/uname/uname.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // Print build information about the kernel and machine.
 //
 // Synopsis:

--- a/cmds/wc/wc_test.go
+++ b/cmds/wc/wc_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2016-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/wc/wc_test.go
+++ b/cmds/wc/wc_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/wget/wget_test.go
+++ b/cmds/wget/wget_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/cmds/wget/wget_test.go
+++ b/cmds/wget/wget_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/memmap/memmap.go
+++ b/memmap/memmap.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/memmap/memmap.go
+++ b/memmap/memmap.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // package memmap contains funtions that let us figure out system memory.
 package memmap
 

--- a/memmap/memmap_test.go
+++ b/memmap/memmap_test.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package memmap
 
 import (

--- a/memmap/memmap_test.go
+++ b/memmap/memmap_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/scripts/checklicenses.go
+++ b/scripts/checklicenses.go
@@ -1,0 +1,107 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Run with `go run checklicenses.go`. This script has one drawback:
+// - It does not correct the licenses; it simply outputs a list of files which
+//   do not conform and returns 1 if the list is non-empty.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var absPath = flag.Bool("a", false, "Print absolute paths")
+
+const uroot = "$GOPATH/src/github.com/u-root/u-root"
+
+// The first few lines of every go file is expected to contain this license.
+var license = regexp.MustCompile(
+	`^// Copyright [\d\-, ]+ the u-root Authors\. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file\.
+`)
+
+type rule struct {
+	*regexp.Regexp
+	invert bool
+}
+
+func accept(s string) rule {
+	return rule{
+		regexp.MustCompile("^" + s + "$"),
+		false,
+	}
+}
+
+func reject(s string) rule {
+	return rule{
+		regexp.MustCompile("^" + s + "$"),
+		true,
+	}
+}
+
+// A file is checked iff all the accepts and none of the rejects match.
+var rules = []rule{
+	accept(`.*\.go`),
+	reject(`/vendor/.*`),      // Various authors
+	reject(`/cmds/dhcp/.*`),   // Graham King
+	reject(`/cmds/ectool/.*`), // Chromium authors
+	reject(`/cmds/ldd/.*`),    // Go authors
+	reject(`/cmds/ping/.*`),   // Go authors
+	reject(`/netlink/.*`),     // Docker (Apache license)
+}
+
+func main() {
+	flag.Parse()
+	uroot := os.ExpandEnv(uroot)
+	incorrect := []string{}
+
+	// Walk u-root tree.
+	err := filepath.Walk(uroot, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		// Test rules
+		trimmedPath := strings.TrimPrefix(path, uroot)
+		for _, r := range rules {
+			if r.MatchString(trimmedPath) == r.invert {
+				return nil
+			}
+		}
+		// Read from the file.
+		r, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer r.Close()
+		contents, err := ioutil.ReadAll(r)
+		if err != nil {
+			return err
+		}
+		if !license.Match(contents) {
+			p := trimmedPath
+			if *absPath {
+				p = path
+			}
+			incorrect = append(incorrect, p)
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print files with incorrect licenses.
+	if len(incorrect) > 0 {
+		fmt.Println(strings.Join(incorrect, "\n"))
+		os.Exit(1)
+	}
+}

--- a/scripts/ramfs.go
+++ b/scripts/ramfs.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/scripts/ramfs.go
+++ b/scripts/ramfs.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/uroot/root.go
+++ b/uroot/root.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // package uroot contains various functions that might be needed more than
 // one place.
 package uroot

--- a/uroot/root.go
+++ b/uroot/root.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2014-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/uroot/uname_386.go
+++ b/uroot/uname_386.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/uroot/uname_386.go
+++ b/uroot/uname_386.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // package uroot contains various functions that might be needed more than
 // one place.
 // +build 386

--- a/uroot/uname_amd64.go
+++ b/uroot/uname_amd64.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // package uroot contains various functions that might be needed more than
 // one place.
 // +build amd64

--- a/uroot/uname_amd64.go
+++ b/uroot/uname_amd64.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/uroot/uname_arm.go
+++ b/uroot/uname_arm.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // package uroot contains various functions that might be needed more than
 // one place.
 // +build arm

--- a/uroot/uname_arm.go
+++ b/uroot/uname_arm.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/uroot/uname_ppc64le.go
+++ b/uroot/uname_ppc64le.go
@@ -1,4 +1,4 @@
-// Copyright 2017 the u-root Authors. All rights reserved
+// Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/uroot/uname_ppc64le.go
+++ b/uroot/uname_ppc64le.go
@@ -1,3 +1,7 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 // package uroot contains various functions that might be needed more than
 // one place.
 // +build ppc64le


### PR DESCRIPTION
This commit also adds a script `go run scripts/checklicenses.go` which
prints the names of any files which do not contain a u-root license.

The script ignores the following files:

  - `/vendor/.*`      : Various authors
  - `/cmds/dhcp/.*`   : Graham King
  - `/cmds/ectool/.*` : Chromium authors
  - `/cmds/ldd/.*`    : Go authors
  - `/cmds/ping/.*`   : Go authors
  - `/netlink/.*`     : Docker (Apache license)