### PR TITLE
ramfs: support selection of package names

### DIFF
--- a/bb/bb.go
+++ b/bb/bb.go
@@ -291,6 +291,22 @@ func main() {
 		log.Fatalf("%v", err)
 	}
 
+	if len(flag.Args()) > 0 {
+		config.Args = []string{}
+		for _, v := range flag.Args() {
+			v = path.Join(config.Uroot, "cmds", v)
+			g, err := filepath.Glob(v)
+			if err != nil {
+				log.Fatalf("Glob error: %v", err)
+			}
+
+			for i := range g {
+				g[i] = path.Base(g[i])
+			}
+			config.Args = append(config.Args, g...)
+		}
+	}
+
 	for _, v := range config.Args {
 		// Yes, gross. Fix me.
 		config.CmdName = v


### PR DESCRIPTION
ramfs will default, as before, to all the files in cmds/.
It uses the filepath.Glob to find those files with the
pattern [a-zA-Z]* (this avoids useless warnings about
files like .gitignore).

If there are arguments left after flag.Parse, these are
used as Glob patterns instead. For example,
ramfs rush date
will build a ramfs with the full go toolchain but only
rush and date.
ramfs i*
will include commands starting with i.

It is NOT an error to specify a glob which matches nothing.
This results in an initramfs with init and Go toolchain,
but no pkg sources or u-root commands. This is useful for merging
into another initramfs cpio if you want to put a Go toolchain
in it.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>