### PR TITLE
rush: lua support: WIP

### DIFF
--- a/cmds/rush/lua.go
+++ b/cmds/rush/lua.go
@@ -1,0 +1,41 @@
+// Copyright 2012 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Run lua code or call a lua function
+//
+// Synopsis:
+//     lua CMD [ARG]...
+//     luacall FUNCTION [ARG]...
+//
+// Description:
+//     lua assemble the named args into a string and pass the string to the interpreter
+//     luacall will assembled the args and string into this: FUNCTION(ARG...) and pass that string to the interpreter.
+//
+// Bugs:
+//     luacall is a lot to type. What's a better name?
+package main
+
+import (
+	"strings"
+
+	"github.com/Shopify/go-lua"
+)
+
+var (
+	l = lua.NewState()
+)
+
+func init() {
+	lua.OpenLibraries(l)
+	addBuiltIn("lua", runlua)
+	addBuiltIn("calllua", calllua)
+}
+
+func runlua(c *Command) error {
+	return lua.DoString(l, strings.Join(c.argv, " "))
+}
+
+func calllua(c *Command) error {
+	return lua.DoString(l, c.argv[0]+"("+strings.Join(c.argv[1:], ",")+")")
+}

--- a/vendor/github.com/Shopify/go-lua/LICENSE.md
+++ b/vendor/github.com/Shopify/go-lua/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/Shopify/go-lua/README.md
+++ b/vendor/github.com/Shopify/go-lua/README.md
@@ -1,0 +1,164 @@
+[![Build Status](https://circleci.com/gh/Shopify/go-lua.png?circle-token=997f951c602c0c63a263eba92975428a49ee4c2e)](https://circleci.com/gh/Shopify/go-lua)
+[![GoDoc](https://godoc.org/github.com/Shopify/go-lua?status.png)](https://godoc.org/github.com/Shopify/go-lua)
+
+A Lua VM in pure Go
+===================
+
+go-lua is a port of the Lua 5.2 VM to pure Go. It is compatible with binary files dumped by `luac`, from the [Lua reference implementation](http://www.lua.org/).
+
+The motivation is to enable simple scripting of Go applications. For example, it is used to describe flows in [Shopify's](http://www.shopify.com/) load generation tool, Genghis.
+
+Usage
+-----
+
+go-lua is intended to be used as a Go package. It does not include a command to run the interpreter. To start using the library, run:
+```sh
+go get github.com/Shopify/go-lua
+```
+
+To develop & test go-lua, you'll also need the [lua-tests](https://github.com/Shopify/lua-tests) submodule checked out:
+```sh
+git submodule update --init
+```
+
+You can then develop with the usual Go commands, e.g.:
+```sh
+go build
+go test -cover
+```
+
+A simple example that loads & runs a Lua script is:
+```go
+package main
+
+import "github.com/Shopify/go-lua"
+
+func main() {
+  l := lua.NewState()
+  lua.OpenLibraries(l)
+  if err := lua.DoFile(l, "hello.lua"); err != nil {
+    panic(err)
+  }
+}
+```
+
+Status
+------
+
+go-lua has been used in production in Shopify's load generation tool, Genghis, since May 2014, and is also part of Shopify's resiliency tooling.
+
+The core VM and compiler has been ported and tested. The compiler is able to correctly process all Lua source files from the [Lua test suite](https://github.com/Shopify/lua-tests). The VM has been tested to correctly execute over a third of the Lua test cases.
+
+Most core Lua libraries are at least partially implemented. Prominent exceptions are regular expressions, coroutines and `string.dump`.
+
+Weak reference tables are not and will not be supported. go-lua uses the Go heap for Lua objects, and Go does not support weak references.
+
+Benchmarks
+----------
+
+Benchmark results shown here are taken from a Mid 2012 MacBook Pro Retina with a 2.6 GHz Core i7 CPU running OS X 10.10.2, go 1.4.2 and Lua 5.2.2.
+
+The Fibonacci function can be written a few different ways to evaluate different performance characteristics of a language interpreter. The simplest way is as a recursive function:
+```lua
+  function fib(n)
+    if n == 0 then
+      return 0
+    elseif n == 1 then
+      return 1
+    end
+    return fib(n-1) + fib(n-2)
+  end
+```
+
+This exercises the call stack implementation. When computing `fib(35)`, go-lua is about 6x slower than the C Lua interpreter. [Gopher-lua](https://github.com/yuin/gopher-lua) is about 20% faster than go-lua. Much of the performance difference between go-lua and gopher-lua comes from the inclusion of debug hooks in go-lua. The remainder is due to the call stack implementation - go-lua heap-allocates Lua stack frames with a separately allocated variant struct, as outlined above. Although it caches recently used stack frames, it is outperformed by the simpler statically allocated call stacks in gopher-lua.
+```
+  $ time lua fibr.lua
+  real  0m2.807s
+  user  0m2.795s
+  sys   0m0.006s
+  
+  $ time glua fibr.lua
+  real  0m14.528s
+  user  0m14.513s
+  sys   0m0.031s
+  
+  $ time go-lua fibr.lua
+  real  0m17.411s
+  user  0m17.514s
+  sys   0m1.287s
+```
+
+The recursive Fibonacci function can be transformed into a tail-recursive variant:
+```lua
+  function fibt(n0, n1, c)
+    if c == 0 then
+      return n0
+    else if c == 1 then
+      return n1
+    end
+    return fibt(n1, n0+n1, c-1)
+  end
+  
+  function fib(n)
+    fibt(0, 1, n)
+  end
+```
+
+The Lua interpreter detects and optimizes tail calls. This exhibits similar relative performance between the 3 interpreters, though gopher-lua edges ahead a little due to its simpler stack model and reduced bookkeeping.
+```
+  $ time lua fibt.lua
+  real  0m0.099s
+  user  0m0.096s
+  sys   0m0.002s
+
+  $ time glua fibt.lua
+  real  0m0.489s
+  user  0m0.484s
+  sys   0m0.005s
+
+  $ time go-lua fibt.lua
+  real  0m0.607s
+  user  0m0.610s
+  sys   0m0.068s
+```
+
+Finally, we can write an explicitly iterative implementation:
+```lua
+  function fib(n)
+    if n == 0 then
+      return 0
+    else if n == 1 then
+      return 1
+    end
+    local n0, n1 = 0, 1
+    for i = n, 2, -1 do
+      local tmp = n0 + n1
+      n0 = n1
+      n1 = tmp
+    end
+    return n1
+  end
+```
+
+This exercises more of the bytecode interpreter’s inner loop. Here we see the performance impact of Go’s `switch` implementation. Both go-lua and gopher-lua are an order of magnitude slower than the C Lua interpreter.
+```
+  $ time lua fibi.lua
+  real  0m0.023s
+  user  0m0.020s
+  sys   0m0.003s
+
+  $ time glua fibi.lua
+  real  0m0.242s
+  user  0m0.235s
+  sys   0m0.005s
+
+  $ time go-lua fibi.lua
+  real  0m0.242s
+  user  0m0.240s
+  sys   0m0.028s
+```
+
+License
+-------
+
+go-lua is licensed under the [MIT license](https://github.com/Shopify/go-lua/blob/master/LICENSE.md).

--- a/vendor/github.com/Shopify/go-lua/auxiliary.go
+++ b/vendor/github.com/Shopify/go-lua/auxiliary.go
@@ -1,0 +1,582 @@
+package lua
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func functionName(l *State, d Debug) string {
+	switch {
+	case d.NameKind != "":
+		return fmt.Sprintf("function '%s'", d.Name)
+	case d.What == "main":
+		return "main chunk"
+	case d.What == "Go":
+		if pushGlobalFunctionName(l, d.callInfo) {
+			s, _ := l.ToString(-1)
+			l.Pop(1)
+			return fmt.Sprintf("function '%s'", s)
+		} else {
+			return "?"
+		}
+	}
+	return fmt.Sprintf("function <%s:%d>", d.ShortSource, d.LineDefined)
+}
+
+func countLevels(l *State) int {
+	li, le := 1, 1
+	for _, ok := Stack(l, le); ok; _, ok = Stack(l, le) {
+		li = le
+		le *= 2
+	}
+	for li < le {
+		m := (li + le) / 2
+		if _, ok := Stack(l, m); ok {
+			li = m + 1
+		} else {
+			le = m
+		}
+	}
+	return le - 1
+}
+
+// Traceback creates and pushes a traceback of the stack l1. If message is not
+// nil it is appended at the beginning of the traceback. The level parameter
+// tells at which level to start the traceback.
+func Traceback(l, l1 *State, message string, level int) {
+	const levels1, levels2 = 12, 10
+	levels := countLevels(l1)
+	mark := 0
+	if levels > levels1+levels2 {
+		mark = levels1
+	}
+	buf := message
+	if buf != "" {
+		buf += "\n"
+	}
+	buf += "stack traceback:"
+	for f, ok := Stack(l1, level); ok; f, ok = Stack(l1, level) {
+		if level++; level == mark {
+			buf += "\n\t..."
+			level = levels - levels2
+		} else {
+			d, _ := Info(l1, "Slnt", f)
+			buf += "\n\t" + d.ShortSource + ":"
+			if d.CurrentLine > 0 {
+				buf += fmt.Sprintf("%d:", d.CurrentLine)
+			}
+			buf += " in " + functionName(l, d)
+			if d.IsTailCall {
+				buf += "\n\t(...tail calls...)"
+			}
+		}
+	}
+	l.PushString(buf)
+}
+
+// MetaField pushes onto the stack the field event from the metatable of the
+// object at index. If the object does not have a metatable, or if the
+// metatable does not have this field, returns false and pushes nothing.
+func MetaField(l *State, index int, event string) bool {
+	if !l.MetaTable(index) {
+		return false
+	}
+	l.PushString(event)
+	l.RawGet(-2)
+	if l.IsNil(-1) {
+		l.Pop(2) // remove metatable and metafield
+		return false
+	}
+	l.Remove(-2) // remove only metatable
+	return true
+}
+
+// CallMeta calls a metamethod.
+//
+// If the object at index has a metatable and this metatable has a field event,
+// this function calls this field passing the object as its only argument. In
+// this case this function returns true and pushes onto the stack the value
+// returned by the call. If there is no metatable or no metamethod, this
+// function returns false (without pushing any value on the stack).
+func CallMeta(l *State, index int, event string) bool {
+	index = l.AbsIndex(index)
+	if !MetaField(l, index, event) {
+		return false
+	}
+	l.PushValue(index)
+	l.Call(1, 1)
+	return true
+}
+
+// ArgumentError raises an error with a standard message that includes extraMessage as a comment.
+//
+// This function never returns. It is an idiom to use it in Go functions as
+//  lua.ArgumentError(l, args, "message")
+//  panic("unreachable")
+func ArgumentError(l *State, argCount int, extraMessage string) {
+	f, ok := Stack(l, 0)
+	if !ok { // no stack frame?
+		Errorf(l, "bad argument #%d (%s)", argCount, extraMessage)
+		return
+	}
+	d, _ := Info(l, "n", f)
+	if d.NameKind == "method" {
+		argCount--         // do not count 'self'
+		if argCount == 0 { // error is in the self argument itself?
+			Errorf(l, "calling '%s' on bad self (%s)", d.Name, extraMessage)
+			return
+		}
+	}
+	if d.Name == "" {
+		if pushGlobalFunctionName(l, f) {
+			d.Name, _ = l.ToString(-1)
+		} else {
+			d.Name = "?"
+		}
+	}
+	Errorf(l, "bad argument #%d to '%s' (%s)", argCount, d.Name, extraMessage)
+}
+
+func findField(l *State, objectIndex, level int) bool {
+	if level == 0 || !l.IsTable(-1) {
+		return false
+	}
+	for l.PushNil(); l.Next(-2); l.Pop(1) { // for each pair in table
+		if l.IsString(-2) { // ignore non-string keys
+			if l.RawEqual(objectIndex, -1) { // found object?
+				l.Pop(1) // remove value (but keep name)
+				return true
+			} else if findField(l, objectIndex, level-1) { // try recursively
+				l.Remove(-2) // remove table (but keep name)
+				l.PushString(".")
+				l.Insert(-2) // place "." between the two names
+				l.Concat(3)
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func pushGlobalFunctionName(l *State, f Frame) bool {
+	top := l.Top()
+	Info(l, "f", f) // push function
+	l.PushGlobalTable()
+	if findField(l, top+1, 2) {
+		l.Copy(-1, top+1) // move name to proper place
+		l.Pop(2)          // remove pushed values
+		return true
+	}
+	l.SetTop(top) // remove function and global table
+	return false
+}
+
+func typeError(l *State, argCount int, typeName string) {
+	ArgumentError(l, argCount, l.PushString(typeName+" expected, got "+TypeNameOf(l, argCount)))
+}
+
+func tagError(l *State, argCount int, tag Type) { typeError(l, argCount, tag.String()) }
+
+// Where pushes onto the stack a string identifying the current position of
+// the control at level in the call stack. Typically this string has the
+// following format:
+//   chunkname:currentline:
+// Level 0 is the running function, level 1 is the function that called the
+// running function, etc.
+//
+// This function is used to build a prefix for error messages.
+func Where(l *State, level int) {
+	if f, ok := Stack(l, level); ok { // check function at level
+		ar, _ := Info(l, "Sl", f) // get info about it
+		if ar.CurrentLine > 0 {   // is there info?
+			l.PushString(fmt.Sprintf("%s:%d: ", ar.ShortSource, ar.CurrentLine))
+			return
+		}
+	}
+	l.PushString("") // else, no information available...
+}
+
+// Errorf raises an error. The error message format is given by format plus
+// any extra arguments, following the same rules as PushFString. It also adds
+// at the beginning of the message the file name and the line number where
+// the error occurred, if this information is available.
+//
+// This function never returns. It is an idiom to use it in Go functions as:
+//   lua.Errorf(l, args)
+//   panic("unreachable")
+func Errorf(l *State, format string, a ...interface{}) {
+	Where(l, 1)
+	l.PushFString(format, a...)
+	l.Concat(2)
+	l.Error()
+}
+
+// ToStringMeta converts any Lua value at the given index to a Go string in a
+// reasonable format. The resulting string is pushed onto the stack and also
+// returned by the function.
+//
+// If the value has a metatable with a "__tostring" field, then ToStringMeta
+// calls the corresponding metamethod with the value as argument, and uses
+// the result of the call as its result.
+func ToStringMeta(l *State, index int) (string, bool) {
+	if !CallMeta(l, index, "__tostring") {
+		switch l.TypeOf(index) {
+		case TypeNumber, TypeString:
+			l.PushValue(index)
+		case TypeBoolean:
+			if l.ToBoolean(index) {
+				l.PushString("true")
+			} else {
+				l.PushString("false")
+			}
+		case TypeNil:
+			l.PushString("nil")
+		default:
+			l.PushFString("%s: %p", TypeNameOf(l, index), l.ToValue(index))
+		}
+	}
+	return l.ToString(-1)
+}
+
+// NewMetaTable returns false if the registry already has the key name. Otherwise,
+// creates a new table to be used as a metatable for userdata, adds it to the
+// registry with key name, and returns true.
+//
+// In both cases it pushes onto the stack the final value associated with name in
+// the registry.
+func NewMetaTable(l *State, name string) bool {
+	if MetaTableNamed(l, name); !l.IsNil(-1) {
+		return false
+	}
+	l.Pop(1)
+	l.NewTable()
+	l.PushValue(-1)
+	l.SetField(RegistryIndex, name)
+	return true
+}
+
+func MetaTableNamed(l *State, name string) {
+	l.Field(RegistryIndex, name)
+}
+
+func SetMetaTableNamed(l *State, name string) {
+	MetaTableNamed(l, name)
+	l.SetMetaTable(-2)
+}
+
+func TestUserData(l *State, index int, name string) interface{} {
+	if d := l.ToUserData(index); d != nil {
+		if l.MetaTable(index) {
+			if MetaTableNamed(l, name); !l.RawEqual(-1, -2) {
+				d = nil
+			}
+			l.Pop(2)
+			return d
+		}
+	}
+	return nil
+}
+
+// CheckUserData checks whether the function argument at index is a userdata
+// of the type name (see NewMetaTable) and returns the userdata (see
+// ToUserData).
+func CheckUserData(l *State, index int, name string) interface{} {
+	if d := TestUserData(l, index, name); d != nil {
+		return d
+	}
+	typeError(l, index, name)
+	panic("unreachable")
+}
+
+// CheckType checks whether the function argument at index has type t. See Type for the encoding of types for t.
+func CheckType(l *State, index int, t Type) {
+	if l.TypeOf(index) != t {
+		tagError(l, index, t)
+	}
+}
+
+// CheckAny checks whether the function has an argument of any type (including nil) at position index.
+func CheckAny(l *State, index int) {
+	if l.TypeOf(index) == TypeNone {
+		ArgumentError(l, index, "value expected")
+	}
+}
+
+// ArgumentCheck checks whether cond is true. If not, raises an error with a standard message.
+func ArgumentCheck(l *State, cond bool, index int, extraMessage string) {
+	if !cond {
+		ArgumentError(l, index, extraMessage)
+	}
+}
+
+// CheckString checks whether the function argument at index is a string and returns this string.
+//
+// This function uses ToString to get its result, so all conversions and caveats of that function apply here.
+func CheckString(l *State, index int) string {
+	if s, ok := l.ToString(index); ok {
+		return s
+	}
+	tagError(l, index, TypeString)
+	panic("unreachable")
+}
+
+// OptString returns the string at index if it is a string. If this argument is
+// absent or is nil, returns def. Otherwise, raises an error.
+func OptString(l *State, index int, def string) string {
+	if l.IsNoneOrNil(index) {
+		return def
+	}
+	return CheckString(l, index)
+}
+
+func CheckNumber(l *State, index int) float64 {
+	n, ok := l.ToNumber(index)
+	if !ok {
+		tagError(l, index, TypeNumber)
+	}
+	return n
+}
+
+func OptNumber(l *State, index int, def float64) float64 {
+	if l.IsNoneOrNil(index) {
+		return def
+	}
+	return CheckNumber(l, index)
+}
+
+func CheckInteger(l *State, index int) int {
+	i, ok := l.ToInteger(index)
+	if !ok {
+		tagError(l, index, TypeNumber)
+	}
+	return i
+}
+
+func OptInteger(l *State, index, def int) int {
+	if l.IsNoneOrNil(index) {
+		return def
+	}
+	return CheckInteger(l, index)
+}
+
+func CheckUnsigned(l *State, index int) uint {
+	i, ok := l.ToUnsigned(index)
+	if !ok {
+		tagError(l, index, TypeNumber)
+	}
+	return i
+}
+
+func OptUnsigned(l *State, index int, def uint) uint {
+	if l.IsNoneOrNil(index) {
+		return def
+	}
+	return CheckUnsigned(l, index)
+}
+
+func TypeNameOf(l *State, index int) string { return l.TypeOf(index).String() }
+
+func SetFunctions(l *State, functions []RegistryFunction, upValueCount uint8) {
+	uvCount := int(upValueCount)
+	CheckStackWithMessage(l, uvCount, "too many upvalues")
+	for _, r := range functions { // fill the table with given functions
+		for i := 0; i < uvCount; i++ { // copy upvalues to the top
+			l.PushValue(-uvCount)
+		}
+		l.PushGoClosure(r.Function, upValueCount) // closure with those upvalues
+		l.SetField(-(uvCount + 2), r.Name)
+	}
+	l.Pop(uvCount) // remove upvalues
+}
+
+func CheckStackWithMessage(l *State, space int, message string) {
+	// keep some extra space to run error routines, if needed
+	if !l.CheckStack(space + MinStack) {
+		if message != "" {
+			Errorf(l, "stack overflow (%s)", message)
+		} else {
+			Errorf(l, "stack overflow")
+		}
+	}
+}
+
+func CheckOption(l *State, index int, def string, list []string) int {
+	var name string
+	if def == "" {
+		name = OptString(l, index, def)
+	} else {
+		name = CheckString(l, index)
+	}
+	for i, s := range list {
+		if name == s {
+			return i
+		}
+	}
+	ArgumentError(l, index, l.PushFString("invalid option '%s'", name))
+	panic("unreachable")
+}
+
+func SubTable(l *State, index int, name string) bool {
+	l.Field(index, name)
+	if l.IsTable(-1) {
+		return true // table already there
+	}
+	l.Pop(1) // remove previous result
+	index = l.AbsIndex(index)
+	l.NewTable()
+	l.PushValue(-1)         // copy to be left at top
+	l.SetField(index, name) // assign new table to field
+	return false            // did not find table there
+}
+
+// Require calls function f with string name as an argument and sets the call
+// result in package.loaded[name], as if that function had been called
+// through require.
+//
+// If global is true, also stores the result into global name.
+//
+// Leaves a copy of that result on the stack.
+func Require(l *State, name string, f Function, global bool) {
+	l.PushGoFunction(f)
+	l.PushString(name) // argument to f
+	l.Call(1, 1)       // open module
+	SubTable(l, RegistryIndex, "_LOADED")
+	l.PushValue(-2)      // make copy of module (call result)
+	l.SetField(-2, name) // _LOADED[name] = module
+	l.Pop(1)             // remove _LOADED table
+	if global {
+		l.PushValue(-1)   // copy of module
+		l.SetGlobal(name) // _G[name] = module
+	}
+}
+
+func NewLibraryTable(l *State, functions []RegistryFunction) { l.CreateTable(0, len(functions)) }
+
+func NewLibrary(l *State, functions []RegistryFunction) {
+	NewLibraryTable(l, functions)
+	SetFunctions(l, functions, 0)
+}
+
+func skipComment(r *bufio.Reader) (bool, error) {
+	bom := "\xEF\xBB\xBF"
+	if ba, err := r.Peek(len(bom)); err != nil {
+		return false, err
+	} else if string(ba) == bom {
+		_, _ = r.Read(ba)
+	}
+	if c, _, err := r.ReadRune(); err != nil {
+		return false, err
+	} else if c == '#' {
+		_, err = r.ReadBytes('\n')
+		return true, err
+	}
+	return false, r.UnreadRune()
+}
+
+func LoadFile(l *State, fileName, mode string) error {
+	var f *os.File
+	fileNameIndex := l.Top() + 1
+	fileError := func(what string) error {
+		fileName, _ := l.ToString(fileNameIndex)
+		l.PushFString("cannot %s %s", what, fileName[1:])
+		l.Remove(fileNameIndex)
+		return FileError
+	}
+	if fileName == "" {
+		l.PushString("=stdin")
+		f = os.Stdin
+	} else {
+		l.PushString("@" + fileName)
+		var err error
+		if f, err = os.Open(fileName); err != nil {
+			return fileError("open")
+		}
+	}
+	r := bufio.NewReader(f)
+	if skipped, err := skipComment(r); err != nil {
+		l.SetTop(fileNameIndex)
+		return fileError("read")
+	} else if skipped {
+		r = bufio.NewReader(io.MultiReader(strings.NewReader("\n"), r))
+	}
+	s, _ := l.ToString(-1)
+	err := l.Load(r, s, mode)
+	if f != os.Stdin {
+		_ = f.Close()
+	}
+	if err != nil {
+		l.SetTop(fileNameIndex)
+		return fileError("read")
+	}
+	l.Remove(fileNameIndex)
+	return err
+}
+
+func LoadString(l *State, s string) error { return LoadBuffer(l, s, s, "") }
+
+func LoadBuffer(l *State, b, name, mode string) error {
+	return l.Load(strings.NewReader(b), name, mode)
+}
+
+// NewStateEx creates a new Lua state. It calls NewState and then sets a panic
+// function that prints an error message to the standard error output in case
+// of fatal errors.
+//
+// Returns the new state.
+func NewStateEx() *State {
+	l := NewState()
+	if l != nil {
+		_ = AtPanic(l, func(l *State) int {
+			s, _ := l.ToString(-1)
+			fmt.Fprintf(os.Stderr, "PANIC: unprotected error in call to Lua API (%s)\n", s)
+			return 0
+		})
+	}
+	return l
+}
+
+func LengthEx(l *State, index int) int {
+	l.Length(index)
+	if length, ok := l.ToInteger(-1); ok {
+		l.Pop(1)
+		return length
+	}
+	Errorf(l, "object length is not a number")
+	panic("unreachable")
+}
+
+// FileResult produces the return values for file-related functions in the standard
+// library (io.open, os.rename, file:seek, etc.).
+func FileResult(l *State, err error, filename string) int {
+	if err == nil {
+		l.PushBoolean(true)
+		return 1
+	}
+	l.PushNil()
+	if filename != "" {
+		l.PushString(filename + ": " + err.Error())
+	} else {
+		l.PushString(err.Error())
+	}
+	l.PushInteger(0) // TODO map err to errno
+	return 3
+}
+
+// DoFile loads and runs the given file.
+func DoFile(l *State, fileName string) error {
+	if err := LoadFile(l, fileName, ""); err != nil {
+		return err
+	}
+	return l.ProtectedCall(0, MultipleReturns, 0)
+}
+
+// DoString loads and runs the given string.
+func DoString(l *State, s string) error {
+	if err := LoadString(l, s); err != nil {
+		return err
+	}
+	return l.ProtectedCall(0, MultipleReturns, 0)
+}

--- a/vendor/github.com/Shopify/go-lua/base.go
+++ b/vendor/github.com/Shopify/go-lua/base.go
@@ -1,0 +1,330 @@
+package lua
+
+import (
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+func next(l *State) int {
+	CheckType(l, 1, TypeTable)
+	l.SetTop(2)
+	if l.Next(1) {
+		return 2
+	}
+	l.PushNil()
+	return 1
+}
+
+func pairs(method string, isZero bool, iter Function) Function {
+	return func(l *State) int {
+		if hasMetamethod := MetaField(l, 1, method); !hasMetamethod {
+			CheckType(l, 1, TypeTable) // argument must be a table
+			l.PushGoFunction(iter)     // will return generator,
+			l.PushValue(1)             // state,
+			if isZero {                // and initial value
+				l.PushInteger(0)
+			} else {
+				l.PushNil()
+			}
+		} else {
+			l.PushValue(1) // argument 'self' to metamethod
+			l.Call(1, 3)   // get 3 values from metamethod
+		}
+		return 3
+	}
+}
+
+func intPairs(l *State) int {
+	i := CheckInteger(l, 2)
+	CheckType(l, 1, TypeTable)
+	i++ // next value
+	l.PushInteger(i)
+	l.RawGetInt(1, i)
+	if l.IsNil(-1) {
+		return 1
+	}
+	return 2
+}
+
+func finishProtectedCall(l *State, status bool) int {
+	if !l.CheckStack(1) {
+		l.SetTop(0) // create space for return values
+		l.PushBoolean(false)
+		l.PushString("stack overflow")
+		return 2 // return false, message
+	}
+	l.PushBoolean(status) // first result (status)
+	l.Replace(1)          // put first result in the first slot
+	return l.Top()
+}
+
+func protectedCallContinuation(l *State) int {
+	_, shouldYield, _ := l.Context()
+	return finishProtectedCall(l, shouldYield)
+}
+
+func loadHelper(l *State, s error, e int) int {
+	if s == nil {
+		if e != 0 {
+			l.PushValue(e)
+			if _, ok := SetUpValue(l, -2, 1); !ok {
+				l.Pop(1)
+			}
+		}
+		return 1
+	}
+	l.PushNil()
+	l.Insert(-2)
+	return 2
+}
+
+type genericReader struct {
+	l *State
+	r *strings.Reader
+	e error
+}
+
+func (r *genericReader) Read(b []byte) (n int, err error) {
+	if r.e != nil {
+		return 0, r.e
+	}
+	if l := r.l; r.r == nil {
+		CheckStackWithMessage(l, 2, "too many nested functions")
+		l.PushValue(1)
+		if l.Call(0, 1); l.IsNil(-1) {
+			l.Pop(1)
+			return 0, io.EOF
+		} else if !l.IsString(-1) {
+			Errorf(l, "reader function must return a string")
+		}
+		if s, ok := l.ToString(-1); ok {
+			r.r = strings.NewReader(s)
+		} else {
+			return 0, io.EOF
+		}
+	}
+	if n, err = r.r.Read(b); err == io.EOF {
+		r.r, err = nil, nil
+	} else if err != nil {
+		r.e = err
+	}
+	return
+}
+
+var baseLibrary = []RegistryFunction{
+	{"assert", func(l *State) int {
+		if !l.ToBoolean(1) {
+			Errorf(l, "%s", OptString(l, 2, "assertion failed!"))
+			panic("unreachable")
+		}
+		return l.Top()
+	}},
+	{"collectgarbage", func(l *State) int {
+		switch opt, _ := OptString(l, 1, "collect"), OptInteger(l, 2, 0); opt {
+		case "collect":
+			runtime.GC()
+			l.PushInteger(0)
+		case "step":
+			runtime.GC()
+			l.PushBoolean(true)
+		case "count":
+			var stats runtime.MemStats
+			runtime.ReadMemStats(&stats)
+			l.PushNumber(float64(stats.HeapAlloc >> 10))
+			l.PushInteger(int(stats.HeapAlloc & 0x3ff))
+			return 2
+		default:
+			l.PushInteger(-1)
+		}
+		return 1
+	}},
+	{"dofile", func(l *State) int {
+		f := OptString(l, 1, "")
+		if l.SetTop(1); LoadFile(l, f, "") != nil {
+			l.Error()
+			panic("unreachable")
+		}
+		continuation := func(l *State) int { return l.Top() - 1 }
+		l.CallWithContinuation(0, MultipleReturns, 0, continuation)
+		return continuation(l)
+	}},
+	{"error", func(l *State) int {
+		level := OptInteger(l, 2, 1)
+		l.SetTop(1)
+		if l.IsString(1) && level > 0 {
+			Where(l, level)
+			l.PushValue(1)
+			l.Concat(2)
+		}
+		l.Error()
+		panic("unreachable")
+	}},
+	{"getmetatable", func(l *State) int {
+		CheckAny(l, 1)
+		if !l.MetaTable(1) {
+			l.PushNil()
+			return 1
+		}
+		MetaField(l, 1, "__metatable")
+		return 1
+	}},
+	{"ipairs", pairs("__ipairs", true, intPairs)},
+	{"loadfile", func(l *State) int {
+		f, m, e := OptString(l, 1, ""), OptString(l, 2, ""), 3
+		if l.IsNone(e) {
+			e = 0
+		}
+		return loadHelper(l, LoadFile(l, f, m), e)
+	}},
+	{"load", func(l *State) int {
+		m, e := OptString(l, 3, "bt"), 4
+		if l.IsNone(e) {
+			e = 0
+		}
+		var err error
+		if s, ok := l.ToString(1); ok {
+			err = LoadBuffer(l, s, OptString(l, 2, s), m)
+		} else {
+			chunkName := OptString(l, 2, "=(load)")
+			CheckType(l, 1, TypeFunction)
+			err = l.Load(&genericReader{l: l}, chunkName, m)
+		}
+		return loadHelper(l, err, e)
+	}},
+	{"next", next},
+	{"pairs", pairs("__pairs", false, next)},
+	{"pcall", func(l *State) int {
+		CheckAny(l, 1)
+		l.PushNil()
+		l.Insert(1) // create space for status result
+		return finishProtectedCall(l, nil == l.ProtectedCallWithContinuation(l.Top()-2, MultipleReturns, 0, 0, protectedCallContinuation))
+	}},
+	{"print", func(l *State) int {
+		n := l.Top()
+		l.Global("tostring")
+		for i := 1; i <= n; i++ {
+			l.PushValue(-1) // function to be called
+			l.PushValue(i)  // value to print
+			l.Call(1, 1)
+			s, ok := l.ToString(-1)
+			if !ok {
+				Errorf(l, "'tostring' must return a string to 'print'")
+				panic("unreachable")
+			}
+			if i > 1 {
+				os.Stdout.WriteString("\t")
+			}
+			os.Stdout.WriteString(s)
+			l.Pop(1) // pop result
+		}
+		os.Stdout.WriteString("\n")
+		os.Stdout.Sync()
+		return 0
+	}},
+	{"rawequal", func(l *State) int {
+		CheckAny(l, 1)
+		CheckAny(l, 2)
+		l.PushBoolean(l.RawEqual(1, 2))
+		return 1
+	}},
+	{"rawlen", func(l *State) int {
+		t := l.TypeOf(1)
+		ArgumentCheck(l, t == TypeTable || t == TypeString, 1, "table or string expected")
+		l.PushInteger(l.RawLength(1))
+		return 1
+	}},
+	{"rawget", func(l *State) int {
+		CheckType(l, 1, TypeTable)
+		CheckAny(l, 2)
+		l.SetTop(2)
+		l.RawGet(1)
+		return 1
+	}},
+	{"rawset", func(l *State) int {
+		CheckType(l, 1, TypeTable)
+		CheckAny(l, 2)
+		CheckAny(l, 3)
+		l.SetTop(3)
+		l.RawSet(1)
+		return 1
+	}},
+	{"select", func(l *State) int {
+		n := l.Top()
+		if l.TypeOf(1) == TypeString {
+			if s, _ := l.ToString(1); s[0] == '#' {
+				l.PushInteger(n - 1)
+				return 1
+			}
+		}
+		i := CheckInteger(l, 1)
+		if i < 0 {
+			i = n + i
+		} else if i > n {
+			i = n
+		}
+		ArgumentCheck(l, 1 <= i, 1, "index out of range")
+		return n - i
+	}},
+	{"setmetatable", func(l *State) int {
+		t := l.TypeOf(2)
+		CheckType(l, 1, TypeTable)
+		ArgumentCheck(l, t == TypeNil || t == TypeTable, 2, "nil or table expected")
+		if MetaField(l, 1, "__metatable") {
+			Errorf(l, "cannot change a protected metatable")
+		}
+		l.SetTop(2)
+		l.SetMetaTable(1)
+		return 1
+	}},
+	{"tonumber", func(l *State) int {
+		if l.IsNoneOrNil(2) { // standard conversion
+			if n, ok := l.ToNumber(1); ok {
+				l.PushNumber(n)
+				return 1
+			}
+			CheckAny(l, 1)
+		} else {
+			s := CheckString(l, 1)
+			base := CheckInteger(l, 2)
+			ArgumentCheck(l, 2 <= base && base <= 36, 2, "base out of range")
+			if i, err := strconv.ParseInt(strings.TrimSpace(s), base, 64); err == nil {
+				l.PushNumber(float64(i))
+				return 1
+			}
+		}
+		l.PushNil()
+		return 1
+	}},
+	{"tostring", func(l *State) int {
+		CheckAny(l, 1)
+		ToStringMeta(l, 1)
+		return 1
+	}},
+	{"type", func(l *State) int {
+		CheckAny(l, 1)
+		l.PushString(TypeNameOf(l, 1))
+		return 1
+	}},
+	{"xpcall", func(l *State) int {
+		n := l.Top()
+		ArgumentCheck(l, n >= 2, 2, "value expected")
+		l.PushValue(1) // exchange function and error handler
+		l.Copy(2, 1)
+		l.Replace(2)
+		return finishProtectedCall(l, nil == l.ProtectedCallWithContinuation(n-2, MultipleReturns, 1, 0, protectedCallContinuation))
+	}},
+}
+
+// BaseOpen opens the basic library. Usually passed to Require.
+func BaseOpen(l *State) int {
+	l.PushGlobalTable()
+	l.PushGlobalTable()
+	l.SetField(-2, "_G")
+	SetFunctions(l, baseLibrary, 0)
+	l.PushString(VersionString)
+	l.SetField(-2, "_VERSION")
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/bit32.go
+++ b/vendor/github.com/Shopify/go-lua/bit32.go
@@ -1,0 +1,106 @@
+package lua
+
+import (
+	"math"
+)
+
+const bitCount = 32
+
+func trim(x uint) uint { return x & math.MaxUint32 }
+func mask(n uint) uint { return ^(math.MaxUint32 << n) }
+
+func shift(l *State, r uint, i int) int {
+	if i < 0 {
+		if i, r = -i, trim(r); i >= bitCount {
+			r = 0
+		} else {
+			r >>= uint(i)
+		}
+	} else {
+		if i >= bitCount {
+			r = 0
+		} else {
+			r <<= uint(i)
+		}
+		r = trim(r)
+	}
+	l.PushUnsigned(r)
+	return 1
+}
+
+func rotate(l *State, i int) int {
+	r := trim(CheckUnsigned(l, 1))
+	if i &= bitCount - 1; i != 0 {
+		r = trim((r << uint(i)) | (r >> uint(bitCount-i)))
+	}
+	l.PushUnsigned(r)
+	return 1
+}
+
+func bitOp(l *State, init uint, f func(a, b uint) uint) uint {
+	r := init
+	for i, n := 1, l.Top(); i <= n; i++ {
+		r = f(r, CheckUnsigned(l, i))
+	}
+	return trim(r)
+}
+
+func andHelper(l *State) uint {
+	x := bitOp(l, ^uint(0), func(a, b uint) uint { return a & b })
+	return x
+}
+
+func fieldArguments(l *State, fieldIndex int) (uint, uint) {
+	f, w := CheckInteger(l, fieldIndex), OptInteger(l, fieldIndex+1, 1)
+	ArgumentCheck(l, 0 <= f, fieldIndex, "field cannot be negative")
+	ArgumentCheck(l, 0 < w, fieldIndex+1, "width must be positive")
+	if f+w > bitCount {
+		Errorf(l, "trying to access non-existent bits")
+	}
+	return uint(f), uint(w)
+}
+
+var bitLibrary = []RegistryFunction{
+	{"arshift", func(l *State) int {
+		if r, i := CheckUnsigned(l, 1), CheckInteger(l, 2); i < 0 || 0 == (r&(1<<(bitCount-1))) {
+			return shift(l, r, -i)
+		} else {
+			if i >= bitCount {
+				r = math.MaxUint32
+			} else {
+				r = trim((r >> uint(i)) | ^(math.MaxUint32 >> uint(i)))
+			}
+			l.PushUnsigned(r)
+		}
+		return 1
+	}},
+	{"band", func(l *State) int { l.PushUnsigned(andHelper(l)); return 1 }},
+	{"bnot", func(l *State) int { l.PushUnsigned(trim(^CheckUnsigned(l, 1))); return 1 }},
+	{"bor", func(l *State) int { l.PushUnsigned(bitOp(l, 0, func(a, b uint) uint { return a | b })); return 1 }},
+	{"bxor", func(l *State) int { l.PushUnsigned(bitOp(l, 0, func(a, b uint) uint { return a ^ b })); return 1 }},
+	{"btest", func(l *State) int { l.PushBoolean(andHelper(l) != 0); return 1 }},
+	{"extract", func(l *State) int {
+		r := CheckUnsigned(l, 1)
+		f, w := fieldArguments(l, 2)
+		l.PushUnsigned((r >> f) & mask(w))
+		return 1
+	}},
+	{"lrotate", func(l *State) int { return rotate(l, CheckInteger(l, 2)) }},
+	{"lshift", func(l *State) int { return shift(l, CheckUnsigned(l, 1), CheckInteger(l, 2)) }},
+	{"replace", func(l *State) int {
+		r, v := CheckUnsigned(l, 1), CheckUnsigned(l, 2)
+		f, w := fieldArguments(l, 3)
+		m := mask(w)
+		v &= m
+		l.PushUnsigned((r & ^(m << f)) | (v << f))
+		return 1
+	}},
+	{"rrotate", func(l *State) int { return rotate(l, -CheckInteger(l, 2)) }},
+	{"rshift", func(l *State) int { return shift(l, CheckUnsigned(l, 1), -CheckInteger(l, 2)) }},
+}
+
+// Bit32Open opens the bit32 library. Usually passed to Require.
+func Bit32Open(l *State) int {
+	NewLibrary(l, bitLibrary)
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/circle.yml
+++ b/vendor/github.com/Shopify/go-lua/circle.yml
@@ -1,0 +1,7 @@
+checkout:
+  post:
+    - git submodule update --init
+
+dependencies:
+  pre:
+    - sudo apt-get install lua5.2

--- a/vendor/github.com/Shopify/go-lua/code.go
+++ b/vendor/github.com/Shopify/go-lua/code.go
@@ -1,0 +1,1155 @@
+package lua
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	oprMinus = iota
+	oprNot
+	oprLength
+	oprNoUnary
+)
+
+const (
+	noJump            = -1
+	noRegister        = maxArgA
+	maxLocalVariables = 200
+)
+
+const (
+	oprAdd = iota
+	oprSub
+	oprMul
+	oprDiv
+	oprMod
+	oprPow
+	oprConcat
+	oprEq
+	oprLT
+	oprLE
+	oprNE
+	oprGT
+	oprGE
+	oprAnd
+	oprOr
+	oprNoBinary
+)
+
+const (
+	kindVoid = iota // no value
+	kindNil
+	kindTrue
+	kindFalse
+	kindConstant       // info = index of constant
+	kindNumber         // value = numerical value
+	kindNonRelocatable // info = result register
+	kindLocal          // info = local register
+	kindUpValue        // info = index of upvalue
+	kindIndexed        // table = table register/upvalue, index = register/constant index
+	kindJump           // info = instruction pc
+	kindRelocatable    // info = instruction pc
+	kindCall           // info = instruction pc
+	kindVarArg         // info = instruction pc
+)
+
+var kinds []string = []string{
+	"void",
+	"nil",
+	"true",
+	"false",
+	"constant",
+	"number",
+	"nonrelocatable",
+	"local",
+	"upvalue",
+	"indexed",
+	"jump",
+	"relocatable",
+	"call",
+	"vararg",
+}
+
+type exprDesc struct {
+	kind      int
+	index     int // register/constant index
+	table     int // register or upvalue
+	tableType int // whether 'table' is register (kindLocal) or upvalue (kindUpValue)
+	info      int
+	t, f      int // patch lists for 'exit when true/false'
+	value     float64
+}
+
+type assignmentTarget struct {
+	previous *assignmentTarget
+	exprDesc
+}
+
+type label struct {
+	name                string
+	pc, line            int
+	activeVariableCount int
+}
+
+type block struct {
+	previous              *block
+	firstLabel, firstGoto int
+	activeVariableCount   int
+	hasUpValue, isLoop    bool
+}
+
+type function struct {
+	constantLookup      map[value]int
+	f                   *prototype
+	previous            *function
+	p                   *parser
+	block               *block
+	jumpPC, lastTarget  int
+	freeRegisterCount   int
+	activeVariableCount int
+	firstLocal          int
+}
+
+func (f *function) OpenFunction(line int) {
+	f.f.prototypes = append(f.f.prototypes, prototype{source: f.p.source, maxStackSize: 2, lineDefined: line})
+	f.p.function = &function{f: &f.f.prototypes[len(f.f.prototypes)-1], constantLookup: make(map[value]int), previous: f, p: f.p, jumpPC: noJump, firstLocal: len(f.p.activeVariables)}
+	f.p.function.EnterBlock(false)
+}
+
+func (f *function) CloseFunction() exprDesc {
+	e := f.previous.ExpressionToNextRegister(makeExpression(kindRelocatable, f.previous.encodeABx(opClosure, 0, len(f.previous.f.prototypes)-1)))
+	f.ReturnNone()
+	f.LeaveBlock()
+	f.assert(f.block == nil)
+	f.p.function = f.previous
+	return e
+}
+
+func (f *function) EnterBlock(isLoop bool) {
+	// TODO www.lua.org uses a trick here to stack allocate the block, and chain blocks in the stack
+	f.block = &block{previous: f.block, firstLabel: len(f.p.activeLabels), firstGoto: len(f.p.pendingGotos), activeVariableCount: f.activeVariableCount, isLoop: isLoop}
+	f.assert(f.freeRegisterCount == f.activeVariableCount)
+}
+
+func (f *function) undefinedGotoError(g label) {
+	if isReserved(g.name) {
+		f.semanticError(fmt.Sprintf("<%s> at line %d not inside a loop", g.name, g.line))
+	} else {
+		f.semanticError(fmt.Sprintf("no visible label '%s' for <goto> at line %d", g.name, g.line))
+	}
+}
+
+func (f *function) LocalVariable(i int) *localVariable {
+	index := f.p.activeVariables[f.firstLocal+i]
+	return &f.f.localVariables[index]
+}
+
+func (f *function) AdjustLocalVariables(n int) {
+	for f.activeVariableCount += n; n != 0; n-- {
+		f.LocalVariable(f.activeVariableCount - n).startPC = pc(len(f.f.code))
+	}
+}
+
+func (f *function) removeLocalVariables(level int) {
+	for i := level; i < f.activeVariableCount; i++ {
+		f.LocalVariable(i).endPC = pc(len(f.f.code))
+	}
+	f.p.activeVariables = f.p.activeVariables[:len(f.p.activeVariables)-(f.activeVariableCount-level)]
+	f.activeVariableCount = level
+}
+
+func (f *function) MakeLocalVariable(name string) {
+	r := len(f.f.localVariables)
+	f.f.localVariables = append(f.f.localVariables, localVariable{name: name})
+	f.p.checkLimit(len(f.p.activeVariables)+1-f.firstLocal, maxLocalVariables, "local variables")
+	f.p.activeVariables = append(f.p.activeVariables, r)
+}
+
+func (f *function) MakeGoto(name string, line, pc int) {
+	f.p.pendingGotos = append(f.p.pendingGotos, label{name: name, line: line, pc: pc, activeVariableCount: f.activeVariableCount})
+	f.findLabel(len(f.p.pendingGotos) - 1)
+}
+
+func (f *function) MakeLabel(name string, line int) int {
+	f.p.activeLabels = append(f.p.activeLabels, label{name: name, line: line, pc: len(f.f.code), activeVariableCount: f.activeVariableCount})
+	return len(f.p.activeLabels) - 1
+}
+
+func (f *function) closeGoto(i int, l label) {
+	g := f.p.pendingGotos[i]
+	if f.assert(g.name == l.name); g.activeVariableCount < l.activeVariableCount {
+		f.semanticError(fmt.Sprintf("<goto %s> at line %d jumps into the scope of local '%s'", g.name, g.line, f.LocalVariable(g.activeVariableCount).name))
+	}
+	f.PatchList(g.pc, l.pc)
+	copy(f.p.pendingGotos[i:], f.p.pendingGotos[i+1:])
+	f.p.pendingGotos = f.p.pendingGotos[:len(f.p.pendingGotos)-1]
+}
+
+func (f *function) findLabel(i int) int {
+	g, b := f.p.pendingGotos[i], f.block
+	for _, l := range f.p.activeLabels[b.firstLabel:] {
+		if l.name == g.name {
+			if g.activeVariableCount > l.activeVariableCount && (b.hasUpValue || len(f.p.activeLabels) > b.firstLabel) {
+				f.PatchClose(g.pc, l.activeVariableCount)
+			}
+			f.closeGoto(i, l)
+			return 0
+		}
+	}
+	return 1
+}
+
+func (f *function) CheckRepeatedLabel(name string) {
+	for _, l := range f.p.activeLabels[f.block.firstLabel:] {
+		if l.name == name {
+			f.semanticError(fmt.Sprintf("label '%s' already defined on line %d", name, l.line))
+		}
+	}
+}
+
+func (f *function) FindGotos(label int) {
+	for i, l := f.block.firstGoto, f.p.activeLabels[label]; i < len(f.p.pendingGotos); {
+		if f.p.pendingGotos[i].name == l.name {
+			f.closeGoto(i, l)
+		} else {
+			i++
+		}
+	}
+}
+
+func (f *function) moveGotosOut(b block) {
+	for i := b.firstGoto; i < len(f.p.pendingGotos); i += f.findLabel(i) {
+		if f.p.pendingGotos[i].activeVariableCount > b.activeVariableCount {
+			if b.hasUpValue {
+				f.PatchClose(f.p.pendingGotos[i].pc, b.activeVariableCount)
+			}
+			f.p.pendingGotos[i].activeVariableCount = b.activeVariableCount
+		}
+	}
+}
+
+func (f *function) LeaveBlock() {
+	b := f.block
+	if b.previous != nil && b.hasUpValue { // create a 'jump to here' to close upvalues
+		j := f.Jump()
+		f.PatchClose(j, b.activeVariableCount)
+		f.PatchToHere(j)
+	}
+	if b.isLoop {
+		f.breakLabel() // close pending breaks
+	}
+	f.block = b.previous
+	f.removeLocalVariables(b.activeVariableCount)
+	f.assert(b.activeVariableCount == f.activeVariableCount)
+	f.freeRegisterCount = f.activeVariableCount
+	f.p.activeLabels = f.p.activeLabels[:b.firstLabel]
+	if b.previous != nil { // inner block
+		f.moveGotosOut(*b) // update pending gotos to outer block
+	} else if b.firstGoto < len(f.p.pendingGotos) { // pending gotos in outer block
+		f.undefinedGotoError(f.p.pendingGotos[b.firstGoto])
+	}
+}
+
+func abs(i int) int {
+	if i < 0 {
+		return -i
+	}
+	return i
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func not(b int) int {
+	if b == 0 {
+		return 1
+	}
+	return 0
+}
+
+func makeExpression(kind, info int) exprDesc {
+	return exprDesc{f: noJump, t: noJump, kind: kind, info: info}
+}
+
+func (f *function) semanticError(message string) {
+	f.p.t = 0 // remove "near to" from final message
+	f.p.syntaxError(message)
+}
+
+func (f *function) breakLabel()                         { f.FindGotos(f.MakeLabel("break", 0)) }
+func (f *function) unreachable()                        { f.assert(false) }
+func (f *function) assert(cond bool)                    { f.p.l.assert(cond) }
+func (f *function) Instruction(e exprDesc) *instruction { return &f.f.code[e.info] }
+func (e exprDesc) hasJumps() bool                       { return e.t != e.f }
+func (e exprDesc) isNumeral() bool                      { return e.kind == kindNumber && e.t == noJump && e.f == noJump }
+func (e exprDesc) isVariable() bool                     { return kindLocal <= e.kind && e.kind <= kindIndexed }
+func (e exprDesc) hasMultipleReturns() bool             { return e.kind == kindCall || e.kind == kindVarArg }
+
+func (f *function) assertEqual(a, b interface{}) {
+	if a != b {
+		panic(fmt.Sprintf("%v != %v", a, b))
+	}
+}
+
+func (f *function) encode(i instruction) int {
+	f.assert(len(f.f.code) == len(f.f.lineInfo))
+	f.dischargeJumpPC()
+	f.f.code = append(f.f.code, i)
+	f.f.lineInfo = append(f.f.lineInfo, int32(f.p.lastLine))
+	return len(f.f.code) - 1
+}
+
+func (f *function) dropLastInstruction() {
+	f.assert(len(f.f.code) == len(f.f.lineInfo))
+	f.f.code = f.f.code[:len(f.f.code)-1]
+	f.f.lineInfo = f.f.lineInfo[:len(f.f.lineInfo)-1]
+}
+
+func (f *function) EncodeABC(op opCode, a, b, c int) int {
+	f.assert(opMode(op) == iABC)
+	f.assert(bMode(op) != opArgN || b == 0)
+	f.assert(cMode(op) != opArgN || c == 0)
+	f.assert(a <= maxArgA && b <= maxArgB && c <= maxArgC)
+	return f.encode(createABC(op, a, b, c))
+}
+
+func (f *function) encodeABx(op opCode, a, bx int) int {
+	f.assert(opMode(op) == iABx || opMode(op) == iAsBx)
+	f.assert(cMode(op) == opArgN)
+	f.assert(a <= maxArgA && bx <= maxArgBx)
+	return f.encode(createABx(op, a, bx))
+}
+
+func (f *function) encodeAsBx(op opCode, a, sbx int) int { return f.encodeABx(op, a, sbx+maxArgSBx) }
+
+func (f *function) encodeExtraArg(a int) int {
+	f.assert(a <= maxArgAx)
+	return f.encode(createAx(opExtraArg, a))
+}
+
+func (f *function) EncodeConstant(r, constant int) int {
+	if constant <= maxArgBx {
+		return f.encodeABx(opLoadConstant, r, constant)
+	}
+	pc := f.encodeABx(opLoadConstant, r, 0)
+	f.encodeExtraArg(constant)
+	return pc
+}
+
+func (f *function) EncodeString(s string) exprDesc {
+	return makeExpression(kindConstant, f.stringConstant(s))
+}
+
+func (f *function) loadNil(from, n int) {
+	if len(f.f.code) > f.lastTarget { // no jumps to current position
+		if previous := &f.f.code[len(f.f.code)-1]; previous.opCode() == opLoadNil {
+			if pf, pl, l := previous.a(), previous.a()+previous.b(), from+n-1; pf <= from && from <= pl+1 || from <= pf && pf <= l+1 { // can connect both
+				from, l = min(from, pf), max(l, pl)
+				previous.setA(from)
+				previous.setB(l - from)
+				return
+			}
+		}
+	}
+	f.EncodeABC(opLoadNil, from, n-1, 0)
+}
+
+func (f *function) Jump() int {
+	f.assert(f.isJumpListWalkable(f.jumpPC))
+	jumpPC := f.jumpPC
+	f.jumpPC = noJump
+	return f.Concatenate(f.encodeAsBx(opJump, 0, noJump), jumpPC)
+}
+
+func (f *function) JumpTo(target int)             { f.PatchList(f.Jump(), target) }
+func (f *function) ReturnNone()                   { f.EncodeABC(opReturn, 0, 1, 0) }
+func (f *function) SetMultipleReturns(e exprDesc) { f.setReturns(e, MultipleReturns) }
+
+func (f *function) Return(e exprDesc, resultCount int) {
+	if e.hasMultipleReturns() {
+		if f.SetMultipleReturns(e); e.kind == kindCall && resultCount == 1 {
+			f.Instruction(e).setOpCode(opTailCall)
+			f.assert(f.Instruction(e).a() == f.activeVariableCount)
+		}
+		f.EncodeABC(opReturn, f.activeVariableCount, MultipleReturns+1, 0)
+	} else if resultCount == 1 {
+		f.EncodeABC(opReturn, f.ExpressionToAnyRegister(e).info, 1+1, 0)
+	} else {
+		_ = f.ExpressionToNextRegister(e)
+		f.assert(resultCount == f.freeRegisterCount-f.activeVariableCount)
+		f.EncodeABC(opReturn, f.activeVariableCount, resultCount+1, 0)
+	}
+}
+
+func (f *function) conditionalJump(op opCode, a, b, c int) int {
+	f.EncodeABC(op, a, b, c)
+	return f.Jump()
+}
+
+func (f *function) fixJump(pc, dest int) {
+	f.assert(f.isJumpListWalkable(pc))
+	f.assert(dest != noJump)
+	offset := dest - (pc + 1)
+	if abs(offset) > maxArgSBx {
+		f.p.syntaxError("control structure too long")
+	}
+	f.f.code[pc].setSBx(offset)
+}
+
+func (f *function) Label() int {
+	f.lastTarget = len(f.f.code)
+	return f.lastTarget
+}
+
+func (f *function) jump(pc int) int {
+	f.assert(f.isJumpListWalkable(pc))
+	if offset := f.f.code[pc].sbx(); offset != noJump {
+		return pc + 1 + offset
+	}
+	return noJump
+}
+
+func (f *function) isJumpListWalkable(list int) bool {
+	if list == noJump {
+		return true
+	}
+	if list < 0 || list >= len(f.f.code) {
+		return false
+	}
+	offset := f.f.code[list].sbx()
+	return offset == noJump || f.isJumpListWalkable(list+1+offset)
+}
+
+func (f *function) jumpControl(pc int) *instruction {
+	if pc >= 1 && testTMode(f.f.code[pc-1].opCode()) {
+		return &f.f.code[pc-1]
+	}
+	return &f.f.code[pc]
+}
+
+func (f *function) needValue(list int) bool {
+	f.assert(f.isJumpListWalkable(list))
+	for ; list != noJump; list = f.jump(list) {
+		if f.jumpControl(list).opCode() != opTestSet {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *function) patchTestRegister(node, register int) bool {
+	if i := f.jumpControl(node); i.opCode() != opTestSet {
+		return false
+	} else if register != noRegister && register != i.b() {
+		i.setA(register)
+	} else {
+		*i = createABC(opTest, i.b(), 0, i.c())
+	}
+	return true
+}
+
+func (f *function) removeValues(list int) {
+	f.assert(f.isJumpListWalkable(list))
+	for ; list != noJump; list = f.jump(list) {
+		_ = f.patchTestRegister(list, noRegister)
+	}
+}
+
+func (f *function) patchListHelper(list, target, register, defaultTarget int) {
+	f.assert(f.isJumpListWalkable(list))
+	for list != noJump {
+		next := f.jump(list)
+		if f.patchTestRegister(list, register) {
+			f.fixJump(list, target)
+		} else {
+			f.fixJump(list, defaultTarget)
+		}
+		list = next
+	}
+}
+
+func (f *function) dischargeJumpPC() {
+	f.assert(f.isJumpListWalkable(f.jumpPC))
+	f.patchListHelper(f.jumpPC, len(f.f.code), noRegister, len(f.f.code))
+	f.jumpPC = noJump
+}
+
+func (f *function) PatchList(list, target int) {
+	if target == len(f.f.code) {
+		f.PatchToHere(list)
+	} else {
+		f.assert(target < len(f.f.code))
+		f.patchListHelper(list, target, noRegister, target)
+	}
+}
+
+func (f *function) PatchClose(list, level int) {
+	f.assert(f.isJumpListWalkable(list))
+	for level, next := level+1, 0; list != noJump; list = next {
+		next = f.jump(list)
+		f.assert(f.f.code[list].opCode() == opJump && f.f.code[list].a() == 0 || f.f.code[list].a() >= level)
+		f.f.code[list].setA(level)
+	}
+}
+
+func (f *function) PatchToHere(list int) {
+	f.assert(f.isJumpListWalkable(list))
+	f.assert(f.isJumpListWalkable(f.jumpPC))
+	f.Label()
+	f.jumpPC = f.Concatenate(f.jumpPC, list)
+	f.assert(f.isJumpListWalkable(f.jumpPC))
+}
+
+func (f *function) Concatenate(l1, l2 int) int {
+	f.assert(f.isJumpListWalkable(l1))
+	switch {
+	case l2 == noJump:
+	case l1 == noJump:
+		return l2
+	default:
+		list := l1
+		for next := f.jump(list); next != noJump; list, next = next, f.jump(next) {
+		}
+		f.fixJump(list, l2)
+	}
+	return l1
+}
+
+func (f *function) addConstant(k, v value) int {
+	if index, ok := f.constantLookup[k]; ok && f.f.constants[index] == v {
+		return index
+	}
+	index := len(f.f.constants)
+	f.constantLookup[k] = index
+	f.f.constants = append(f.f.constants, v)
+	return index
+}
+
+func (f *function) NumberConstant(n float64) int {
+	if n == 0.0 || math.IsNaN(n) {
+		return f.addConstant(math.Float64bits(n), n)
+	}
+	return f.addConstant(n, n)
+}
+
+func (f *function) CheckStack(n int) {
+	if n += f.freeRegisterCount; n >= maxStack {
+		f.p.syntaxError("function or expression too complex")
+	} else if n > f.f.maxStackSize {
+		f.f.maxStackSize = n
+	}
+}
+
+func (f *function) ReserveRegisters(n int) {
+	f.CheckStack(n)
+	f.freeRegisterCount += n
+}
+
+func (f *function) freeRegister(r int) {
+	if !isConstant(r) && r >= f.activeVariableCount {
+		f.freeRegisterCount--
+		f.assertEqual(r, f.freeRegisterCount)
+	}
+}
+
+func (f *function) freeExpression(e exprDesc) {
+	if e.kind == kindNonRelocatable {
+		f.freeRegister(e.info)
+	}
+}
+
+func (f *function) stringConstant(s string) int { return f.addConstant(s, s) }
+func (f *function) booleanConstant(b bool) int  { return f.addConstant(b, b) }
+func (f *function) nilConstant() int            { return f.addConstant(f, nil) }
+
+func (f *function) setReturns(e exprDesc, resultCount int) {
+	if e.kind == kindCall {
+		f.Instruction(e).setC(resultCount + 1)
+	} else if e.kind == kindVarArg {
+		f.Instruction(e).setB(resultCount + 1)
+		f.Instruction(e).setA(f.freeRegisterCount)
+		f.ReserveRegisters(1)
+	}
+}
+
+func (f *function) SetReturn(e exprDesc) exprDesc {
+	if e.kind == kindCall {
+		e.kind, e.info = kindNonRelocatable, f.Instruction(e).a()
+	} else if e.kind == kindVarArg {
+		f.Instruction(e).setB(2)
+		e.kind = kindRelocatable
+	}
+	return e
+}
+
+func (f *function) DischargeVariables(e exprDesc) exprDesc {
+	switch e.kind {
+	case kindLocal:
+		e.kind = kindNonRelocatable
+	case kindUpValue:
+		e.kind, e.info = kindRelocatable, f.EncodeABC(opGetUpValue, 0, e.info, 0)
+	case kindIndexed:
+		if f.freeRegister(e.index); e.tableType == kindLocal {
+			f.freeRegister(e.table)
+			e.kind, e.info = kindRelocatable, f.EncodeABC(opGetTable, 0, e.table, e.index)
+		} else {
+			e.kind, e.info = kindRelocatable, f.EncodeABC(opGetTableUp, 0, e.table, e.index)
+		}
+	case kindVarArg, kindCall:
+		e = f.SetReturn(e)
+	}
+	return e
+}
+
+func (f *function) dischargeToRegister(e exprDesc, r int) exprDesc {
+	switch e = f.DischargeVariables(e); e.kind {
+	case kindNil:
+		f.loadNil(r, 1)
+	case kindFalse:
+		f.EncodeABC(opLoadBool, r, 0, 0)
+	case kindTrue:
+		f.EncodeABC(opLoadBool, r, 1, 0)
+	case kindConstant:
+		f.EncodeConstant(r, e.info)
+	case kindNumber:
+		f.EncodeConstant(r, f.NumberConstant(e.value))
+	case kindRelocatable:
+		f.Instruction(e).setA(r)
+	case kindNonRelocatable:
+		if r != e.info {
+			f.EncodeABC(opMove, r, e.info, 0)
+		}
+	default:
+		f.assert(e.kind == kindVoid || e.kind == kindJump)
+		return e
+	}
+	e.kind, e.info = kindNonRelocatable, r
+	return e
+}
+
+func (f *function) dischargeToAnyRegister(e exprDesc) exprDesc {
+	if e.kind != kindNonRelocatable {
+		f.ReserveRegisters(1)
+		e = f.dischargeToRegister(e, f.freeRegisterCount-1)
+	}
+	return e
+}
+
+func (f *function) encodeLabel(a, b, jump int) int {
+	f.Label()
+	return f.EncodeABC(opLoadBool, a, b, jump)
+}
+
+func (f *function) expressionToRegister(e exprDesc, r int) exprDesc {
+	if e = f.dischargeToRegister(e, r); e.kind == kindJump {
+		e.t = f.Concatenate(e.t, e.info)
+	}
+	if e.hasJumps() {
+		loadFalse, loadTrue := noJump, noJump
+		if f.needValue(e.t) || f.needValue(e.f) {
+			jump := noJump
+			if e.kind != kindJump {
+				jump = f.Jump()
+			}
+			loadFalse, loadTrue = f.encodeLabel(r, 0, 1), f.encodeLabel(r, 1, 0)
+			f.PatchToHere(jump)
+		}
+		end := f.Label()
+		f.patchListHelper(e.f, end, r, loadFalse)
+		f.patchListHelper(e.t, end, r, loadTrue)
+	}
+	e.f, e.t, e.info, e.kind = noJump, noJump, r, kindNonRelocatable
+	return e
+}
+
+func (f *function) ExpressionToNextRegister(e exprDesc) exprDesc {
+	e = f.DischargeVariables(e)
+	f.freeExpression(e)
+	f.ReserveRegisters(1)
+	return f.expressionToRegister(e, f.freeRegisterCount-1)
+}
+
+func (f *function) ExpressionToAnyRegister(e exprDesc) exprDesc {
+	if e = f.DischargeVariables(e); e.kind == kindNonRelocatable {
+		if !e.hasJumps() {
+			return e
+		}
+		if e.info >= f.activeVariableCount {
+			return f.expressionToRegister(e, e.info)
+		}
+	}
+	return f.ExpressionToNextRegister(e)
+}
+
+func (f *function) ExpressionToAnyRegisterOrUpValue(e exprDesc) exprDesc {
+	if e.kind != kindUpValue || e.hasJumps() {
+		e = f.ExpressionToAnyRegister(e)
+	}
+	return e
+}
+
+func (f *function) ExpressionToValue(e exprDesc) exprDesc {
+	if e.hasJumps() {
+		return f.ExpressionToAnyRegister(e)
+	}
+	return f.DischargeVariables(e)
+}
+
+func (f *function) expressionToRegisterOrConstant(e exprDesc) (exprDesc, int) {
+	switch e = f.ExpressionToValue(e); e.kind {
+	case kindTrue, kindFalse:
+		if len(f.f.constants) <= maxIndexRK {
+			e.info, e.kind = f.booleanConstant(e.kind == kindTrue), kindConstant
+			return e, asConstant(e.info)
+		}
+	case kindNil:
+		if len(f.f.constants) <= maxIndexRK {
+			e.info, e.kind = f.nilConstant(), kindConstant
+			return e, asConstant(e.info)
+		}
+	case kindNumber:
+		e.info, e.kind = f.NumberConstant(e.value), kindConstant
+		fallthrough
+	case kindConstant:
+		if e.info <= maxIndexRK {
+			return e, asConstant(e.info)
+		}
+	}
+	e = f.ExpressionToAnyRegister(e)
+	return e, e.info
+}
+
+func (f *function) StoreVariable(v, e exprDesc) {
+	switch v.kind {
+	case kindLocal:
+		f.freeExpression(e)
+		f.expressionToRegister(e, v.info)
+		return
+	case kindUpValue:
+		e = f.ExpressionToAnyRegister(e)
+		f.EncodeABC(opSetUpValue, e.info, v.info, 0)
+	case kindIndexed:
+		var r int
+		e, r = f.expressionToRegisterOrConstant(e)
+		if v.tableType == kindLocal {
+			f.EncodeABC(opSetTable, v.table, v.index, r)
+		} else {
+			f.EncodeABC(opSetTableUp, v.table, v.index, r)
+		}
+	default:
+		f.unreachable()
+	}
+	f.freeExpression(e)
+}
+
+func (f *function) Self(e, key exprDesc) exprDesc {
+	e = f.ExpressionToAnyRegister(e)
+	r := e.info
+	f.freeExpression(e)
+	result := exprDesc{info: f.freeRegisterCount, kind: kindNonRelocatable} // base register for opSelf
+	f.ReserveRegisters(2)                                                   // function and 'self' produced by opSelf
+	key, k := f.expressionToRegisterOrConstant(key)
+	f.EncodeABC(opSelf, result.info, r, k)
+	f.freeExpression(key)
+	return result
+}
+
+func (f *function) invertJump(pc int) {
+	i := f.jumpControl(pc)
+	f.p.l.assert(testTMode(i.opCode()) && i.opCode() != opTestSet && i.opCode() != opTest)
+	i.setA(not(i.a()))
+}
+
+func (f *function) jumpOnCondition(e exprDesc, cond int) int {
+	if e.kind == kindRelocatable {
+		if i := f.Instruction(e); i.opCode() == opNot {
+			f.dropLastInstruction() // remove previous opNot
+			return f.conditionalJump(opTest, i.b(), 0, not(cond))
+		}
+	}
+	e = f.dischargeToAnyRegister(e)
+	f.freeExpression(e)
+	return f.conditionalJump(opTestSet, noRegister, e.info, cond)
+}
+
+func (f *function) GoIfTrue(e exprDesc) exprDesc {
+	pc := noJump
+	switch e = f.DischargeVariables(e); e.kind {
+	case kindJump:
+		f.invertJump(e.info)
+		pc = e.info
+	case kindConstant, kindNumber, kindTrue:
+	default:
+		pc = f.jumpOnCondition(e, 0)
+	}
+	e.f = f.Concatenate(e.f, pc)
+	f.PatchToHere(e.t)
+	e.t = noJump
+	return e
+}
+
+func (f *function) GoIfFalse(e exprDesc) exprDesc {
+	pc := noJump
+	switch e = f.DischargeVariables(e); e.kind {
+	case kindJump:
+		pc = e.info
+	case kindNil, kindFalse:
+	default:
+		pc = f.jumpOnCondition(e, 1)
+	}
+	e.t = f.Concatenate(e.t, pc)
+	f.PatchToHere(e.f)
+	e.f = noJump
+	return e
+}
+
+func (f *function) encodeNot(e exprDesc) exprDesc {
+	switch e = f.DischargeVariables(e); e.kind {
+	case kindNil, kindFalse:
+		e.kind = kindTrue
+	case kindConstant, kindNumber, kindTrue:
+		e.kind = kindFalse
+	case kindJump:
+		f.invertJump(e.info)
+	case kindRelocatable, kindNonRelocatable:
+		e = f.dischargeToAnyRegister(e)
+		f.freeExpression(e)
+		e.info, e.kind = f.EncodeABC(opNot, 0, e.info, 0), kindRelocatable
+	default:
+		f.unreachable()
+	}
+	e.f, e.t = e.t, e.f
+	f.removeValues(e.f)
+	f.removeValues(e.t)
+	return e
+}
+
+func (f *function) Indexed(t, k exprDesc) (r exprDesc) {
+	f.assert(!t.hasJumps())
+	r = makeExpression(kindIndexed, 0)
+	r.table = t.info
+	k, r.index = f.expressionToRegisterOrConstant(k)
+	if t.kind == kindUpValue {
+		r.tableType = kindUpValue
+	} else {
+		f.assert(t.kind == kindNonRelocatable || t.kind == kindLocal)
+		r.tableType = kindLocal
+	}
+	return
+}
+
+func foldConstants(op opCode, e1, e2 exprDesc) (exprDesc, bool) {
+	if !e1.isNumeral() || !e2.isNumeral() {
+		return e1, false
+	} else if (op == opDiv || op == opMod) && e2.value == 0.0 {
+		return e1, false
+	}
+	e1.value = arith(Operator(op-opAdd)+OpAdd, e1.value, e2.value)
+	return e1, true
+}
+
+func (f *function) encodeArithmetic(op opCode, e1, e2 exprDesc, line int) exprDesc {
+	if e, folded := foldConstants(op, e1, e2); folded {
+		return e
+	}
+	o2 := 0
+	if op != opUnaryMinus && op != opLength {
+		e2, o2 = f.expressionToRegisterOrConstant(e2)
+	}
+	e1, o1 := f.expressionToRegisterOrConstant(e1)
+	if o1 > o2 {
+		f.freeExpression(e1)
+		f.freeExpression(e2)
+	} else {
+		f.freeExpression(e2)
+		f.freeExpression(e1)
+	}
+	e1.info, e1.kind = f.EncodeABC(op, 0, o1, o2), kindRelocatable
+	f.FixLine(line)
+	return e1
+}
+
+func (f *function) Prefix(op int, e exprDesc, line int) exprDesc {
+	switch op {
+	case oprMinus:
+		if e.isNumeral() {
+			e.value = -e.value
+			return e
+		} else {
+			return f.encodeArithmetic(opUnaryMinus, f.ExpressionToAnyRegister(e), makeExpression(kindNumber, 0), line)
+		}
+	case oprNot:
+		return f.encodeNot(e)
+	case oprLength:
+		return f.encodeArithmetic(opLength, f.ExpressionToAnyRegister(e), makeExpression(kindNumber, 0), line)
+	}
+	panic("unreachable")
+}
+
+func (f *function) Infix(op int, e exprDesc) exprDesc {
+	switch op {
+	case oprAnd:
+		e = f.GoIfTrue(e)
+	case oprOr:
+		e = f.GoIfFalse(e)
+	case oprConcat:
+		e = f.ExpressionToNextRegister(e)
+	case oprAdd, oprSub, oprMul, oprDiv, oprMod, oprPow:
+		if !e.isNumeral() {
+			e, _ = f.expressionToRegisterOrConstant(e)
+		}
+	default:
+		e, _ = f.expressionToRegisterOrConstant(e)
+	}
+	return e
+}
+
+func (f *function) encodeComparison(op opCode, cond int, e1, e2 exprDesc) exprDesc {
+	e1, o1 := f.expressionToRegisterOrConstant(e1)
+	e2, o2 := f.expressionToRegisterOrConstant(e2)
+	f.freeExpression(e2)
+	f.freeExpression(e1)
+	if cond == 0 && op != opEqual {
+		o1, o2, cond = o2, o1, 1
+	}
+	return makeExpression(kindJump, f.conditionalJump(op, cond, o1, o2))
+}
+
+func (f *function) Postfix(op int, e1, e2 exprDesc, line int) exprDesc {
+	switch op {
+	case oprAnd:
+		f.assert(e1.t == noJump)
+		e2 = f.DischargeVariables(e2)
+		e2.f = f.Concatenate(e2.f, e1.f)
+		return e2
+	case oprOr:
+		f.assert(e1.f == noJump)
+		e2 = f.DischargeVariables(e2)
+		e2.t = f.Concatenate(e2.t, e1.t)
+		return e2
+	case oprConcat:
+		if e2 = f.ExpressionToValue(e2); e2.kind == kindRelocatable && f.Instruction(e2).opCode() == opConcat {
+			f.assert(e1.info == f.Instruction(e2).b()-1)
+			f.freeExpression(e1)
+			f.Instruction(e2).setB(e1.info)
+			return makeExpression(kindRelocatable, e2.info)
+		}
+		return f.encodeArithmetic(opConcat, e1, f.ExpressionToNextRegister(e2), line)
+	case oprAdd, oprSub, oprMul, oprDiv, oprMod, oprPow:
+		return f.encodeArithmetic(opCode(op-oprAdd)+opAdd, e1, e2, line)
+	case oprEq, oprLT, oprLE:
+		return f.encodeComparison(opCode(op-oprEq)+opEqual, 1, e1, e2)
+	case oprNE, oprGT, oprGE:
+		return f.encodeComparison(opCode(op-oprNE)+opEqual, 0, e1, e2)
+	}
+	panic("unreachable")
+}
+
+func (f *function) FixLine(line int) { f.f.lineInfo[len(f.f.code)-1] = int32(line) }
+
+func (f *function) setList(base, elementCount, storeCount int) {
+	if f.assert(storeCount != 0); storeCount == MultipleReturns {
+		storeCount = 0
+	}
+	if c := (elementCount-1)/listItemsPerFlush + 1; c <= maxArgC {
+		f.EncodeABC(opSetList, base, storeCount, c)
+	} else if c <= maxArgAx {
+		f.EncodeABC(opSetList, base, storeCount, 0)
+		f.encodeExtraArg(c)
+	} else {
+		f.p.syntaxError("constructor too long")
+	}
+	f.freeRegisterCount = base + 1
+}
+
+func (f *function) CheckConflict(t *assignmentTarget, e exprDesc) {
+	extra, conflict := f.freeRegisterCount, false
+	for ; t != nil; t = t.previous {
+		if t.kind == kindIndexed {
+			if t.tableType == e.kind && t.table == e.info {
+				conflict = true
+				t.table, t.tableType = extra, kindLocal
+			}
+			if e.kind == kindLocal && t.index == e.info {
+				conflict = true
+				t.index = extra
+			}
+		}
+	}
+	if conflict {
+		if e.kind == kindLocal {
+			f.EncodeABC(opMove, extra, e.info, 0)
+		} else {
+			f.EncodeABC(opGetUpValue, extra, e.info, 0)
+		}
+		f.ReserveRegisters(1)
+	}
+}
+
+func (f *function) AdjustAssignment(variableCount, expressionCount int, e exprDesc) {
+	if extra := variableCount - expressionCount; e.hasMultipleReturns() {
+		if extra++; extra < 0 {
+			extra = 0
+		}
+		if f.setReturns(e, extra); extra > 1 {
+			f.ReserveRegisters(extra - 1)
+		}
+	} else {
+		if expressionCount > 0 {
+			_ = f.ExpressionToNextRegister(e)
+		}
+		if extra > 0 {
+			r := f.freeRegisterCount
+			f.ReserveRegisters(extra)
+			f.loadNil(r, extra)
+		}
+	}
+}
+
+func (f *function) makeUpValue(name string, e exprDesc) int {
+	f.p.checkLimit(len(f.f.upValues)+1, maxUpValue, "upvalues")
+	f.f.upValues = append(f.f.upValues, upValueDesc{name: name, isLocal: e.kind == kindLocal, index: e.info})
+	return len(f.f.upValues) - 1
+}
+
+func singleVariableHelper(f *function, name string, base bool) (e exprDesc, found bool) {
+	owningBlock := func(b *block, level int) *block {
+		for b.activeVariableCount > level {
+			b = b.previous
+		}
+		return b
+	}
+	find := func() (int, bool) {
+		for i := f.activeVariableCount - 1; i >= 0; i-- {
+			if name == f.LocalVariable(i).name {
+				return i, true
+			}
+		}
+		return 0, false
+	}
+	findUpValue := func() (int, bool) {
+		for i, u := range f.f.upValues {
+			if u.name == name {
+				return i, true
+			}
+		}
+		return 0, false
+	}
+	if f == nil {
+		return
+	}
+	var v int
+	if v, found = find(); found {
+		if e = makeExpression(kindLocal, v); !base {
+			owningBlock(f.block, v).hasUpValue = true
+		}
+		return
+	}
+	if v, found = findUpValue(); found {
+		return makeExpression(kindUpValue, v), true
+	}
+	if e, found = singleVariableHelper(f.previous, name, false); !found {
+		return
+	}
+	return makeExpression(kindUpValue, f.makeUpValue(name, e)), true
+}
+
+func (f *function) SingleVariable(name string) (e exprDesc) {
+	var found bool
+	if e, found = singleVariableHelper(f, name, true); !found {
+		e, found = singleVariableHelper(f, "_ENV", true)
+		f.assert(found && (e.kind == kindLocal || e.kind == kindUpValue))
+		e = f.Indexed(e, f.EncodeString(name))
+	}
+	return
+}
+
+func (f *function) OpenConstructor() (pc int, t exprDesc) {
+	pc = f.EncodeABC(opNewTable, 0, 0, 0)
+	t = f.ExpressionToNextRegister(makeExpression(kindRelocatable, pc))
+	return
+}
+
+func (f *function) FlushFieldToConstructor(tableRegister, freeRegisterCount int, k exprDesc, v func() exprDesc) {
+	_, rk := f.expressionToRegisterOrConstant(k)
+	_, rv := f.expressionToRegisterOrConstant(v())
+	f.EncodeABC(opSetTable, tableRegister, rk, rv)
+	f.freeRegisterCount = freeRegisterCount
+}
+
+func (f *function) FlushToConstructor(tableRegister, pending, arrayCount int, e exprDesc) int {
+	f.ExpressionToNextRegister(e)
+	if pending == listItemsPerFlush {
+		f.setList(tableRegister, arrayCount, listItemsPerFlush)
+		pending = 0
+	}
+	return pending
+}
+
+func (f *function) CloseConstructor(pc, tableRegister, pending, arrayCount, hashCount int, e exprDesc) {
+	if pending != 0 {
+		if e.hasMultipleReturns() {
+			f.SetMultipleReturns(e)
+			f.setList(tableRegister, arrayCount, MultipleReturns)
+			arrayCount--
+		} else {
+			if e.kind != kindVoid {
+				f.ExpressionToNextRegister(e)
+			}
+			f.setList(tableRegister, arrayCount, pending)
+		}
+	}
+	f.f.code[pc].setB(int(float8FromInt(arrayCount)))
+	f.f.code[pc].setC(int(float8FromInt(hashCount)))
+}
+
+func (f *function) OpenForBody(base, n int, isNumeric bool) (prep int) {
+	if isNumeric {
+		prep = f.encodeAsBx(opForPrep, base, noJump)
+	} else {
+		prep = f.Jump()
+	}
+	f.EnterBlock(false)
+	f.AdjustLocalVariables(n)
+	f.ReserveRegisters(n)
+	return
+}
+
+func (f *function) CloseForBody(prep, base, line, n int, isNumeric bool) {
+	f.LeaveBlock()
+	f.PatchToHere(prep)
+	var end int
+	if isNumeric {
+		end = f.encodeAsBx(opForLoop, base, noJump)
+	} else {
+		f.EncodeABC(opTForCall, base, 0, n)
+		f.FixLine(line)
+		end = f.encodeAsBx(opTForLoop, base+2, noJump)
+	}
+	f.PatchList(end, prep+1)
+	f.FixLine(line)
+}
+
+func (f *function) OpenMainFunction() {
+	f.EnterBlock(false)
+	f.makeUpValue("_ENV", makeExpression(kindLocal, 0))
+}
+
+func (f *function) CloseMainFunction() *function {
+	f.ReturnNone()
+	f.LeaveBlock()
+	f.assert(f.block == nil)
+	return f.previous
+}

--- a/vendor/github.com/Shopify/go-lua/config.go
+++ b/vendor/github.com/Shopify/go-lua/config.go
@@ -1,0 +1,20 @@
+package lua
+
+import "math"
+
+const (
+	maxStack          = 1000000
+	maxCallCount      = 200
+	errorStackSize    = maxStack + 200
+	extraStack        = 5
+	basicStackSize    = 2 * MinStack
+	maxTagLoop        = 100
+	firstPseudoIndex  = -maxStack - 1000
+	maxUpValue        = math.MaxUint8
+	idSize            = 60
+	apiCheck          = false
+	internalCheck     = false
+	pathListSeparator = ';'
+)
+
+var defaultPath = "./?.lua" // TODO "${LUA_LDIR}?.lua;${LUA_LDIR}?/init.lua;./?.lua"

--- a/vendor/github.com/Shopify/go-lua/debug.go
+++ b/vendor/github.com/Shopify/go-lua/debug.go
@@ -1,0 +1,577 @@
+package lua
+
+import (
+	"fmt"
+	"strings"
+)
+
+// A Frame is a token representing an activation record. It is returned by
+// Stack and passed to Info.
+type Frame *callInfo
+
+func (l *State) resetHookCount() { l.hookCount = l.baseHookCount }
+func (l *State) prototype(ci *callInfo) *prototype {
+	return l.stack[ci.function].(*luaClosure).prototype
+}
+func (l *State) currentLine(ci *callInfo) int {
+	return int(l.prototype(ci).lineInfo[ci.savedPC])
+}
+
+func chunkID(source string) string {
+	switch source[0] {
+	case '=': // "literal" source
+		if len(source) <= idSize {
+			return source[1:]
+		}
+		return source[1:idSize]
+	case '@': // file name
+		if len(source) <= idSize {
+			return source[1:]
+		}
+		return "..." + source[1:idSize-3]
+	}
+	source = strings.Split(source, "\n")[0]
+	if l := len("[string \"...\"]"); len(source) > idSize-l {
+		return "[string \"" + source + "...\"]"
+	}
+	return "[string \"" + source + "\"]"
+}
+
+func (l *State) runtimeError(message string) {
+	l.push(message)
+	if ci := l.callInfo; ci.isLua() {
+		line, source := l.currentLine(ci), l.prototype(ci).source
+		if source == "" {
+			source = "?"
+		} else {
+			source = chunkID(source)
+		}
+		l.push(fmt.Sprintf("%s:%d: %s", source, line, message))
+	}
+	l.errorMessage()
+}
+
+func (l *State) typeError(v value, operation string) {
+	typeName := l.valueToType(v).String()
+	if ci := l.callInfo; ci.isLua() {
+		c := l.stack[ci.function].(*luaClosure)
+		var kind, name string
+		isUpValue := func() bool {
+			for i, uv := range c.upValues {
+				if uv.value() == v {
+					kind, name = "upvalue", c.prototype.upValueName(i)
+					return true
+				}
+			}
+			return false
+		}
+		frameIndex := 0
+		isInStack := func() bool {
+			for i, e := range ci.frame {
+				if e == v {
+					frameIndex = i
+					return true
+				}
+			}
+			return false
+		}
+		if !isUpValue() && isInStack() {
+			name, kind = c.prototype.objectName(frameIndex, ci.savedPC)
+		}
+		if kind != "" {
+			l.runtimeError(fmt.Sprintf("attempt to %s %s '%s' (a %s value)", operation, kind, name, typeName))
+		}
+	}
+	l.runtimeError(fmt.Sprintf("attempt to %s a %s value", operation, typeName))
+}
+
+func (l *State) orderError(left, right value) {
+	leftType, rightType := l.valueToType(left).String(), l.valueToType(right).String()
+	if leftType == rightType {
+		l.runtimeError(fmt.Sprintf("attempt to compare two '%s' values", leftType))
+	}
+	l.runtimeError(fmt.Sprintf("attempt to compare '%s' with '%s'", leftType, rightType))
+}
+
+func (l *State) arithError(v1, v2 value) {
+	if _, ok := l.toNumber(v1); !ok {
+		v2 = v1
+	}
+	l.typeError(v2, "perform arithmetic on")
+}
+
+func (l *State) concatError(v1, v2 value) {
+	_, isString := v1.(string)
+	_, isNumber := v1.(float64)
+	if isString || isNumber {
+		v1 = v2
+	}
+	_, isString = v1.(string)
+	_, isNumber = v1.(float64)
+	l.assert(!isString && !isNumber)
+	l.typeError(v1, "concatenate")
+}
+
+func (l *State) assert(cond bool) {
+	if !cond {
+		l.runtimeError("assertion failure")
+	}
+}
+
+func (l *State) errorMessage() {
+	if l.errorFunction != 0 { // is there an error handling function?
+		errorFunction := l.stack[l.errorFunction]
+		switch errorFunction.(type) {
+		case closure:
+		case *goFunction:
+		default:
+			l.throw(ErrorError)
+		}
+		l.stack[l.top] = l.stack[l.top-1] // move argument
+		l.stack[l.top-1] = errorFunction  // push function
+		l.top++
+		l.call(l.top-2, 1, false)
+	}
+	l.throw(RuntimeError(CheckString(l, -1)))
+}
+
+// SetDebugHook sets the debugging hook function.
+//
+// f is the hook function. mask specifies on which events the hook will be
+// called: it is formed by a bitwise or of the constants MaskCall, MaskReturn,
+// MaskLine, and MaskCount. The count argument is only meaningful when the
+// mask includes MaskCount. For each event, the hook is called as explained
+// below:
+//
+// Call hook is called when the interpreter calls a function. The hook is
+// called just after Lua enters the new function, before the function gets
+// its arguments.
+//
+// Return hook is called when the interpreter returns from a function. The
+// hook is called just before Lua leaves the function. There is no standard
+// way to access the values to be returned by the function.
+//
+// Line hook is called when the interpreter is about to start the execution
+// of a new line of code, or when it jumps back in the code (even to the same
+// line). (This event only happens while Lua is executing a Lua function.)
+//
+// Count hook is called after the interpreter executes every count
+// instructions. (This event only happens while Lua is executing a Lua
+// function.)
+//
+// A hook is disabled by setting mask to zero.
+func SetDebugHook(l *State, f Hook, mask byte, count int) {
+	if f == nil || mask == 0 {
+		f, mask = nil, 0
+	}
+	if ci := l.callInfo; ci.isLua() {
+		l.oldPC = ci.savedPC
+	}
+	l.hooker, l.baseHookCount = f, count
+	l.resetHookCount()
+	l.hookMask = mask
+	l.internalHook = false
+}
+
+// DebugHook returns the current hook function.
+func DebugHook(l *State) Hook { return l.hooker }
+
+// DebugHookMask returns the current hook mask.
+func DebugHookMask(l *State) byte { return l.hookMask }
+
+// DebugHookCount returns the current hook count.
+func DebugHookCount(l *State) int { return l.hookCount }
+
+// Stack gets information about the interpreter runtime stack.
+//
+// It returns a Frame identifying the activation record of the
+// function executing at a given level. Level 0 is the current running
+// function, whereas level n+1 is the function that has called level n (except
+// for tail calls, which do not count on the stack). When there are no errors,
+// Stack returns true; when called with a level greater than the stack depth,
+// it returns false.
+func Stack(l *State, level int) (f Frame, ok bool) {
+	if level < 0 {
+		return // invalid (negative) level
+	}
+	callInfo := l.callInfo
+	for ; level > 0 && callInfo != &l.baseCallInfo; level, callInfo = level-1, callInfo.previous {
+	}
+	if level == 0 && callInfo != &l.baseCallInfo { // level found?
+		f, ok = callInfo, true
+	}
+	return
+}
+
+func functionInfo(p Debug, f closure) (d Debug) {
+	d = p
+	if l, ok := f.(*luaClosure); !ok {
+		d.Source = "=[Go]"
+		d.LineDefined, d.LastLineDefined = -1, -1
+		d.What = "Go"
+	} else {
+		p := l.prototype
+		d.Source = p.source
+		if d.Source == "" {
+			d.Source = "=?"
+		}
+		d.LineDefined, d.LastLineDefined = p.lineDefined, p.lastLineDefined
+		d.What = "Lua"
+		if d.LineDefined == 0 {
+			d.What = "main"
+		}
+	}
+	d.ShortSource = chunkID(d.Source)
+	return
+}
+
+func (l *State) functionName(ci *callInfo) (name, kind string) {
+	var tm tm
+	p := l.prototype(ci)
+	pc := ci.savedPC
+	switch i := p.code[pc]; i.opCode() {
+	case opCall, opTailCall:
+		return p.objectName(i.a(), pc)
+	case opTForCall:
+		return "for iterator", "for iterator"
+	case opSelf, opGetTableUp, opGetTable:
+		tm = tmIndex
+	case opSetTableUp, opSetTable:
+		tm = tmNewIndex
+	case opEqual:
+		tm = tmEq
+	case opAdd:
+		tm = tmAdd
+	case opSub:
+		tm = tmSub
+	case opMul:
+		tm = tmMul
+	case opDiv:
+		tm = tmDiv
+	case opMod:
+		tm = tmMod
+	case opPow:
+		tm = tmPow
+	case opUnaryMinus:
+		tm = tmUnaryMinus
+	case opLength:
+		tm = tmLen
+	case opLessThan:
+		tm = tmLT
+	case opLessOrEqual:
+		tm = tmLE
+	case opConcat:
+		tm = tmConcat
+	default:
+		return
+	}
+	return eventNames[tm], "metamethod"
+}
+
+func (l *State) collectValidLines(f closure) {
+	if lc, ok := f.(*luaClosure); !ok {
+		l.apiPush(nil)
+	} else {
+		t := newTable()
+		l.apiPush(t)
+		for _, i := range lc.prototype.lineInfo {
+			t.putAtInt(int(i), true)
+		}
+	}
+}
+
+// Info gets information about a specific function or function invocation.
+//
+// To get information about a function invocation, the parameter where must
+// be a valid activation record that was filled by a previous call to Stack
+// or given as an argument to a hook (see Hook).
+//
+// To get information about a function you push it onto the stack and start
+// the what string with the character '>'. (In that case, Info pops the
+// function from the top of the stack.) For instance, to know in which line
+// a function f was defined, you can write the following code:
+//   l.Global("f") // Get global 'f'.
+//   d, _ := lua.Info(l, ">S", nil)
+//   fmt.Printf("%d\n", d.LineDefined)
+//
+// Each character in the string what selects some fields of the Debug struct
+// to be filled or a value to be pushed on the stack:
+// 	 'n': fills in the field Name and NameKind
+// 	 'S': fills in the fields Source, ShortSource, LineDefined, LastLineDefined, and What
+// 	 'l': fills in the field CurrentLine
+// 	 't': fills in the field IsTailCall
+// 	 'u': fills in the fields UpValueCount, ParameterCount, and IsVarArg
+// 	 'f': pushes onto the stack the function that is running at the given level
+// 	 'L': pushes onto the stack a table whose indices are the numbers of the lines that are valid on the function
+// (A valid line is a line with some associated code, that is, a line where you
+// can put a break point. Non-valid lines include empty lines and comments.)
+//
+// This function returns false on error (for instance, an invalid option in what).
+func Info(l *State, what string, where Frame) (d Debug, ok bool) {
+	var f closure
+	var fun value
+	if what[0] == '>' {
+		where = nil
+		fun = l.stack[l.top-1]
+		switch fun := fun.(type) {
+		case closure:
+			f = fun
+		case *goFunction:
+		default:
+			panic("function expected")
+		}
+		what = what[1:] // skip the '>'
+		l.top--         // pop function
+	} else {
+		fun = l.stack[where.function]
+		switch fun := fun.(type) {
+		case closure:
+			f = fun
+		case *goFunction:
+		default:
+			l.assert(false)
+		}
+	}
+	ok, hasL, hasF := true, false, false
+	d.callInfo = where
+	ci := d.callInfo
+	for _, r := range what {
+		switch r {
+		case 'S':
+			d = functionInfo(d, f)
+		case 'l':
+			d.CurrentLine = -1
+			if where != nil && ci.isLua() {
+				d.CurrentLine = l.currentLine(where)
+			}
+		case 'u':
+			if f == nil {
+				d.UpValueCount = 0
+			} else {
+				d.UpValueCount = f.upValueCount()
+			}
+			if lf, ok := f.(*luaClosure); !ok {
+				d.IsVarArg = true
+				d.ParameterCount = 0
+			} else {
+				d.IsVarArg = lf.prototype.isVarArg
+				d.ParameterCount = lf.prototype.parameterCount
+			}
+		case 't':
+			d.IsTailCall = where != nil && ci.isCallStatus(callStatusTail)
+		case 'n':
+			// calling function is a known Lua function?
+			if where != nil && !ci.isCallStatus(callStatusTail) && where.previous.isLua() {
+				d.Name, d.NameKind = l.functionName(where.previous)
+			} else {
+				d.NameKind = ""
+			}
+			if d.NameKind == "" {
+				d.NameKind = "" // not found
+				d.Name = ""
+			}
+		case 'L':
+			hasL = true
+		case 'f':
+			hasF = true
+		default:
+			ok = false
+		}
+	}
+	if hasF {
+		l.apiPush(f)
+	}
+	if hasL {
+		l.collectValidLines(f)
+	}
+	return d, ok
+}
+
+func upValueHelper(f func(*State, int, int) (string, bool), returnValueCount int) Function {
+	return func(l *State) int {
+		CheckType(l, 1, TypeFunction)
+		if name, ok := f(l, 1, CheckInteger(l, 2)); !ok {
+			return 0
+		} else {
+			l.PushString(name)
+		}
+		l.Insert(-returnValueCount)
+		return returnValueCount
+	}
+}
+
+func (l *State) checkUpValue(f, upValueCount int) int {
+	n := CheckInteger(l, upValueCount)
+	CheckType(l, f, TypeFunction)
+	l.PushValue(f)
+	debug, _ := Info(l, ">u", nil)
+	ArgumentCheck(l, 1 <= n && n <= debug.UpValueCount, upValueCount, "invalue upvalue index")
+	return n
+}
+
+func threadArg(l *State) (int, *State) {
+	if l.IsThread(1) {
+		return 1, l.ToThread(1)
+	}
+	return 0, l
+}
+
+func hookTable(l *State) bool { return SubTable(l, RegistryIndex, "_HKEY") }
+
+func internalHook(l *State, d Debug) {
+	hookNames := []string{"call", "return", "line", "count", "tail call"}
+	hookTable(l)
+	l.PushThread()
+	l.RawGet(-2)
+	if l.IsFunction(-1) {
+		l.PushString(hookNames[d.Event])
+		if d.CurrentLine >= 0 {
+			l.PushInteger(d.CurrentLine)
+		} else {
+			l.PushNil()
+		}
+		_, ok := Info(l, "lS", d.callInfo)
+		l.assert(ok)
+		l.Call(2, 0)
+	}
+}
+
+func maskToString(mask byte) (s string) {
+	if mask&MaskCall != 0 {
+		s += "c"
+	}
+	if mask&MaskReturn != 0 {
+		s += "r"
+	}
+	if mask&MaskLine != 0 {
+		s += "l"
+	}
+	return
+}
+
+func stringToMask(s string, maskCount bool) (mask byte) {
+	for r, b := range map[rune]byte{'c': MaskCall, 'r': MaskReturn, 'l': MaskLine} {
+		if strings.ContainsRune(s, r) {
+			mask |= b
+		}
+	}
+	if maskCount {
+		mask |= MaskCount
+	}
+	return
+}
+
+var debugLibrary = []RegistryFunction{
+	// {"debug", db_debug},
+	{"getuservalue", func(l *State) int {
+		if l.TypeOf(1) != TypeUserData {
+			l.PushNil()
+		} else {
+			l.UserValue(1)
+		}
+		return 1
+	}},
+	{"gethook", func(l *State) int {
+		_, l1 := threadArg(l)
+		hooker, mask := DebugHook(l1), DebugHookMask(l1)
+		if hooker != nil && !l.internalHook {
+			l.PushString("external hook")
+		} else {
+			hookTable(l)
+			l1.PushThread()
+			//			XMove(l1, l, 1)
+			panic("XMove not implemented yet")
+			l.RawGet(-2)
+			l.Remove(-2)
+		}
+		l.PushString(maskToString(mask))
+		l.PushInteger(DebugHookCount(l1))
+		return 3
+	}},
+	// {"getinfo", db_getinfo},
+	// {"getlocal", db_getlocal},
+	{"getregistry", func(l *State) int { l.PushValue(RegistryIndex); return 1 }},
+	{"getmetatable", func(l *State) int {
+		CheckAny(l, 1)
+		if !l.MetaTable(1) {
+			l.PushNil()
+		}
+		return 1
+	}},
+	{"getupvalue", upValueHelper(UpValue, 2)},
+	{"upvaluejoin", func(l *State) int {
+		n1 := l.checkUpValue(1, 2)
+		n2 := l.checkUpValue(3, 4)
+		ArgumentCheck(l, !l.IsGoFunction(1), 1, "Lua function expected")
+		ArgumentCheck(l, !l.IsGoFunction(3), 3, "Lua function expected")
+		UpValueJoin(l, 1, n1, 3, n2)
+		return 0
+	}},
+	{"upvalueid", func(l *State) int { l.PushLightUserData(UpValueId(l, 1, l.checkUpValue(1, 2))); return 1 }},
+	{"setuservalue", func(l *State) int {
+		if l.TypeOf(1) == TypeLightUserData {
+			ArgumentError(l, 1, "full userdata expected, got light userdata")
+		}
+		CheckType(l, 1, TypeUserData)
+		if !l.IsNoneOrNil(2) {
+			CheckType(l, 2, TypeTable)
+		}
+		l.SetTop(2)
+		l.SetUserValue(1)
+		return 1
+	}},
+	{"sethook", func(l *State) int {
+		var hook Hook
+		var mask byte
+		var count int
+		i, l1 := threadArg(l)
+		if l.IsNoneOrNil(i + 1) {
+			l.SetTop(i + 1)
+		} else {
+			s := CheckString(l, i+2)
+			CheckType(l, i+1, TypeFunction)
+			count = OptInteger(l, i+3, 0)
+			hook, mask = internalHook, stringToMask(s, count > 0)
+		}
+		if !hookTable(l) {
+			l.PushString("k")
+			l.SetField(-2, "__mode")
+			l.PushValue(-1)
+			l.SetMetaTable(-2)
+		}
+		l1.PushThread()
+		//	 	XMove(l1, l, 1)
+		panic("XMove not yet implemented")
+		l.PushValue(i + 1)
+		l.RawSet(-3)
+		SetDebugHook(l1, hook, mask, count)
+		l1.internalHook = true
+		return 0
+	}},
+	// {"setlocal", db_setlocal},
+	{"setmetatable", func(l *State) int {
+		t := l.TypeOf(2)
+		ArgumentCheck(l, t == TypeNil || t == TypeTable, 2, "nil or table expected")
+		l.SetTop(2)
+		l.SetMetaTable(1)
+		return 1
+	}},
+	{"setupvalue", upValueHelper(SetUpValue, 1)},
+	{"traceback", func(l *State) int {
+		i, l1 := threadArg(l)
+		if s, ok := l.ToString(i + 1); !ok && !l.IsNoneOrNil(i+1) {
+			l.PushValue(i + 1)
+		} else if l == l1 {
+			Traceback(l, l, s, OptInteger(l, i+2, 1))
+		} else {
+			Traceback(l, l1, s, OptInteger(l, i+2, 0))
+		}
+		return 1
+	}},
+}
+
+// DebugOpen opens the debug library. Usually passed to Require.
+func DebugOpen(l *State) int {
+	NewLibrary(l, debugLibrary)
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/dev.yml
+++ b/vendor/github.com/Shopify/go-lua/dev.yml
@@ -1,0 +1,17 @@
+name: go-lua
+
+up:
+  - go: 1.7.3
+  - custom:
+      name: Initializing submodules
+      met?: test -f lua-tests/.git
+      meet: git submodule update --init
+
+commands:
+  test:
+    run: go test ./...
+    desc: 'run unit tests'
+
+packages:
+  - git@github.com:Shopify/dev-shopify.git
+

--- a/vendor/github.com/Shopify/go-lua/doc.go
+++ b/vendor/github.com/Shopify/go-lua/doc.go
@@ -1,0 +1,2 @@
+// Package lua is a port of the Lua VM from http://lua.org/ from C to Go.
+package lua

--- a/vendor/github.com/Shopify/go-lua/instructions.go
+++ b/vendor/github.com/Shopify/go-lua/instructions.go
@@ -1,0 +1,269 @@
+package lua
+
+import "fmt"
+
+type opCode uint
+
+const (
+	iABC int = iota
+	iABx
+	iAsBx
+	iAx
+)
+
+const (
+	opMove opCode = iota
+	opLoadConstant
+	opLoadConstantEx
+	opLoadBool
+	opLoadNil
+	opGetUpValue
+	opGetTableUp
+	opGetTable
+	opSetTableUp
+	opSetUpValue
+	opSetTable
+	opNewTable
+	opSelf
+	opAdd
+	opSub
+	opMul
+	opDiv
+	opMod
+	opPow
+	opUnaryMinus
+	opNot
+	opLength
+	opConcat
+	opJump
+	opEqual
+	opLessThan
+	opLessOrEqual
+	opTest
+	opTestSet
+	opCall
+	opTailCall
+	opReturn
+	opForLoop
+	opForPrep
+	opTForCall
+	opTForLoop
+	opSetList
+	opClosure
+	opVarArg
+	opExtraArg
+)
+
+var opNames = []string{
+	"MOVE",
+	"LOADK",
+	"LOADKX",
+	"LOADBOOL",
+	"LOADNIL",
+	"GETUPVAL",
+	"GETTABUP",
+	"GETTABLE",
+	"SETTABUP",
+	"SETUPVAL",
+	"SETTABLE",
+	"NEWTABLE",
+	"SELF",
+	"ADD",
+	"SUB",
+	"MUL",
+	"DIV",
+	"MOD",
+	"POW",
+	"UNM",
+	"NOT",
+	"LEN",
+	"CONCAT",
+	"JMP",
+	"EQ",
+	"LT",
+	"LE",
+	"TEST",
+	"TESTSET",
+	"CALL",
+	"TAILCALL",
+	"RETURN",
+	"FORLOOP",
+	"FORPREP",
+	"TFORCALL",
+	"TFORLOOP",
+	"SETLIST",
+	"CLOSURE",
+	"VARARG",
+	"EXTRAARG",
+}
+
+const (
+	sizeC             = 9
+	sizeB             = 9
+	sizeBx            = sizeC + sizeB
+	sizeA             = 8
+	sizeAx            = sizeC + sizeB + sizeA
+	sizeOp            = 6
+	posOp             = 0
+	posA              = posOp + sizeOp
+	posC              = posA + sizeA
+	posB              = posC + sizeC
+	posBx             = posC
+	posAx             = posA
+	bitRK             = 1 << (sizeB - 1)
+	maxIndexRK        = bitRK - 1
+	maxArgAx          = 1<<sizeAx - 1
+	maxArgBx          = 1<<sizeBx - 1
+	maxArgSBx         = maxArgBx >> 1 // sBx is signed
+	maxArgA           = 1<<sizeA - 1
+	maxArgB           = 1<<sizeB - 1
+	maxArgC           = 1<<sizeC - 1
+	listItemsPerFlush = 50 // # list items to accumulate before a setList instruction
+)
+
+type instruction uint32
+
+func isConstant(x int) bool   { return 0 != x&bitRK }
+func constantIndex(r int) int { return r & ^bitRK }
+func asConstant(r int) int    { return r | bitRK }
+
+// creates a mask with 'n' 1 bits at position 'p'
+func mask1(n, p uint) instruction { return ^(^instruction(0) << n) << p }
+
+// creates a mask with 'n' 0 bits at position 'p'
+func mask0(n, p uint) instruction { return ^mask1(n, p) }
+
+func (i instruction) opCode() opCode         { return opCode(i >> posOp & (1<<sizeOp - 1)) }
+func (i instruction) arg(pos, size uint) int { return int(i >> pos & mask1(size, 0)) }
+func (i *instruction) setOpCode(op opCode)   { i.setArg(posOp, sizeOp, int(op)) }
+func (i *instruction) setArg(pos, size uint, arg int) {
+	*i = *i&mask0(size, pos) | instruction(arg)<<pos&mask1(size, pos)
+}
+
+// Note: the gc optimizer cannot inline through multiple function calls. Manually inline for now.
+// func (i instruction) a() int   { return i.arg(posA, sizeA) }
+// func (i instruction) b() int   { return i.arg(posB, sizeB) }
+// func (i instruction) c() int   { return i.arg(posC, sizeC) }
+// func (i instruction) bx() int  { return i.arg(posBx, sizeBx) }
+// func (i instruction) ax() int  { return i.arg(posAx, sizeAx) }
+// func (i instruction) sbx() int { return i.bx() - maxArgSBx }
+
+func (i instruction) a() int   { return int(i >> posA & maxArgA) }
+func (i instruction) b() int   { return int(i >> posB & maxArgB) }
+func (i instruction) c() int   { return int(i >> posC & maxArgC) }
+func (i instruction) bx() int  { return int(i >> posBx & maxArgBx) }
+func (i instruction) ax() int  { return int(i >> posAx & maxArgAx) }
+func (i instruction) sbx() int { return int(i>>posBx&maxArgBx) - maxArgSBx }
+
+func (i *instruction) setA(arg int)   { i.setArg(posA, sizeA, arg) }
+func (i *instruction) setB(arg int)   { i.setArg(posB, sizeB, arg) }
+func (i *instruction) setC(arg int)   { i.setArg(posC, sizeC, arg) }
+func (i *instruction) setBx(arg int)  { i.setArg(posBx, sizeBx, arg) }
+func (i *instruction) setAx(arg int)  { i.setArg(posAx, sizeAx, arg) }
+func (i *instruction) setSBx(arg int) { i.setArg(posBx, sizeBx, arg+maxArgSBx) }
+
+func createABC(op opCode, a, b, c int) instruction {
+	return instruction(op)<<posOp |
+		instruction(a)<<posA |
+		instruction(b)<<posB |
+		instruction(c)<<posC
+}
+
+func createABx(op opCode, a, bx int) instruction {
+	return instruction(op)<<posOp |
+		instruction(a)<<posA |
+		instruction(bx)<<posBx
+}
+
+func createAx(op opCode, a int) instruction { return instruction(op)<<posOp | instruction(a)<<posAx }
+
+func (i instruction) String() string {
+	op := i.opCode()
+	s := opNames[op]
+	switch opMode(op) {
+	case iABC:
+		s = fmt.Sprintf("%s %d", s, i.a())
+		if bMode(op) == opArgK && isConstant(i.b()) {
+			s = fmt.Sprintf("%s constant %d", s, constantIndex(i.b()))
+		} else if bMode(op) != opArgN {
+			s = fmt.Sprintf("%s %d", s, i.b())
+		}
+		if cMode(op) == opArgK && isConstant(i.c()) {
+			s = fmt.Sprintf("%s constant %d", s, constantIndex(i.c()))
+		} else if cMode(op) != opArgN {
+			s = fmt.Sprintf("%s %d", s, i.c())
+		}
+	case iAsBx:
+		s = fmt.Sprintf("%s %d", s, i.a())
+		if bMode(op) != opArgN {
+			s = fmt.Sprintf("%s %d", s, i.sbx())
+		}
+	case iABx:
+		s = fmt.Sprintf("%s %d", s, i.a())
+		if bMode(op) != opArgN {
+			s = fmt.Sprintf("%s %d", s, i.bx())
+		}
+	case iAx:
+		s = fmt.Sprintf("%s %d", s, i.ax())
+	}
+	return s
+}
+
+func opmode(t, a, b, c, m int) byte { return byte(t<<7 | a<<6 | b<<4 | c<<2 | m) }
+
+const (
+	opArgN = iota // argument is not used
+	opArgU        // argument is used
+	opArgR        // argument is a register or a jump offset
+	opArgK        // argument is a constant or register/constant
+)
+
+func opMode(m opCode) int     { return int(opModes[m] & 3) }
+func bMode(m opCode) byte     { return (opModes[m] >> 4) & 3 }
+func cMode(m opCode) byte     { return (opModes[m] >> 2) & 3 }
+func testAMode(m opCode) bool { return opModes[m]&(1<<6) != 0 }
+func testTMode(m opCode) bool { return opModes[m]&(1<<7) != 0 }
+
+var opModes []byte = []byte{
+	//     T  A    B       C     mode		    opcode
+	opmode(0, 1, opArgR, opArgN, iABC),  // opMove
+	opmode(0, 1, opArgK, opArgN, iABx),  // opLoadConstant
+	opmode(0, 1, opArgN, opArgN, iABx),  // opLoadConstantEx
+	opmode(0, 1, opArgU, opArgU, iABC),  // opLoadBool
+	opmode(0, 1, opArgU, opArgN, iABC),  // opLoadNil
+	opmode(0, 1, opArgU, opArgN, iABC),  // opGetUpValue
+	opmode(0, 1, opArgU, opArgK, iABC),  // opGetTableUp
+	opmode(0, 1, opArgR, opArgK, iABC),  // opGetTable
+	opmode(0, 0, opArgK, opArgK, iABC),  // opSetTableUp
+	opmode(0, 0, opArgU, opArgN, iABC),  // opSetUpValue
+	opmode(0, 0, opArgK, opArgK, iABC),  // opSetTable
+	opmode(0, 1, opArgU, opArgU, iABC),  // opNewTable
+	opmode(0, 1, opArgR, opArgK, iABC),  // opSelf
+	opmode(0, 1, opArgK, opArgK, iABC),  // opAdd
+	opmode(0, 1, opArgK, opArgK, iABC),  // opSub
+	opmode(0, 1, opArgK, opArgK, iABC),  // opMul
+	opmode(0, 1, opArgK, opArgK, iABC),  // opDiv
+	opmode(0, 1, opArgK, opArgK, iABC),  // opMod
+	opmode(0, 1, opArgK, opArgK, iABC),  // opPow
+	opmode(0, 1, opArgR, opArgN, iABC),  // opUnaryMinus
+	opmode(0, 1, opArgR, opArgN, iABC),  // opNot
+	opmode(0, 1, opArgR, opArgN, iABC),  // opLength
+	opmode(0, 1, opArgR, opArgR, iABC),  // opConcat
+	opmode(0, 0, opArgR, opArgN, iAsBx), // opJump
+	opmode(1, 0, opArgK, opArgK, iABC),  // opEqual
+	opmode(1, 0, opArgK, opArgK, iABC),  // opLessThan
+	opmode(1, 0, opArgK, opArgK, iABC),  // opLessOrEqual
+	opmode(1, 0, opArgN, opArgU, iABC),  // opTest
+	opmode(1, 1, opArgR, opArgU, iABC),  // opTestSet
+	opmode(0, 1, opArgU, opArgU, iABC),  // opCall
+	opmode(0, 1, opArgU, opArgU, iABC),  // opTailCall
+	opmode(0, 0, opArgU, opArgN, iABC),  // opReturn
+	opmode(0, 1, opArgR, opArgN, iAsBx), // opForLoop
+	opmode(0, 1, opArgR, opArgN, iAsBx), // opForPrep
+	opmode(0, 0, opArgN, opArgU, iABC),  // opTForCall
+	opmode(0, 1, opArgR, opArgN, iAsBx), // opTForLoop
+	opmode(0, 0, opArgU, opArgU, iABC),  // opSetList
+	opmode(0, 1, opArgU, opArgN, iABx),  // opClosure
+	opmode(0, 1, opArgU, opArgN, iABC),  // opVarArg
+	opmode(0, 0, opArgU, opArgU, iAx),   // opExtraArg
+}

--- a/vendor/github.com/Shopify/go-lua/io.go
+++ b/vendor/github.com/Shopify/go-lua/io.go
@@ -1,0 +1,324 @@
+package lua
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+const fileHandle = "FILE*"
+const input = "_IO_input"
+const output = "_IO_output"
+
+type stream struct {
+	f     *os.File
+	close Function
+}
+
+func toStream(l *State) *stream { return CheckUserData(l, 1, fileHandle).(*stream) }
+
+func toFile(l *State) *os.File {
+	s := toStream(l)
+	if s.close == nil {
+		Errorf(l, "attempt to use a closed file")
+	}
+	l.assert(s.f != nil)
+	return s.f
+}
+
+func newStream(l *State, f *os.File, close Function) *stream {
+	s := &stream{f: f, close: close}
+	l.PushUserData(s)
+	SetMetaTableNamed(l, fileHandle)
+	return s
+}
+
+func newFile(l *State) *stream {
+	return newStream(l, nil, func(l *State) int { return FileResult(l, toStream(l).f.Close(), "") })
+}
+
+func ioFile(l *State, name string) *os.File {
+	l.Field(RegistryIndex, name)
+	s := l.ToUserData(-1).(*stream)
+	if s.close == nil {
+		Errorf(l, fmt.Sprintf("standard %s file is closed", name[len("_IO_"):]))
+	}
+	return s.f
+}
+
+func forceOpen(l *State, name, mode string) {
+	s := newFile(l)
+	flags, err := flags(mode)
+	if err == nil {
+		s.f, err = os.OpenFile(name, flags, 0666)
+	}
+	if err != nil {
+		Errorf(l, fmt.Sprintf("cannot open file '%s' (%s)", name, err.Error()))
+	}
+}
+
+func ioFileHelper(name, mode string) Function {
+	return func(l *State) int {
+		if !l.IsNoneOrNil(1) {
+			if name, ok := l.ToString(1); ok {
+				forceOpen(l, name, mode)
+			} else {
+				toFile(l)
+				l.PushValue(1)
+			}
+			l.SetField(RegistryIndex, name)
+		}
+		l.Field(RegistryIndex, name)
+		return 1
+	}
+}
+
+func closeHelper(l *State) int {
+	s := toStream(l)
+	close := s.close
+	s.close = nil
+	return close(l)
+}
+
+func close(l *State) int {
+	if l.IsNone(1) {
+		l.Field(RegistryIndex, output)
+	}
+	toFile(l)
+	return closeHelper(l)
+}
+
+func write(l *State, f *os.File, argIndex int) int {
+	var err error
+	for argCount := l.Top(); argIndex < argCount && err == nil; argIndex++ {
+		if n, ok := l.ToNumber(argIndex); ok {
+			_, err = f.WriteString(numberToString(n))
+		} else {
+			_, err = f.WriteString(CheckString(l, argIndex))
+		}
+	}
+	if err == nil {
+		return 1
+	}
+	return FileResult(l, err, "")
+}
+
+func readNumber(l *State, f *os.File) (err error) {
+	var n float64
+	if _, err = fmt.Fscanf(f, "%f", &n); err == nil {
+		l.PushNumber(n)
+	} else {
+		l.PushNil()
+	}
+	return
+}
+
+func read(l *State, f *os.File, argIndex int) int {
+	resultCount := 0
+	var err error
+	if argCount := l.Top() - 1; argCount == 0 {
+		//		err = readLineHelper(l, f, true)
+		resultCount = argIndex + 1
+	} else {
+		// TODO
+	}
+	if err != nil {
+		return FileResult(l, err, "")
+	}
+	if err == io.EOF {
+		l.Pop(1)
+		l.PushNil()
+	}
+	return resultCount - argIndex
+}
+
+func readLine(l *State) int {
+	s := l.ToUserData(UpValueIndex(1)).(*stream)
+	argCount, _ := l.ToInteger(UpValueIndex(2))
+	if s.close == nil {
+		Errorf(l, "file is already closed")
+	}
+	l.SetTop(1)
+	for i := 1; i <= argCount; i++ {
+		l.PushValue(UpValueIndex(3 + i))
+	}
+	resultCount := read(l, s.f, 2)
+	l.assert(resultCount > 0)
+	if !l.IsNil(-resultCount) {
+		return resultCount
+	}
+	if resultCount > 1 {
+		m, _ := l.ToString(-resultCount + 1)
+		Errorf(l, m)
+	}
+	if l.ToBoolean(UpValueIndex(3)) {
+		l.SetTop(0)
+		l.PushValue(UpValueIndex(1))
+		closeHelper(l)
+	}
+	return 0
+}
+
+func lines(l *State, shouldClose bool) {
+	argCount := l.Top() - 1
+	ArgumentCheck(l, argCount <= MinStack-3, MinStack-3, "too many options")
+	l.PushValue(1)
+	l.PushInteger(argCount)
+	l.PushBoolean(shouldClose)
+	for i := 1; i <= argCount; i++ {
+		l.PushValue(i + 1)
+	}
+	l.PushGoClosure(readLine, uint8(3+argCount))
+}
+
+func flags(m string) (f int, err error) {
+	if len(m) > 0 && m[len(m)-1] == 'b' {
+		m = m[:len(m)-1]
+	}
+	switch m {
+	case "r":
+		f = os.O_RDONLY
+	case "r+":
+		f = os.O_RDWR
+	case "w":
+		f = os.O_WRONLY | os.O_CREATE | os.O_TRUNC
+	case "w+":
+		f = os.O_RDWR | os.O_CREATE | os.O_TRUNC
+	case "a":
+		f = os.O_WRONLY | os.O_CREATE | os.O_APPEND
+	case "a+":
+		f = os.O_RDWR | os.O_CREATE | os.O_APPEND
+	default:
+		err = os.ErrInvalid
+	}
+	return
+}
+
+var ioLibrary = []RegistryFunction{
+	{"close", close},
+	{"flush", func(l *State) int { return FileResult(l, ioFile(l, output).Sync(), "") }},
+	{"input", ioFileHelper(input, "r")},
+	{"lines", func(l *State) int {
+		if l.IsNone(1) {
+			l.PushNil()
+		}
+		if l.IsNil(1) { // No file name.
+			l.Field(RegistryIndex, input)
+			l.Replace(1)
+			toFile(l)
+			lines(l, false)
+		} else {
+			forceOpen(l, CheckString(l, 1), "r")
+			l.Replace(1)
+			lines(l, true)
+		}
+		return 1
+	}},
+	{"open", func(l *State) int {
+		name := CheckString(l, 1)
+		flags, err := flags(OptString(l, 2, "r"))
+		s := newFile(l)
+		ArgumentCheck(l, err == nil, 2, "invalid mode")
+		s.f, err = os.OpenFile(name, flags, 0666)
+		if err == nil {
+			return 1
+		}
+		return FileResult(l, err, name)
+	}},
+	{"output", ioFileHelper(output, "w")},
+	{"popen", func(l *State) int { Errorf(l, "'popen' not supported"); panic("unreachable") }},
+	{"read", func(l *State) int { return read(l, ioFile(l, input), 1) }},
+	{"tmpfile", func(l *State) int {
+		s := newFile(l)
+		f, err := ioutil.TempFile("", "")
+		if err == nil {
+			s.f = f
+			return 1
+		}
+		return FileResult(l, err, "")
+	}},
+	{"type", func(l *State) int {
+		CheckAny(l, 1)
+		if f, ok := TestUserData(l, 1, fileHandle).(*stream); !ok {
+			l.PushNil()
+		} else if f.close == nil {
+			l.PushString("closed file")
+		} else {
+			l.PushString("file")
+		}
+		return 1
+	}},
+	{"write", func(l *State) int { return write(l, ioFile(l, output), 1) }},
+}
+
+var fileHandleMethods = []RegistryFunction{
+	{"close", close},
+	{"flush", func(l *State) int { return FileResult(l, toFile(l).Sync(), "") }},
+	{"lines", func(l *State) int { toFile(l); lines(l, false); return 1 }},
+	{"read", func(l *State) int { return read(l, toFile(l), 2) }},
+	{"seek", func(l *State) int {
+		whence := []int{os.SEEK_SET, os.SEEK_CUR, os.SEEK_END}
+		f := toFile(l)
+		op := CheckOption(l, 2, "cur", []string{"set", "cur", "end"})
+		p3 := OptNumber(l, 3, 0)
+		offset := int64(p3)
+		ArgumentCheck(l, float64(offset) == p3, 3, "not an integer in proper range")
+		ret, err := f.Seek(offset, whence[op])
+		if err != nil {
+			return FileResult(l, err, "")
+		}
+		l.PushNumber(float64(ret))
+		return 1
+	}},
+	{"setvbuf", func(l *State) int { // Files are unbuffered in Go. Fake support for now.
+		//		f := toFile(l)
+		//		op := CheckOption(l, 2, "", []string{"no", "full", "line"})
+		//		size := OptInteger(l, 3, 1024)
+		// TODO err := setvbuf(f, nil, mode[op], size)
+		return FileResult(l, nil, "")
+	}},
+	{"write", func(l *State) int { l.PushValue(1); return write(l, toFile(l), 2) }},
+	//	{"__gc", },
+	{"__tostring", func(l *State) int {
+		if s := toStream(l); s.close == nil {
+			l.PushString("file (closed)")
+		} else {
+			l.PushString(fmt.Sprintf("file (%p)", s.f))
+		}
+		return 1
+	}},
+}
+
+func dontClose(l *State) int {
+	toStream(l).close = dontClose
+	l.PushNil()
+	l.PushString("cannot close standard file")
+	return 2
+}
+
+func registerStdFile(l *State, f *os.File, reg, name string) {
+	newStream(l, f, dontClose)
+	if reg != "" {
+		l.PushValue(-1)
+		l.SetField(RegistryIndex, reg)
+	}
+	l.SetField(-2, name)
+}
+
+// IOOpen opens the io library. Usually passed to Require.
+func IOOpen(l *State) int {
+	NewLibrary(l, ioLibrary)
+
+	NewMetaTable(l, fileHandle)
+	l.PushValue(-1)
+	l.SetField(-2, "__index")
+	SetFunctions(l, fileHandleMethods, 0)
+	l.Pop(1)
+
+	registerStdFile(l, os.Stdin, input, "stdin")
+	registerStdFile(l, os.Stdout, output, "stdout")
+	registerStdFile(l, os.Stderr, "", "stderr")
+
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/libs.go
+++ b/vendor/github.com/Shopify/go-lua/libs.go
@@ -1,0 +1,54 @@
+package lua
+
+// OpenLibraries opens all standard libraries. Alternatively, the host program
+// can open them individually by using Require to call BaseOpen (for the basic
+// library), PackageOpen (for the package library), CoroutineOpen (for the
+// coroutine library), StringOpen (for the string library), TableOpen (for the
+// table library), MathOpen (for the mathematical library), Bit32Open (for the
+// bit library), IOOpen (for the I/O library), OSOpen (for the Operating System
+// library), and DebugOpen (for the debug library).
+//
+// The standard Lua libraries provide useful functions that are implemented
+// directly through the Go API. Some of these functions provide essential
+// services to the language (e.g. Type and MetaTable); others provide access
+// to "outside" services (e.g. I/O); and others could be implemented in Lua
+// itself, but are quite useful or have critical performance requirements that
+// deserve an implementation in Go (e.g. table.sort).
+//
+// All libraries are implemented through the official Go API. Currently, Lua
+// has the following standard libraries:
+//  basic library
+//  package library
+//  string manipulation
+//  table manipulation
+//  mathematical functions (sin, log, etc.);
+//  bitwise operations
+//  input and output
+//  operating system facilities
+//  debug facilities
+// Except for the basic and the package libraries, each library provides all
+// its functions as fields of a global table or as methods of its objects.
+func OpenLibraries(l *State, preloaded ...RegistryFunction) {
+	libs := []RegistryFunction{
+		{"_G", BaseOpen},
+		{"package", PackageOpen},
+		// {"coroutine", CoroutineOpen},
+		{"table", TableOpen},
+		{"io", IOOpen},
+		{"os", OSOpen},
+		{"string", StringOpen},
+		{"bit32", Bit32Open},
+		{"math", MathOpen},
+		{"debug", DebugOpen},
+	}
+	for _, lib := range libs {
+		Require(l, lib.Name, lib.Function, true)
+		l.Pop(1)
+	}
+	SubTable(l, RegistryIndex, "_PRELOAD")
+	for _, lib := range preloaded {
+		l.PushGoFunction(lib.Function)
+		l.SetField(-2, lib.Name)
+	}
+	l.Pop(1)
+}

--- a/vendor/github.com/Shopify/go-lua/load.go
+++ b/vendor/github.com/Shopify/go-lua/load.go
@@ -1,0 +1,191 @@
+package lua
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func findLoader(l *State, name string) {
+	var msg string
+	if l.Field(UpValueIndex(1), "searchers"); !l.IsTable(3) {
+		Errorf(l, "'package.searchers' must be a table")
+	}
+	for i := 1; ; i++ {
+		if l.RawGetInt(3, i); l.IsNil(-1) {
+			l.Pop(1)
+			l.PushString(msg)
+			Errorf(l, "module '%s' not found: %s", name, msg)
+		}
+		l.PushString(name)
+		if l.Call(1, 2); l.IsFunction(-2) {
+			return
+		} else if l.IsString(-2) {
+			msg += CheckString(l, -2)
+		}
+		l.Pop(2)
+	}
+}
+
+func findFile(l *State, name, field, dirSep string) (string, error) {
+	l.Field(UpValueIndex(1), field)
+	path, ok := l.ToString(-1)
+	if !ok {
+		Errorf(l, "'package.%s' must be a string", field)
+	}
+	return searchPath(l, name, path, ".", dirSep)
+}
+
+func checkLoad(l *State, loaded bool, fileName string) int {
+	if loaded { // Module loaded successfully?
+		l.PushString(fileName) // Second argument to module.
+		return 2               // Return open function & file name.
+	}
+	m := CheckString(l, 1)
+	e := CheckString(l, -1)
+	Errorf(l, "error loading module '%s' from file '%s':\n\t%s", m, fileName, e)
+	panic("unreachable")
+}
+
+func searcherLua(l *State) int {
+	name := CheckString(l, 1)
+	filename, err := findFile(l, name, "path", string(filepath.Separator))
+	if err != nil {
+		return 1 // Module not found in this path.
+	}
+	return checkLoad(l, LoadFile(l, filename, "") == nil, filename)
+}
+
+func searcherPreload(l *State) int {
+	name := CheckString(l, 1)
+	l.Field(RegistryIndex, "_PRELOAD")
+	l.Field(-1, name)
+	if l.IsNil(-1) {
+		l.PushString(fmt.Sprintf("\n\tno field package.preload['%s']", name))
+	}
+	return 1
+}
+
+func createSearchersTable(l *State) {
+	searchers := []Function{searcherPreload, searcherLua}
+	l.CreateTable(len(searchers), 0)
+	for i, s := range searchers {
+		l.PushValue(-2)
+		l.PushGoClosure(s, 1)
+		l.RawSetInt(-2, i+1)
+	}
+}
+
+func readable(filename string) bool {
+	f, err := os.Open(filename)
+	if f != nil {
+		f.Close()
+	}
+	return err == nil
+}
+
+func searchPath(l *State, name, path, sep, dirSep string) (string, error) {
+	var msg string
+	if sep != "" {
+		name = strings.Replace(name, sep, dirSep, -1) // Replace sep by dirSep.
+	}
+	path = strings.Replace(path, string(pathListSeparator), string(filepath.ListSeparator), -1)
+	for _, template := range filepath.SplitList(path) {
+		if template != "" {
+			filename := strings.Replace(template, "?", name, -1)
+			if readable(filename) {
+				return filename, nil
+			}
+			msg = fmt.Sprintf("%s\n\tno file '%s'", msg, filename)
+		}
+	}
+	return "", errors.New(msg)
+}
+
+func noEnv(l *State) bool {
+	l.Field(RegistryIndex, "LUA_NOENV")
+	b := l.ToBoolean(-1)
+	l.Pop(1)
+	return b
+}
+
+func setPath(l *State, field, env, def string) {
+	if path := os.Getenv(env); path == "" || noEnv(l) {
+		l.PushString(def)
+	} else {
+		o := fmt.Sprintf("%c%c", pathListSeparator, pathListSeparator)
+		n := fmt.Sprintf("%c%s%c", pathListSeparator, def, pathListSeparator)
+		path = strings.Replace(path, o, n, -1)
+		l.PushString(path)
+	}
+	l.SetField(-2, field)
+}
+
+var packageLibrary = []RegistryFunction{
+	{"loadlib", func(l *State) int {
+		_ = CheckString(l, 1) // path
+		_ = CheckString(l, 2) // init
+		l.PushNil()
+		l.PushString("dynamic libraries not enabled; check your Lua installation")
+		l.PushString("absent")
+		return 3 // Return nil, error message, and where.
+	}},
+	{"searchpath", func(l *State) int {
+		name := CheckString(l, 1)
+		path := CheckString(l, 2)
+		sep := OptString(l, 3, ".")
+		dirSep := OptString(l, 4, string(filepath.Separator))
+		f, err := searchPath(l, name, path, sep, dirSep)
+		if err != nil {
+			l.PushNil()
+			l.PushString(err.Error())
+			return 2
+		}
+		l.PushString(f)
+		return 1
+	}},
+}
+
+// PackageOpen opens the package library. Usually passed to Require.
+func PackageOpen(l *State) int {
+	NewLibrary(l, packageLibrary)
+	createSearchersTable(l)
+	l.SetField(-2, "searchers")
+	setPath(l, "path", "LUA_PATH", defaultPath)
+	l.PushString(fmt.Sprintf("%c\n%c\n?\n!\n-\n", filepath.Separator, pathListSeparator))
+	l.SetField(-2, "config")
+	SubTable(l, RegistryIndex, "_LOADED")
+	l.SetField(-2, "loaded")
+	SubTable(l, RegistryIndex, "_PRELOAD")
+	l.SetField(-2, "preload")
+	l.PushGlobalTable()
+	l.PushValue(-2)
+	SetFunctions(l, []RegistryFunction{{"require", func(l *State) int {
+		name := CheckString(l, 1)
+		l.SetTop(1)
+		l.Field(RegistryIndex, "_LOADED")
+		l.Field(2, name)
+		if l.ToBoolean(-1) {
+			return 1
+		}
+		l.Pop(1)
+		findLoader(l, name)
+		l.PushString(name)
+		l.Insert(-2)
+		l.Call(2, 1)
+		if !l.IsNil(-1) {
+			l.SetField(2, name)
+		}
+		l.Field(2, name)
+		if l.IsNil(-1) {
+			l.PushBoolean(true)
+			l.PushValue(-1)
+			l.SetField(2, name)
+		}
+		return 1
+	}}}, 1)
+	l.Pop(1)
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/lua.go
+++ b/vendor/github.com/Shopify/go-lua/lua.go
@@ -1,0 +1,1518 @@
+package lua
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+)
+
+// MultipleReturns is the argument for argCount or resultCount in ProtectedCall and Call.
+const MultipleReturns = -1
+
+// Debug.Event and SetDebugHook mask argument values.
+const (
+	HookCall, MaskCall = iota, 1 << iota
+	HookReturn, MaskReturn
+	HookLine, MaskLine
+	HookCount, MaskCount
+	HookTailCall, MaskTailCall
+)
+
+// Errors introduced by the Lua VM.
+var (
+	SyntaxError = errors.New("syntax error")
+	MemoryError = errors.New("memory error")
+	ErrorError  = errors.New("error within the error handler")
+	FileError   = errors.New("file error")
+)
+
+// A RuntimeError is an error raised internally by the Lua VM or through Error.
+type RuntimeError string
+
+func (r RuntimeError) Error() string { return "runtime error: " + string(r) }
+
+// A Type is a symbolic representation of a Lua VM type.
+type Type int
+
+// Valid Type values.
+const (
+	TypeNil Type = iota
+	TypeBoolean
+	TypeLightUserData
+	TypeNumber
+	TypeString
+	TypeTable
+	TypeFunction
+	TypeUserData
+	TypeThread
+
+	TypeCount
+	TypeNone = TypeNil - 1
+)
+
+// An Operator is an op argument for Arith.
+type Operator int
+
+// Valid Operator values for Arith.
+const (
+	OpAdd        Operator = iota // Performs addition (+).
+	OpSub                        // Performs subtraction (-).
+	OpMul                        // Performs multiplication (*).
+	OpDiv                        // Performs division (/).
+	OpMod                        // Performs modulo (%).
+	OpPow                        // Performs exponentiation (^).
+	OpUnaryMinus                 // Performs mathematical negation (unary -).
+)
+
+// A ComparisonOperator is an op argument for Compare.
+type ComparisonOperator int
+
+// Valid ComparisonOperator values for Compare.
+const (
+	OpEq ComparisonOperator = iota // Compares for equality (==).
+	OpLT                           // Compares for less than (<).
+	OpLE                           // Compares for less or equal (<=).
+)
+
+// Lua provides a registry, a predefined table, that can be used by any Go code
+// to store whatever Lua values it needs to store. The registry table is always
+// located at pseudo-index RegistryIndex, which is a valid index. Any Go
+// library can store data into this table, but it should take care to choose
+// keys that are different from those used by other libraries, to avoid
+// collisions. Typically, you should use as key a string containing your
+// library name, or a light userdata object in your code, or any Lua object
+// created by your code. As with global names, string keys starting with an
+// underscore followed by uppercase letters are reserved for Lua.
+//
+// The integer keys in the registry are used by the reference mechanism
+// and by some predefined values. Therefore, integer keys should not be used
+// for other purposes.
+//
+// When you create a new Lua state, its registry comes with some predefined
+// values. These predefined values are indexed with integer keys defined as
+// constants.
+const (
+	// RegistryIndex is the psuedo-index for the registry table.
+	RegistryIndex = firstPseudoIndex
+
+	// RegistryIndexMainThread is the registry index for the main thread of the
+	// State. (The main thread is the one created together with the State.)
+	RegistryIndexMainThread = iota
+
+	// RegistryIndexGlobals is the registry index for the global environment.
+	RegistryIndexGlobals
+)
+
+// Signature is the mark for precompiled code ('<esc>Lua').
+const Signature = "\033Lua"
+
+// MinStack is the minimum Lua stack available to a Go function.
+const MinStack = 20
+
+const (
+	VersionMajor  = 5
+	VersionMinor  = 2
+	VersionNumber = 502
+	VersionString = "Lua " + string('0'+VersionMajor) + "." + string('0'+VersionMinor)
+)
+
+// A RegistryFunction is used for arrays of functions to be registered by
+// SetFunctions. Name is the function name and Function is the function.
+type RegistryFunction struct {
+	Name     string
+	Function Function
+}
+
+// A Debug carries different pieces of information about a function or an
+// activation record. Stack fills only the private part of this structure, for
+// later use. To fill the other fields of a Debug with useful information, call
+// Info.
+type Debug struct {
+	Event int
+
+	// Name is a reasonable name for the given function. Because functions in
+	// Lua are first-class values, they do not have a fixed name. Some functions
+	// can be the value of multiple global variables, while others can be stored
+	// only in a table field. The Info function checks how the function was
+	// called to find a suitable name. If it cannot find a name, then Name is "".
+	Name string
+
+	// NameKind explains the name field. The value of NameKind can be "global",
+	// "local", "method", "field", "upvalue", or "" (the empty string), according
+	// to how the function was called. (Lua uses the empty string when no other
+	// option seems to apply.)
+	NameKind string
+
+	// What is the string "Lua" if the function is a Lua function, "Go" if it is
+	// a Go function, "main" if it is the main part of a chunk.
+	What string
+
+	// Source is the source of the chunk that created the function. If Source
+	// starts with a '@', it means that the function was defined in a file where
+	// the file name follows the '@'. If Source starts with a '=', the remainder
+	// of its contents describe the source in a user-dependent manner. Otherwise,
+	// the function was defined in a string where Source is that string.
+	Source string
+
+	// ShortSource is a "printable" version of source, to be used in error messages.
+	ShortSource string
+
+	// CurrentLine is the current line where the given function is executing.
+	// When no line information is available, CurrentLine is set to -1.
+	CurrentLine int
+
+	// LineDefined is the line number where the definition of the function starts.
+	LineDefined int
+
+	// LastLineDefined is the line number where the definition of the function ends.
+	LastLineDefined int
+
+	// UpValueCount is the number of upvalues of the function.
+	UpValueCount int
+
+	// ParameterCount is the number of fixed parameters of the function (always 0
+	// for Go functions).
+	ParameterCount int
+
+	// IsVarArg is true if the function is a vararg function (always true for Go
+	// functions).
+	IsVarArg bool
+
+	// IsTailCall is true if this function invocation was called by a tail call.
+	// In this case, the caller of this level is not in the stack.
+	IsTailCall bool
+
+	// callInfo is the active function.
+	callInfo *callInfo
+}
+
+// A Hook is a callback function that can be registered with SetDebugHook to trace various VM events.
+type Hook func(state *State, activationRecord Debug)
+
+// A Function is a Go function intended to be called from Lua.
+type Function func(state *State) int
+
+// TODO XMove(from, to State, n int)
+//
+// Set functions (stack -> Lua)
+// RawSetValue(index int, p interface{})
+//
+// Debug API
+// Local(activationRecord *Debug, index int) string
+// SetLocal(activationRecord *Debug, index int) string
+
+type pc int
+type callStatus byte
+
+const (
+	callStatusLua                callStatus = 1 << iota // call is running a Lua function
+	callStatusHooked                                    // call is running a debug hook
+	callStatusReentry                                   // call is running on same invocation of execute of previous call
+	callStatusYielded                                   // call reentered after suspension
+	callStatusYieldableProtected                        // call is a yieldable protected call
+	callStatusError                                     // call has an error status (pcall)
+	callStatusTail                                      // call was tail called
+	callStatusHookYielded                               // last hook called yielded
+)
+
+// A State is an opaque structure representing per thread Lua state.
+type State struct {
+	error                 error
+	shouldYield           bool
+	top                   int // first free slot in the stack
+	global                *globalState
+	callInfo              *callInfo // call info for current function
+	oldPC                 pc        // last pC traced
+	stackLast             int       // last free slot in the stack
+	stack                 []value
+	nonYieldableCallCount int
+	nestedGoCallCount     int
+	hookMask              byte
+	allowHook             bool
+	internalHook          bool
+	baseHookCount         int
+	hookCount             int
+	hooker                Hook
+	upValues              *openUpValue
+	errorFunction         int      // current error handling function (stack index)
+	baseCallInfo          callInfo // callInfo for first level (go calling lua)
+	protectFunction       func()
+}
+
+type globalState struct {
+	mainThread         *State
+	tagMethodNames     [tmCount]string
+	metaTables         [TypeCount]*table // metatables for basic types
+	registry           *table
+	panicFunction      Function // to be called in unprotected errors
+	version            *float64 // pointer to version number
+	memoryErrorMessage string
+	// seed uint // randomized seed for hashes
+	// upValueHead upValue // head of double-linked list of all open upvalues
+}
+
+func (g *globalState) metaTable(o value) *table {
+	var t Type
+	switch o.(type) {
+	case nil:
+		t = TypeNil
+	case bool:
+		t = TypeBoolean
+	// TODO TypeLightUserData
+	case float64:
+		t = TypeNumber
+	case string:
+		t = TypeString
+	case *table:
+		t = TypeTable
+	case *goFunction:
+		t = TypeFunction
+	case closure:
+		t = TypeFunction
+	case *userData:
+		t = TypeUserData
+	case *State:
+		t = TypeThread
+	default:
+		return nil
+	}
+	return g.metaTables[t]
+}
+
+func (l *State) adjustResults(resultCount int) {
+	if resultCount == MultipleReturns && l.callInfo.top < l.top {
+		l.callInfo.setTop(l.top)
+	}
+}
+
+func (l *State) apiIncrementTop() {
+	l.top++
+	if apiCheck && l.top > l.callInfo.top {
+		panic("stack overflow")
+	}
+}
+
+func (l *State) apiPush(v value) {
+	l.push(v)
+	if apiCheck && l.top > l.callInfo.top {
+		panic("stack overflow")
+	}
+}
+
+func (l *State) checkElementCount(n int) {
+	if apiCheck && n >= l.top-l.callInfo.function {
+		panic("not enough elements in the stack")
+	}
+}
+
+func (l *State) checkResults(argCount, resultCount int) {
+	if apiCheck && resultCount != MultipleReturns && l.callInfo.top-l.top < resultCount-argCount {
+		panic("results from function overflow current stack size")
+	}
+}
+
+// Context is called by a continuation function to retrieve the status of the
+// thread and context information. When called in the origin function, it
+// will always return (0, false, nil). When called inside a continuation function,
+// it will return (ctx, shouldYield, err), where ctx is the value that was
+// passed to the callee together with the continuation function.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_getctx
+func (l *State) Context() (int, bool, error) {
+	if l.callInfo.isCallStatus(callStatusYielded) {
+		return l.callInfo.context, l.callInfo.shouldYield, l.callInfo.error
+	}
+	return 0, false, nil
+}
+
+// CallWithContinuation is exactly like Call, but allows the called function to
+// yield.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_callk
+func (l *State) CallWithContinuation(argCount, resultCount, context int, continuation Function) {
+	if apiCheck && continuation != nil && l.callInfo.isLua() {
+		panic("cannot use continuations inside hooks")
+	}
+	l.checkElementCount(argCount + 1)
+	if apiCheck && l.shouldYield {
+		panic("cannot do calls on non-normal thread")
+	}
+	l.checkResults(argCount, resultCount)
+	f := l.top - (argCount + 1)
+	if continuation != nil && l.nonYieldableCallCount == 0 { // need to prepare continuation?
+		l.callInfo.continuation = continuation
+		l.callInfo.context = context
+		l.call(f, resultCount, true) // just do the call
+	} else { // no continuation or not yieldable
+		l.call(f, resultCount, false) // just do the call
+	}
+	l.adjustResults(resultCount)
+}
+
+// ProtectedCall calls a function in protected mode. Both argCount and
+// resultCount have the same meaning as in Call. If there are no errors
+// during the call, ProtectedCall behaves exactly like Call.
+//
+// However, if there is any error, ProtectedCall catches it, pushes a single
+// value on the stack (the error message), and returns an error. Like Call,
+// ProtectedCall always removes the function and its arguments from the stack.
+//
+// If errorFunction is 0, then the error message returned on the stack is
+// exactly the original error message. Otherwise, errorFunction is the stack
+// index of an error handler (in the Lua C, message handler). This cannot be
+// a pseudo-index in the current implementation. In case of runtime errors,
+// this function will be called with the error message and its return value
+// will be the message returned on the stack by ProtectedCall.
+//
+// Typically, the error handler is used to add more debug information to the
+// error message, such as a stack traceback. Such information cannot be
+// gathered after the return of ProtectedCall, since by then, the stack has
+// unwound.
+//
+// The possible errors are the following:
+//
+//    RuntimeError  a runtime error
+//    MemoryError   allocating memory, the error handler is not called
+//    ErrorError    running the error handler
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pcall
+func (l *State) ProtectedCall(argCount, resultCount, errorFunction int) error {
+	return l.ProtectedCallWithContinuation(argCount, resultCount, errorFunction, 0, nil)
+}
+
+// ProtectedCallWithContinuation behaves exactly like ProtectedCall, but
+// allows the called function to yield.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pcallk
+func (l *State) ProtectedCallWithContinuation(argCount, resultCount, errorFunction, context int, continuation Function) (err error) {
+	if apiCheck && continuation != nil && l.callInfo.isLua() {
+		panic("cannot use continuations inside hooks")
+	}
+	l.checkElementCount(argCount + 1)
+	if apiCheck && l.shouldYield {
+		panic("cannot do calls on non-normal thread")
+	}
+	l.checkResults(argCount, resultCount)
+	if errorFunction != 0 {
+		apiCheckStackIndex(errorFunction, l.indexToValue(errorFunction))
+		errorFunction = l.AbsIndex(errorFunction)
+	}
+
+	f := l.top - (argCount + 1)
+
+	if continuation == nil || l.nonYieldableCallCount > 0 {
+		err = l.protectedCall(func() { l.call(f, resultCount, false) }, f, errorFunction)
+	} else {
+		c := l.callInfo
+		c.continuation, c.context, c.extra, c.oldAllowHook, c.oldErrorFunction = continuation, context, f, l.allowHook, l.errorFunction
+		l.errorFunction = errorFunction
+		l.callInfo.setCallStatus(callStatusYieldableProtected)
+		l.call(f, resultCount, true)
+		l.callInfo.clearCallStatus(callStatusYieldableProtected)
+		l.errorFunction = c.oldErrorFunction
+	}
+	l.adjustResults(resultCount)
+	return
+}
+
+// Load loads a Lua chunk, without running it. If there are no errors, it
+// pushes the compiled chunk as a Lua function on top of the stack.
+// Otherwise, it pushes an error message.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_load
+func (l *State) Load(r io.Reader, chunkName string, mode string) error {
+	if chunkName == "" {
+		chunkName = "?"
+	}
+
+	if err := protectedParser(l, r, chunkName, mode); err != nil {
+		return err
+	}
+
+	if f := l.stack[l.top-1].(*luaClosure); f.upValueCount() == 1 {
+		f.setUpValue(0, l.global.registry.atInt(RegistryIndexGlobals))
+	}
+	return nil
+}
+
+// NewState creates a new thread running in a new, independent state.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_newstate
+func NewState() *State {
+	v := float64(VersionNumber)
+	l := &State{allowHook: true, error: nil, nonYieldableCallCount: 1}
+	g := &globalState{mainThread: l, registry: newTable(), version: &v, memoryErrorMessage: "not enough memory"}
+	l.global = g
+	l.initializeStack()
+	g.registry.putAtInt(RegistryIndexMainThread, l)
+	g.registry.putAtInt(RegistryIndexGlobals, newTable())
+	copy(g.tagMethodNames[:], eventNames)
+	return l
+}
+
+func apiCheckStackIndex(index int, v value) {
+	if apiCheck && (v == none || isPseudoIndex(index)) {
+		panic(fmt.Sprintf("index %d not in the stack", index))
+	}
+}
+
+// SetField does the equivalent of table[key]=v where table is the value at
+// index and v is the value on top of the stack.
+//
+// This function pops the value from the stack. As in Lua, this function may
+// trigger a metamethod for the __newindex event.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_setfield
+func (l *State) SetField(index int, key string) {
+	l.checkElementCount(1)
+	t := l.indexToValue(index)
+	l.push(key)
+	l.setTableAt(t, key, l.stack[l.top-2])
+	l.top -= 2
+}
+
+var none value = &struct{}{}
+
+func (l *State) indexToValue(index int) value {
+	switch {
+	case index > 0:
+		// TODO apiCheck(index <= callInfo.top_-(callInfo.function+1), "unacceptable index")
+		// if i := callInfo.function + index; i < l.top {
+		// 	return l.stack[i]
+		// }
+		// return none
+		if l.callInfo.function+index >= l.top {
+			return none
+		}
+		return l.stack[l.callInfo.function:l.top][index]
+	case index > RegistryIndex: // negative index
+		// TODO apiCheck(index != 0 && -index <= l.top-(callInfo.function+1), "invalid index")
+		return l.stack[l.top+index]
+	case index == RegistryIndex:
+		return l.global.registry
+	default: // upvalues
+		i := RegistryIndex - index
+		return l.stack[l.callInfo.function].(*goClosure).upValues[i-1]
+		// if closure := l.stack[callInfo.function].(*goClosure); i <= len(closure.upValues) {
+		// 	return closure.upValues[i-1]
+		// }
+		// return none
+	}
+}
+
+func (l *State) setIndexToValue(index int, v value) {
+	switch {
+	case index > 0:
+		l.stack[l.callInfo.function:l.top][index] = v
+		// if i := callInfo.function + index; i < l.top {
+		// 	l.stack[i] = v
+		// } else {
+		// 	panic("unacceptable index")
+		// }
+	case index > RegistryIndex: // negative index
+		l.stack[l.top+index] = v
+	case index == RegistryIndex:
+		l.global.registry = v.(*table)
+	default: // upvalues
+		i := RegistryIndex - index
+		l.stack[l.callInfo.function].(*goClosure).upValues[i-1] = v
+	}
+}
+
+// AbsIndex converts the acceptable index index to an absolute index (that
+// is, one that does not depend on the stack top).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_absindex
+func (l *State) AbsIndex(index int) int {
+	if index > 0 || isPseudoIndex(index) {
+		return index
+	}
+	return l.top - l.callInfo.function + index
+}
+
+// SetTop accepts any index, or 0, and sets the stack top to index. If the
+// new top is larger than the old one, then the new elements are filled with
+// nil. If index is 0, then all stack elements are removed.
+//
+// If index is negative, the stack will be decremented by that much. If
+// the decrement is larger than the stack, SetTop will panic().
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_settop
+func (l *State) SetTop(index int) {
+	f := l.callInfo.function
+	if index >= 0 {
+		if apiCheck && index > l.stackLast-(f+1) {
+			panic("new top too large")
+		}
+		i := l.top
+		for l.top = f + 1 + index; i < l.top; i++ {
+			l.stack[i] = nil
+		}
+	} else {
+		if apiCheck && -(index+1) > l.top-(f+1) {
+			panic("invalid new top")
+		}
+		l.top += index + 1 // 'subtract' index (index is negative)
+	}
+}
+
+// Remove the element at the given valid index, shifting down the elements
+// above index to fill the gap. This function cannot be called with a
+// pseudo-index, because a pseudo-index is not an actual stack position.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_remove
+func (l *State) Remove(index int) {
+	apiCheckStackIndex(index, l.indexToValue(index))
+	i := l.callInfo.function + l.AbsIndex(index)
+	copy(l.stack[i:l.top-1], l.stack[i+1:l.top])
+	l.top--
+}
+
+// Insert moves the top element into the given valid index, shifting up the
+// elements above this index to open space.  This function cannot be called
+// with a pseudo-index, because a pseudo-index is not an actual stack position.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_insert
+func (l *State) Insert(index int) {
+	apiCheckStackIndex(index, l.indexToValue(index))
+	i := l.callInfo.function + l.AbsIndex(index)
+	copy(l.stack[i+1:l.top+1], l.stack[i:l.top])
+	l.stack[i] = l.stack[l.top]
+}
+
+func (l *State) move(dest int, src value) { l.setIndexToValue(dest, src) }
+
+// Replace moves the top element into the given valid index without shifting
+// any element (therefore replacing the value at the given index), and then
+// pops the top element.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_replace
+func (l *State) Replace(index int) {
+	l.checkElementCount(1)
+	l.move(index, l.stack[l.top-1])
+	l.top--
+}
+
+// CheckStack ensures that there are at least size free stack slots in the
+// stack. This call will not panic(), unlike the other Check*() functions.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_checkstack
+func (l *State) CheckStack(size int) bool {
+	callInfo := l.callInfo
+	ok := l.stackLast-l.top > size
+	if !ok && l.top+extraStack <= maxStack-size {
+		ok = l.protect(func() { l.growStack(size) }) == nil
+	}
+	if ok && callInfo.top < l.top+size {
+		callInfo.setTop(l.top + size)
+	}
+	return ok
+}
+
+// AtPanic sets a new panic function and returns the old one.
+func AtPanic(l *State, panicFunction Function) Function {
+	panicFunction, l.global.panicFunction = l.global.panicFunction, panicFunction
+	return panicFunction
+}
+
+func (l *State) valueToType(v value) Type {
+	switch v.(type) {
+	case nil:
+		return TypeNil
+	case bool:
+		return TypeBoolean
+	// case lightUserData:
+	// 	return TypeLightUserData
+	case float64:
+		return TypeNumber
+	case string:
+		return TypeString
+	case *table:
+		return TypeTable
+	case *goFunction:
+		return TypeFunction
+	case *userData:
+		return TypeUserData
+	case *State:
+		return TypeThread
+	case *luaClosure:
+		return TypeFunction
+	case *goClosure:
+		return TypeFunction
+	}
+	return TypeNone
+}
+
+// TypeOf returns the type of the value at index, or TypeNone for a
+// non-valid (but acceptable) index.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_type
+func (l *State) TypeOf(index int) Type {
+	return l.valueToType(l.indexToValue(index))
+}
+
+// IsGoFunction verifies that the value at index is a Go function.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_iscfunction
+func (l *State) IsGoFunction(index int) bool {
+	if _, ok := l.indexToValue(index).(*goFunction); ok {
+		return true
+	}
+	_, ok := l.indexToValue(index).(*goClosure)
+	return ok
+}
+
+// IsNumber verifies that the value at index is a number.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isnumber
+func (l *State) IsNumber(index int) bool {
+	_, ok := l.toNumber(l.indexToValue(index))
+	return ok
+}
+
+// IsString verifies that the value at index is a string, or a number (which
+// is always convertible to a string).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isstring
+func (l *State) IsString(index int) bool {
+	if _, ok := l.indexToValue(index).(string); ok {
+		return true
+	}
+	_, ok := l.indexToValue(index).(float64)
+	return ok
+}
+
+// IsUserData verifies that the value at index is a userdata.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isuserdata
+func (l *State) IsUserData(index int) bool {
+	_, ok := l.indexToValue(index).(*userData)
+	return ok
+}
+
+// Arith performs an arithmetic operation over the two values (or one, in
+// case of negation) at the top of the stack, with the value at the top being
+// the second operand, ops these values and pushes the result of the operation.
+// The function follows the semantics of the corresponding Lua operator
+// (that is, it may call metamethods).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_arith
+func (l *State) Arith(op Operator) {
+	if op != OpUnaryMinus {
+		l.checkElementCount(2)
+	} else {
+		l.checkElementCount(1)
+		l.push(l.stack[l.top-1])
+	}
+	o1, o2 := l.stack[l.top-2], l.stack[l.top-1]
+	if n1, n2, ok := pairAsNumbers(o1, o2); ok {
+		l.stack[l.top-2] = arith(op, n1, n2)
+	} else {
+		l.stack[l.top-2] = l.arith(o1, o2, tm(op-OpAdd)+tmAdd)
+	}
+	l.top--
+}
+
+// RawEqual verifies that the values at index1 and index2 are primitively
+// equal (that is, without calling their metamethods).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_rawequal
+func (l *State) RawEqual(index1, index2 int) bool {
+	if o1, o2 := l.indexToValue(index1), l.indexToValue(index2); o1 != nil && o2 != nil {
+		return o1 == o2
+	}
+	return false
+}
+
+// Compare compares two values.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_compare
+func (l *State) Compare(index1, index2 int, op ComparisonOperator) bool {
+	if o1, o2 := l.indexToValue(index1), l.indexToValue(index2); o1 != nil && o2 != nil {
+		switch op {
+		case OpEq:
+			return l.equalObjects(o1, o2)
+		case OpLT:
+			return l.lessThan(o1, o2)
+		case OpLE:
+			return l.lessOrEqual(o1, o2)
+		default:
+			panic("invalid option")
+		}
+	}
+	return false
+}
+
+// ToInteger converts the Lua value at index into a signed integer. The Lua
+// value must be a number, or a string convertible to a number.
+//
+// If the number is not an integer, it is truncated in some non-specified way.
+//
+// If the operation failed, the second return value will be false.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_tointegerx
+func (l *State) ToInteger(index int) (int, bool) {
+	if n, ok := l.toNumber(l.indexToValue(index)); ok {
+		return int(n), true
+	}
+	return 0, false
+}
+
+// ToUnsigned converts the Lua value at index to a Go uint. The Lua value
+// must be a number or a string convertible to a number.
+//
+// If the number is not an unsigned integer, it is truncated in some
+// non-specified way.  If the number is outside the range of uint, it is
+// normalized to the remainder of its division by one more than the maximum
+// representable value.
+//
+// If the operation failed, the second return value will be false.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_tounsignedx
+func (l *State) ToUnsigned(index int) (uint, bool) {
+	if n, ok := l.toNumber(l.indexToValue(index)); ok {
+		const supUnsigned = float64(^uint32(0)) + 1
+		return uint(n - math.Floor(n/supUnsigned)*supUnsigned), true
+	}
+	return 0, false
+}
+
+// ToString  converts the Lua value at index to a Go string.  The Lua value
+// must also be a string or a number; otherwise the function returns
+// false for its second return value.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_tolstring
+func (l *State) ToString(index int) (s string, ok bool) {
+	if s, ok = toString(l.indexToValue(index)); ok { // Bug compatibility: replace a number with its string representation.
+		l.setIndexToValue(index, s)
+	}
+	return
+}
+
+// RawLength returns the length of the value at index.  For strings, this is
+// the length.  For tables, this is the result of the # operator with no
+// metamethods.  For userdata, this is the size of the block of memory
+// allocated for the userdata (not implemented yet). For other values, it is 0.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_rawlen
+func (l *State) RawLength(index int) int {
+	switch v := l.indexToValue(index).(type) {
+	case string:
+		return len(v)
+	// case *userData:
+	// 	return reflect.Sizeof(v.data)
+	case *table:
+		return v.length()
+	}
+	return 0
+}
+
+// ToGoFunction converts a value at index into a Go function.  That value
+// must be a Go function, otherwise it returns nil.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_tocfunction
+func (l *State) ToGoFunction(index int) Function {
+	switch v := l.indexToValue(index).(type) {
+	case *goFunction:
+		return v.Function
+	case *goClosure:
+		return v.function
+	}
+	return nil
+}
+
+// ToUserData returns an interface{} of the userdata of the value at index.
+// Otherwise, it returns nil.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_touserdata
+func (l *State) ToUserData(index int) interface{} {
+	if d, ok := l.indexToValue(index).(*userData); ok {
+		return d.data
+	}
+	return nil
+}
+
+// ToThread converts the value at index to a Lua thread (a State). This
+// value must be a thread, otherwise the return value will be nil.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_tothread
+func (l *State) ToThread(index int) *State {
+	if t, ok := l.indexToValue(index).(*State); ok {
+		return t
+	}
+	return nil
+}
+
+// ToValue convertes the value at index into a generic Go interface{}.  The
+// value can be a userdata, a table, a thread, a function, or Go string, bool
+// or float64 types. Otherwise, the function returns nil.
+//
+// Different objects will give different values.  There is no way to convert
+// the value back into its original value.
+//
+// Typically, this function is used only for debug information.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_tovalue
+func (l *State) ToValue(index int) interface{} {
+	v := l.indexToValue(index)
+	switch v := v.(type) {
+	case string, float64, bool, *table, *luaClosure, *goClosure, *goFunction, *State:
+	case *userData:
+		return v.data
+	default:
+		return nil
+	}
+	return v
+}
+
+// PushString pushes a string onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushstring
+func (l *State) PushString(s string) string { // TODO is it useful to return the argument?
+	l.apiPush(s)
+	return s
+}
+
+// PushFString pushes onto the stack a formatted string and returns that
+// string.  It is similar to fmt.Sprintf, but has some differences: the
+// conversion specifiers are quite restricted.  There are no flags, widths,
+// or precisions.  The conversion specifiers can only be %% (inserts a %
+// in the string), %s, %f (a Lua number), %p (a pointer as a hexadecimal
+// numeral), %d and %c (an integer as a byte).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushfstring
+func (l *State) PushFString(format string, args ...interface{}) string {
+	n, i := 0, 0
+	for {
+		e := strings.IndexRune(format, '%')
+		if e < 0 {
+			break
+		}
+		l.checkStack(2) // format + item
+		l.push(format[:e])
+		switch format[e+1] {
+		case 's':
+			if args[i] == nil {
+				l.push("(null)")
+			} else {
+				l.push(args[i].(string))
+			}
+			i++
+		case 'c':
+			l.push(string(args[i].(rune)))
+			i++
+		case 'd':
+			l.push(float64(args[i].(int)))
+			i++
+		case 'f':
+			l.push(args[i].(float64))
+			i++
+		case 'p':
+			l.push(fmt.Sprintf("%p", args[i]))
+			i++
+		case '%':
+			l.push("%")
+		default:
+			l.runtimeError("invalid option " + format[e:e+2] + " to 'lua_pushfstring'")
+		}
+		n += 2
+		format = format[e+2:]
+	}
+	l.checkStack(1)
+	l.push(format)
+	if n > 0 {
+		l.concat(n + 1)
+	}
+	return l.stack[l.top-1].(string)
+}
+
+// PushGoClosure pushes a new Go closure onto the stack.
+//
+// When a Go function is created, it is possible to associate some values with
+// it, thus creating a Go closure; these values are then accessible to the
+// function whenever it is called.  To associate values with a Go function,
+// first these values should be pushed onto the stack (when there are multiple
+// values, the first value is pushed first).  Then PushGoClosure is called to
+// create and push the Go function onto the stack, with the argument upValueCount
+// telling how many values should be associated with the function.  Calling
+// PushGoClosure also pops these values from the stack.
+//
+// When upValueCount is 0, this function creates a light Go function, which is just a
+// Go function.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushcclosure
+func (l *State) PushGoClosure(function Function, upValueCount uint8) {
+	if upValueCount == 0 {
+		l.apiPush(&goFunction{function})
+	} else {
+		n := int(upValueCount)
+
+		l.checkElementCount(n)
+		cl := &goClosure{function: function, upValues: make([]value, upValueCount)}
+		l.top -= n
+		copy(cl.upValues, l.stack[l.top:l.top+n])
+		l.apiPush(cl)
+	}
+}
+
+// PushThread pushes the thread l onto the stack.  It returns true if l is
+// the main thread of its state.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushthread
+func (l *State) PushThread() bool {
+	l.apiPush(l)
+	return l.global.mainThread == l
+}
+
+// Global pushes onto the stack the value of the global name.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_getglobal
+func (l *State) Global(name string) {
+	g := l.global.registry.atInt(RegistryIndexGlobals)
+	l.push(name)
+	l.stack[l.top-1] = l.tableAt(g, l.stack[l.top-1])
+}
+
+// Field pushes onto the stack the value table[name], where table is the
+// table on the stack at the given index. This call may trigger a
+// metamethod for the __index event.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_getfield
+func (l *State) Field(index int, name string) {
+	t := l.indexToValue(index)
+	l.apiPush(name)
+	l.stack[l.top-1] = l.tableAt(t, l.stack[l.top-1])
+}
+
+// RawGet is similar to GetTable, but does a raw access (without metamethods).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_rawget
+func (l *State) RawGet(index int) {
+	t := l.indexToValue(index).(*table)
+	l.stack[l.top-1] = t.at(l.stack[l.top-1])
+}
+
+// RawGetInt pushes onto the stack the value table[key] where table is the
+// value at index on the stack. The access is raw, as it doesn't invoke
+// metamethods.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_rawgeti
+func (l *State) RawGetInt(index, key int) {
+	t := l.indexToValue(index).(*table)
+	l.apiPush(t.atInt(key))
+}
+
+// RawGetValue pushes onto the stack value table[p] where table is the
+// value at index on the stack, and p is a light userdata.  The access is
+// raw, as it doesn't invoke metamethods.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_rawgetp
+func (l *State) RawGetValue(index int, p interface{}) {
+	t := l.indexToValue(index).(*table)
+	l.apiPush(t.at(p))
+}
+
+// CreateTable creates a new empty table and pushes it onto the stack.
+// arrayCount is a hint for how many elements the table will have as a
+// sequence; recordCount is a hint for how many other elements the table
+// will have.  Lua may use these hints to preallocate memory for the the new
+// table.  This pre-allocation is useful for performance when you know in
+// advance how many elements the table will have.  Otherwise, you can use the
+// function NewTable.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_createtable
+func (l *State) CreateTable(arrayCount, recordCount int) {
+	l.apiPush(newTableWithSize(arrayCount, recordCount))
+}
+
+// MetaTable pushes onto the stack the metatable of the value at index.  If
+// the value at index does not have a metatable, the function returns
+// false and nothing is put onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_getmetatable
+func (l *State) MetaTable(index int) bool {
+	var mt *table
+	switch v := l.indexToValue(index).(type) {
+	case *table:
+		mt = v.metaTable
+	case *userData:
+		mt = v.metaTable
+	default:
+		mt = l.global.metaTable(v)
+	}
+	if mt == nil {
+		return false
+	}
+	l.apiPush(mt)
+	return true
+}
+
+// UserValue pushes onto the stack the Lua value associated with the userdata
+// at index.  This value must be a table or nil.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_getuservalue
+func (l *State) UserValue(index int) {
+	d := l.indexToValue(index).(*userData)
+	if d.env == nil {
+		l.apiPush(nil)
+	} else {
+		l.apiPush(d.env)
+	}
+}
+
+// SetGlobal pops a value from the stack and sets it as the new value of
+// global name.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_setglobal
+func (l *State) SetGlobal(name string) {
+	l.checkElementCount(1)
+	g := l.global.registry.atInt(RegistryIndexGlobals)
+	l.push(name)
+	l.setTableAt(g, l.stack[l.top-1], l.stack[l.top-2])
+	l.top -= 2 // pop value and key
+}
+
+// SetTable does the equivalent of table[key]=v, where table is the value
+// at index, v is the value at the top of the stack and key is the value
+// just below the top.
+//
+// The function pops both the key and the value from the stack.  As in Lua,
+// this function may trigger a metamethod for the __newindex event.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_settable
+func (l *State) SetTable(index int) {
+	l.checkElementCount(2)
+	l.setTableAt(l.indexToValue(index), l.stack[l.top-2], l.stack[l.top-1])
+	l.top -= 2
+}
+
+// RawSet is similar to SetTable, but does a raw assignment (without
+// metamethods).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_rawset
+func (l *State) RawSet(index int) {
+	l.checkElementCount(2)
+	t := l.indexToValue(index).(*table)
+	t.put(l, l.stack[l.top-2], l.stack[l.top-1])
+	t.invalidateTagMethodCache()
+	l.top -= 2
+}
+
+// RawSetInt does the equivalent of table[n]=v where table is the table at
+// index and v is the value at the top of the stack.
+//
+// This function pops the value from the stack.  The assignment is raw; it
+// doesn't invoke metamethods.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_rawseti
+func (l *State) RawSetInt(index, key int) {
+	l.checkElementCount(1)
+	t := l.indexToValue(index).(*table)
+	t.putAtInt(key, l.stack[l.top-1])
+	l.top--
+}
+
+// SetUserValue pops a table or nil from the stack and sets it as the new
+// value associated to the userdata at index.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_setuservalue
+func (l *State) SetUserValue(index int) {
+	l.checkElementCount(1)
+	d := l.indexToValue(index).(*userData)
+	if l.stack[l.top-1] == nil {
+		d.env = nil
+	} else {
+		t := l.stack[l.top-1].(*table)
+		d.env = t
+	}
+	l.top--
+}
+
+// SetMetaTable pops a table from the stack and sets it as the new metatable
+// for the value at index.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_setmetatable
+func (l *State) SetMetaTable(index int) {
+	l.checkElementCount(1)
+	mt, ok := l.stack[l.top-1].(*table)
+	if apiCheck && !ok && l.stack[l.top-1] != nil {
+		panic("table expected")
+	}
+	switch v := l.indexToValue(index).(type) {
+	case *table:
+		v.metaTable = mt
+	case *userData:
+		v.metaTable = mt
+	default:
+		l.global.metaTables[l.TypeOf(index)] = mt
+	}
+	l.top--
+}
+
+// Error generates a Lua error.  The error message must be on the stack top.
+// The error can be any of any Lua type. This function will panic().
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_error
+func (l *State) Error() {
+	l.checkElementCount(1)
+	l.errorMessage()
+}
+
+// Next pops a key from the stack and pushes a key-value pair from the table
+// at index, while the table has next elements.  If there are no more
+// elements, nothing is pushed on the stack and Next returns false.
+//
+// A typical traversal looks like this:
+//
+//  // Table is on top of the stack (index -1).
+//  l.PushNil() // Add nil entry on stack (need 2 free slots).
+//  for l.Next(-2) {
+//  	key := lua.CheckString(l, -2)
+//  	val := lua.CheckString(l, -1)
+//  	l.Pop(1) // Remove val, but need key for the next iter.
+//  }
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_next
+func (l *State) Next(index int) bool {
+	t := l.indexToValue(index).(*table)
+	if l.next(t, l.top-1) {
+		l.apiIncrementTop()
+		return true
+	}
+	// no more elements
+	l.top-- // remove key
+	return false
+}
+
+// Concat concatenates the n values at the top of the stack, pops them, and
+// leaves the result at the top. If n is 1, the result is the single value
+// on the stack (that is, the function does nothing); if n is 0, the result
+// is the empty string. Concatenation is performed following the usual
+// semantic of Lua.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_concat
+func (l *State) Concat(n int) {
+	l.checkElementCount(n)
+	if n >= 2 {
+		l.concat(n)
+	} else if n == 0 { // push empty string
+		l.apiPush("")
+	} // else n == 1; nothing to do
+}
+
+// Register sets the Go function f as the new value of global name. If
+// name was already defined, it is overwritten.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_register
+func (l *State) Register(name string, f Function) {
+	l.PushGoFunction(f)
+	l.SetGlobal(name)
+}
+
+func (l *State) setErrorObject(err error, oldTop int) {
+	switch err {
+	case MemoryError:
+		l.stack[oldTop] = l.global.memoryErrorMessage
+	case ErrorError:
+		l.stack[oldTop] = "error in error handling"
+	default:
+		l.stack[oldTop] = l.stack[l.top-1]
+	}
+	l.top = oldTop + 1
+}
+
+func (l *State) protectedCall(f func(), oldTop, errorFunc int) error {
+	callInfo, allowHook, nonYieldableCallCount, errorFunction := l.callInfo, l.allowHook, l.nonYieldableCallCount, l.errorFunction
+	l.errorFunction = errorFunc
+	err := l.protect(f)
+	if err != nil {
+		l.close(oldTop)
+		l.setErrorObject(err, oldTop)
+		l.callInfo, l.allowHook, l.nonYieldableCallCount = callInfo, allowHook, nonYieldableCallCount
+		// TODO l.shrinkStack()
+	}
+	l.errorFunction = errorFunction
+	return err
+}
+
+// UpValue returns the name of the upvalue at index away from function,
+// where index cannot be greater than the number of upvalues.
+//
+// Returns an empty string and false if the index is greater than the number
+// of upvalues.
+func UpValue(l *State, function, index int) (name string, ok bool) {
+	if c, isClosure := l.indexToValue(function).(closure); isClosure {
+		if ok = 1 <= index && index <= c.upValueCount(); ok {
+			if c, isLua := c.(*luaClosure); isLua {
+				name = c.prototype.upValues[index-1].name
+			}
+			l.apiPush(c.upValue(index - 1))
+		}
+	}
+	return
+}
+
+// SetUpValue sets the value of a closure's upvalue. It assigns the value at
+// the top of the stack to the upvalue and returns its name.  It also pops a
+// value from the stack. function and index are as in UpValue.
+//
+// Returns an empty string and false if the index is greater than the number
+// of upvalues.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_setupvalue
+func SetUpValue(l *State, function, index int) (name string, ok bool) {
+	if c, isClosure := l.indexToValue(function).(closure); isClosure {
+		if ok = 1 <= index && index <= c.upValueCount(); ok {
+			if c, isLua := c.(*luaClosure); isLua {
+				name = c.prototype.upValues[index-1].name
+			}
+			l.top--
+			c.setUpValue(index-1, l.stack[l.top])
+		}
+	}
+	return
+}
+
+func (l *State) upValue(f, n int) **upValue {
+	return &l.indexToValue(f).(*luaClosure).upValues[n-1]
+}
+
+// UpValueId returns a unique identifier for the upvalue numbered n from the
+// closure at index f. Parameters f and n are as in UpValue (but n cannot be
+// greater than the number of upvalues).
+//
+// These unique identifiers allow a program to check whether different
+// closures share upvalues. Lua closures that share an upvalue (that is, that
+// access a same external local variable) will return identical ids for those
+// upvalue indices.
+func UpValueId(l *State, f, n int) interface{} {
+	switch fun := l.indexToValue(f).(type) {
+	case *luaClosure:
+		return *l.upValue(f, n)
+	case *goClosure:
+		return &fun.upValues[n-1]
+	}
+	panic("closure expected")
+}
+
+// UpValueJoin makes the n1-th upvalue of the Lua closure at index f1 refer to
+// the n2-th upvalue of the Lua closure at index f2.
+func UpValueJoin(l *State, f1, n1, f2, n2 int) {
+	u1 := l.upValue(f1, n1)
+	u2 := l.upValue(f2, n2)
+	*u1 = *u2
+}
+
+// Call calls a function. To do so, use the following protocol: first, the
+// function to be called is pushed onto the stack; then, the arguments to the
+// function are pushed in direct order - that is, the first argument is pushed
+// first. Finally, call Call. argCount is the number of arguments that you
+// pushed onto the stack. All arguments and the function value are popped
+// from the stack when the function is called.
+//
+// The results are pushed onto the stack when the function returns. The
+// number of results is adjusted to resultCount, unless resultCount is
+// MultipleReturns. In this case, all results from the function are pushed.
+// Lua takes care that the returned values fit into the stack space. The
+// function results are pushed onto the stack in direct order (the first
+// result is pushed first), so that after the call the last result is on the
+// top of the stack.
+//
+// Any error inside the called function provokes a call to panic().
+//
+// The following example shows how the host program can do the equivalent to
+// this Lua code:
+//
+//		a = f("how", t.x, 14)
+//
+// Here it is in Go:
+//
+//		l.Global("f")       // Function to be called.
+//		l.PushString("how") // 1st argument.
+//		l.Global("t")       // Table to be indexed.
+//		l.Field(-1, "x")    // Push result of t.x (2nd arg).
+//		l.Remove(-2)        // Remove t from the stack.
+//		l.PushInteger(14)   // 3rd argument.
+//		l.Call(3, 1)        // Call f with 3 arguments and 1 result.
+//		l.SetGlobal("a")    // Set global a.
+//
+// Note that the code above is "balanced": at its end, the stack is back to
+// its original configuration. This is considered good programming practice.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_call
+func (l *State) Call(argCount, resultCount int) {
+	l.CallWithContinuation(argCount, resultCount, 0, nil)
+}
+
+// Top returns the index of the top element in the stack. Because Lua indices
+// start at 1, this result is equal to the number of elements in the stack
+// (hence 0 means an empty stack).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_gettop
+func (l *State) Top() int { return l.top - (l.callInfo.function + 1) }
+
+// Copy moves the element at the index from into the valid index to
+// without shifting any element (therefore replacing the value at that
+// position).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_copy
+func (l *State) Copy(from, to int) { l.move(to, l.indexToValue(from)) }
+
+// Version returns the address of the version number stored in the Lua core.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_version
+func Version(l *State) *float64 { return l.global.version }
+
+// UpValueIndex returns the pseudo-index that represents the i-th upvalue of
+// the running function.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_upvalueindex
+func UpValueIndex(i int) int   { return RegistryIndex - i }
+func isPseudoIndex(i int) bool { return i <= RegistryIndex }
+
+func apiCheckStackSpace(l *State, n int) { l.assert(n < l.top-l.callInfo.function) }
+
+// String returns the name of Type t.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_typename
+func (t Type) String() string { return typeNames[t+1] }
+
+// ToNumber converts the Lua value at index to the Go type for a Lua number
+// (float64). The Lua value must be a number or a string convertible to a
+// number.
+//
+// If the operation failed, the second return value will be false.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_tonumberx
+func (l *State) ToNumber(index int) (float64, bool) { return l.toNumber(l.indexToValue(index)) }
+
+// ToBoolean converts the Lua value at index to a Go boolean. Like all
+// tests in Lua, the only false values are false booleans and nil.
+// Otherwise, all other Lua values evaluate to true.
+//
+// To accept only actual boolean values, use the test IsBoolean.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_toboolean
+func (l *State) ToBoolean(index int) bool { return !isFalse(l.indexToValue(index)) }
+
+// Table pushes onto the stack the value table[top], where table is the
+// value at index, and top is the value at the top of the stack. This
+// function pops the key from the stack, putting the resulting value in its
+// place.  As in Lua, this function may trigger a metamethod for the __index
+// event.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_gettable
+func (l *State) Table(index int) {
+	l.stack[l.top-1] = l.tableAt(l.indexToValue(index), l.stack[l.top-1])
+}
+
+// PushValue pushes a copy of the element at index onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushvalue
+func (l *State) PushValue(index int) { l.apiPush(l.indexToValue(index)) }
+
+// PushNil pushes a nil value onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushnil
+func (l *State) PushNil() { l.apiPush(nil) }
+
+// PushNumber pushes a number onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushnumber
+func (l *State) PushNumber(n float64) { l.apiPush(n) }
+
+// PushInteger pushes n onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushinteger
+func (l *State) PushInteger(n int) { l.apiPush(float64(n)) }
+
+// PushUnsigned pushes n onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushunsigned
+func (l *State) PushUnsigned(n uint) { l.apiPush(float64(n)) }
+
+// PushBoolean pushes a boolean value with value b onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushboolean
+func (l *State) PushBoolean(b bool) { l.apiPush(b) }
+
+// PushLightUserData pushes a light user data onto the stack. Userdata
+// represents Go values in Lua. A light userdata is an interface{}. Its
+// equality matches the Go rules (http://golang.org/ref/spec#Comparison_operators).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushlightuserdata
+func (l *State) PushLightUserData(d interface{}) { l.apiPush(d) }
+
+// PushUserData is similar to PushLightUserData, but pushes a full userdata
+// onto the stack.
+func (l *State) PushUserData(d interface{}) { l.apiPush(&userData{data: d}) }
+
+// Length of the value at index; it is equivalent to the # operator in
+// Lua. The result is pushed on the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_len
+func (l *State) Length(index int) { l.apiPush(l.objectLength(l.indexToValue(index))) }
+
+// Pop pops n elements from the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pop
+func (l *State) Pop(n int) { l.SetTop(-n - 1) }
+
+// NewTable creates a new empty table and pushes it onto the stack. It is
+// equivalent to l.CreateTable(0, 0).
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_newtable
+func (l *State) NewTable() { l.CreateTable(0, 0) }
+
+// PushGoFunction pushes a Function implemented in Go onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushcfunction
+func (l *State) PushGoFunction(f Function) { l.PushGoClosure(f, 0) }
+
+// IsFunction verifies that the value at index is a function, either Go or
+// Lua function.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isfunction
+func (l *State) IsFunction(index int) bool { return l.TypeOf(index) == TypeFunction }
+
+// IsTable verifies that the value at index is a table.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_istable
+func (l *State) IsTable(index int) bool { return l.TypeOf(index) == TypeTable }
+
+// IsLightUserData verifies that the value at index is a light userdata.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_islightuserdata
+func (l *State) IsLightUserData(index int) bool { return l.TypeOf(index) == TypeLightUserData }
+
+// IsNil verifies that the value at index is nil.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isnil
+func (l *State) IsNil(index int) bool { return l.TypeOf(index) == TypeNil }
+
+// IsBoolean verifies that the value at index is a boolean.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isboolean
+func (l *State) IsBoolean(index int) bool { return l.TypeOf(index) == TypeBoolean }
+
+// IsThread verifies that the value at index is a thread.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isthread
+func (l *State) IsThread(index int) bool { return l.TypeOf(index) == TypeThread }
+
+// IsNone verifies that the value at index is not valid.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isnone
+func (l *State) IsNone(index int) bool { return l.TypeOf(index) == TypeNone }
+
+// IsNoneOrNil verifies that the value at index is either nil or invalid.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_isnonornil.
+func (l *State) IsNoneOrNil(index int) bool { return l.TypeOf(index) <= TypeNil }
+
+// PushGlobalTable pushes the global environment onto the stack.
+//
+// http://www.lua.org/manual/5.2/manual.html#lua_pushglobaltable
+func (l *State) PushGlobalTable() { l.RawGetInt(RegistryIndex, RegistryIndexGlobals) }

--- a/vendor/github.com/Shopify/go-lua/math.go
+++ b/vendor/github.com/Shopify/go-lua/math.go
@@ -1,0 +1,119 @@
+package lua
+
+import (
+	"math"
+	"math/rand"
+)
+
+const radiansPerDegree = math.Pi / 180.0
+
+func mathUnaryOp(f func(float64) float64) Function {
+	return func(l *State) int {
+		l.PushNumber(f(CheckNumber(l, 1)))
+		return 1
+	}
+}
+
+func mathBinaryOp(f func(float64, float64) float64) Function {
+	return func(l *State) int {
+		l.PushNumber(f(CheckNumber(l, 1), CheckNumber(l, 2)))
+		return 1
+	}
+}
+
+func reduce(f func(float64, float64) float64) Function {
+	return func(l *State) int {
+		n := l.Top() // number of arguments
+		v := CheckNumber(l, 1)
+		for i := 2; i <= n; i++ {
+			v = f(v, CheckNumber(l, i))
+		}
+		l.PushNumber(v)
+		return 1
+	}
+}
+
+var mathLibrary = []RegistryFunction{
+	{"abs", mathUnaryOp(math.Abs)},
+	{"acos", mathUnaryOp(math.Acos)},
+	{"asin", mathUnaryOp(math.Asin)},
+	{"atan2", mathBinaryOp(math.Atan2)},
+	{"atan", mathUnaryOp(math.Atan)},
+	{"ceil", mathUnaryOp(math.Ceil)},
+	{"cosh", mathUnaryOp(math.Cosh)},
+	{"cos", mathUnaryOp(math.Cos)},
+	{"deg", mathUnaryOp(func(x float64) float64 { return x / radiansPerDegree })},
+	{"exp", mathUnaryOp(math.Exp)},
+	{"floor", mathUnaryOp(math.Floor)},
+	{"fmod", mathBinaryOp(math.Mod)},
+	{"frexp", func(l *State) int {
+		f, e := math.Frexp(CheckNumber(l, 1))
+		l.PushNumber(f)
+		l.PushInteger(e)
+		return 2
+	}},
+	{"ldexp", func(l *State) int {
+		x, e := CheckNumber(l, 1), CheckInteger(l, 2)
+		l.PushNumber(math.Ldexp(x, e))
+		return 1
+	}},
+	{"log", func(l *State) int {
+		x := CheckNumber(l, 1)
+		if l.IsNoneOrNil(2) {
+			l.PushNumber(math.Log(x))
+		} else if base := CheckNumber(l, 2); base == 10.0 {
+			l.PushNumber(math.Log10(x))
+		} else {
+			l.PushNumber(math.Log(x) / math.Log(base))
+		}
+		return 1
+	}},
+	{"max", reduce(math.Max)},
+	{"min", reduce(math.Min)},
+	{"modf", func(l *State) int {
+		i, f := math.Modf(CheckNumber(l, 1))
+		l.PushNumber(i)
+		l.PushNumber(f)
+		return 2
+	}},
+	{"pow", mathBinaryOp(math.Pow)},
+	{"rad", mathUnaryOp(func(x float64) float64 { return x * radiansPerDegree })},
+	{"random", func(l *State) int {
+		r := rand.Float64()
+		switch l.Top() {
+		case 0: // no arguments
+			l.PushNumber(r)
+		case 1: // upper limit only
+			u := CheckNumber(l, 1)
+			ArgumentCheck(l, 1.0 <= u, 1, "interval is empty")
+			l.PushNumber(math.Floor(r*u) + 1.0) // [1, u]
+		case 2: // lower and upper limits
+			lo, u := CheckNumber(l, 1), CheckNumber(l, 2)
+			ArgumentCheck(l, lo <= u, 2, "interval is empty")
+			l.PushNumber(math.Floor(r*(u-lo+1)) + lo) // [lo, u]
+		default:
+			Errorf(l, "wrong number of arguments")
+		}
+		return 1
+	}},
+	{"randomseed", func(l *State) int {
+		rand.Seed(int64(CheckUnsigned(l, 1)))
+		rand.Float64() // discard first value to avoid undesirable correlations
+		return 0
+	}},
+	{"sinh", mathUnaryOp(math.Sinh)},
+	{"sin", mathUnaryOp(math.Sin)},
+	{"sqrt", mathUnaryOp(math.Sqrt)},
+	{"tanh", mathUnaryOp(math.Tanh)},
+	{"tan", mathUnaryOp(math.Tan)},
+}
+
+// MathOpen opens the math library. Usually passed to Require.
+func MathOpen(l *State) int {
+	NewLibrary(l, mathLibrary)
+	l.PushNumber(3.1415926535897932384626433832795) // TODO use math.Pi instead? Values differ.
+	l.SetField(-2, "pi")
+	l.PushNumber(math.MaxFloat64)
+	l.SetField(-2, "huge")
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/os.go
+++ b/vendor/github.com/Shopify/go-lua/os.go
@@ -1,0 +1,147 @@
+package lua
+
+import (
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"syscall"
+	"time"
+)
+
+func field(l *State, key string, def int) int {
+	l.Field(-1, key)
+	r, ok := l.ToInteger(-1)
+	if !ok {
+		if def < 0 {
+			Errorf(l, "field '%s' missing in date table", key)
+		}
+		r = def
+	}
+	l.Pop(1)
+	return r
+}
+
+var osLibrary = []RegistryFunction{
+	{"clock", clock},
+	// {"date", os_date},
+	{"difftime", func(l *State) int {
+		l.PushNumber(time.Unix(int64(CheckNumber(l, 1)), 0).Sub(time.Unix(int64(OptNumber(l, 2, 0)), 0)).Seconds())
+		return 1
+	}},
+
+	// From the Lua manual:
+	// "This function is equivalent to the ISO C function system"
+	// https://www.lua.org/manual/5.2/manual.html#pdf-os.execute
+	{"execute", func(l *State) int {
+		c := OptString(l, 1, "")
+
+		if c == "" {
+			// Check whether "sh" is available on the system.
+			err := exec.Command("sh").Run()
+			l.PushBoolean(err == nil)
+			return 1
+		}
+
+		terminatedSuccessfully := true
+		terminationReason := "exit"
+		terminationData := 0
+
+		// Create the command.
+		cmd := exec.Command("sh", "-c", c)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		// Run the command.
+		if err := cmd.Run(); err != nil {
+			terminatedSuccessfully = false
+			terminationReason = "exit"
+			terminationData = 1
+
+			if exiterr, ok := err.(*exec.ExitError); ok {
+				if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+					if status.Signaled() {
+						terminationReason = "signal"
+						terminationData = int(status.Signal())
+					} else {
+						terminationData = status.ExitStatus()
+					}
+				} else {
+					// Unsupported system?
+				}
+			} else {
+				// From man 3 system:
+				// "If a child process could not be created, or its
+				// status could not be retrieved, the return value
+				// is -1."
+				terminationData = -1
+			}
+		}
+
+		// Deal with the return values.
+		if terminatedSuccessfully {
+			l.PushBoolean(true)
+		} else {
+			l.PushNil()
+		}
+
+		l.PushString(terminationReason)
+		l.PushInteger(terminationData)
+
+		return 3
+	}},
+	{"exit", func(l *State) int {
+		var status int
+		if l.IsBoolean(1) {
+			if !l.ToBoolean(1) {
+				status = 1
+			}
+		} else {
+			status = OptInteger(l, 1, status)
+		}
+		// if l.ToBoolean(2) {
+		// 	Close(l)
+		// }
+		os.Exit(status)
+		panic("unreachable")
+	}},
+	{"getenv", func(l *State) int { l.PushString(os.Getenv(CheckString(l, 1))); return 1 }},
+	{"remove", func(l *State) int { name := CheckString(l, 1); return FileResult(l, os.Remove(name), name) }},
+	{"rename", func(l *State) int { return FileResult(l, os.Rename(CheckString(l, 1), CheckString(l, 2)), "") }},
+	// {"setlocale", func(l *State) int {
+	// 	op := CheckOption(l, 2, "all", []string{"all", "collate", "ctype", "monetary", "numeric", "time"})
+	// 	l.PushString(setlocale([]int{LC_ALL, LC_COLLATE, LC_CTYPE, LC_MONETARY, LC_NUMERIC, LC_TIME}, OptString(l, 1, "")))
+	// 	return 1
+	// }},
+	{"time", func(l *State) int {
+		if l.IsNoneOrNil(1) {
+			l.PushNumber(float64(time.Now().Unix()))
+		} else {
+			CheckType(l, 1, TypeTable)
+			l.SetTop(1)
+			year := field(l, "year", -1) - 1900
+			month := field(l, "month", -1) - 1
+			day := field(l, "day", -1)
+			hour := field(l, "hour", 12)
+			min := field(l, "min", 0)
+			sec := field(l, "sec", 0)
+			// dst := boolField(l, "isdst") // TODO how to use dst?
+			l.PushNumber(float64(time.Date(year, time.Month(month), day, hour, min, sec, 0, time.Local).Unix()))
+		}
+		return 1
+	}},
+	{"tmpname", func(l *State) int {
+		f, err := ioutil.TempFile("", "lua_")
+		if err != nil {
+			Errorf(l, "unable to generate a unique filename")
+		}
+		defer f.Close()
+		l.PushString(f.Name())
+		return 1
+	}},
+}
+
+// OSOpen opens the os library. Usually passed to Require.
+func OSOpen(l *State) int {
+	NewLibrary(l, osLibrary)
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/os_windows.go
+++ b/vendor/github.com/Shopify/go-lua/os_windows.go
@@ -1,0 +1,6 @@
+package lua
+
+func clock(l *State) int {
+	Errorf(l, "os.clock not yet supported on Windows")
+	panic("unreachable")
+}

--- a/vendor/github.com/Shopify/go-lua/parser.go
+++ b/vendor/github.com/Shopify/go-lua/parser.go
@@ -1,0 +1,698 @@
+package lua
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+type parser struct {
+	scanner
+	function                   *function
+	activeVariables            []int
+	pendingGotos, activeLabels []label
+}
+
+func (p *parser) checkCondition(c bool, message string) {
+	if !c {
+		p.syntaxError(message)
+	}
+}
+
+func (p *parser) checkName() string {
+	p.check(tkName)
+	s := p.s
+	p.next()
+	return s
+}
+
+func (p *parser) checkLimit(val, limit int, what string) {
+	if val > limit {
+		where := "main function"
+		if line := p.function.f.lineDefined; line != 0 {
+			where = fmt.Sprintf("function at line %d", line)
+		}
+		p.syntaxError(fmt.Sprintf("too many %s (limit is %d) in %s", what, limit, where))
+	}
+}
+
+func (p *parser) checkNext(t rune) {
+	p.check(t)
+	p.next()
+}
+
+func (p *parser) checkNameAsExpression() exprDesc { return p.function.EncodeString(p.checkName()) }
+func (p *parser) singleVariable() exprDesc        { return p.function.SingleVariable(p.checkName()) }
+func (p *parser) leaveLevel()                     { p.l.nestedGoCallCount-- }
+func (p *parser) enterLevel() {
+	p.l.nestedGoCallCount++
+	p.checkLimit(p.l.nestedGoCallCount, maxCallCount, "Go levels")
+}
+
+func (p *parser) expressionList() (e exprDesc, n int) {
+	for n, e = 1, p.expression(); p.testNext(','); n, e = n+1, p.expression() {
+		_ = p.function.ExpressionToNextRegister(e)
+	}
+	return
+}
+
+func (p *parser) field(tableRegister, a, h, pending int, e exprDesc) (int, int, int, exprDesc) {
+	freeRegisterCount := p.function.freeRegisterCount
+	hashField := func(k exprDesc) {
+		h++
+		p.checkNext('=')
+		p.function.FlushFieldToConstructor(tableRegister, freeRegisterCount, k, p.expression)
+	}
+	switch {
+	case p.t == tkName && p.lookAhead() == '=':
+		p.checkLimit(h, maxInt, "items in a constructor")
+		hashField(p.checkNameAsExpression())
+	case p.t == '[':
+		hashField(p.index())
+	default:
+		e = p.expression()
+		p.checkLimit(a, maxInt, "items in a constructor")
+		a++
+		pending++
+	}
+	return a, h, pending, e
+}
+
+func (p *parser) constructor() exprDesc {
+	pc, t := p.function.OpenConstructor()
+	line, a, h, pending := p.lineNumber, 0, 0, 0
+	var e exprDesc
+	if p.checkNext('{'); p.t != '}' {
+		for a, h, pending, e = p.field(t.info, a, h, pending, e); (p.testNext(',') || p.testNext(';')) && p.t != '}'; {
+			if e.kind != kindVoid {
+				pending = p.function.FlushToConstructor(t.info, pending, a, e)
+				e.kind = kindVoid
+			}
+			a, h, pending, e = p.field(t.info, a, h, pending, e)
+		}
+	}
+	p.checkMatch('}', '{', line)
+	p.function.CloseConstructor(pc, t.info, pending, a, h, e)
+	return t
+}
+
+func (p *parser) functionArguments(f exprDesc, line int) exprDesc {
+	var args exprDesc
+	switch p.t {
+	case '(':
+		p.next()
+		if p.t == ')' {
+			args.kind = kindVoid
+		} else {
+			args, _ = p.expressionList()
+			p.function.SetMultipleReturns(args)
+		}
+		p.checkMatch(')', '(', line)
+	case '{':
+		args = p.constructor()
+	case tkString:
+		args = p.function.EncodeString(p.s)
+		p.next()
+	default:
+		p.syntaxError("function arguments expected")
+	}
+	base, parameterCount := f.info, MultipleReturns
+	if !args.hasMultipleReturns() {
+		if args.kind != kindVoid {
+			args = p.function.ExpressionToNextRegister(args)
+		}
+		parameterCount = p.function.freeRegisterCount - (base + 1)
+	}
+	e := makeExpression(kindCall, p.function.EncodeABC(opCall, base, parameterCount+1, 2))
+	p.function.FixLine(line)
+	p.function.freeRegisterCount = base + 1 // call removed function and args & leaves (unless changed) one result
+	return e
+}
+
+func (p *parser) primaryExpression() (e exprDesc) {
+	switch p.t {
+	case '(':
+		line := p.lineNumber
+		p.next()
+		e = p.expression()
+		p.checkMatch(')', '(', line)
+		e = p.function.DischargeVariables(e)
+	case tkName:
+		e = p.singleVariable()
+	default:
+		p.syntaxError("unexpected symbol")
+	}
+	return
+}
+
+func (p *parser) suffixedExpression() exprDesc {
+	line := p.lineNumber
+	e := p.primaryExpression()
+	for {
+		switch p.t {
+		case '.':
+			e = p.fieldSelector(e)
+		case '[':
+			e = p.function.Indexed(p.function.ExpressionToAnyRegisterOrUpValue(e), p.index())
+		case ':':
+			p.next()
+			e = p.functionArguments(p.function.Self(e, p.checkNameAsExpression()), line)
+		case '(', tkString, '{':
+			e = p.functionArguments(p.function.ExpressionToNextRegister(e), line)
+		default:
+			return e
+		}
+	}
+	panic("unreachable")
+}
+
+func (p *parser) simpleExpression() (e exprDesc) {
+	switch p.t {
+	case tkNumber:
+		e = makeExpression(kindNumber, 0)
+		e.value = p.n
+	case tkString:
+		e = p.function.EncodeString(p.s)
+	case tkNil:
+		e = makeExpression(kindNil, 0)
+	case tkTrue:
+		e = makeExpression(kindTrue, 0)
+	case tkFalse:
+		e = makeExpression(kindFalse, 0)
+	case tkDots:
+		p.checkCondition(p.function.f.isVarArg, "cannot use '...' outside a vararg function")
+		e = makeExpression(kindVarArg, p.function.EncodeABC(opVarArg, 0, 1, 0))
+	case '{':
+		e = p.constructor()
+		return
+	case tkFunction:
+		p.next()
+		e = p.body(false, p.lineNumber)
+		return
+	default:
+		e = p.suffixedExpression()
+		return
+	}
+	p.next()
+	return
+}
+
+func unaryOp(op rune) int {
+	switch op {
+	case tkNot:
+		return oprNot
+	case '-':
+		return oprMinus
+	case '#':
+		return oprLength
+	}
+	return oprNoUnary
+}
+
+func binaryOp(op rune) int {
+	switch op {
+	case '+':
+		return oprAdd
+	case '-':
+		return oprSub
+	case '*':
+		return oprMul
+	case '/':
+		return oprDiv
+	case '%':
+		return oprMod
+	case '^':
+		return oprPow
+	case tkConcat:
+		return oprConcat
+	case tkNE:
+		return oprNE
+	case tkEq:
+		return oprEq
+	case '<':
+		return oprLT
+	case tkLE:
+		return oprLE
+	case '>':
+		return oprGT
+	case tkGE:
+		return oprGE
+	case tkAnd:
+		return oprAnd
+	case tkOr:
+		return oprOr
+	}
+	return oprNoBinary
+}
+
+var priority []struct{ left, right int } = []struct{ left, right int }{
+	{6, 6}, {6, 6}, {7, 7}, {7, 7}, {7, 7}, // `+' `-' `*' `/' `%'
+	{10, 9}, {5, 4}, // ^, .. (right associative)
+	{3, 3}, {3, 3}, {3, 3}, // ==, <, <=
+	{3, 3}, {3, 3}, {3, 3}, // ~=, >, >=
+	{2, 2}, {1, 1}, // and, or
+}
+
+const unaryPriority = 8
+
+func (p *parser) subExpression(limit int) (e exprDesc, op int) {
+	p.enterLevel()
+	if u := unaryOp(p.t); u != oprNoUnary {
+		line := p.lineNumber
+		p.next()
+		e, _ = p.subExpression(unaryPriority)
+		e = p.function.Prefix(u, e, line)
+	} else {
+		e = p.simpleExpression()
+	}
+	op = binaryOp(p.t)
+	for op != oprNoBinary && priority[op].left > limit {
+		line := p.lineNumber
+		p.next()
+		e = p.function.Infix(op, e)
+		e2, next := p.subExpression(priority[op].right)
+		e = p.function.Postfix(op, e, e2, line)
+		op = next
+	}
+	p.leaveLevel()
+	return
+}
+
+func (p *parser) expression() (e exprDesc) {
+	e, _ = p.subExpression(0)
+	return
+}
+
+func (p *parser) blockFollow(withUntil bool) bool {
+	switch p.t {
+	case tkElse, tkElseif, tkEnd, tkEOS:
+		return true
+	case tkUntil:
+		return withUntil
+	}
+	return false
+}
+
+func (p *parser) statementList() {
+	for !p.blockFollow(true) {
+		if p.t == tkReturn {
+			p.statement()
+			return
+		}
+		p.statement()
+	}
+}
+
+func (p *parser) fieldSelector(e exprDesc) exprDesc {
+	e = p.function.ExpressionToAnyRegisterOrUpValue(e)
+	p.next() // skip dot or colon
+	return p.function.Indexed(e, p.checkNameAsExpression())
+}
+
+func (p *parser) index() exprDesc {
+	p.next() // skip '['
+	e := p.function.ExpressionToValue(p.expression())
+	p.checkNext(']')
+	return e
+}
+
+func (p *parser) assignment(t *assignmentTarget, variableCount int) {
+	if p.checkCondition(t.isVariable(), "syntax error"); p.testNext(',') {
+		e := p.suffixedExpression()
+		if e.kind != kindIndexed {
+			p.function.CheckConflict(t, e)
+		}
+		p.checkLimit(variableCount+p.l.nestedGoCallCount, maxCallCount, "Go levels")
+		p.assignment(&assignmentTarget{previous: t, exprDesc: e}, variableCount+1)
+	} else {
+		p.checkNext('=')
+		if e, n := p.expressionList(); n != variableCount {
+			if p.function.AdjustAssignment(variableCount, n, e); n > variableCount {
+				p.function.freeRegisterCount -= n - variableCount // remove extra values
+			}
+		} else {
+			p.function.StoreVariable(t.exprDesc, p.function.SetReturn(e))
+			return // avoid default
+		}
+	}
+	p.function.StoreVariable(t.exprDesc, makeExpression(kindNonRelocatable, p.function.freeRegisterCount-1))
+}
+
+func (p *parser) forBody(base, line, n int, isNumeric bool) {
+	p.function.AdjustLocalVariables(3)
+	p.checkNext(tkDo)
+	prep := p.function.OpenForBody(base, n, isNumeric)
+	p.block()
+	p.function.CloseForBody(prep, base, line, n, isNumeric)
+}
+
+func (p *parser) forNumeric(name string, line int) {
+	expr := func() { p.assert(p.function.ExpressionToNextRegister(p.expression()).kind == kindNonRelocatable) }
+	base := p.function.freeRegisterCount
+	p.function.MakeLocalVariable("(for index)")
+	p.function.MakeLocalVariable("(for limit)")
+	p.function.MakeLocalVariable("(for step)")
+	p.function.MakeLocalVariable(name)
+	p.checkNext('=')
+	expr()
+	p.checkNext(',')
+	expr()
+	if p.testNext(',') {
+		expr()
+	} else {
+		p.function.EncodeConstant(p.function.freeRegisterCount, p.function.NumberConstant(1))
+		p.function.ReserveRegisters(1)
+	}
+	p.forBody(base, line, 1, true)
+}
+
+func (p *parser) forList(name string) {
+	n, base := 4, p.function.freeRegisterCount
+	p.function.MakeLocalVariable("(for generator)")
+	p.function.MakeLocalVariable("(for state)")
+	p.function.MakeLocalVariable("(for control)")
+	p.function.MakeLocalVariable(name)
+	for ; p.testNext(','); n++ {
+		p.function.MakeLocalVariable(p.checkName())
+	}
+	p.checkNext(tkIn)
+	line := p.lineNumber
+	e, c := p.expressionList()
+	p.function.AdjustAssignment(3, c, e)
+	p.function.CheckStack(3)
+	p.forBody(base, line, n-3, false)
+}
+
+func (p *parser) forStatement(line int) {
+	p.function.EnterBlock(true)
+	p.next()
+	switch name := p.checkName(); p.t {
+	case '=':
+		p.forNumeric(name, line)
+	case ',', tkIn:
+		p.forList(name)
+	default:
+		p.syntaxError("'=' or 'in' expected")
+	}
+	p.checkMatch(tkEnd, tkFor, line)
+	p.function.LeaveBlock()
+}
+
+func (p *parser) testThenBlock(escapes int) int {
+	var jumpFalse int
+	p.next()
+	e := p.expression()
+	p.checkNext(tkThen)
+	if p.t == tkGoto || p.t == tkBreak {
+		e = p.function.GoIfFalse(e)
+		p.function.EnterBlock(false)
+		p.gotoStatement(e.t)
+		p.skipEmptyStatements()
+		if p.blockFollow(false) {
+			p.function.LeaveBlock()
+			return escapes
+		}
+		jumpFalse = p.function.Jump()
+	} else {
+		e = p.function.GoIfTrue(e)
+		p.function.EnterBlock(false)
+		jumpFalse = e.f
+	}
+	p.statementList()
+	p.function.LeaveBlock()
+	if p.t == tkElse || p.t == tkElseif {
+		escapes = p.function.Concatenate(escapes, p.function.Jump())
+	}
+	p.function.PatchToHere(jumpFalse)
+	return escapes
+}
+
+func (p *parser) ifStatement(line int) {
+	escapes := p.testThenBlock(noJump)
+	for p.t == tkElseif {
+		escapes = p.testThenBlock(escapes)
+	}
+	if p.testNext(tkElse) {
+		p.block()
+	}
+	p.checkMatch(tkEnd, tkIf, line)
+	p.function.PatchToHere(escapes)
+}
+
+func (p *parser) block() {
+	p.function.EnterBlock(false)
+	p.statementList()
+	p.function.LeaveBlock()
+}
+
+func (p *parser) whileStatement(line int) {
+	p.next()
+	top, conditionExit := p.function.Label(), p.condition()
+	p.function.EnterBlock(true)
+	p.checkNext(tkDo)
+	p.block()
+	p.function.JumpTo(top)
+	p.checkMatch(tkEnd, tkWhile, line)
+	p.function.LeaveBlock()
+	p.function.PatchToHere(conditionExit) // false conditions finish the loop
+}
+
+func (p *parser) repeatStatement(line int) {
+	top := p.function.Label()
+	p.function.EnterBlock(true)  // loop block
+	p.function.EnterBlock(false) // scope block
+	p.next()
+	p.statementList()
+	p.checkMatch(tkUntil, tkRepeat, line)
+	conditionExit := p.condition()
+	if p.function.block.hasUpValue {
+		p.function.PatchClose(conditionExit, p.function.block.activeVariableCount)
+	}
+	p.function.LeaveBlock()                  // finish scope
+	p.function.PatchList(conditionExit, top) // close loop
+	p.function.LeaveBlock()                  // finish loop
+}
+
+func (p *parser) condition() int {
+	e := p.expression()
+	if e.kind == kindNil {
+		e.kind = kindFalse
+	}
+	return p.function.GoIfTrue(e).f
+}
+
+func (p *parser) gotoStatement(pc int) {
+	if line := p.lineNumber; p.testNext(tkGoto) {
+		p.function.MakeGoto(p.checkName(), line, pc)
+	} else {
+		p.next()
+		p.function.MakeGoto("break", line, pc)
+	}
+}
+
+func (p *parser) skipEmptyStatements() {
+	for p.t == ';' || p.t == tkDoubleColon {
+		p.statement()
+	}
+}
+
+func (p *parser) labelStatement(label string, line int) {
+	p.function.CheckRepeatedLabel(label)
+	p.checkNext(tkDoubleColon)
+	l := p.function.MakeLabel(label, line)
+	p.skipEmptyStatements()
+	if p.blockFollow(false) {
+		p.activeLabels[l].activeVariableCount = p.function.block.activeVariableCount
+	}
+	p.function.FindGotos(l)
+}
+
+func (p *parser) parameterList() {
+	n, isVarArg := 0, false
+	if p.t != ')' {
+		for first := true; first || (!isVarArg && p.testNext(',')); first = false {
+			switch p.t {
+			case tkName:
+				p.function.MakeLocalVariable(p.checkName())
+				n++
+			case tkDots:
+				p.next()
+				isVarArg = true
+			default:
+				p.syntaxError("<name> or '...' expected")
+			}
+		}
+	}
+	// TODO the following lines belong in a *function method
+	p.function.f.isVarArg = isVarArg
+	p.function.AdjustLocalVariables(n)
+	p.function.f.parameterCount = p.function.activeVariableCount
+	p.function.ReserveRegisters(p.function.activeVariableCount)
+}
+
+func (p *parser) body(isMethod bool, line int) exprDesc {
+	p.function.OpenFunction(line)
+	p.checkNext('(')
+	if isMethod {
+		p.function.MakeLocalVariable("self")
+		p.function.AdjustLocalVariables(1)
+	}
+	p.parameterList()
+	p.checkNext(')')
+	p.statementList()
+	p.function.f.lastLineDefined = p.lineNumber
+	p.checkMatch(tkEnd, tkFunction, line)
+	return p.function.CloseFunction()
+}
+
+func (p *parser) functionName() (e exprDesc, isMethod bool) {
+	for e = p.singleVariable(); p.t == '.'; e = p.fieldSelector(e) {
+	}
+	if p.t == ':' {
+		e, isMethod = p.fieldSelector(e), true
+	}
+	return
+}
+
+func (p *parser) functionStatement(line int) {
+	p.next()
+	v, m := p.functionName()
+	p.function.StoreVariable(v, p.body(m, line))
+	p.function.FixLine(line)
+}
+
+func (p *parser) localFunction() {
+	p.function.MakeLocalVariable(p.checkName())
+	p.function.AdjustLocalVariables(1)
+	p.function.LocalVariable(p.body(false, p.lineNumber).info).startPC = pc(len(p.function.f.code))
+}
+
+func (p *parser) localStatement() {
+	v := 0
+	for first := true; first || p.testNext(','); v++ {
+		p.function.MakeLocalVariable(p.checkName())
+		first = false
+	}
+	if p.testNext('=') {
+		e, n := p.expressionList()
+		p.function.AdjustAssignment(v, n, e)
+	} else {
+		var e exprDesc
+		p.function.AdjustAssignment(v, 0, e)
+	}
+	p.function.AdjustLocalVariables(v)
+}
+
+func (p *parser) expressionStatement() {
+	if e := p.suffixedExpression(); p.t == '=' || p.t == ',' {
+		p.assignment(&assignmentTarget{exprDesc: e}, 1)
+	} else {
+		p.checkCondition(e.kind == kindCall, "syntax error")
+		p.function.Instruction(e).setC(1) // call statement uses no results
+	}
+}
+
+func (p *parser) returnStatement() {
+	if f := p.function; p.blockFollow(true) || p.t == ';' {
+		f.ReturnNone()
+	} else {
+		f.Return(p.expressionList())
+	}
+	p.testNext(';')
+}
+
+func (p *parser) statement() {
+	line := p.lineNumber
+	p.enterLevel()
+	switch p.t {
+	case ';':
+		p.next()
+	case tkIf:
+		p.ifStatement(line)
+	case tkWhile:
+		p.whileStatement(line)
+	case tkDo:
+		p.next()
+		p.block()
+		p.checkMatch(tkEnd, tkDo, line)
+	case tkFor:
+		p.forStatement(line)
+	case tkRepeat:
+		p.repeatStatement(line)
+	case tkFunction:
+		p.functionStatement(line)
+	case tkLocal:
+		p.next()
+		if p.testNext(tkFunction) {
+			p.localFunction()
+		} else {
+			p.localStatement()
+		}
+	case tkDoubleColon:
+		p.next()
+		p.labelStatement(p.checkName(), line)
+	case tkReturn:
+		p.next()
+		p.returnStatement()
+	case tkBreak, tkGoto:
+		p.gotoStatement(p.function.Jump())
+	default:
+		p.expressionStatement()
+	}
+	p.assert(p.function.f.maxStackSize >= p.function.freeRegisterCount && p.function.freeRegisterCount >= p.function.activeVariableCount)
+	p.function.freeRegisterCount = p.function.activeVariableCount
+	p.leaveLevel()
+}
+
+func (p *parser) mainFunction() {
+	p.function.OpenMainFunction()
+	p.next()
+	p.statementList()
+	p.check(tkEOS)
+	p.function = p.function.CloseMainFunction()
+}
+
+func (l *State) parse(r io.ByteReader, name string) *luaClosure {
+	p := &parser{scanner: scanner{r: r, lineNumber: 1, lastLine: 1, lookAheadToken: token{t: tkEOS}, l: l, source: name}}
+	f := &function{f: &prototype{source: name, maxStackSize: 2, isVarArg: true}, constantLookup: make(map[value]int), p: p, jumpPC: noJump}
+	p.function = f
+	p.mainFunction()
+	// TODO assertions about parser state
+	c := l.newLuaClosure(f.f)
+	l.push(c)
+	return c
+}
+
+func (l *State) checkMode(mode, x string) {
+	if mode != "" && !strings.Contains(mode, x[:1]) {
+		l.push(fmt.Sprintf("attempt to load a %s chunk (mode is '%s')", x, mode))
+		l.throw(SyntaxError)
+	}
+}
+
+func protectedParser(l *State, r io.Reader, name, chunkMode string) error {
+	l.nonYieldableCallCount++
+	err := l.protectedCall(func() {
+		var closure *luaClosure
+		b := bufio.NewReader(r)
+		if c, err := b.ReadByte(); err != nil {
+			l.checkMode(chunkMode, "text")
+			closure = l.parse(b, name)
+		} else if c == Signature[0] {
+			l.checkMode(chunkMode, "binary")
+			b.UnreadByte()
+			closure, err = l.undump(b, name) // TODO handle err
+		} else {
+			l.checkMode(chunkMode, "text")
+			b.UnreadByte()
+			closure = l.parse(b, name)
+		}
+		l.assert(closure.upValueCount() == len(closure.prototype.upValues))
+		for i := range closure.upValues {
+			closure.upValues[i] = l.newUpValue()
+		}
+	}, l.top, l.errorFunction)
+	l.nonYieldableCallCount--
+	return err
+}

--- a/vendor/github.com/Shopify/go-lua/scanner.go
+++ b/vendor/github.com/Shopify/go-lua/scanner.go
@@ -1,0 +1,544 @@
+package lua
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const firstReserved = 257
+const endOfStream = -1
+const maxInt = int(^uint(0) >> 1)
+
+const (
+	tkAnd = iota + firstReserved
+	tkBreak
+	tkDo
+	tkElse
+	tkElseif
+	tkEnd
+	tkFalse
+	tkFor
+	tkFunction
+	tkGoto
+	tkIf
+	tkIn
+	tkLocal
+	tkNil
+	tkNot
+	tkOr
+	tkRepeat
+	tkReturn
+	tkThen
+	tkTrue
+	tkUntil
+	tkWhile
+	tkConcat
+	tkDots
+	tkEq
+	tkGE
+	tkLE
+	tkNE
+	tkDoubleColon
+	tkEOS
+	tkNumber
+	tkName
+	tkString
+	reservedCount = tkWhile - firstReserved + 1
+)
+
+var tokens []string = []string{
+	"and", "break", "do", "else", "elseif",
+	"end", "false", "for", "function", "goto", "if",
+	"in", "local", "nil", "not", "or", "repeat",
+	"return", "then", "true", "until", "while",
+	"..", "...", "==", ">=", "<=", "~=", "::", "<eof>",
+	"<number>", "<name>", "<string>",
+}
+
+type token struct {
+	t rune
+	n float64
+	s string
+}
+
+type scanner struct {
+	l                    *State
+	buffer               bytes.Buffer
+	r                    io.ByteReader
+	current              rune
+	lineNumber, lastLine int
+	source               string
+	lookAheadToken       token
+	token
+}
+
+func (s *scanner) assert(cond bool)           { s.l.assert(cond) }
+func (s *scanner) syntaxError(message string) { s.scanError(message, s.t) }
+func (l *scanner) errorExpected(t rune)       { l.syntaxError(l.tokenToString(t) + " expected") }
+func (s *scanner) numberError()               { s.scanError("malformed number", tkNumber) }
+func isNewLine(c rune) bool                   { return c == '\n' || c == '\r' }
+func isDecimal(c rune) bool                   { return '0' <= c && c <= '9' }
+
+func (s *scanner) tokenToString(t rune) string {
+	switch {
+	case t == tkName || t == tkString:
+		return s.s
+	case t == tkNumber:
+		return fmt.Sprintf("%f", s.n)
+	case t < firstReserved:
+		return string(t) // TODO check for printable rune
+	case t < tkEOS:
+		return fmt.Sprintf("'%s'", tokens[t-firstReserved])
+	}
+	return tokens[t-firstReserved]
+}
+
+func (s *scanner) scanError(message string, token rune) {
+	if token != 0 {
+		message = fmt.Sprintf("%s:%d: %s near %s", s.source, s.lineNumber, message, s.tokenToString(token))
+	} else {
+		message = fmt.Sprintf("%s:%d: %s", s.source, s.lineNumber, message)
+	}
+	s.l.push(message)
+	s.l.throw(SyntaxError)
+}
+
+func (s *scanner) incrementLineNumber() {
+	old := s.current
+	s.assert(isNewLine(old))
+	if s.advance(); isNewLine(s.current) && s.current != old {
+		s.advance()
+	}
+	if s.lineNumber++; s.lineNumber >= maxInt {
+		s.syntaxError("chunk has too many lines")
+	}
+}
+
+func (s *scanner) advance() {
+	if c, err := s.r.ReadByte(); err != nil {
+		s.current = endOfStream
+	} else {
+		s.current = rune(c)
+	}
+}
+
+func (s *scanner) saveAndAdvance() {
+	s.save(s.current)
+	s.advance()
+}
+
+func (s *scanner) advanceAndSave(c rune) {
+	s.advance()
+	s.save(c)
+}
+
+func (s *scanner) save(c rune) {
+	if err := s.buffer.WriteByte(byte(c)); err != nil {
+		s.scanError("lexical element too long", 0)
+	}
+}
+
+func (s *scanner) checkNext(str string) bool {
+	if s.current == 0 || !strings.ContainsRune(str, s.current) {
+		return false
+	}
+	s.saveAndAdvance()
+	return true
+}
+
+func (s *scanner) skipSeparator() int { // TODO is this the right name?
+	i, c := 0, s.current
+	s.assert(c == '[' || c == ']')
+	for s.saveAndAdvance(); s.current == '='; i++ {
+		s.saveAndAdvance()
+	}
+	if s.current == c {
+		return i
+	}
+	return -i - 1
+}
+
+func (s *scanner) readMultiLine(comment bool, sep int) (str string) {
+	if s.saveAndAdvance(); isNewLine(s.current) {
+		s.incrementLineNumber()
+	}
+	for {
+		switch s.current {
+		case endOfStream:
+			if comment {
+				s.scanError("unfinished long comment", tkEOS)
+			} else {
+				s.scanError("unfinished long string", tkEOS)
+			}
+		case ']':
+			if s.skipSeparator() == sep {
+				s.saveAndAdvance()
+				if !comment {
+					str = s.buffer.String()
+					str = str[2+sep : len(str)-(2+sep)]
+				}
+				s.buffer.Reset()
+				return
+			}
+		case '\r':
+			s.current = '\n'
+			fallthrough
+		case '\n':
+			s.save(s.current)
+			s.incrementLineNumber()
+		default:
+			if !comment {
+				s.save(s.current)
+			}
+			s.advance()
+		}
+	}
+}
+
+func (s *scanner) readDigits() (c rune) {
+	for c = s.current; isDecimal(c); c = s.current {
+		s.saveAndAdvance()
+	}
+	return
+}
+
+func isHexadecimal(c rune) bool {
+	return '0' <= c && c <= '9' || 'a' <= c && c <= 'f' || 'A' <= c && c <= 'F'
+}
+
+func (s *scanner) readHexNumber(x float64) (n float64, c rune, i int) {
+	if c, n = s.current, x; !isHexadecimal(c) {
+		return
+	}
+	for {
+		switch {
+		case '0' <= c && c <= '9':
+			c = c - '0'
+		case 'a' <= c && c <= 'f':
+			c = c - 'a' + 10
+		case 'A' <= c && c <= 'F':
+			c = c - 'A' + 10
+		default:
+			return
+		}
+		s.advance()
+		c, n, i = s.current, n*16.0+float64(c), i+1
+	}
+}
+
+func (s *scanner) readNumber() token {
+	const bits64, base10 = 64, 10
+	c := s.current
+	s.assert(isDecimal(c))
+	s.saveAndAdvance()
+	if c == '0' && s.checkNext("Xx") { // hexadecimal
+		prefix := s.buffer.String()
+		s.assert(prefix == "0x" || prefix == "0X")
+		s.buffer.Reset()
+		var exponent int
+		fraction, c, i := s.readHexNumber(0)
+		if c == '.' {
+			s.advance()
+			fraction, c, exponent = s.readHexNumber(fraction)
+		}
+		if i == 0 && exponent == 0 {
+			s.numberError()
+		}
+		exponent *= -4
+		if c == 'p' || c == 'P' {
+			s.advance()
+			var negativeExponent bool
+			if c = s.current; c == '+' || c == '-' {
+				negativeExponent = c == '-'
+				s.advance()
+			}
+			if !isDecimal(s.current) {
+				s.numberError()
+			}
+			_ = s.readDigits()
+			if e, err := strconv.ParseInt(s.buffer.String(), base10, bits64); err != nil {
+				s.numberError()
+			} else if negativeExponent {
+				exponent += int(-e)
+			} else {
+				exponent += int(e)
+			}
+			s.buffer.Reset()
+		}
+		return token{t: tkNumber, n: math.Ldexp(fraction, exponent)}
+	}
+	c = s.readDigits()
+	if c == '.' {
+		s.saveAndAdvance()
+		c = s.readDigits()
+	}
+	if c == 'e' || c == 'E' {
+		s.saveAndAdvance()
+		if c = s.current; c == '+' || c == '-' {
+			s.saveAndAdvance()
+		}
+		_ = s.readDigits()
+	}
+	str := s.buffer.String()
+	if strings.HasPrefix(str, "0") {
+		if str = strings.TrimLeft(str, "0"); str == "" || !isDecimal(rune(str[0])) {
+			str = "0" + str
+		}
+	}
+	f, err := strconv.ParseFloat(str, bits64)
+	if err != nil {
+		s.numberError()
+	}
+	s.buffer.Reset()
+	return token{t: tkNumber, n: f}
+}
+
+var escapes map[rune]rune = map[rune]rune{
+	'a': '\a', 'b': '\b', 'f': '\f', 'n': '\n', 'r': '\r', 't': '\t', 'v': '\v', '\\': '\\', '"': '"', '\'': '\'',
+}
+
+func (s *scanner) escapeError(c []rune, message string) {
+	s.buffer.Reset()
+	s.save('\\')
+	for _, r := range c {
+		if r == endOfStream {
+			break
+		}
+		s.save(r)
+	}
+	s.scanError(message, tkString)
+}
+
+func (s *scanner) readHexEscape() (r rune) {
+	s.advance()
+	for i, c, b := 1, s.current, [3]rune{'x'}; i < len(b); i, c, r = i+1, s.current, r<<4+c {
+		switch b[i] = c; {
+		case '0' <= c && c <= '9':
+			c = c - '0'
+		case 'a' <= c && c <= 'f':
+			c = c - 'a' + 10
+		case 'A' <= c && c <= 'F':
+			c = c - 'A' + 10
+		default:
+			s.escapeError(b[:i+1], "hexadecimal digit expected")
+		}
+		s.advance()
+	}
+	return
+}
+
+func (s *scanner) readDecimalEscape() (r rune) {
+	b := [3]rune{}
+	for c, i := s.current, 0; i < len(b) && isDecimal(c); i, c = i+1, s.current {
+		b[i], r = c, 10*r+c-'0'
+		s.advance()
+	}
+	if r > math.MaxUint8 {
+		s.escapeError(b[:], "decimal escape too large")
+	}
+	return
+}
+
+func (s *scanner) readString() token {
+	delimiter := s.current
+	for s.saveAndAdvance(); s.current != delimiter; {
+		switch s.current {
+		case endOfStream:
+			s.scanError("unfinished string", tkEOS)
+		case '\n', '\r':
+			s.scanError("unfinished string", tkString)
+		case '\\':
+			s.advance()
+			c := s.current
+			switch esc, ok := escapes[c]; {
+			case ok:
+				s.advanceAndSave(esc)
+			case isNewLine(c):
+				s.incrementLineNumber()
+				s.save('\n')
+			case c == endOfStream: // do nothing
+			case c == 'x':
+				s.save(s.readHexEscape())
+			case c == 'z':
+				for s.advance(); unicode.IsSpace(s.current); {
+					if isNewLine(s.current) {
+						s.incrementLineNumber()
+					} else {
+						s.advance()
+					}
+				}
+			default:
+				if !isDecimal(c) {
+					s.escapeError([]rune{c}, "invalid escape sequence")
+				}
+				s.save(s.readDecimalEscape())
+			}
+		default:
+			s.saveAndAdvance()
+		}
+	}
+	s.saveAndAdvance()
+	str := s.buffer.String()
+	s.buffer.Reset()
+	return token{t: tkString, s: str[1 : len(str)-1]}
+}
+
+func isReserved(s string) bool {
+	for _, reserved := range tokens[:reservedCount] {
+		if s == reserved {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *scanner) reservedOrName() token {
+	str := s.buffer.String()
+	s.buffer.Reset()
+	for i, reserved := range tokens[:reservedCount] {
+		if str == reserved {
+			return token{t: rune(i + firstReserved), s: reserved}
+		}
+	}
+	return token{t: tkName, s: str}
+}
+
+func (s *scanner) scan() token {
+	const comment, str = true, false
+	for {
+		switch c := s.current; c {
+		case '\n', '\r':
+			s.incrementLineNumber()
+		case ' ', '\f', '\t', '\v':
+			s.advance()
+		case '-':
+			if s.advance(); s.current != '-' {
+				return token{t: '-'}
+			}
+			if s.advance(); s.current == '[' {
+				if sep := s.skipSeparator(); sep >= 0 {
+					_ = s.readMultiLine(comment, sep)
+					break
+				}
+				s.buffer.Reset()
+			}
+			for !isNewLine(s.current) && s.current != endOfStream {
+				s.advance()
+			}
+		case '[':
+			if sep := s.skipSeparator(); sep >= 0 {
+				return token{t: tkString, s: s.readMultiLine(str, sep)}
+			} else if s.buffer.Reset(); sep == -1 {
+				return token{t: '['}
+			}
+			s.scanError("invalid long string delimiter", tkString)
+		case '=':
+			if s.advance(); s.current != '=' {
+				return token{t: '='}
+			}
+			s.advance()
+			return token{t: tkEq}
+		case '<':
+			if s.advance(); s.current != '=' {
+				return token{t: '<'}
+			}
+			s.advance()
+			return token{t: tkLE}
+		case '>':
+			if s.advance(); s.current != '=' {
+				return token{t: '>'}
+			}
+			s.advance()
+			return token{t: tkGE}
+		case '~':
+			if s.advance(); s.current != '=' {
+				return token{t: '~'}
+			}
+			s.advance()
+			return token{t: tkNE}
+		case ':':
+			if s.advance(); s.current != ':' {
+				return token{t: ':'}
+			}
+			s.advance()
+			return token{t: tkDoubleColon}
+		case '"', '\'':
+			return s.readString()
+		case endOfStream:
+			return token{t: tkEOS}
+		case '.':
+			if s.saveAndAdvance(); s.checkNext(".") {
+				if s.checkNext(".") {
+					s.buffer.Reset()
+					return token{t: tkDots}
+				} else {
+					s.buffer.Reset()
+					return token{t: tkConcat}
+				}
+			} else if !unicode.IsDigit(s.current) {
+				s.buffer.Reset()
+				return token{t: '.'}
+			} else {
+				return s.readNumber()
+			}
+		case 0:
+			s.advance()
+		default:
+			if unicode.IsDigit(c) {
+				return s.readNumber()
+			} else if c == '_' || unicode.IsLetter(c) {
+				for ; c == '_' || unicode.IsLetter(c) || unicode.IsDigit(c); c = s.current {
+					s.saveAndAdvance()
+				}
+				return s.reservedOrName()
+			}
+			s.advance()
+			return token{t: c}
+		}
+	}
+	panic("unreachable")
+}
+
+func (l *scanner) next() {
+	l.lastLine = l.lineNumber
+	if l.lookAheadToken.t != tkEOS {
+		l.token = l.lookAheadToken
+		l.lookAheadToken.t = tkEOS
+	} else {
+		l.token = l.scan()
+	}
+}
+
+func (l *scanner) lookAhead() rune {
+	l.l.assert(l.lookAheadToken.t == tkEOS)
+	l.lookAheadToken = l.scan()
+	return l.lookAheadToken.t
+}
+
+func (l *scanner) testNext(t rune) (r bool) {
+	if r = l.t == t; r {
+		l.next()
+	}
+	return
+}
+
+func (l *scanner) check(t rune) {
+	if l.t != t {
+		l.errorExpected(t)
+	}
+}
+
+func (l *scanner) checkMatch(what, who rune, where int) {
+	if !l.testNext(what) {
+		if where == l.lineNumber {
+			l.errorExpected(what)
+		} else {
+			l.syntaxError(fmt.Sprintf("%s expected (to close %s at line %d)", l.tokenToString(what), l.tokenToString(who), where))
+		}
+	}
+}

--- a/vendor/github.com/Shopify/go-lua/stack.go
+++ b/vendor/github.com/Shopify/go-lua/stack.go
@@ -1,0 +1,489 @@
+package lua
+
+import "log"
+
+func (l *State) push(v value) {
+	l.stack[l.top] = v
+	l.top++
+}
+
+func (l *State) pop() value {
+	l.top--
+	return l.stack[l.top]
+}
+
+type upValue struct {
+	home interface{}
+}
+
+type closure interface {
+	upValue(i int) value
+	setUpValue(i int, v value)
+	upValueCount() int
+}
+
+type luaClosure struct {
+	prototype *prototype
+	upValues  []*upValue
+}
+
+type goClosure struct {
+	function Function
+	upValues []value
+}
+
+// Function wrapper, to allow go functions as keys in maps. Explicitly not a closure.
+type goFunction struct {
+	Function
+}
+
+func (c *luaClosure) upValue(i int) value {
+	uv := c.upValues[i]
+	if home, ok := uv.home.(stackLocation); ok {
+		return home.state.stack[home.index]
+	}
+	return uv.home
+}
+
+func (c *luaClosure) setUpValue(i int, v value) {
+	uv := c.upValues[i]
+	if home, ok := uv.home.(stackLocation); ok {
+		home.state.stack[home.index] = v
+	} else {
+		uv.home = v
+	}
+}
+
+func (c *luaClosure) upValueCount() int        { return len(c.upValues) }
+func (c *goClosure) upValue(i int) value       { return c.upValues[i] }
+func (c *goClosure) setUpValue(i int, v value) { c.upValues[i] = v }
+func (c *goClosure) upValueCount() int         { return len(c.upValues) }
+func (l *State) newUpValue() *upValue          { return &upValue{home: nil} }
+
+func (uv *upValue) value() value {
+	if home, ok := uv.home.(stackLocation); ok {
+		return home.state.stack[home.index]
+	}
+	return uv.home
+}
+
+func (uv *upValue) close() {
+	if home, ok := uv.home.(stackLocation); ok {
+		uv.home = home.state.stack[home.index]
+	} else {
+		panic("attempt to close already-closed up value")
+	}
+}
+
+func (uv *upValue) isInStackAt(level int) bool {
+	if home, ok := uv.home.(stackLocation); ok {
+		return home.index == level
+	}
+	return false
+}
+
+func (uv *upValue) isInStackAbove(level int) bool {
+	if home, ok := uv.home.(stackLocation); ok {
+		return home.index >= level
+	}
+	return false
+}
+
+type openUpValue struct {
+	upValue *upValue
+	next    *openUpValue
+}
+
+func (l *State) newUpValueAt(level int) *upValue {
+	uv := &upValue{home: stackLocation{state: l, index: level}}
+	l.upValues = &openUpValue{upValue: uv, next: l.upValues}
+	return uv
+}
+
+func (l *State) close(level int) {
+	// TODO this seems really inefficient - how can we terminate early?
+	var p *openUpValue
+	for e := l.upValues; e != nil; e, p = e.next, e {
+		if e.upValue.isInStackAbove(level) {
+			e.upValue.close()
+			if p != nil {
+				p.next = e.next
+			} else {
+				l.upValues = e.next
+			}
+		}
+	}
+}
+
+// information about a call
+type callInfo struct {
+	function, top, resultCount int
+	previous, next             *callInfo
+	callStatus                 callStatus
+	*luaCallInfo
+	*goCallInfo
+}
+
+type luaCallInfo struct {
+	frame   []value
+	savedPC pc
+	code    []instruction
+}
+
+type goCallInfo struct {
+	context, extra, oldErrorFunction int
+	continuation                     Function
+	oldAllowHook, shouldYield        bool
+	error                            error
+}
+
+func (ci *callInfo) setCallStatus(flag callStatus)     { ci.callStatus |= flag }
+func (ci *callInfo) clearCallStatus(flag callStatus)   { ci.callStatus &^= flag }
+func (ci *callInfo) isCallStatus(flag callStatus) bool { return ci.callStatus&flag != 0 }
+func (ci *callInfo) isLua() bool                       { return ci.luaCallInfo != nil }
+
+func (ci *callInfo) stackIndex(slot int) int { return ci.top - len(ci.frame) + slot }
+func (ci *callInfo) base() int               { return ci.top - len(ci.frame) }
+func (ci *callInfo) skip()                   { ci.savedPC++ }
+func (ci *callInfo) jump(offset int)         { ci.savedPC += pc(offset) }
+
+func (ci *callInfo) setTop(top int) {
+	if ci.luaCallInfo != nil {
+		diff := top - ci.top
+		ci.frame = ci.frame[:len(ci.frame)+diff]
+	}
+	ci.top = top
+}
+
+func (ci *callInfo) frameIndex(stackSlot int) int {
+	if stackSlot < ci.top-len(ci.frame) || ci.top <= stackSlot {
+		panic("frameIndex called with out-of-range stackSlot")
+	}
+	return stackSlot - ci.top + len(ci.frame)
+}
+
+func (l *State) pushLuaFrame(function, base, resultCount int, p *prototype) *callInfo {
+	ci := l.callInfo.next
+	if ci == nil {
+		ci = &callInfo{previous: l.callInfo, luaCallInfo: &luaCallInfo{code: p.code}}
+		l.callInfo.next = ci
+	} else if ci.luaCallInfo == nil {
+		ci.goCallInfo = nil
+		ci.luaCallInfo = &luaCallInfo{code: p.code}
+	} else {
+		ci.savedPC = 0
+		ci.code = p.code
+	}
+	ci.function = function
+	ci.top = base + p.maxStackSize
+	// TODO l.assert(ci.top <= l.stackLast)
+	ci.resultCount = resultCount
+	ci.callStatus = callStatusLua
+	ci.frame = l.stack[base:ci.top]
+	l.callInfo = ci
+	l.top = ci.top
+	return ci
+}
+
+func (l *State) pushGoFrame(function, resultCount int) {
+	ci := l.callInfo.next
+	if ci == nil {
+		ci = &callInfo{previous: l.callInfo, goCallInfo: &goCallInfo{}}
+		l.callInfo.next = ci
+	} else if ci.goCallInfo == nil {
+		ci.goCallInfo = &goCallInfo{}
+		ci.luaCallInfo = nil
+	}
+	ci.function = function
+	ci.top = l.top + MinStack
+	// TODO l.assert(ci.top <= l.stackLast)
+	ci.resultCount = resultCount
+	ci.callStatus = 0
+	l.callInfo = ci
+}
+
+func (ci *luaCallInfo) step() instruction {
+	i := ci.code[ci.savedPC]
+	ci.savedPC++
+	return i
+}
+
+func (l *State) newLuaClosure(p *prototype) *luaClosure {
+	return &luaClosure{prototype: p, upValues: make([]*upValue, len(p.upValues))}
+}
+
+func (l *State) findUpValue(level int) *upValue {
+	for e := l.upValues; e != nil; e = e.next {
+		if e.upValue.isInStackAt(level) {
+			return e.upValue
+		}
+	}
+	return l.newUpValueAt(level)
+}
+
+func (l *State) newClosure(p *prototype, upValues []*upValue, base int) value {
+	c := l.newLuaClosure(p)
+	p.cache = c
+	for i, uv := range p.upValues {
+		if uv.isLocal { // upValue refers to local variable
+			c.upValues[i] = l.findUpValue(base + uv.index)
+		} else { // get upValue from enclosing function
+			c.upValues[i] = upValues[uv.index]
+		}
+	}
+	return c
+}
+
+func cached(p *prototype, upValues []*upValue, base int) *luaClosure {
+	c := p.cache
+	if c != nil {
+		for i, uv := range p.upValues {
+			if uv.isLocal && !c.upValues[i].isInStackAt(base+uv.index) {
+				return nil
+			} else if !uv.isLocal && c.upValues[i].home != upValues[uv.index].home {
+				return nil
+			}
+		}
+	}
+	return c
+}
+
+func (l *State) callGo(f value, function int, resultCount int) {
+	l.checkStack(MinStack)
+	l.pushGoFrame(function, resultCount)
+	if l.hookMask&MaskCall != 0 {
+		l.hook(HookCall, -1)
+	}
+	var n int
+	switch f := f.(type) {
+	case *goClosure:
+		n = f.function(l)
+	case *goFunction:
+		n = f.Function(l)
+	}
+	apiCheckStackSpace(l, n)
+	l.postCall(l.top - n)
+}
+
+func (l *State) preCall(function int, resultCount int) bool {
+	for {
+		switch f := l.stack[function].(type) {
+		case *goClosure:
+			l.callGo(f, function, resultCount)
+			return true
+		case *goFunction:
+			l.callGo(f, function, resultCount)
+			return true
+		case *luaClosure:
+			p := f.prototype
+			l.checkStack(p.maxStackSize)
+			argCount, parameterCount := l.top-function-1, p.parameterCount
+			if argCount < parameterCount {
+				extra := parameterCount - argCount
+				args := l.stack[l.top : l.top+extra]
+				for i := range args {
+					args[i] = nil
+				}
+				l.top += extra
+				argCount += extra
+			}
+			base := function + 1
+			if p.isVarArg {
+				base = l.adjustVarArgs(p, argCount)
+			}
+			ci := l.pushLuaFrame(function, base, resultCount, p)
+			if l.hookMask&MaskCall != 0 {
+				l.callHook(ci)
+			}
+			return false
+		default:
+			tm := l.tagMethodByObject(f, tmCall)
+			switch tm.(type) {
+			case closure:
+			case *goFunction:
+			default:
+				l.typeError(f, "call")
+			}
+			// Slide the args + function up 1 slot and poke in the tag method
+			for p := l.top; p > function; p-- {
+				l.stack[p] = l.stack[p-1]
+			}
+			l.top++
+			l.checkStack(0)
+			l.stack[function] = tm
+		}
+	}
+	panic("unreachable")
+}
+
+func (l *State) callHook(ci *callInfo) {
+	ci.savedPC++ // hooks assume 'pc' is already incremented
+	if pci := ci.previous; pci.isLua() && pci.code[pci.savedPC-1].opCode() == opTailCall {
+		ci.setCallStatus(callStatusTail)
+		l.hook(HookTailCall, -1)
+	} else {
+		l.hook(HookCall, -1)
+	}
+	ci.savedPC-- // correct 'pc'
+}
+
+func (l *State) adjustVarArgs(p *prototype, argCount int) int {
+	fixedArgCount := p.parameterCount
+	l.assert(argCount >= fixedArgCount)
+	// move fixed parameters to final position
+	fixed := l.top - argCount // first fixed argument
+	base := l.top             // final position of first argument
+	fixedArgs := l.stack[fixed : fixed+fixedArgCount]
+	copy(l.stack[base:base+fixedArgCount], fixedArgs)
+	for i := range fixedArgs {
+		fixedArgs[i] = nil
+	}
+	return base
+}
+
+func (l *State) postCall(firstResult int) bool {
+	ci := l.callInfo
+	if l.hookMask&MaskReturn != 0 {
+		l.hook(HookReturn, -1)
+	}
+	result, wanted, i := ci.function, ci.resultCount, 0
+	l.callInfo = ci.previous // back to caller
+	// TODO this is obscure - I don't fully understand the control flow, but it works
+	for i = wanted; i != 0 && firstResult < l.top; i-- {
+		l.stack[result] = l.stack[firstResult]
+		result++
+		firstResult++
+	}
+	for ; i > 0; i-- {
+		l.stack[result] = nil
+		result++
+	}
+	l.top = result
+	if l.hookMask&(MaskReturn|MaskLine) != 0 {
+		l.oldPC = l.callInfo.savedPC // oldPC for caller function
+	}
+	return wanted != MultipleReturns
+}
+
+// Call a Go or Lua function. The function to be called is at function.
+// The arguments are on the stack, right after the function. On return, all the
+// results are on the stack, starting at the original function position.
+func (l *State) call(function int, resultCount int, allowYield bool) {
+	if l.nestedGoCallCount++; l.nestedGoCallCount == maxCallCount {
+		l.runtimeError("Go stack overflow")
+	} else if l.nestedGoCallCount >= maxCallCount+maxCallCount>>3 {
+		l.throw(ErrorError) // error while handling stack error
+	}
+	if !allowYield {
+		l.nonYieldableCallCount++
+	}
+	if !l.preCall(function, resultCount) { // is a Lua function?
+		l.execute() // call it
+	}
+	if !allowYield {
+		l.nonYieldableCallCount--
+	}
+	l.nestedGoCallCount--
+}
+
+func (l *State) throw(errorCode error) {
+	if l.protectFunction != nil {
+		panic(errorCode)
+	} else {
+		l.error = errorCode
+		if g := l.global.mainThread; g.protectFunction != nil {
+			g.push(l.stack[l.top-1])
+			g.throw(errorCode)
+		} else {
+			if l.global.panicFunction != nil {
+				l.global.panicFunction(l)
+			}
+			log.Panicf("Uncaught Lua error: %v", errorCode)
+		}
+	}
+}
+
+func (l *State) protect(f func()) (err error) {
+	nestedGoCallCount, protectFunction := l.nestedGoCallCount, l.protectFunction
+	l.protectFunction = func() {
+		if e := recover(); e != nil {
+			err = e.(error)
+			l.nestedGoCallCount, l.protectFunction = nestedGoCallCount, protectFunction
+		}
+	}
+	defer l.protectFunction()
+	f()
+	l.nestedGoCallCount, l.protectFunction = nestedGoCallCount, protectFunction
+	return err
+}
+
+func (l *State) hook(event, line int) {
+	if l.hooker == nil || !l.allowHook {
+		return
+	}
+	ci := l.callInfo
+	top := l.top
+	ciTop := ci.top
+	ar := Debug{Event: event, CurrentLine: line, callInfo: ci}
+	l.checkStack(MinStack)
+	ci.setTop(l.top + MinStack)
+	l.assert(ci.top <= l.stackLast)
+	l.allowHook = false // can't hook calls inside a hook
+	ci.setCallStatus(callStatusHooked)
+	l.hooker(l, ar)
+	l.assert(!l.allowHook)
+	l.allowHook = true
+	ci.setTop(ciTop)
+	l.top = top
+	ci.clearCallStatus(callStatusHooked)
+}
+
+func (l *State) initializeStack() {
+	l.stack = make([]value, basicStackSize)
+	l.stackLast = basicStackSize - extraStack
+	l.top++
+	l.baseCallInfo.luaCallInfo = &luaCallInfo{frame: l.stack[:0]}
+	l.baseCallInfo.setTop(l.top + MinStack)
+	l.callInfo = &l.baseCallInfo
+}
+
+func (l *State) checkStack(n int) {
+	if l.stackLast-l.top <= n {
+		l.growStack(n)
+	}
+}
+
+func (l *State) reallocStack(newSize int) {
+	l.assert(newSize <= maxStack || newSize == errorStackSize)
+	l.assert(l.stackLast == len(l.stack)-extraStack)
+	l.stack = append(l.stack, make([]value, newSize-len(l.stack))...)
+	l.stackLast = len(l.stack) - extraStack
+	l.callInfo.next = nil
+	for ci := l.callInfo; ci != nil; ci = ci.previous {
+		if ci.isLua() {
+			top := ci.top
+			ci.frame = l.stack[top-len(ci.frame) : top]
+		}
+	}
+}
+
+func (l *State) growStack(n int) {
+	if len(l.stack) > maxStack { // error after extra size?
+		l.throw(ErrorError)
+	} else {
+		needed := l.top + n + extraStack
+		newSize := 2 * len(l.stack)
+		if newSize > maxStack {
+			newSize = maxStack
+		}
+		if newSize < needed {
+			newSize = needed
+		}
+		if newSize > maxStack { // stack overflow?
+			l.reallocStack(errorStackSize)
+			l.runtimeError("stack overflow")
+		} else {
+			l.reallocStack(newSize)
+		}
+	}
+}

--- a/vendor/github.com/Shopify/go-lua/string.go
+++ b/vendor/github.com/Shopify/go-lua/string.go
@@ -1,0 +1,246 @@
+package lua
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+func relativePosition(pos, length int) int {
+	if pos >= 0 {
+		return pos
+	} else if -pos > length {
+		return 0
+	}
+	return length + pos + 1
+}
+
+func findHelper(l *State, isFind bool) int {
+	s, p := CheckString(l, 1), CheckString(l, 2)
+	init := relativePosition(OptInteger(l, 3, 1), len(s))
+	if init < 1 {
+		init = 1
+	} else if init > len(s)+1 {
+		l.PushNil()
+		return 1
+	}
+	isPlain := l.TypeOf(4) == TypeNone || l.ToBoolean(4)
+	if isFind && (isPlain || !strings.ContainsAny(p, "^$*+?.([%-")) {
+		if start := strings.Index(s[init-1:], p); start >= 0 {
+			l.PushInteger(start + init)
+			l.PushInteger(start + init + len(p) - 1)
+			return 2
+		}
+	} else {
+		l.assert(false) // TODO implement pattern matching
+	}
+	l.PushNil()
+	return 1
+}
+
+func scanFormat(l *State, fs string) string {
+	i := 0
+	skipDigit := func() {
+		if unicode.IsDigit(rune(fs[i])) {
+			i++
+		}
+	}
+	flags := "-+ #0"
+	for i < len(fs) && strings.ContainsRune(flags, rune(fs[i])) {
+		i++
+	}
+	if i >= len(flags) {
+		Errorf(l, "invalid format (repeated flags)")
+	}
+	skipDigit()
+	skipDigit()
+	if fs[i] == '.' {
+		i++
+		skipDigit()
+		skipDigit()
+	}
+	if unicode.IsDigit(rune(fs[i])) {
+		Errorf(l, "invalid format (width or precision too long)")
+	}
+	i++
+	return "%" + fs[:i]
+}
+
+func formatHelper(l *State, fs string, argCount int) string {
+	var b bytes.Buffer
+	for i, arg := 0, 1; i < len(fs); i++ {
+		if fs[i] != '%' {
+			b.WriteByte(fs[i])
+		} else if i++; fs[i] == '%' {
+			b.WriteByte(fs[i])
+		} else {
+			if arg++; arg > argCount {
+				ArgumentError(l, arg, "no value")
+			}
+			f := scanFormat(l, fs[i:])
+			switch i += len(f) - 2; fs[i] {
+			case 'c':
+				// Ensure each character is represented by a single byte, while preserving format modifiers.
+				c := CheckInteger(l, arg)
+				fmt.Fprintf(&b, f, 'x')
+				buf := b.Bytes()
+				buf[len(buf)-1] = byte(c)
+			case 'i': // The fmt package doesn't support %i.
+				f = f[:len(f)-1] + "d"
+				fallthrough
+			case 'd':
+				n := CheckNumber(l, arg)
+				ni := int(n)
+				diff := n - float64(ni)
+				ArgumentCheck(l, -1 < diff && diff < 1, arg, "not a number in proper range")
+				fmt.Fprintf(&b, f, ni)
+			case 'u': // The fmt package doesn't support %u.
+				f = f[:len(f)-1] + "d"
+				fallthrough
+			case 'o', 'x', 'X':
+				n := CheckNumber(l, arg)
+				ni := uint(n)
+				diff := n - float64(ni)
+				ArgumentCheck(l, -1 < diff && diff < 1, arg, "not a non-negative number in proper range")
+				fmt.Fprintf(&b, f, ni)
+			case 'e', 'E', 'f', 'g', 'G':
+				fmt.Fprintf(&b, f, CheckNumber(l, arg))
+			case 'q':
+				s := CheckString(l, arg)
+				b.WriteByte('"')
+				for i := 0; i < len(s); i++ {
+					switch s[i] {
+					case '"', '\\', '\n':
+						b.WriteByte('\\')
+						b.WriteByte(s[i])
+					default:
+						if 0x20 <= s[i] && s[i] != 0x7f { // ASCII control characters don't correspond to a Unicode range.
+							b.WriteByte(s[i])
+						} else if i+1 < len(s) && unicode.IsDigit(rune(s[i+1])) {
+							fmt.Fprintf(&b, "\\%03d", s[i])
+						} else {
+							fmt.Fprintf(&b, "\\%d", s[i])
+						}
+					}
+				}
+				b.WriteByte('"')
+			case 's':
+				if s, _ := ToStringMeta(l, arg); !strings.ContainsRune(f, '.') && len(s) >= 100 {
+					b.WriteString(s)
+				} else {
+					fmt.Fprintf(&b, f, s)
+				}
+			default:
+				Errorf(l, fmt.Sprintf("invalid option '%%%c' to 'format'", fs[i]))
+			}
+		}
+	}
+	return b.String()
+}
+
+var stringLibrary = []RegistryFunction{
+	{"byte", func(l *State) int {
+		s := CheckString(l, 1)
+		start := relativePosition(OptInteger(l, 2, 1), len(s))
+		end := relativePosition(OptInteger(l, 3, start), len(s))
+		if start < 1 {
+			start = 1
+		}
+		if end > len(s) {
+			end = len(s)
+		}
+		if start > end {
+			return 0
+		}
+		n := end - start + 1
+		if start+n <= end {
+			Errorf(l, "string slice too long")
+		}
+		CheckStackWithMessage(l, n, "string slice too long")
+		for _, c := range []byte(s[start-1 : end]) {
+			l.PushInteger(int(c))
+		}
+		return n
+	}},
+	{"char", func(l *State) int {
+		var b bytes.Buffer
+		for i, n := 1, l.Top(); i <= n; i++ {
+			c := CheckInteger(l, i)
+			ArgumentCheck(l, int(byte(c)) == c, i, "value out of range")
+			b.WriteByte(byte(c))
+		}
+		l.PushString(b.String())
+		return 1
+	}},
+	// {"dump", ...},
+	{"find", func(l *State) int { return findHelper(l, true) }},
+	{"format", func(l *State) int {
+		l.PushString(formatHelper(l, CheckString(l, 1), l.Top()))
+		return 1
+	}},
+	// {"gmatch", ...},
+	// {"gsub", ...},
+	{"len", func(l *State) int { l.PushInteger(len(CheckString(l, 1))); return 1 }},
+	{"lower", func(l *State) int { l.PushString(strings.ToLower(CheckString(l, 1))); return 1 }},
+	// {"match", ...},
+	{"rep", func(l *State) int {
+		s, n, sep := CheckString(l, 1), CheckInteger(l, 2), OptString(l, 3, "")
+		if n <= 0 {
+			l.PushString("")
+		} else if len(s)+len(sep) < len(s) || len(s)+len(sep) >= maxInt/n {
+			Errorf(l, "resulting string too large")
+		} else if sep == "" {
+			l.PushString(strings.Repeat(s, n))
+		} else {
+			var b bytes.Buffer
+			b.Grow(n*len(s) + (n-1)*len(sep))
+			b.WriteString(s)
+			for ; n > 1; n-- {
+				b.WriteString(sep)
+				b.WriteString(s)
+			}
+			l.PushString(b.String())
+		}
+		return 1
+	}},
+	{"reverse", func(l *State) int {
+		r := []rune(CheckString(l, 1))
+		for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+			r[i], r[j] = r[j], r[i]
+		}
+		l.PushString(string(r))
+		return 1
+	}},
+	{"sub", func(l *State) int {
+		s := CheckString(l, 1)
+		start, end := relativePosition(CheckInteger(l, 2), len(s)), relativePosition(OptInteger(l, 3, -1), len(s))
+		if start < 1 {
+			start = 1
+		}
+		if end > len(s) {
+			end = len(s)
+		}
+		if start <= end {
+			l.PushString(s[start-1 : end])
+		} else {
+			l.PushString("")
+		}
+		return 1
+	}},
+	{"upper", func(l *State) int { l.PushString(strings.ToUpper(CheckString(l, 1))); return 1 }},
+}
+
+// StringOpen opens the string library. Usually passed to Require.
+func StringOpen(l *State) int {
+	NewLibrary(l, stringLibrary)
+	l.CreateTable(0, 1)
+	l.PushString("")
+	l.PushValue(-2)
+	l.SetMetaTable(-2)
+	l.Pop(1)
+	l.PushValue(-2)
+	l.SetField(-2, "__index")
+	l.Pop(1)
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/table.go
+++ b/vendor/github.com/Shopify/go-lua/table.go
@@ -1,0 +1,170 @@
+package lua
+
+import (
+	"fmt"
+	"sort"
+)
+
+type sortHelper struct {
+	l           *State
+	n           int
+	hasFunction bool
+}
+
+func (h sortHelper) Len() int { return h.n }
+
+func (h sortHelper) Swap(i, j int) {
+	// Convert Go to Lua indices
+	i++
+	j++
+	h.l.RawGetInt(1, i)
+	h.l.RawGetInt(1, j)
+	h.l.RawSetInt(1, i)
+	h.l.RawSetInt(1, j)
+}
+
+func (h sortHelper) Less(i, j int) bool {
+	// Convert Go to Lua indices
+	i++
+	j++
+	if h.hasFunction {
+		h.l.PushValue(2)
+		h.l.RawGetInt(1, i)
+		h.l.RawGetInt(1, j)
+		h.l.Call(2, 1)
+		b := h.l.ToBoolean(-1)
+		h.l.Pop(1)
+		return b
+	}
+	h.l.RawGetInt(1, i)
+	h.l.RawGetInt(1, j)
+	b := h.l.Compare(-2, -1, OpLT)
+	h.l.Pop(2)
+	return b
+}
+
+var tableLibrary = []RegistryFunction{
+	{"concat", func(l *State) int {
+		CheckType(l, 1, TypeTable)
+		sep := OptString(l, 2, "")
+		i := OptInteger(l, 3, 1)
+		var last int
+		if l.IsNoneOrNil(4) {
+			last = LengthEx(l, 1)
+		} else {
+			last = CheckInteger(l, 4)
+		}
+		s := ""
+		addField := func() {
+			l.RawGetInt(1, i)
+			if str, ok := l.ToString(-1); ok {
+				s += str
+			} else {
+				Errorf(l, fmt.Sprintf("invalid value (%s) at index %d in table for 'concat'", TypeNameOf(l, -1), i))
+			}
+			l.Pop(1)
+		}
+		for ; i < last; i++ {
+			addField()
+			s += sep
+		}
+		if i == last {
+			addField()
+		}
+		l.PushString(s)
+		return 1
+	}},
+	{"insert", func(l *State) int {
+		CheckType(l, 1, TypeTable)
+		e := LengthEx(l, 1) + 1 // First empty element.
+		switch l.Top() {
+		case 2:
+			l.RawSetInt(1, e) // Insert new element at the end.
+		case 3:
+			pos := CheckInteger(l, 2)
+			ArgumentCheck(l, 1 <= pos && pos <= e, 2, "position out of bounds")
+			for i := e; i > pos; i-- {
+				l.RawGetInt(1, i-1)
+				l.RawSetInt(1, i) // t[i] = t[i-1]
+			}
+			l.RawSetInt(1, pos) // t[pos] = v
+		default:
+			Errorf(l, "wrong number of arguments to 'insert'")
+		}
+		return 0
+	}},
+	{"pack", func(l *State) int {
+		n := l.Top()
+		l.CreateTable(n, 1)
+		l.PushInteger(n)
+		l.SetField(-2, "n")
+		if n > 0 {
+			l.PushValue(1)
+			l.RawSetInt(-2, 1)
+			l.Replace(1)
+			for i := n; i >= 2; i-- {
+				l.RawSetInt(1, i)
+			}
+		}
+		return 1
+	}},
+	{"unpack", func(l *State) int {
+		CheckType(l, 1, TypeTable)
+		i := OptInteger(l, 2, 1)
+		var e int
+		if l.IsNoneOrNil(3) {
+			e = LengthEx(l, 1)
+		} else {
+			e = CheckInteger(l, 3)
+		}
+		if i > e {
+			return 0
+		}
+		n := e - i + 1
+		if n <= 0 || !l.CheckStack(n) {
+			Errorf(l, "too many results to unpack")
+			panic("unreachable")
+		}
+		for l.RawGetInt(1, i); i < e; i++ {
+			l.RawGetInt(1, i+1)
+		}
+		return n
+	}},
+	{"remove", func(l *State) int {
+		CheckType(l, 1, TypeTable)
+		size := LengthEx(l, 1)
+		pos := OptInteger(l, 2, size)
+		if pos != size {
+			ArgumentCheck(l, 1 <= pos && pos <= size+1, 2, "position out of bounds")
+		}
+		for l.RawGetInt(1, pos); pos < size; pos++ {
+			l.RawGetInt(1, pos+1)
+			l.RawSetInt(1, pos) // t[pos] = t[pos+1]
+		}
+		l.PushNil()
+		l.RawSetInt(1, pos) // t[pos] = nil
+		return 1
+	}},
+	{"sort", func(l *State) int {
+		CheckType(l, 1, TypeTable)
+		n := LengthEx(l, 1)
+		hasFunction := !l.IsNoneOrNil(2)
+		if hasFunction {
+			CheckType(l, 2, TypeFunction)
+		}
+		l.SetTop(2)
+		h := sortHelper{l, n, hasFunction}
+		sort.Sort(h)
+		// Check result is sorted.
+		if n > 0 && h.Less(n-1, 0) {
+			Errorf(l, "invalid order function for sorting")
+		}
+		return 0
+	}},
+}
+
+// TableOpen opens the table library. Usually passed to Require.
+func TableOpen(l *State) int {
+	NewLibrary(l, tableLibrary)
+	return 1
+}

--- a/vendor/github.com/Shopify/go-lua/tables.go
+++ b/vendor/github.com/Shopify/go-lua/tables.go
@@ -1,0 +1,254 @@
+package lua
+
+import (
+	"math"
+)
+
+type table struct {
+	array         []value
+	hash          map[value]value
+	metaTable     *table
+	flags         byte
+	iterationKeys []value
+}
+
+func newTable() *table                     { return &table{hash: make(map[value]value)} }
+func (t *table) invalidateTagMethodCache() { t.flags = 0 }
+func (t *table) atString(k string) value   { return t.hash[k] }
+
+func newTableWithSize(arraySize, hashSize int) *table {
+	t := new(table)
+	if arraySize > 0 {
+		t.array = make([]value, arraySize)
+	}
+	if hashSize > 0 {
+		t.hash = make(map[value]value, hashSize)
+	} else {
+		t.hash = make(map[value]value)
+	}
+	return t
+}
+
+func (l *State) fastTagMethod(table *table, event tm) value {
+	if table == nil || table.flags&1<<event != 0 {
+		return nil
+	}
+	return table.tagMethod(event, l.global.tagMethodNames[event])
+}
+
+func (t *table) extendArray(last int) {
+	t.array = append(t.array, make([]value, last-len(t.array))...)
+	for k, v := range t.hash {
+		if f, ok := k.(float64); ok {
+			if i := int(f); float64(i) == f {
+				if 0 < i && i <= len(t.array) {
+					t.array[i-1] = v
+					delete(t.hash, k)
+				}
+			}
+		}
+	}
+}
+
+func (t *table) atInt(k int) value {
+	if 0 < k && k <= len(t.array) {
+		return t.array[k-1]
+	}
+	return t.hash[float64(k)]
+}
+
+func (t *table) maybeResizeArray(key int) bool {
+	// Precondition: key > len(t.array).
+	occupancy := 0
+	for _, v := range t.array {
+		if v != nil {
+			occupancy++
+		}
+	}
+	for k, v := range t.hash {
+		if f, ok := k.(float64); ok && v != nil {
+			if i := int(f); i <= key && float64(i) == f {
+				occupancy++
+			}
+		}
+	}
+	if occupancy >= key>>1 {
+		t.extendArray(max(occupancy*2, key)) // TODO Tune growth function.
+		return true
+	}
+	return false
+}
+
+func (t *table) putAtInt(k int, v value) {
+	if 0 < k && k <= len(t.array) {
+		t.array[k-1] = v
+	} else if k > 0 && v != nil && t.maybeResizeArray(k) {
+		t.array[k-1] = v
+	} else if v == nil {
+		delete(t.hash, float64(k))
+	} else {
+		t.hash[float64(k)] = v
+	}
+}
+
+func (t *table) at(k value) value {
+	switch k := k.(type) {
+	case nil:
+		return nil
+	case float64:
+		if i := int(k); float64(i) == k { // OPT: Inlined copy of atInt.
+			if 0 < i && i <= len(t.array) {
+				return t.array[i-1]
+			}
+			return t.hash[k]
+		}
+	case string:
+		return t.hash[k]
+	}
+	return t.hash[k]
+}
+
+func (t *table) put(l *State, k, v value) {
+	switch k := k.(type) {
+	case nil:
+		l.runtimeError("table index is nil")
+	case float64:
+		if i := int(k); float64(i) == k {
+			t.putAtInt(i, v)
+		} else if math.IsNaN(k) {
+			l.runtimeError("table index is NaN")
+		} else if v == nil {
+			delete(t.hash, k)
+		} else {
+			t.hash[k] = v
+		}
+	case string:
+		if v == nil {
+			delete(t.hash, k)
+		} else {
+			t.hash[k] = v
+		}
+	default:
+		if v == nil {
+			delete(t.hash, k)
+		} else {
+			t.hash[k] = v
+		}
+	}
+}
+
+// OPT: tryPut is an optimized variant of the at/put pair used by setTableAt to avoid hashing the key twice.
+func (t *table) tryPut(l *State, k, v value) bool {
+	switch k := k.(type) {
+	case nil:
+	case float64:
+		if i := int(k); float64(i) == k && 0 < i && i <= len(t.array) && t.array[i-1] != nil {
+			t.array[i-1] = v
+			return true
+		} else if math.IsNaN(k) {
+			return false
+		} else if t.hash[k] != nil && v != nil {
+			t.hash[k] = v
+			return true
+		}
+	case string:
+		if t.hash[k] != nil && v != nil {
+			t.hash[k] = v
+			return true
+		}
+	default:
+		if t.hash[k] != nil && v != nil {
+			t.hash[k] = v
+			return true
+		}
+	}
+	return false
+}
+
+func (t *table) unboundSearch(j int) int {
+	i := j
+	for j++; nil != t.atInt(j); {
+		i = j
+		if j *= 2; j < 0 {
+			for i = 1; nil != t.atInt(i); i++ {
+			}
+			return i - 1
+		}
+	}
+	for j-i > 1 {
+		m := (i + j) / 2
+		if nil == t.atInt(m) {
+			j = m
+		} else {
+			i = m
+		}
+	}
+	return i
+}
+
+func (t *table) length() int {
+	j := len(t.array)
+	if j > 0 && t.array[j-1] == nil {
+		i := 0
+		for j-i > 1 {
+			m := (i + j) / 2
+			if t.array[m-1] == nil {
+				j = m
+			} else {
+				i = m
+			}
+		}
+		return i
+	} else if t.hash == nil {
+		return j
+	}
+	return t.unboundSearch(j)
+}
+
+func arrayIndex(k value) int {
+	if n, ok := k.(float64); ok {
+		if i := int(n); float64(i) == n {
+			return i
+		}
+	}
+	return -1
+}
+
+func (l *State) next(t *table, key int) bool {
+	i, k := 0, l.stack[key]
+	if k == nil { // first iteration
+		t.iterationKeys = nil
+	} else if i = arrayIndex(k); 0 < i && i <= len(t.array) {
+	} else if _, ok := t.hash[k]; !ok {
+		l.runtimeError("invalid key to 'next'") // key not found
+	} else {
+		i = len(t.array)
+	}
+	for ; i < len(t.array); i++ {
+		if t.array[i] != nil {
+			l.stack[key] = float64(i + 1)
+			l.stack[key+1] = t.array[i]
+			return true
+		}
+	}
+	if t.iterationKeys == nil {
+		j, keys := 0, make([]value, len(t.hash))
+		for hk, _ := range t.hash {
+			keys[j] = hk
+			j++
+		}
+		t.iterationKeys = keys
+	}
+	found := k == nil
+	for _, hk := range t.iterationKeys {
+		if found {
+			l.stack[key] = hk
+			l.stack[key+1] = t.hash[hk]
+			return true
+		} else if l.equalObjects(hk, k) {
+			found = true
+		}
+	}
+	t.iterationKeys = nil
+	return false // no more elements
+}

--- a/vendor/github.com/Shopify/go-lua/tag_methods.go
+++ b/vendor/github.com/Shopify/go-lua/tag_methods.go
@@ -1,0 +1,100 @@
+package lua
+
+type tm uint
+
+const (
+	tmIndex tm = iota
+	tmNewIndex
+	tmGC
+	tmMode
+	tmLen
+	tmEq
+	tmAdd
+	tmSub
+	tmMul
+	tmDiv
+	tmMod
+	tmPow
+	tmUnaryMinus
+	tmLT
+	tmLE
+	tmConcat
+	tmCall
+	tmCount // number of tag methods
+)
+
+var eventNames = []string{
+	"__index",
+	"__newindex",
+	"__gc",
+	"__mode",
+	"__len",
+	"__eq",
+	"__add",
+	"__sub",
+	"__mul",
+	"__div",
+	"__mod",
+	"__pow",
+	"__unm",
+	"__lt",
+	"__le",
+	"__concat",
+	"__call",
+}
+
+var typeNames = []string{
+	"no value",
+	"nil",
+	"boolean",
+	"userdata",
+	"number",
+	"string",
+	"table",
+	"function",
+	"userdata",
+	"thread",
+	"proto", // these last two cases are used for tests only
+	"upval",
+}
+
+func (events *table) tagMethod(event tm, name string) value {
+	tm := events.atString(name)
+	//l.assert(event <= tmEq)
+	if tm == nil {
+		events.flags |= 1 << event
+	}
+	return tm
+}
+
+func (l *State) tagMethodByObject(o value, event tm) value {
+	var mt *table
+	switch o := o.(type) {
+	case *table:
+		mt = o.metaTable
+	case *userData:
+		mt = o.metaTable
+	default:
+		mt = l.global.metaTable(o)
+	}
+	if mt == nil {
+		return nil
+	}
+	return mt.atString(l.global.tagMethodNames[event])
+}
+
+func (l *State) callTagMethod(f, p1, p2 value) value {
+	l.push(f)
+	l.push(p1)
+	l.push(p2)
+	l.call(l.top-3, 1, l.callInfo.isLua())
+	return l.pop()
+}
+
+func (l *State) callTagMethodV(f, p1, p2, p3 value) {
+	l.push(f)
+	l.push(p1)
+	l.push(p2)
+	l.push(p3)
+	l.call(l.top-4, 0, l.callInfo.isLua())
+}

--- a/vendor/github.com/Shopify/go-lua/types.go
+++ b/vendor/github.com/Shopify/go-lua/types.go
@@ -1,0 +1,327 @@
+package lua
+
+import (
+	"fmt"
+	"math"
+	"reflect"
+	"runtime"
+	"strings"
+)
+
+type value interface{}
+type float8 int
+
+func debugValue(v value) string {
+	switch v := v.(type) {
+	case *table:
+		entry := func(x value) string {
+			if t, ok := x.(*table); ok {
+				return fmt.Sprintf("table %#v", t)
+			} else {
+				return debugValue(x)
+			}
+		}
+		s := fmt.Sprintf("table %#v {[", v)
+		for _, x := range v.array {
+			s += entry(x) + ", "
+		}
+		s += "], {"
+		for k, x := range v.hash {
+			s += entry(k) + ": " + entry(x) + ", "
+		}
+		return s + "}}"
+	case string:
+		return "'" + v + "'"
+	case float64:
+		return fmt.Sprintf("%f", v)
+	case *luaClosure:
+		return fmt.Sprintf("closure %s:%d %v", v.prototype.source, v.prototype.lineDefined, v)
+	case *goClosure:
+		return fmt.Sprintf("go closure %#v", v)
+	case *goFunction:
+		pc := reflect.ValueOf(v.Function).Pointer()
+		f := runtime.FuncForPC(pc)
+		file, line := f.FileLine(pc)
+		return fmt.Sprintf("go function %s %s:%d", f.Name(), file, line)
+	case *userData:
+		return fmt.Sprintf("userdata %#v", v)
+	case nil:
+		return "nil"
+	case bool:
+		return fmt.Sprintf("%#v", v)
+	}
+	return fmt.Sprintf("unknown %#v %s", v, reflect.TypeOf(v).Name())
+}
+
+func stack(s []value) string {
+	r := fmt.Sprintf("stack (len: %d, cap: %d):\n", len(s), cap(s))
+	for i, v := range s {
+		r = fmt.Sprintf("%s %d: %s\n", r, i, debugValue(v))
+	}
+	return r
+}
+
+func isFalse(s value) bool {
+	if s == nil || s == none {
+		return true
+	}
+	b, isBool := s.(bool)
+	return isBool && !b
+}
+
+type localVariable struct {
+	name           string
+	startPC, endPC pc
+}
+
+type userData struct {
+	metaTable, env *table
+	data           interface{}
+}
+
+type upValueDesc struct {
+	name    string
+	isLocal bool
+	index   int
+}
+
+type stackLocation struct {
+	state *State
+	index int
+}
+
+type prototype struct {
+	constants                    []value
+	code                         []instruction
+	prototypes                   []prototype
+	lineInfo                     []int32
+	localVariables               []localVariable
+	upValues                     []upValueDesc
+	cache                        *luaClosure
+	source                       string
+	lineDefined, lastLineDefined int
+	parameterCount, maxStackSize int
+	isVarArg                     bool
+}
+
+func (p *prototype) upValueName(index int) string {
+	if s := p.upValues[index].name; s != "" {
+		return s
+	}
+	return "?"
+}
+
+func (p *prototype) lastLoad(reg int, lastPC pc) (loadPC pc, found bool) {
+	var ip, jumpTarget pc
+	for ; ip < lastPC; ip++ {
+		i, maybe := p.code[ip], false
+		switch i.opCode() {
+		case opLoadNil:
+			maybe = i.a() <= reg && reg <= i.a()+i.b()
+		case opTForCall:
+			maybe = reg >= i.a()+2
+		case opCall, opTailCall:
+			maybe = reg >= i.a()
+		case opJump:
+			if dest := ip + 1 + pc(i.sbx()); ip < dest && dest <= lastPC && dest > jumpTarget {
+				jumpTarget = dest
+			}
+		case opTest:
+			maybe = reg == i.a()
+		default:
+			maybe = testAMode(i.opCode()) && reg == i.a()
+		}
+		if maybe {
+			if ip < jumpTarget { // Can't know loading instruction because code is conditional.
+				found = false
+			} else {
+				loadPC, found = ip, true
+			}
+		}
+	}
+	return
+}
+
+func (p *prototype) objectName(reg int, lastPC pc) (name, kind string) {
+	if name, isLocal := p.localName(reg+1, lastPC); isLocal {
+		return name, "local"
+	}
+	if pc, found := p.lastLoad(reg, lastPC); found {
+		i := p.code[pc]
+		switch op := i.opCode(); op {
+		case opMove:
+			if b := i.b(); b < i.a() {
+				return p.objectName(b, pc)
+			}
+		case opGetTableUp:
+			name, kind = p.constantName(i.c(), pc), "local"
+			if p.upValueName(i.b()) == "_ENV" {
+				kind = "global"
+			}
+			return
+		case opGetTable:
+			name, kind = p.constantName(i.c(), pc), "local"
+			if v, ok := p.localName(i.b()+1, pc); ok && v == "_ENV" {
+				kind = "global"
+			}
+			return
+		case opGetUpValue:
+			return p.upValueName(i.b()), "upvalue"
+		case opLoadConstant:
+			if s, ok := p.constants[i.bx()].(string); ok {
+				return s, "constant"
+			}
+		case opLoadConstantEx:
+			if s, ok := p.constants[p.code[pc+1].ax()].(string); ok {
+				return s, "constant"
+			}
+		case opSelf:
+			return p.constantName(i.c(), pc), "method"
+		}
+	}
+	return
+}
+
+func (p *prototype) constantName(k int, pc pc) string {
+	if isConstant(k) {
+		if s, ok := p.constants[constantIndex(k)].(string); ok {
+			return s
+		}
+	} else if name, kind := p.objectName(k, pc); kind == "c" {
+		return name
+	}
+	return "?"
+}
+
+func (p *prototype) localName(index int, pc pc) (string, bool) {
+	for i := 0; i < len(p.localVariables) && p.localVariables[i].startPC <= pc; i++ {
+		if pc < p.localVariables[i].endPC {
+			if index--; index == 0 {
+				return p.localVariables[i].name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// Converts an integer to a "floating point byte", represented as
+// (eeeeexxx), where the real value is (1xxx) * 2^(eeeee - 1) if
+// eeeee != 0 and (xxx) otherwise.
+func float8FromInt(x int) float8 {
+	if x < 8 {
+		return float8(x)
+	}
+	e := 0
+	for ; x >= 0x10; e++ {
+		x = (x + 1) >> 1
+	}
+	return float8(((e + 1) << 3) | (x - 8))
+}
+
+func intFromFloat8(x float8) int {
+	e := x >> 3 & 0x1f
+	if e == 0 {
+		return int(x)
+	}
+	return int(x&7+8) << uint(e-1)
+}
+
+func arith(op Operator, v1, v2 float64) float64 {
+	switch op {
+	case OpAdd:
+		return v1 + v2
+	case OpSub:
+		return v1 - v2
+	case OpMul:
+		return v1 * v2
+	case OpDiv:
+		return v1 / v2
+	case OpMod:
+		return v1 - math.Floor(v1/v2)*v2
+	case OpPow:
+		// Golang bug: math.Pow(10.0, 33.0) is incorrect by 1 bit.
+		if v1 == 10.0 && float64(int(v2)) == v2 {
+			return math.Pow10(int(v2))
+		}
+		return math.Pow(v1, v2)
+	case OpUnaryMinus:
+		return -v1
+	}
+	panic(fmt.Sprintf("not an arithmetic op code (%d)", op))
+}
+
+func (l *State) parseNumber(s string) (v float64, ok bool) { // TODO this is f*cking ugly - scanner.readNumber should be refactored.
+	if len(strings.Fields(s)) != 1 || strings.ContainsRune(s, 0) {
+		return
+	}
+	scanner := scanner{l: l, r: strings.NewReader(s)}
+	t := scanner.scan()
+	if t.t == '-' {
+		if t := scanner.scan(); t.t == tkNumber {
+			v, ok = -t.n, true
+		}
+	} else if t.t == tkNumber {
+		v, ok = t.n, true
+	} else if t.t == '+' {
+		if t := scanner.scan(); t.t == tkNumber {
+			v, ok = t.n, true
+		}
+	}
+	if ok && scanner.scan().t != tkEOS {
+		ok = false
+	} else if math.IsInf(v, 0) || math.IsNaN(v) {
+		ok = false
+	}
+	return
+}
+
+func (l *State) toNumber(r value) (v float64, ok bool) {
+	if v, ok = r.(float64); ok {
+		return
+	}
+	var s string
+	if s, ok = r.(string); ok {
+		if err := l.protectedCall(func() { v, ok = l.parseNumber(strings.TrimSpace(s)) }, l.top, l.errorFunction); err != nil {
+			l.pop() // Remove error message from the stack.
+			ok = false
+		}
+	}
+	return
+}
+
+func (l *State) toString(index int) (s string, ok bool) {
+	if s, ok = toString(l.stack[index]); ok {
+		l.stack[index] = s
+	}
+	return
+}
+
+func numberToString(f float64) string {
+	return fmt.Sprintf("%.14g", f)
+}
+
+func toString(r value) (string, bool) {
+	switch r := r.(type) {
+	case string:
+		return r, true
+	case float64:
+		return numberToString(r), true
+	}
+	return "", false
+}
+
+func pairAsNumbers(p1, p2 value) (f1, f2 float64, ok bool) {
+	if f1, ok = p1.(float64); !ok {
+		return
+	}
+	f2, ok = p2.(float64)
+	return
+}
+
+func pairAsStrings(p1, p2 value) (s1, s2 string, ok bool) {
+	if s1, ok = p1.(string); !ok {
+		return
+	}
+	s2, ok = p2.(string)
+	return
+}

--- a/vendor/github.com/Shopify/go-lua/undump.go
+++ b/vendor/github.com/Shopify/go-lua/undump.go
@@ -1,0 +1,300 @@
+package lua
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"unsafe"
+)
+
+type loadState struct {
+	in    io.Reader
+	order binary.ByteOrder
+}
+
+var header struct {
+	Signature                            [4]byte
+	Version, Format, Endianness, IntSize byte
+	PointerSize, InstructionSize         byte
+	NumberSize, IntegralNumber           byte
+	Tail                                 [6]byte
+}
+
+var (
+	errUnknownConstantType = errors.New("lua: unknown constant type in lua binary")
+	errNotPrecompiledChunk = errors.New("lua: is not a precompiled chunk")
+	errVersionMismatch     = errors.New("lua: version mismatch in precompiled chunk")
+	errIncompatible        = errors.New("lua: incompatible precompiled chunk")
+	errCorrupted           = errors.New("lua: corrupted precompiled chunk")
+)
+
+func (state *loadState) read(data interface{}) error {
+	return binary.Read(state.in, state.order, data)
+}
+
+func (state *loadState) readNumber() (f float64, err error) {
+	err = state.read(&f)
+	return
+}
+
+func (state *loadState) readInt() (i int32, err error) {
+	err = state.read(&i)
+	return
+}
+
+func (state *loadState) readPC() (pc, error) {
+	i, err := state.readInt()
+	return pc(i), err
+}
+
+func (state *loadState) readByte() (b byte, err error) {
+	err = state.read(&b)
+	return
+}
+
+func (state *loadState) readBool() (bool, error) {
+	b, err := state.readByte()
+	return b != 0, err
+}
+
+func (state *loadState) readString() (s string, err error) {
+	// Feel my pain
+	maxUint := ^uint(0)
+	var size uintptr
+	var size64 uint64
+	var size32 uint32
+	if uint64(maxUint) == math.MaxUint64 {
+		err = state.read(&size64)
+		size = uintptr(size64)
+	} else if maxUint == math.MaxUint32 {
+		err = state.read(&size32)
+		size = uintptr(size32)
+	} else {
+		panic(fmt.Sprintf("unsupported pointer size (%d)", maxUint))
+	}
+	if err != nil || size == 0 {
+		return
+	}
+	ba := make([]byte, size)
+	if err = state.read(ba); err == nil {
+		s = string(ba[:len(ba)-1])
+	}
+	return
+}
+
+func (state *loadState) readCode() (code []instruction, err error) {
+	n, err := state.readInt()
+	if err != nil {
+		return
+	}
+	code = make([]instruction, n)
+	err = state.read(code)
+	return
+}
+
+func (state *loadState) readUpValues() (u []upValueDesc, err error) {
+	n, err := state.readInt()
+	if err != nil {
+		return
+	}
+	v := make([]struct{ IsLocal, Index byte }, n)
+	err = state.read(v)
+	if err != nil {
+		return
+	}
+	u = make([]upValueDesc, n)
+	for i := range v {
+		u[i].isLocal, u[i].index = v[i].IsLocal != 0, int(v[i].Index)
+	}
+	return
+}
+
+func (state *loadState) readDebug(p *prototype) (source string, lineInfo []int32, localVariables []localVariable, names []string, err error) {
+	var n int32
+	if source, err = state.readString(); err != nil {
+		return
+	}
+	if n, err = state.readInt(); err != nil {
+		return
+	}
+	lineInfo = make([]int32, n)
+	if err = state.read(lineInfo); err != nil {
+		return
+	}
+	if n, err = state.readInt(); err != nil {
+		return
+	}
+	localVariables = make([]localVariable, n)
+	for i := range localVariables {
+		if localVariables[i].name, err = state.readString(); err != nil {
+			return
+		}
+		if localVariables[i].startPC, err = state.readPC(); err != nil {
+			return
+		}
+		if localVariables[i].endPC, err = state.readPC(); err != nil {
+			return
+		}
+	}
+	if n, err = state.readInt(); err != nil {
+		return
+	}
+	names = make([]string, n)
+	for i := range names {
+		if names[i], err = state.readString(); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (state *loadState) readConstants() (constants []value, prototypes []prototype, err error) {
+	var n int32
+	if n, err = state.readInt(); err != nil {
+		return
+	}
+	constants = make([]value, n)
+	for i := range constants {
+		var t byte
+		switch t, err = state.readByte(); {
+		case err != nil:
+			return
+		case t == byte(TypeNil):
+			constants[i] = nil
+		case t == byte(TypeBoolean):
+			constants[i], err = state.readBool()
+		case t == byte(TypeNumber):
+			constants[i], err = state.readNumber()
+		case t == byte(TypeString):
+			constants[i], err = state.readString()
+		default:
+			err = errUnknownConstantType
+		}
+		if err != nil {
+			return
+		}
+	}
+	if n, err = state.readInt(); err != nil {
+		return
+	}
+	prototypes = make([]prototype, n)
+	for i := range prototypes {
+		if prototypes[i], err = state.readFunction(); err != nil {
+			return
+		}
+	}
+	return
+}
+
+func (state *loadState) readFunction() (p prototype, err error) {
+	var n int32
+	if n, err = state.readInt(); err != nil {
+		return
+	}
+	p.lineDefined = int(n)
+	if n, err = state.readInt(); err != nil {
+		return
+	}
+	p.lastLineDefined = int(n)
+	var b byte
+	if b, err = state.readByte(); err != nil {
+		return
+	}
+	p.parameterCount = int(b)
+	if b, err = state.readByte(); err != nil {
+		return
+	}
+	p.isVarArg = b != 0
+	if b, err = state.readByte(); err != nil {
+		return
+	}
+	p.maxStackSize = int(b)
+	if p.code, err = state.readCode(); err != nil {
+		return
+	}
+	if p.constants, p.prototypes, err = state.readConstants(); err != nil {
+		return
+	}
+	if p.upValues, err = state.readUpValues(); err != nil {
+		return
+	}
+	var names []string
+	if p.source, p.lineInfo, p.localVariables, names, err = state.readDebug(&p); err != nil {
+		return
+	}
+	for i, name := range names {
+		p.upValues[i].name = name
+	}
+	return
+}
+
+func init() {
+	copy(header.Signature[:], Signature)
+	header.Version = VersionMajor<<4 | VersionMinor
+	header.Format = 0
+	if endianness() == binary.LittleEndian {
+		header.Endianness = 1
+	} else {
+		header.Endianness = 0
+	}
+	header.IntSize = 4
+	header.PointerSize = byte(1+^uintptr(0)>>32&1) * 4
+	header.InstructionSize = byte(1+^instruction(0)>>32&1) * 4
+	header.NumberSize = 8
+	header.IntegralNumber = 0
+	tail := "\x19\x93\r\n\x1a\n"
+	copy(header.Tail[:], tail)
+
+	// The uintptr numeric type is implementation-specific
+	uintptrBitCount := byte(0)
+	for bits := ^uintptr(0); bits != 0; bits >>= 1 {
+		uintptrBitCount++
+	}
+	if uintptrBitCount != header.PointerSize*8 {
+		panic(fmt.Sprintf("invalid pointer size (%d)", uintptrBitCount))
+	}
+}
+
+func endianness() binary.ByteOrder {
+	if x := 1; *(*byte)(unsafe.Pointer(&x)) == 1 {
+		return binary.LittleEndian
+	}
+	return binary.BigEndian
+}
+
+func (state *loadState) checkHeader() error {
+	h := header
+	if err := state.read(&h); err != nil {
+		return err
+	} else if h == header {
+		return nil
+	} else if string(h.Signature[:]) != Signature {
+		return errNotPrecompiledChunk
+	} else if h.Version != header.Version || h.Format != header.Format {
+		return errVersionMismatch
+	} else if h.Tail != header.Tail {
+		return errCorrupted
+	}
+	return errIncompatible
+}
+
+func (l *State) undump(in io.Reader, name string) (c *luaClosure, err error) {
+	if name[0] == '@' || name[0] == '=' {
+		name = name[1:]
+	} else if name[0] == Signature[0] {
+		name = "binary string"
+	}
+	// TODO assign name to p.source?
+	s := &loadState{in, endianness()}
+	var p prototype
+	if err = s.checkHeader(); err != nil {
+		return
+	} else if p, err = s.readFunction(); err != nil {
+		return
+	}
+	c = l.newLuaClosure(&p)
+	l.push(c)
+	return
+}

--- a/vendor/github.com/Shopify/go-lua/unix.go
+++ b/vendor/github.com/Shopify/go-lua/unix.go
@@ -1,0 +1,15 @@
+// +build !windows
+
+package lua
+
+import (
+	"syscall"
+)
+
+func clock(l *State) int {
+	var rusage syscall.Rusage
+	_ = syscall.Getrusage(syscall.RUSAGE_SELF, &rusage) // ignore errors
+	l.PushNumber(float64(rusage.Utime.Sec+rusage.Stime.Sec) + float64(rusage.Utime.Usec+rusage.Stime.Usec)/1000000.0)
+	return 1
+
+}

--- a/vendor/github.com/Shopify/go-lua/vm.go
+++ b/vendor/github.com/Shopify/go-lua/vm.go
@@ -1,0 +1,1338 @@
+package lua
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+func (l *State) arith(rb, rc value, op tm) value {
+	if b, ok := l.toNumber(rb); ok {
+		if c, ok := l.toNumber(rc); ok {
+			return arith(Operator(op-tmAdd)+OpAdd, b, c)
+		}
+	}
+	if result, ok := l.callBinaryTagMethod(rb, rc, op); ok {
+		return result
+	}
+	l.arithError(rb, rc)
+	return nil
+}
+
+func (l *State) tableAt(t value, key value) value {
+	for loop := 0; loop < maxTagLoop; loop++ {
+		var tm value
+		if table, ok := t.(*table); ok {
+			if result := table.at(key); result != nil {
+				return result
+			} else if tm = l.fastTagMethod(table.metaTable, tmIndex); tm == nil {
+				return nil
+			}
+		} else if tm = l.tagMethodByObject(t, tmIndex); tm == nil {
+			l.typeError(t, "index")
+		}
+		switch tm.(type) {
+		case closure, *goFunction:
+			return l.callTagMethod(tm, t, key)
+		}
+		t = tm
+	}
+	l.runtimeError("loop in table")
+	return nil
+}
+
+func (l *State) setTableAt(t value, key value, val value) {
+	for loop := 0; loop < maxTagLoop; loop++ {
+		var tm value
+		if table, ok := t.(*table); ok {
+			if table.tryPut(l, key, val) {
+				// previous non-nil value ==> metamethod irrelevant
+				table.invalidateTagMethodCache()
+				return
+			} else if tm = l.fastTagMethod(table.metaTable, tmNewIndex); tm == nil {
+				// no metamethod
+				table.put(l, key, val)
+				table.invalidateTagMethodCache()
+				return
+			}
+		} else if tm = l.tagMethodByObject(t, tmNewIndex); tm == nil {
+			l.typeError(t, "index")
+		}
+		switch tm.(type) {
+		case closure, *goFunction:
+			l.callTagMethodV(tm, t, key, val)
+			return
+		}
+		t = tm
+	}
+	l.runtimeError("loop in setTable")
+}
+
+func (l *State) objectLength(v value) value {
+	var tm value
+	switch v := v.(type) {
+	case *table:
+		if tm = l.fastTagMethod(v.metaTable, tmLen); tm == nil {
+			return float64(v.length())
+		}
+	case string:
+		return float64(len(v))
+	default:
+		if tm = l.tagMethodByObject(v, tmLen); tm == nil {
+			l.typeError(v, "get length of")
+		}
+	}
+	return l.callTagMethod(tm, v, v)
+}
+
+func (l *State) equalTagMethod(mt1, mt2 *table, event tm) value {
+	if tm1 := l.fastTagMethod(mt1, event); tm1 == nil { // no metamethod
+	} else if mt1 == mt2 { // same metatables => same metamethods
+		return tm1
+	} else if tm2 := l.fastTagMethod(mt2, event); tm2 == nil { // no metamethod
+	} else if tm1 == tm2 { // same metamethods
+		return tm1
+	}
+	return nil
+}
+
+func (l *State) equalObjects(t1, t2 value) bool {
+	var tm value
+	switch t1 := t1.(type) {
+	case *userData:
+		if t1 == t2 {
+			return true
+		} else if t2, ok := t2.(*userData); ok {
+			tm = l.equalTagMethod(t1.metaTable, t2.metaTable, tmEq)
+		}
+	case *table:
+		if t1 == t2 {
+			return true
+		} else if t2, ok := t2.(*table); ok {
+			tm = l.equalTagMethod(t1.metaTable, t2.metaTable, tmEq)
+		}
+	default:
+		return t1 == t2
+	}
+	return tm != nil && !isFalse(l.callTagMethod(tm, t1, t2))
+}
+
+func (l *State) callBinaryTagMethod(p1, p2 value, event tm) (value, bool) {
+	tm := l.tagMethodByObject(p1, event)
+	if tm == nil {
+		tm = l.tagMethodByObject(p2, event)
+	}
+	if tm == nil {
+		return nil, false
+	}
+	return l.callTagMethod(tm, p1, p2), true
+}
+
+func (l *State) callOrderTagMethod(left, right value, event tm) (bool, bool) {
+	result, ok := l.callBinaryTagMethod(left, right, event)
+	return !isFalse(result), ok
+}
+
+func (l *State) lessThan(left, right value) bool {
+	if lf, ok := left.(float64); ok {
+		if rf, ok := right.(float64); ok {
+			return lf < rf
+		}
+	} else if ls, ok := left.(string); ok {
+		if rs, ok := right.(string); ok {
+			return ls < rs
+		}
+	}
+	if result, ok := l.callOrderTagMethod(left, right, tmLT); ok {
+		return result
+	}
+	l.orderError(left, right)
+	return false
+}
+
+func (l *State) lessOrEqual(left, right value) bool {
+	if lf, ok := left.(float64); ok {
+		if rf, ok := right.(float64); ok {
+			return lf <= rf
+		}
+	} else if ls, ok := left.(string); ok {
+		if rs, ok := right.(string); ok {
+			return ls <= rs
+		}
+	}
+	if result, ok := l.callOrderTagMethod(left, right, tmLE); ok {
+		return result
+	} else if result, ok := l.callOrderTagMethod(right, left, tmLT); ok {
+		return !result
+	}
+	l.orderError(left, right)
+	return false
+}
+
+func (l *State) concat(total int) {
+	t := func(i int) value { return l.stack[l.top-i] }
+	put := func(i int, v value) { l.stack[l.top-i] = v }
+	concatTagMethod := func() {
+		if v, ok := l.callBinaryTagMethod(t(2), t(1), tmConcat); !ok {
+			l.concatError(t(2), t(1))
+		} else {
+			put(2, v)
+		}
+	}
+	l.assert(total >= 2)
+	for total > 1 {
+		n := 2 // # of elements handled in this pass (at least 2)
+		s2, ok := t(2).(string)
+		if !ok {
+			_, ok = t(2).(float64)
+		}
+		if !ok {
+			concatTagMethod()
+		} else if s1, ok := l.toString(l.top - 1); !ok {
+			concatTagMethod()
+		} else if len(s1) == 0 {
+			v, _ := l.toString(l.top - 2)
+			put(2, v)
+		} else if s2, ok = t(2).(string); ok && len(s2) == 0 {
+			put(2, t(1))
+		} else {
+			// at least 2 non-empty strings; scarf as many as possible
+			ss := []string{s1}
+			for ; n <= total; n++ {
+				if s, ok := l.toString(l.top - n); ok {
+					ss = append(ss, s)
+				} else {
+					break
+				}
+			}
+			n-- // last increment wasn't valid
+			for i, j := 0, len(ss)-1; i < j; i, j = i+1, j-1 {
+				ss[i], ss[j] = ss[j], ss[i]
+			}
+			put(len(ss), strings.Join(ss, ""))
+		}
+		total -= n - 1 // created 1 new string from `n` strings
+		l.top -= n - 1 // popped `n` strings and pushed 1
+	}
+}
+
+func (l *State) traceExecution() {
+	callInfo := l.callInfo
+	mask := l.hookMask
+	countHook := mask&MaskCount != 0 && l.hookCount == 0
+	if countHook {
+		l.resetHookCount()
+	}
+	if callInfo.isCallStatus(callStatusHookYielded) {
+		callInfo.clearCallStatus(callStatusHookYielded)
+		return
+	}
+	if countHook {
+		l.hook(HookCount, -1)
+	}
+	if mask&MaskLine != 0 {
+		p := l.prototype(callInfo)
+		npc := callInfo.savedPC - 1
+		newline := p.lineInfo[npc]
+		if npc == 0 || callInfo.savedPC <= l.oldPC || newline != p.lineInfo[l.oldPC-1] {
+			l.hook(HookLine, int(newline))
+		}
+	}
+	l.oldPC = callInfo.savedPC
+	if l.shouldYield {
+		if countHook {
+			l.hookCount = 1
+		}
+		callInfo.savedPC--
+		callInfo.setCallStatus(callStatusHookYielded)
+		callInfo.function = l.top - 1
+		panic("Not implemented - use goroutines to emulate yield")
+	}
+}
+
+type engine struct {
+	frame     []value
+	closure   *luaClosure
+	constants []value
+	callInfo  *callInfo
+	l         *State
+}
+
+func (e *engine) k(field int) value {
+	if 0 != field&bitRK { // OPT: Inline isConstant(field).
+		return e.constants[field & ^bitRK] // OPT: Inline constantIndex(field).
+	}
+	return e.frame[field]
+}
+
+func (e *engine) expectNext(expected opCode) instruction {
+	i := e.callInfo.step() // go to next instruction
+	if op := i.opCode(); op != expected {
+		panic(fmt.Sprintf("expected opcode %s, got %s", opNames[expected], opNames[op]))
+	}
+	return i
+}
+
+func clear(r []value) {
+	for i := range r {
+		r[i] = nil
+	}
+}
+
+func (e *engine) newFrame() {
+	ci := e.callInfo
+	// if internalCheck {
+	// 	e.l.assert(ci == e.l.callInfo.variant)
+	// }
+	e.frame = ci.frame
+	e.closure = e.l.stack[ci.function].(*luaClosure)
+	e.constants = e.closure.prototype.constants
+}
+
+func (e *engine) hooked() bool { return e.l.hookMask&(MaskLine|MaskCount) != 0 }
+
+func (e *engine) hook() {
+	if e.l.hookCount--; e.l.hookCount == 0 || e.l.hookMask&MaskLine != 0 {
+		e.l.traceExecution()
+		e.frame = e.callInfo.frame
+	}
+}
+
+type engineOp func(*engine, instruction) (engineOp, instruction)
+
+var jumpTable []engineOp
+
+func init() {
+	jumpTable = []engineOp{
+		func(e *engine, i instruction) (engineOp, instruction) { // opMove
+			e.frame[i.a()] = e.frame[i.b()]
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opLoadConstant
+			e.frame[i.a()] = e.constants[i.bx()]
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opLoadConstantEx
+			e.frame[i.a()] = e.constants[e.expectNext(opExtraArg).ax()]
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opLoadBool
+			e.frame[i.a()] = i.b() != 0
+			if i.c() != 0 {
+				e.callInfo.skip()
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opLoadNil
+			a, b := i.a(), i.b()
+			clear(e.frame[a : a+b+1])
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opGetUpValue
+			e.frame[i.a()] = e.closure.upValue(i.b())
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opGetTableUp
+			tmp := e.l.tableAt(e.closure.upValue(i.b()), e.k(i.c()))
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opGetTable
+			tmp := e.l.tableAt(e.frame[i.b()], e.k(i.c()))
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opSetTableUp
+			e.l.setTableAt(e.closure.upValue(i.a()), e.k(i.b()), e.k(i.c()))
+			e.frame = e.callInfo.frame
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opSetUpValue
+			e.closure.setUpValue(i.b(), e.frame[i.a()])
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opSetTable
+			e.l.setTableAt(e.frame[i.a()], e.k(i.b()), e.k(i.c()))
+			e.frame = e.callInfo.frame
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opNewTable
+			a := i.a()
+			if b, c := float8(i.b()), float8(i.c()); b != 0 || c != 0 {
+				e.frame[a] = newTableWithSize(intFromFloat8(b), intFromFloat8(c))
+			} else {
+				e.frame[a] = newTable()
+			}
+			clear(e.frame[a+1:])
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opSelf
+			a, t := i.a(), e.frame[i.b()]
+			tmp := e.l.tableAt(t, e.k(i.c()))
+			e.frame = e.callInfo.frame
+			e.frame[a+1], e.frame[a] = t, tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opAdd
+			b := e.k(i.b())
+			c := e.k(i.c())
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					e.frame[i.a()] = nb + nc
+					if e.hooked() {
+						e.hook()
+					}
+					i = e.callInfo.step()
+					return jumpTable[i.opCode()], i
+				}
+			}
+			tmp := e.l.arith(b, c, tmAdd)
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opSub
+			b := e.k(i.b())
+			c := e.k(i.c())
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					e.frame[i.a()] = nb - nc
+					if e.hooked() {
+						e.hook()
+					}
+					i = e.callInfo.step()
+					return jumpTable[i.opCode()], i
+				}
+			}
+			tmp := e.l.arith(b, c, tmSub)
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opMul
+			b := e.k(i.b())
+			c := e.k(i.c())
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					e.frame[i.a()] = nb * nc
+					if e.hooked() {
+						e.hook()
+					}
+					i = e.callInfo.step()
+					return jumpTable[i.opCode()], i
+				}
+			}
+			tmp := e.l.arith(b, c, tmMul)
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opDiv
+			b := e.k(i.b())
+			c := e.k(i.c())
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					e.frame[i.a()] = nb / nc
+					if e.hooked() {
+						e.hook()
+					}
+					i = e.callInfo.step()
+					return jumpTable[i.opCode()], i
+				}
+			}
+			tmp := e.l.arith(b, c, tmDiv)
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opMod
+			b := e.k(i.b())
+			c := e.k(i.c())
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					e.frame[i.a()] = math.Mod(nb, nc)
+					if e.hooked() {
+						e.hook()
+					}
+					i = e.callInfo.step()
+					return jumpTable[i.opCode()], i
+				}
+			}
+			tmp := e.l.arith(b, c, tmMod)
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opPow
+			b := e.k(i.b())
+			c := e.k(i.c())
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					e.frame[i.a()] = math.Pow(nb, nc)
+					if e.hooked() {
+						e.hook()
+					}
+					i = e.callInfo.step()
+					return jumpTable[i.opCode()], i
+				}
+			}
+			tmp := e.l.arith(b, c, tmPow)
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opUnaryMinus
+			switch b := e.frame[i.b()].(type) {
+			case float64:
+				e.frame[i.a()] = -b
+			default:
+				tmp := e.l.arith(b, b, tmUnaryMinus)
+				e.frame = e.callInfo.frame
+				e.frame[i.a()] = tmp
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opNot
+			e.frame[i.a()] = isFalse(e.frame[i.b()])
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opLength
+			tmp := e.l.objectLength(e.frame[i.b()])
+			e.frame = e.callInfo.frame
+			e.frame[i.a()] = tmp
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opConcat
+			a, b, c := i.a(), i.b(), i.c()
+			e.l.top = e.callInfo.stackIndex(c + 1) // mark the end of concat operands
+			e.l.concat(c - b + 1)
+			e.frame = e.callInfo.frame
+			e.frame[a] = e.frame[b]
+			if a >= b { // limit of live values
+				clear(e.frame[a+1:])
+			} else {
+				clear(e.frame[b:])
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opJump
+			if a := i.a(); a > 0 {
+				e.l.close(e.callInfo.stackIndex(a - 1))
+			}
+			e.callInfo.jump(i.sbx())
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opEqual
+			test := i.a() != 0
+			result := e.l.equalObjects(e.k(i.b()), e.k(i.c()))
+			if result == test {
+				i := e.callInfo.step()
+				if a := i.a(); a > 0 {
+					e.l.close(e.callInfo.stackIndex(a - 1))
+				}
+				e.callInfo.jump(i.sbx())
+			} else {
+				e.callInfo.skip()
+			}
+			e.frame = e.callInfo.frame
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opLessThan
+			test := i.a() != 0
+			result := e.l.lessThan(e.k(i.b()), e.k(i.c()))
+			if result == test {
+				i := e.callInfo.step()
+				if a := i.a(); a > 0 {
+					e.l.close(e.callInfo.stackIndex(a - 1))
+				}
+				e.callInfo.jump(i.sbx())
+			} else {
+				e.callInfo.skip()
+			}
+			e.frame = e.callInfo.frame
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opLessOrEqual
+			test := i.a() != 0
+			result := e.l.lessOrEqual(e.k(i.b()), e.k(i.c()))
+			if result == test {
+				i := e.callInfo.step()
+				if a := i.a(); a > 0 {
+					e.l.close(e.callInfo.stackIndex(a - 1))
+				}
+				e.callInfo.jump(i.sbx())
+			} else {
+				e.callInfo.skip()
+			}
+			e.frame = e.callInfo.frame
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opTest
+			test := i.c() == 0
+			if isFalse(e.frame[i.a()]) == test {
+				i := e.callInfo.step()
+				if a := i.a(); a > 0 {
+					e.l.close(e.callInfo.stackIndex(a - 1))
+				}
+				e.callInfo.jump(i.sbx())
+			} else {
+				e.callInfo.skip()
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opTestSet
+			b := e.frame[i.b()]
+			test := i.c() == 0
+			if isFalse(b) == test {
+				e.frame[i.a()] = b
+				i := e.callInfo.step()
+				if a := i.a(); a > 0 {
+					e.l.close(e.callInfo.stackIndex(a - 1))
+				}
+				e.callInfo.jump(i.sbx())
+			} else {
+				e.callInfo.skip()
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opCall
+			a, b, c := i.a(), i.b(), i.c()
+			if b != 0 {
+				e.l.top = e.callInfo.stackIndex(a + b)
+			} // else previous instruction set top
+			if n := c - 1; e.l.preCall(e.callInfo.stackIndex(a), n) { // go function
+				if n >= 0 {
+					e.l.top = e.callInfo.top // adjust results
+				}
+				e.frame = e.callInfo.frame
+			} else { // lua function
+				e.callInfo = e.l.callInfo
+				e.callInfo.setCallStatus(callStatusReentry)
+				e.newFrame()
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opTailCall
+			a, b := i.a(), i.b()
+			if b != 0 {
+				e.l.top = e.callInfo.stackIndex(a + b)
+			} // else previous instruction set top
+			// TODO e.l.assert(i.c()-1 == MultipleReturns)
+			if e.l.preCall(e.callInfo.stackIndex(a), MultipleReturns) { // go function
+				e.frame = e.callInfo.frame
+			} else {
+				// tail call: put called frame (n) in place of caller one (o)
+				nci := e.l.callInfo                    // called frame
+				oci := nci.previous                    // caller frame
+				nfn, ofn := nci.function, oci.function // called & caller function
+				// last stack slot filled by 'precall'
+				lim := nci.base() + e.l.stack[nfn].(*luaClosure).prototype.parameterCount
+				if len(e.closure.prototype.prototypes) > 0 { // close all upvalues from previous call
+					e.l.close(oci.base())
+				}
+				// move new frame into old one
+				for i := 0; nfn+i < lim; i++ {
+					e.l.stack[ofn+i] = e.l.stack[nfn+i]
+				}
+				base := ofn + (nci.base() - nfn)  // correct base
+				oci.setTop(ofn + (e.l.top - nfn)) // correct top
+				oci.frame = e.l.stack[base:oci.top]
+				oci.savedPC, oci.code = nci.savedPC, nci.code // correct code (savedPC indexes nci->code)
+				oci.setCallStatus(callStatusTail)             // function was tail called
+				e.l.top, e.l.callInfo, e.callInfo = oci.top, oci, oci
+				// TODO e.l.assert(e.l.top == oci.base()+e.l.stack[ofn].(*luaClosure).prototype.maxStackSize)
+				// TODO e.l.assert(&oci.frame[0] == &e.l.stack[oci.base()] && len(oci.frame) == oci.top-oci.base())
+				e.newFrame()
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opReturn
+			a := i.a()
+			if b := i.b(); b != 0 {
+				e.l.top = e.callInfo.stackIndex(a + b - 1)
+			}
+			if len(e.closure.prototype.prototypes) > 0 {
+				e.l.close(e.callInfo.base())
+			}
+			n := e.l.postCall(e.callInfo.stackIndex(a))
+			if !e.callInfo.isCallStatus(callStatusReentry) { // ci still the called one?
+				return nil, i // external invocation: return
+			}
+			e.callInfo = e.l.callInfo
+			if n {
+				e.l.top = e.callInfo.top
+			}
+			// TODO l.assert(e.callInfo.code[e.callInfo.savedPC-1].opCode() == opCall)
+			e.newFrame()
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opForLoop
+			a := i.a()
+			index, limit, step := e.frame[a+0].(float64), e.frame[a+1].(float64), e.frame[a+2].(float64)
+			if index += step; (0 < step && index <= limit) || (step <= 0 && limit <= index) {
+				e.callInfo.jump(i.sbx())
+				e.frame[a+0] = index // update internal index...
+				e.frame[a+3] = index // ... and external index
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opForPrep
+			a := i.a()
+			if init, ok := e.l.toNumber(e.frame[a+0]); !ok {
+				e.l.runtimeError("'for' initial value must be a number")
+			} else if limit, ok := e.l.toNumber(e.frame[a+1]); !ok {
+				e.l.runtimeError("'for' limit must be a number")
+			} else if step, ok := e.l.toNumber(e.frame[a+2]); !ok {
+				e.l.runtimeError("'for' step must be a number")
+			} else {
+				e.frame[a+0], e.frame[a+1], e.frame[a+2] = init-step, limit, step
+				e.callInfo.jump(i.sbx())
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opTForCall
+			a := i.a()
+			callBase := a + 3
+			copy(e.frame[callBase:callBase+3], e.frame[a:a+3])
+			callBase += e.callInfo.base()
+			e.l.top = callBase + 3 // function + 2 args (state and index)
+			e.l.call(callBase, i.c(), true)
+			e.frame, e.l.top = e.callInfo.frame, e.callInfo.top
+			i = e.expectNext(opTForLoop)         // go to next instruction
+			if a := i.a(); e.frame[a+1] != nil { // continue loop?
+				e.frame[a] = e.frame[a+1] // save control variable
+				e.callInfo.jump(i.sbx())  // jump back
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opTForLoop:
+			if a := i.a(); e.frame[a+1] != nil { // continue loop?
+				e.frame[a] = e.frame[a+1] // save control variable
+				e.callInfo.jump(i.sbx())  // jump back
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opSetList:
+			a, n, c := i.a(), i.b(), i.c()
+			if n == 0 {
+				n = e.l.top - e.callInfo.stackIndex(a) - 1
+			}
+			if c == 0 {
+				c = e.expectNext(opExtraArg).ax()
+			}
+			h := e.frame[a].(*table)
+			start := (c - 1) * listItemsPerFlush
+			last := start + n
+			if last > len(h.array) {
+				h.extendArray(last)
+			}
+			copy(h.array[start:last], e.frame[a+1:a+1+n])
+			e.l.top = e.callInfo.top
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opClosure
+			a, p := i.a(), &e.closure.prototype.prototypes[i.bx()]
+			if ncl := cached(p, e.closure.upValues, e.callInfo.base()); ncl == nil { // no match?
+				e.frame[a] = e.l.newClosure(p, e.closure.upValues, e.callInfo.base()) // create a new one
+			} else {
+				e.frame[a] = ncl
+			}
+			clear(e.frame[a+1:])
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opVarArg
+			ci := e.callInfo
+			a, b := i.a(), i.b()-1
+			n := ci.base() - ci.function - e.closure.prototype.parameterCount - 1
+			if b < 0 {
+				b = n // get all var arguments
+				e.l.checkStack(n)
+				e.l.top = ci.base() + a + n
+				if ci.top < e.l.top {
+					ci.setTop(e.l.top)
+					ci.frame = e.l.stack[ci.base():ci.top]
+				}
+				e.frame = ci.frame
+			}
+			for j := 0; j < b; j++ {
+				if j < n {
+					e.frame[a+j] = e.l.stack[ci.base()-n+j]
+				} else {
+					e.frame[a+j] = nil
+				}
+			}
+			if e.hooked() {
+				e.hook()
+			}
+			i = e.callInfo.step()
+			return jumpTable[i.opCode()], i
+		},
+		func(e *engine, i instruction) (engineOp, instruction) { // opExtraArg
+			panic(fmt.Sprintf("unexpected opExtraArg instruction, '%s'", i.String()))
+		},
+	}
+}
+
+func (l *State) execute() { l.executeFunctionTable() }
+
+func (l *State) executeFunctionTable() {
+	ci := l.callInfo
+	closure, _ := l.stack[ci.function].(*luaClosure)
+	e := engine{callInfo: ci, frame: ci.frame, closure: closure, constants: closure.prototype.constants, l: l}
+	if l.hookMask&(MaskLine|MaskCount) != 0 {
+		if l.hookCount--; l.hookCount == 0 || l.hookMask&MaskLine != 0 {
+			l.traceExecution()
+			e.frame = e.callInfo.frame
+		}
+	}
+	i := e.callInfo.step()
+	f := jumpTable[i.opCode()]
+	for f, i = f(&e, i); f != nil; f, i = f(&e, i) {
+	}
+}
+
+func k(field int, constants []value, frame []value) value {
+	if 0 != field&bitRK { // OPT: Inline isConstant(field).
+		return constants[field & ^bitRK] // OPT: Inline constantIndex(field).
+	}
+	return frame[field]
+}
+
+func newFrame(l *State, ci *callInfo) (frame []value, closure *luaClosure, constants []value) {
+	// TODO l.assert(ci == l.callInfo)
+	frame = ci.frame
+	closure, _ = l.stack[ci.function].(*luaClosure)
+	constants = closure.prototype.constants
+	return
+}
+
+func expectNext(ci *callInfo, expected opCode) instruction {
+	i := ci.step() // go to next instruction
+	if op := i.opCode(); op != expected {
+		panic(fmt.Sprintf("expected opcode %s, got %s", opNames[expected], opNames[op]))
+	}
+	return i
+}
+
+func (l *State) executeSwitch() {
+	ci := l.callInfo
+	frame, closure, constants := newFrame(l, ci)
+	for {
+		if l.hookMask&(MaskLine|MaskCount) != 0 {
+			if l.hookCount--; l.hookCount == 0 || l.hookMask&MaskLine != 0 {
+				l.traceExecution()
+				frame = ci.frame
+			}
+		}
+		switch i := ci.step(); i.opCode() {
+		case opMove:
+			frame[i.a()] = frame[i.b()]
+		case opLoadConstant:
+			frame[i.a()] = constants[i.bx()]
+		case opLoadConstantEx:
+			frame[i.a()] = constants[expectNext(ci, opExtraArg).ax()]
+		case opLoadBool:
+			frame[i.a()] = i.b() != 0
+			if i.c() != 0 {
+				ci.skip()
+			}
+		case opLoadNil:
+			a, b := i.a(), i.b()
+			clear(frame[a : a+b+1])
+		case opGetUpValue:
+			frame[i.a()] = closure.upValue(i.b())
+		case opGetTableUp:
+			tmp := l.tableAt(closure.upValue(i.b()), k(i.c(), constants, frame))
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opGetTable:
+			tmp := l.tableAt(frame[i.b()], k(i.c(), constants, frame))
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opSetTableUp:
+			l.setTableAt(closure.upValue(i.a()), k(i.b(), constants, frame), k(i.c(), constants, frame))
+			frame = ci.frame
+		case opSetUpValue:
+			closure.setUpValue(i.b(), frame[i.a()])
+		case opSetTable:
+			l.setTableAt(frame[i.a()], k(i.b(), constants, frame), k(i.c(), constants, frame))
+			frame = ci.frame
+		case opNewTable:
+			a := i.a()
+			if b, c := float8(i.b()), float8(i.c()); b != 0 || c != 0 {
+				frame[a] = newTableWithSize(intFromFloat8(b), intFromFloat8(c))
+			} else {
+				frame[a] = newTable()
+			}
+			clear(frame[a+1:])
+		case opSelf:
+			a, t := i.a(), frame[i.b()]
+			tmp := l.tableAt(t, k(i.c(), constants, frame))
+			frame = ci.frame
+			frame[a+1], frame[a] = t, tmp
+		case opAdd:
+			b := k(i.b(), constants, frame)
+			c := k(i.c(), constants, frame)
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					frame[i.a()] = nb + nc
+					break
+				}
+			}
+			tmp := l.arith(b, c, tmAdd)
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opSub:
+			b := k(i.b(), constants, frame)
+			c := k(i.c(), constants, frame)
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					frame[i.a()] = nb - nc
+					break
+				}
+			}
+			tmp := l.arith(b, c, tmSub)
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opMul:
+			b := k(i.b(), constants, frame)
+			c := k(i.c(), constants, frame)
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					frame[i.a()] = nb * nc
+					break
+				}
+			}
+			tmp := l.arith(b, c, tmMul)
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opDiv:
+			b := k(i.b(), constants, frame)
+			c := k(i.c(), constants, frame)
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					frame[i.a()] = nb / nc
+					break
+				}
+			}
+			tmp := l.arith(b, c, tmDiv)
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opMod:
+			b := k(i.b(), constants, frame)
+			c := k(i.c(), constants, frame)
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					frame[i.a()] = math.Mod(nb, nc)
+					break
+				}
+			}
+			tmp := l.arith(b, c, tmMod)
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opPow:
+			b := k(i.b(), constants, frame)
+			c := k(i.c(), constants, frame)
+			if nb, ok := b.(float64); ok {
+				if nc, ok := c.(float64); ok {
+					frame[i.a()] = math.Pow(nb, nc)
+					break
+				}
+			}
+			tmp := l.arith(b, c, tmPow)
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opUnaryMinus:
+			switch b := frame[i.b()].(type) {
+			case float64:
+				frame[i.a()] = -b
+			default:
+				tmp := l.arith(b, b, tmUnaryMinus)
+				frame = ci.frame
+				frame[i.a()] = tmp
+			}
+		case opNot:
+			frame[i.a()] = isFalse(frame[i.b()])
+		case opLength:
+			tmp := l.objectLength(frame[i.b()])
+			frame = ci.frame
+			frame[i.a()] = tmp
+		case opConcat:
+			a, b, c := i.a(), i.b(), i.c()
+			l.top = ci.stackIndex(c + 1) // mark the end of concat operands
+			l.concat(c - b + 1)
+			frame = ci.frame
+			frame[a] = frame[b]
+			if a >= b { // limit of live values
+				clear(frame[a+1:])
+			} else {
+				clear(frame[b:])
+			}
+		case opJump:
+			if a := i.a(); a > 0 {
+				l.close(ci.stackIndex(a - 1))
+			}
+			ci.jump(i.sbx())
+		case opEqual:
+			test := i.a() != 0
+			if l.equalObjects(k(i.b(), constants, frame), k(i.c(), constants, frame)) == test {
+				i := ci.step()
+				if a := i.a(); a > 0 {
+					l.close(ci.stackIndex(a - 1))
+				}
+				ci.jump(i.sbx())
+			} else {
+				ci.skip()
+			}
+			frame = ci.frame
+		case opLessThan:
+			test := i.a() != 0
+			if l.lessThan(k(i.b(), constants, frame), k(i.c(), constants, frame)) == test {
+				i := ci.step()
+				if a := i.a(); a > 0 {
+					l.close(ci.stackIndex(a - 1))
+				}
+				ci.jump(i.sbx())
+			} else {
+				ci.skip()
+			}
+			frame = ci.frame
+		case opLessOrEqual:
+			test := i.a() != 0
+			if l.lessOrEqual(k(i.b(), constants, frame), k(i.c(), constants, frame)) == test {
+				i := ci.step()
+				if a := i.a(); a > 0 {
+					l.close(ci.stackIndex(a - 1))
+				}
+				ci.jump(i.sbx())
+			} else {
+				ci.skip()
+			}
+			frame = ci.frame
+		case opTest:
+			test := i.c() == 0
+			if isFalse(frame[i.a()]) == test {
+				i := ci.step()
+				if a := i.a(); a > 0 {
+					l.close(ci.stackIndex(a - 1))
+				}
+				ci.jump(i.sbx())
+			} else {
+				ci.skip()
+			}
+		case opTestSet:
+			b := frame[i.b()]
+			test := i.c() == 0
+			if isFalse(b) == test {
+				frame[i.a()] = b
+				i := ci.step()
+				if a := i.a(); a > 0 {
+					l.close(ci.stackIndex(a - 1))
+				}
+				ci.jump(i.sbx())
+			} else {
+				ci.skip()
+			}
+		case opCall:
+			a, b, c := i.a(), i.b(), i.c()
+			if b != 0 {
+				l.top = ci.stackIndex(a + b)
+			} // else previous instruction set top
+			if n := c - 1; l.preCall(ci.stackIndex(a), n) { // go function
+				if n >= 0 {
+					l.top = ci.top // adjust results
+				}
+				frame = ci.frame
+			} else { // lua function
+				ci = l.callInfo
+				ci.setCallStatus(callStatusReentry)
+				frame, closure, constants = newFrame(l, ci)
+			}
+		case opTailCall:
+			a, b := i.a(), i.b()
+			if b != 0 {
+				l.top = ci.stackIndex(a + b)
+			} // else previous instruction set top
+			// TODO l.assert(i.c()-1 == MultipleReturns)
+			if l.preCall(ci.stackIndex(a), MultipleReturns) { // go function
+				frame = ci.frame
+			} else {
+				// tail call: put called frame (n) in place of caller one (o)
+				nci := l.callInfo                      // called frame
+				oci := nci.previous                    // caller frame
+				nfn, ofn := nci.function, oci.function // called & caller function
+				// last stack slot filled by 'precall'
+				lim := nci.base() + l.stack[nfn].(*luaClosure).prototype.parameterCount
+				if len(closure.prototype.prototypes) > 0 { // close all upvalues from previous call
+					l.close(oci.base())
+				}
+				// move new frame into old one
+				for i := 0; nfn+i < lim; i++ {
+					l.stack[ofn+i] = l.stack[nfn+i]
+				}
+				base := ofn + (nci.base() - nfn) // correct base
+				oci.setTop(ofn + (l.top - nfn))  // correct top
+				oci.frame = l.stack[base:oci.top]
+				oci.savedPC, oci.code = nci.savedPC, nci.code // correct code (savedPC indexes nci->code)
+				oci.setCallStatus(callStatusTail)             // function was tail called
+				l.top, l.callInfo, ci = oci.top, oci, oci
+				// TODO l.assert(l.top == oci.base()+l.stack[ofn].(*luaClosure).prototype.maxStackSize)
+				// TODO l.assert(&oci.frame[0] == &l.stack[oci.base()] && len(oci.frame) == oci.top-oci.base())
+				frame, closure, constants = newFrame(l, ci)
+			}
+		case opReturn:
+			a := i.a()
+			if b := i.b(); b != 0 {
+				l.top = ci.stackIndex(a + b - 1)
+			}
+			if len(closure.prototype.prototypes) > 0 {
+				l.close(ci.base())
+			}
+			n := l.postCall(ci.stackIndex(a))
+			if !ci.isCallStatus(callStatusReentry) { // ci still the called one?
+				return // external invocation: return
+			}
+			ci = l.callInfo
+			if n {
+				l.top = ci.top
+			}
+			// TODO l.assert(ci.code[ci.savedPC-1].opCode() == opCall)
+			frame, closure, constants = newFrame(l, ci)
+		case opForLoop:
+			a := i.a()
+			index, limit, step := frame[a+0].(float64), frame[a+1].(float64), frame[a+2].(float64)
+			if index += step; (0 < step && index <= limit) || (step <= 0 && limit <= index) {
+				ci.jump(i.sbx())
+				frame[a+0] = index // update internal index...
+				frame[a+3] = index // ... and external index
+			}
+		case opForPrep:
+			a := i.a()
+			if init, ok := l.toNumber(frame[a+0]); !ok {
+				l.runtimeError("'for' initial value must be a number")
+			} else if limit, ok := l.toNumber(frame[a+1]); !ok {
+				l.runtimeError("'for' limit must be a number")
+			} else if step, ok := l.toNumber(frame[a+2]); !ok {
+				l.runtimeError("'for' step must be a number")
+			} else {
+				frame[a+0], frame[a+1], frame[a+2] = init-step, limit, step
+				ci.jump(i.sbx())
+			}
+		case opTForCall:
+			a := i.a()
+			callBase := a + 3
+			copy(frame[callBase:callBase+3], frame[a:a+3])
+			callBase += ci.base()
+			l.top = callBase + 3 // function + 2 args (state and index)
+			l.call(callBase, i.c(), true)
+			frame, l.top = ci.frame, ci.top
+			i = expectNext(ci, opTForLoop) // go to next instruction
+			fallthrough
+		case opTForLoop:
+			if a := i.a(); frame[a+1] != nil { // continue loop?
+				frame[a] = frame[a+1] // save control variable
+				ci.jump(i.sbx())      // jump back
+			}
+		case opSetList:
+			a, n, c := i.a(), i.b(), i.c()
+			if n == 0 {
+				n = l.top - ci.stackIndex(a) - 1
+			}
+			if c == 0 {
+				c = expectNext(ci, opExtraArg).ax()
+			}
+			h := frame[a].(*table)
+			start := (c - 1) * listItemsPerFlush
+			last := start + n
+			if last > len(h.array) {
+				h.extendArray(last)
+			}
+			copy(h.array[start:last], frame[a+1:a+1+n])
+			l.top = ci.top
+		case opClosure:
+			a, p := i.a(), &closure.prototype.prototypes[i.bx()]
+			if ncl := cached(p, closure.upValues, ci.base()); ncl == nil { // no match?
+				frame[a] = l.newClosure(p, closure.upValues, ci.base()) // create a new one
+			} else {
+				frame[a] = ncl
+			}
+			clear(frame[a+1:])
+		case opVarArg:
+			a, b := i.a(), i.b()-1
+			n := ci.base() - ci.function - closure.prototype.parameterCount - 1
+			if b < 0 {
+				b = n // get all var arguments
+				l.checkStack(n)
+				l.top = ci.base() + a + n
+				if ci.top < l.top {
+					ci.setTop(l.top)
+					ci.frame = l.stack[ci.base():ci.top]
+				}
+				frame = ci.frame
+			}
+			for j := 0; j < b; j++ {
+				if j < n {
+					frame[a+j] = l.stack[ci.base()-n+j]
+				} else {
+					frame[a+j] = nil
+				}
+			}
+		case opExtraArg:
+			panic(fmt.Sprintf("unexpected opExtraArg instruction, '%s'", i.String()))
+		}
+	}
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -3,6 +3,12 @@
 	"ignore": "test",
 	"package": [
 		{
+			"checksumSHA1": "V6Qhng30E7mgFbXm2jm02BIwAp0=",
+			"path": "github.com/Shopify/go-lua",
+			"revision": "67c3ba03ce822db5f0b4305b83ac822a8bead28a",
+			"revisionTime": "2017-02-07T01:30:01Z"
+		},
+		{
 			"checksumSHA1": "N28uXw8i8WMJcqBiqmJl9j9NPiI=",
 			"path": "github.com/krolaw/dhcp4",
 			"revision": "f61f734b73027e29f7fa2ed623f2ed85a7ef08fa",


### PR DESCRIPTION
This adds lua. If you build with this, and of course
have lua package somewhere, you can do stuff like this

lua print "x"
lua for x = 1,2 do print(x) end

Note that since rush tends not to use lots of characters like "
they just get passed right to lua.

Lots of questions here. Should there be one instance of lua so we can
use lua variables? What about multi line input?

without lua:
-rwxrwxr-x 1 rminnich rminnich 2295429 Feb 13 16:21 rush

with lua:

-rwxrwxr-x 1 rminnich rminnich 3227080 Feb 13 16:21 rush

931651 bytes. Could be worse.

Is there some build tag we could add to make building lua.go optional?

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>