### PR TITLE
Build commands in a background process

### DIFF
--- a/cmds/init/bgbuild.go
+++ b/cmds/init/bgbuild.go
@@ -15,8 +15,11 @@ import (
 	"sort"
 )
 
-// Generally shorter commands (ls, cd, ...) are used more often, so they are
-// compiled first. This avoids maintaining a list for compilation order.
+// Commands are built approximately in order from smallest to largest length of
+// the command name. So, two letter commands like `ls` and `cd` will be built
+// before `mknod` and `mount`. Generally, shorter commands are used more often
+// (that is why they were made short) and are more likely to be used first,
+// thus they should be built first.
 type cmdSlice []os.FileInfo
 
 func (p cmdSlice) Len() int {

--- a/cmds/init/bgbuild.go
+++ b/cmds/init/bgbuild.go
@@ -1,0 +1,70 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Build commands in backgorund processes. This feature certainly makes a
+// non-busybox shell feel more realtime.
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+	"sort"
+)
+
+// Generally shorter commands (ls, cd, ...) are used more often, so they are
+// compiled first. This avoids maintaining a list for compilation order.
+type cmdSlice []os.FileInfo
+
+func (p cmdSlice) Len() int {
+	return len(p)
+}
+
+func (p cmdSlice) Less(i, j int) bool {
+	return len(p[i].Name()) < len(p[j].Name())
+}
+
+func (p cmdSlice) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+
+func worker(cmds chan string) {
+	for cmdName := range cmds {
+		args := []string{"--noexec", "--noforce", "--lowpri", cmdName}
+		cmd := exec.Command("installcommand", args...)
+		if err := cmd.Start(); err != nil {
+			log.Println("Cannot start:", err)
+			continue
+		}
+		if err := cmd.Wait(); err != nil {
+			log.Println("installcommand error:", err)
+		}
+	}
+}
+
+func startBgBuild() {
+	cmds := make(chan string)
+
+	// Start a worker for each CPU.
+	for i := 0; i < runtime.NumCPU(); i++ {
+		go worker(cmds)
+	}
+
+	// Create a slice of commands and order them by the aformentioned
+	// heuristic.
+	fis, err := ioutil.ReadDir("/buildbin")
+	if err != nil {
+		log.Print(err)
+		return
+	}
+	sort.Sort(cmdSlice(fis))
+
+	// Send the command by name to the workers.
+	for _, fi := range fis {
+		cmds <- fi.Name()
+	}
+	close(cmds)
+}

--- a/cmds/init/bgbuild.go
+++ b/cmds/init/bgbuild.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"runtime"
 	"sort"
+	"strings"
 )
 
 // Commands are built approximately in order from smallest to largest length of
@@ -70,4 +71,23 @@ func startBgBuild() {
 		cmds <- fi.Name()
 	}
 	close(cmds)
+}
+
+func cmdlineContainsFlag(flag string) bool {
+	cmdline, err := ioutil.ReadFile("/proc/cmdline")
+	if err != nil {
+		// Procfs not mounted?
+		return false
+	}
+	args := strings.Split(string(cmdline), " ")
+	for _, a := range args {
+		if a == flag {
+			return true
+		}
+	}
+	return false
+}
+
+func isBgBuildEnabled() bool {
+	return !cmdlineContainsFlag("uroot.nobgbuild")
 }

--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -117,7 +117,9 @@ func main() {
 	}
 
 	// Start background build.
-	go startBgBuild()
+	if isBgBuildEnabled() {
+		go startBgBuild()
+	}
 
 	// There may be an inito if we are building on
 	// an existing initramfs. So, first, try to

--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -116,6 +116,9 @@ func main() {
 		}
 	}
 
+	// Start background build.
+	go startBgBuild()
+
 	// There may be an inito if we are building on
 	// an existing initramfs. So, first, try to
 	// run inito and then run our shell

--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -100,7 +100,7 @@ func main() {
 	form := parseCommandLine()
 
 	if form.lowPri {
-		if err := syscall.Setpriority(syscall.PRIO_PGRP, 0, 20); err != nil {
+		if err := syscall.Setpriority(syscall.PRIO_PROCESS, 0, 20); err != nil {
 			log.Printf("Cannot set low priority: %v", err)
 		}
 	}


### PR DESCRIPTION
Commands will start building themselves without any user input. These
"background builds" occur in low priority processes, so in theory, they
should not affect the overall performance of the system. If you
continuously `ls /ubin`, you will see commands appearing automatically.

Here are some design decisions which had to be made:

- `installcommand` sets its own priority to low when passed in the
  `-lowpri` flag. When `installcommand` runs `go build`, `go build` will
  inherit the priority of `installcommand`. Go does not provide the
  means to create processes at a specified priority, so this was the
  work-around.
- Commands are built approximately in order from smallest to largest
  length of the command name. So, two letter commands like `ls` and `cd`
  will be built before `mknod` and `mount`. Generally, shorter commands
  are used more often (that is why they were made short) and are more
  likely to be used first, thus they should be built first.
- The number of `go builds` which can run concurrently is limited to the
  number of CPUs on the machine.

This commit has one drawback. If u-root was build as a busybox, the init
process will perform a lot of useless (albeit harmless) work.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>