### PR TITLE
Use preset env variables for printenv_test.go

### DIFF
--- a/cmds/printenv/printenv_test.go
+++ b/cmds/printenv/printenv_test.go
@@ -12,12 +12,15 @@ import (
 )
 
 func TestPrintenv(t *testing.T) {
+	// Setup some fake environment variables.
+	os.Clearenv()
+	os.Setenv("GIRAFFE", "akaros")
+	os.Setenv("GOPHER", "go")
+	os.Setenv("PENGUIN", "linux")
+
 	var buf bytes.Buffer
-
 	want := os.Environ()
-
 	printenv(&buf)
-
 	found := strings.Split(buf.String(), "\n")
 
 	for i, v := range want {


### PR DESCRIPTION
Before, the test was guaranteed to fail if an environment variable
contained a newline. This part of a larger problem of sending
unstructured data through pipes.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>