### PR TITLE
Fix ps to be stable with terminated processes

### DIFF
--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -193,6 +193,11 @@ func ps(pT ProcessTable) error {
 	for index, p := range pT.table {
 		uid, err := p.GetUid()
 		if err != nil {
+			// It is extremely common for a directory to disappear from
+			// /proc when a process terminates, so ignore those errors.
+			if os.IsNotExist(err) {
+				continue
+			}
 			return err
 		}
 

--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -57,7 +57,7 @@ func init() {
 // main process table of ps
 // used to make more flexible
 type ProcessTable struct {
-	table    []Process
+	table    []*Process
 	headers  []string // each column to print
 	fields   []string // which fields of process to print, on order
 	fstring  []string // formated strings
@@ -83,7 +83,7 @@ func (pT ProcessTable) Swap(i, j int) {
 
 // Gived a pid, search for a process
 // Returns nil if not found
-func (pT ProcessTable) GetProcess(pid int) (found Process) {
+func (pT ProcessTable) GetProcess(pid int) (found *Process) {
 	for _, p := range pT.table {
 		if p.Pid == strconv.Itoa(pid) {
 			found = p

--- a/cmds/ps/ps_linux.go
+++ b/cmds/ps/ps_linux.go
@@ -218,8 +218,9 @@ func (p process) getTime() string {
 // Walk from the proc files
 // and parsing them
 func (pT *ProcessTable) LoadTable() error {
+	var parsingError error
 	pf := regexp.MustCompile(allProc)
-	err := filepath.Walk(proc, func(name string, fi os.FileInfo, err error) error {
+	filepath.Walk(proc, func(name string, fi os.FileInfo, err error) error {
 		if err != nil {
 			log.Printf("%v: %v\n", name, err)
 			return err
@@ -231,18 +232,13 @@ func (pT *ProcessTable) LoadTable() error {
 		if pf.Match([]byte(fi.Name())) {
 			p := &Process{}
 			if err := p.Parse(fi.Name()); err != nil {
-				log.Print(err)
-				return err
+				parsingError = err
 			}
-			pT.table = append(pT.table, *p)
+			pT.table = append(pT.table, p)
 		}
 
 		return filepath.SkipDir
 	})
 
-	if err == filepath.SkipDir {
-		return nil
-	}
-
-	return err
+	return parsingError
 }

--- a/cmds/ps/ps_test.go
+++ b/cmds/ps/ps_test.go
@@ -13,7 +13,6 @@ import (
 // Simple Test trying execute the ps
 // If no errors returns, it's okay
 func TestPsExecution(t *testing.T) {
-	t.Skip("ps is abuggy and this test is breaking travis; skipping")
 	pT := ProcessTable{}
 	if err := pT.LoadTable(); err != nil {
 		t.Fatalf("Loading Table fails on some point; %v", err)


### PR DESCRIPTION
Procfs is very alive. Subdirectories can be added and removed at
anytime. `os.Walk`ing over `/proc` and expecting a file to exist on a
subsequent syscall is a race condition waiting to happen.

The solution is to implement a simpler version of `os.Walk` which simply
walks over a single directory. Additionally, "file does not exist"
errors are ignored.

I tested this issue by killing many processes per second:

	while true; do /bin/true; done

In another terminal, run:

	for i in {1..1000}; do ./ps > /dev/null; done

No longer will you see fatal error messages and SIGSEVs.

Fixes #28 