### PR TITLE
Implement reading/writing FMap to/from JSON files

### DIFF
--- a/cmds/fmap/fmap.go
+++ b/cmds/fmap/fmap.go
@@ -5,21 +5,24 @@
 // Fmap parses flash maps.
 //
 // Synopsis:
-//     fmap [OPTIONS] [FILE]
+//     fmap checksum [md5|sha1|sha256] FILE
+//     fmap extract i FILE
+//     fmap jget JSONFILE FILE
+//     fmap jput JSONFILE FILE
+//     fmap summary FILE
+//     fmap usage FILE
+//     fmap verify FILE
 //
 // Description:
-//     Return 0 if the flash map is valid and 1 otherwise. Detailed information
-//     is printed to stderr. If FILE is not specified, read from stdin.
+//     checksum: Print a checksum using the given hash function.
+//     extract:  Print the i-th area of the flash.
+//     jget:     Write json representation of the fmap to JSONFILE.
+//     jput:     Replace current fmap with json representation in JSONFILE.
+//     summary:  Print a human readable summary.
+//     usage:    Print human readable usage stats.
+//     verify:   Return 1 if the flash map is invalid.
 //
 //     This implementation is based off of https://github.com/dhendrix/flashmap.
-//
-// Options:
-//     -c func: print checksum using the given `hash function` (md5|sha1|sha256)
-//     -r i: read an area from the flash
-//     -s: print human readable summary
-//     -u: print human readable usage stats
-//     -jr FILE: write json representation of the fmap to FILE
-//     -jw FILE: read json representation and replace the current fmap
 package main
 
 import (
@@ -28,26 +31,39 @@ import (
 	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/json"
-	"flag"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
+	"strconv"
 	"text/template"
 
 	fmap "github.com/u-root/u-root/cmds/fmap/lib"
 )
 
-var (
-	checksum  = flag.String("c", "", "print checksum using the given `hash function` (md5|sha1|sha256)")
-	read      = flag.Int("r", -1, "read an area from the flash")
-	summary   = flag.Bool("s", false, "print human readable summary")
-	usage     = flag.Bool("u", false, "print human readable usage summary")
-	jsonRead  = flag.String("jr", "", "print json representation of the fmap to FILE")
-	jsonWrite = flag.String("jw", "", "read json representation and replace the fmap")
-)
+var cmds = map[string]struct {
+	nArgs     int
+	parseFMap bool
+	f         func(a cmdArgs) error
+}{
+	"checksum": {1, true, checksum},
+	"extract":  {1, true, extract},
+	"jget":     {1, true, jsonGet},
+	"jput":     {1, false, jsonPut},
+	"summary":  {0, true, summary},
+	"usage":    {0, true, usage},
+	"verify":   {0, true, verify},
+}
+
+type cmdArgs struct {
+	args []string
+	f    *fmap.FMap         // optional
+	m    *fmap.FMapMetadata // optional
+	r    io.ReadSeeker
+}
 
 var hashFuncs = map[string](func() hash.Hash){
 	"md5":    md5.New,
@@ -60,8 +76,75 @@ type jsonSchema struct {
 	Metadata *fmap.FMapMetadata
 }
 
-// Print human readable summary of the fmap.
-func printFMap(f *fmap.FMap, m *fmap.FMapMetadata) {
+// Print a checksum using the given hash function.
+func checksum(a cmdArgs) error {
+	if _, ok := hashFuncs[a.args[0]]; !ok {
+		msg := "Not a valid hash function. Must be one of:"
+		for k := range hashFuncs {
+			msg += " " + k
+		}
+		return errors.New(msg)
+	}
+
+	checksum, err := a.f.Checksum(a.r, hashFuncs[a.args[0]]())
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%x\n", checksum)
+	return nil
+}
+
+// Print the i-th area of the flash.
+func extract(a cmdArgs) error {
+	i, err := strconv.Atoi(a.args[0])
+	if err != nil {
+		return err
+	}
+	areaReader, err := a.f.ReadArea(a.r, i)
+	if err != nil {
+		return err
+	}
+	_, err = io.Copy(os.Stdout, areaReader)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Write json representation of the fmap to JSONFILE.
+func jsonGet(a cmdArgs) error {
+	data, err := json.MarshalIndent(jsonSchema{a.f, a.m}, "", "\t")
+	if err != nil {
+		return err
+	}
+	data = append(data, byte('\n'))
+	if err := ioutil.WriteFile(a.args[0], data, 0666); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Replace current fmap with json representation in JSONFILE.
+func jsonPut(a cmdArgs) error {
+	r, err := os.OpenFile(a.args[0], os.O_RDWR, 0666)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	data, err := ioutil.ReadFile(a.args[0])
+	if err != nil {
+		return err
+	}
+	j := jsonSchema{}
+	if err := json.Unmarshal(data, &j); err != nil {
+		return err
+	}
+	return fmap.WriteFMap(r, j.FMap, j.Metadata)
+}
+
+// Print a human readable summary.
+func summary(a cmdArgs) error {
 	const desc = `Fmap found at {{printf "%#x" .Metadata.Start}}:
 	Signature:  {{printf "%s" .Signature}}
 	VerMajor:   {{.VerMajor}}
@@ -85,37 +168,15 @@ func printFMap(f *fmap.FMap, m *fmap.FMapMetadata) {
 	combined := struct {
 		*fmap.FMap
 		Metadata *fmap.FMapMetadata
-	}{f, m}
+	}{a.f, a.m}
 	if err := t.Execute(os.Stdout, combined); err != nil {
-		log.Fatal(err)
-	}
-}
-
-func readToJSON(f *fmap.FMap, m *fmap.FMapMetadata) error {
-	data, err := json.MarshalIndent(jsonSchema{f, m}, "", "\t")
-	if err != nil {
-		return err
-	}
-	data = append(data, byte('\n'))
-	if err := ioutil.WriteFile(*jsonRead, data, 0666); err != nil {
 		return err
 	}
 	return nil
 }
 
-func writeFromJSON(f *os.File) error {
-	data, err := ioutil.ReadFile(*jsonWrite)
-	if err != nil {
-		return err
-	}
-	j := jsonSchema{}
-	if err := json.Unmarshal(data, &j); err != nil {
-		return err
-	}
-	return fmap.WriteFMap(f, j.FMap, j.Metadata)
-}
-
-func printUsage(r io.Reader) {
+// Print human readable usage stats.
+func usage(a cmdArgs) error {
 	blockSize := 4 * 1024
 	rowLength := 32
 
@@ -125,13 +186,17 @@ func printUsage(r io.Reader) {
 
 	fmt.Println("Legend: '.' - full (0xff), '0' - zero (0x00), '#' - mixed")
 
+	if _, err := a.r.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+
 	var numBlocks, numFull, numZero int
 loop:
 	for {
 		fmt.Printf("%#08x: ", numBlocks*blockSize)
 		for col := 0; col < rowLength; col++ {
 			// Read next block.
-			_, err := io.ReadFull(r, buffer)
+			_, err := io.ReadFull(a.r, buffer)
 			if err == io.EOF {
 				fmt.Print("\n")
 				break loop
@@ -139,7 +204,7 @@ loop:
 				fmt.Printf("\nWarning: flash is not a multiple of %d", len(buffer))
 				break loop
 			} else if err != nil {
-				log.Fatal(err)
+				return err
 			}
 			numBlocks++
 
@@ -166,98 +231,70 @@ loop:
 	print("Full (0xff): ", numFull)
 	print("Empty (0x00):", numZero)
 	print("Mixed:       ", numBlocks-numFull-numZero)
+	return nil
 }
 
-var btoi = map[bool]int{
-	false: 0,
-	true:  1,
+// Return 1 if the flash map is invalid.
+func verify(a cmdArgs) error {
+	var err error
+	for i, area := range a.f.Areas {
+		if area.Offset+area.Size > a.f.Size {
+			err = errors.New("Invalid flash map")
+			log.Printf("Area %d is out of range", i)
+		}
+	}
+	return err
+}
+
+func printUsage() {
+	fmt.Printf("Usage: %s CMD [ARGS...] FILE\n", os.Args[0])
+	fmt.Printf("CMD can be one of:\n")
+	for k := range cmds {
+		fmt.Printf("\t%s\n", k)
+	}
+	os.Exit(2)
 }
 
 func main() {
-	flag.Parse()
-
-	// Validate flags
-	if (btoi[*summary] +
-		btoi[*usage] +
-		btoi[*read >= 0] +
-		btoi[*checksum != ""] +
-		btoi[*jsonRead != ""] +
-		btoi[*jsonWrite != ""]) > 1 {
-		log.Fatal("Only use one flag at a time")
+	// Validate args.
+	if len(os.Args) <= 2 {
+		printUsage()
 	}
-	if *checksum != "" {
-		if _, ok := hashFuncs[*checksum]; !ok {
-			log.Fatal("Not a valid hash function. Must be one of md5, sha1 or sha256")
+	cmd, ok := cmds[os.Args[1]]
+	if !ok {
+		log.Printf("Invalid command %#v\n", os.Args[1])
+		printUsage()
+	}
+	if len(os.Args) != cmd.nArgs+3 {
+		log.Printf("Expected %d arguments, got %d\n", cmd.nArgs+3, len(os.Args))
+		printUsage()
+	}
+
+	// Args passed to the command.
+	a := cmdArgs{
+		args: os.Args[2 : len(os.Args)-1],
+	}
+
+	// Open file and read fmap, but only for specific commands.
+	if cmd.parseFMap {
+		// Open file.
+		r, err := os.Open(os.Args[len(os.Args)-1])
+		if err != nil {
+			log.Fatal(err)
 		}
-	}
-	if flag.NArg() != 1 {
-		log.Fatal("Incorrect number of arguments")
+		a.r = r
+		defer r.Close()
+
+		// Parse fmap.
+		f, m, err := fmap.ReadFMap(r)
+		if err != nil {
+			log.Fatal(err)
+		}
+		a.f, a.m = f, m
 	}
 
-	// Open file
-	var r *os.File
-	var err error
-	if *jsonWrite != "" {
-		r, err = os.OpenFile(flag.Arg(0), os.O_RDWR, 0666)
-	} else {
-		r, err = os.Open(flag.Arg(0))
-	}
-	if err != nil {
+	// Execute command.
+	if err := cmd.f(a); err != nil {
 		log.Fatal(err)
-	}
-	defer r.Close()
-
-	// Read fmap.
-	var f *fmap.FMap
-	var metadata *fmap.FMapMetadata
-	if *jsonWrite == "" && !*usage {
-		f, metadata, err = fmap.ReadFMap(r)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	switch {
-	// Optionally print checksum.
-	case *checksum != "":
-		checksum, err := f.Checksum(r, hashFuncs[*checksum]())
-		if err != nil {
-			log.Fatal(err)
-		}
-		fmt.Printf("%x\n", checksum)
-
-	// Optionally print area.
-	case *read >= 0:
-		areaReader, err := f.ReadArea(r, *read)
-		if err != nil {
-			log.Fatal(err)
-		}
-		_, err = io.Copy(os.Stdout, areaReader)
-		if err != nil {
-			log.Fatal(err)
-		}
-
-	// Optionally print summary.
-	case *summary:
-		printFMap(f, metadata)
-
-	// Optionally print usage.
-	case *usage:
-		if _, err := r.Seek(0, io.SeekStart); err != nil {
-			log.Fatal(err)
-		}
-		printUsage(r)
-
-	// Optionally print json.
-	case *jsonRead != "":
-		if err := readToJSON(f, metadata); err != nil {
-			log.Fatal(err)
-		}
-
-	// Optionally read json.
-	case *jsonWrite != "":
-		if err := writeFromJSON(r); err != nil {
-			log.Fatal(err)
-		}
 	}
 }

--- a/cmds/fmap/fmap.go
+++ b/cmds/fmap/fmap.go
@@ -126,7 +126,7 @@ func jsonGet(a cmdArgs) error {
 
 // Replace current fmap with json representation in JSONFILE.
 func jsonPut(a cmdArgs) error {
-	r, err := os.OpenFile(a.args[0], os.O_RDWR, 0666)
+	r, err := os.OpenFile(os.Args[len(os.Args)-1], os.O_WRONLY, 0666)
 	if err != nil {
 		return err
 	}

--- a/cmds/fmap/fmap_test.go
+++ b/cmds/fmap/fmap_test.go
@@ -18,12 +18,12 @@ import (
 const testFlash = "fake_test.flash"
 
 var tests = []struct {
-	flag string
-	out  string
+	cmd string
+	out string
 }{
 	// Test summary
 	{
-		flag: "-s",
+		cmd: "summary",
 		out: `Fmap found at 0x5f74:
 	Signature:  __FMAP__
 	VerMajor:   1
@@ -46,7 +46,7 @@ var tests = []struct {
 	},
 	// Test usage
 	{
-		flag: "-u",
+		cmd: "usage",
 		out: `Legend: '.' - full (0xff), '0' - zero (0x00), '#' - mixed
 0x00000000: 0..###
 Blocks:       6 (100.0%)
@@ -63,9 +63,9 @@ func TestFmap(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	for _, tt := range tests {
-		out, err := exec.Command(execPath, tt.flag, testFlash).CombinedOutput()
+		out, err := exec.Command(execPath, tt.cmd, testFlash).CombinedOutput()
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		// Filter out null characters which may be present in fmap strings.
 		out = bytes.Replace(out, []byte{0}, []byte{}, -1)
@@ -80,7 +80,7 @@ func TestJson(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	jsonFile := filepath.Join(tmpDir, "tmp.json")
-	if err := exec.Command(execPath, "-jr", jsonFile, testFlash).Run(); err != nil {
+	if err := exec.Command(execPath, "jget", jsonFile, testFlash).Run(); err != nil {
 		t.Fatal(err)
 	}
 	got, err := ioutil.ReadFile(jsonFile)

--- a/cmds/fmap/lib/fmap_test.go
+++ b/cmds/fmap/lib/fmap_test.go
@@ -81,9 +81,9 @@ func TestReadFMap(t *testing.T) {
 		},
 	}
 	copy(expected.Signature[:], []byte("__FMAP__"))
-	copy(expected.Name[:], fmapName)
-	copy(expected.Areas[0].Name[:], area0Name)
-	copy(expected.Areas[1].Name[:], area1Name)
+	copy(expected.Name.Value[:], fmapName)
+	copy(expected.Areas[0].Name.Value[:], area0Name)
+	copy(expected.Areas[1].Name.Value[:], area1Name)
 	if !reflect.DeepEqual(*fmap, expected) {
 		t.Errorf("expected:\n%+v\ngot:\n%+v", expected, *fmap)
 	}


### PR DESCRIPTION
This add two flags:

- `-jr JSON_FILE`: read from the flash and write a JSON encoded flash
map to `JSON_FILE`
- `-jw JSON_FILE`: read from the JSON file and overwrite the flash map
of flash at the location given in the JSON file

Admittedly, the tool could be a lot safer. For example, the FMap
clobbers any data if it needs to grow larger. Instead, the tool should
(not implemented yet!) check to see if the data it is overwriting is
used (contains all 0x00 or all 0xff) and emit and appropriate warning.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>