### PR TITLE
rush: add handling for ^c

### DIFF
--- a/cmds/rush/rush.go
+++ b/cmds/rush/rush.go
@@ -219,6 +219,7 @@ func main() {
 		os.Exit(1)
 	}
 
+	tty()
 	fmt.Printf("%% ")
 	for {
 		cmds, status, err := getCommand(b)

--- a/cmds/rush/tty_linux.go
+++ b/cmds/rush/tty_linux.go
@@ -1,0 +1,26 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/signal"
+)
+
+const (
+	sysIoctl = 16
+)
+
+// tty does whatever needs to be done to set up a tty for GOOS.
+func tty() {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt)
+	go func() {
+		for range sigs {
+			fmt.Println("")
+		}
+	}()
+}


### PR DESCRIPTION
This turned out to be easy. Also, it is contained in a tty() function
which we will need for all OSes. The current tty() is os-independent
but we don't expect that to last.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>