### PR TITLE
Fix panic when running ps

### DIFF
--- a/cmds/ps/ps_linux.go
+++ b/cmds/ps/ps_linux.go
@@ -240,7 +240,7 @@ func (pT *ProcessTable) LoadTable() error {
 		return filepath.SkipDir
 	})
 
-	if err.Error() == "skip this directory" {
+	if err == filepath.SkipDir {
 		return nil
 	}
 


### PR DESCRIPTION
Running ps (at least for me) would always panic when attempting to call
the `Error` member on `err`.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>