### PR TITLE
Installcommand exec

### DIFF
--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -124,10 +124,17 @@ func main() {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Cloneflags: cloneFlags}
 		debug("Run %v", cmd)
 		if err := cmd.Run(); err != nil {
-			log.Printf("%v\n", err)
+			log.Print(err)
 		}
 		// only the first init needs its own PID space.
 		cloneFlags = 0
 	}
+
 	log.Printf("init: All commands exited")
+	log.Printf("Rebooting...")
+	err := exec.Command("shutdown", "reboot").Run()
+
+	// Regardless of whether err is nil, if shutdown returns at all, it
+	// failed at its job.
+	log.Fatalf("Failed to reboot: %v", err)
 }

--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -31,6 +31,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+	"syscall"
 
 	"github.com/u-root/u-root/uroot"
 )
@@ -121,13 +122,10 @@ func main() {
 		debug(string(out))
 	}
 
-	cmd = exec.Command(destFile)
+	args := append([]string{form.cmdName}, form.cmdArgs...)
+	err = syscall.Exec(destFile, args, os.Environ())
 
-	cmd.Args = append([]string{form.cmdName}, form.cmdArgs...)
-	cmd.Stdin = os.Stdin
-	cmd.Stderr = os.Stderr
-	cmd.Stdout = os.Stdout
-	if err := cmd.Run(); err != nil {
-		log.Fatal(err)
-	}
+	// Regardless of whether err is nil, if Exec returns at all, it failed
+	// at its job.
+	log.Fatalf("Failed to exec %s: %v", form.cmdName, err)
 }


### PR DESCRIPTION
I noticed something inefficient regarding the process tree:

```
    - init
        - installcommand (symlinked from rush)
            - rush
	        - installcommand (symlinked from ps)
	            - ps
```

`init` is PID 1. `installcommand` is `init`'s child. `rush` is
`installcommand`'s child. Etc...

By using syscall.Exec in installcommand, the tree is simplified to what
you would expect:

```
    - init
        - rush
	    - ps
```

This will likely make process control easier because a process's
children are always its children regardless of being run through
`installcommand`. Features like `CTRL-C`, `CTRL-Z`, and `&` should be
easier to implement.


Also in this PR:

- Reboot gracefully when the init process exits