### PR TITLE
Apply lint suggestions to ectool

### DIFF
--- a/cmds/ectool/commands.go
+++ b/cmds/ectool/commands.go
@@ -16,80 +16,80 @@ const (
 	 * determined in other ways.  Remove this once the kernel code no longer
 	 * depends on it.
 	 */
-	EC_PROTO_VERSION = 0x00000002
+	ecProtoVersion = 0x00000002
 
 	/* I/O addresses for ACPI commands */
-	EC_LPC_ADDR_ACPI_DATA = 0x62
-	EC_LPC_ADDR_ACPI_CMD  = 0x66
+	ecLpcAddrAcpiData = 0x62
+	ecLpcAddrAcpiCmd  = 0x66
 
 	/* I/O addresses for host command */
-	EC_LPC_ADDR_HOST_DATA = 0x200
-	EC_LPC_ADDR_HOST_CMD  = 0x204
+	ecLpcAddrHostData = 0x200
+	ecLpcAddrHostCmd  = 0x204
 
 	/* I/O addresses for host command args and params */
 	/* Protocol version 2 */
-	EC_LPC_ADDR_HOST_ARGS  = 0x800 /* And 0x801, 0x802, 0x803 */
-	EC_LPC_ADDR_HOST_PARAM = 0x804 /* For version 2 params; size is
-	 * EC_PROTO2_MAX_PARAM_SIZE */
+	ecLpcAddrHostArgs  = 0x800 /* And 0x801, 0x802, 0x803 */
+	ecLpcAddrHostParam = 0x804 /* For version 2 params; size is
+	 * ecProto2MaxParamSize */
 	/* Protocol version 3 */
-	EC_LPC_ADDR_HOST_PACKET = 0x800 /* Offset of version 3 packet */
-	EC_LPC_HOST_PACKET_SIZE = 0x100 /* Max size of version 3 packet */
+	ecLpcAddrHostPacket = 0x800 /* Offset of version 3 packet */
+	ecLpcHostPacketSize = 0x100 /* Max size of version 3 packet */
 
 	/* The actual block is 0x800-0x8ff, but some BIOSes think it's 0x880-0x8ff
 	 * and they tell the kernel that so we have to think of it as two parts. */
-	EC_HOST_CMD_REGION0     = 0x800
-	EC_HOST_CMD_REGION1     = 0x880
-	EC_HOST_CMD_REGION_SIZE = 0x80
+	ecHostCmdRegion0    = 0x800
+	ecHostCmdRegion1    = 0x880
+	ecHostCmdRegionSize = 0x80
 
 	/* EC command register bit functions */
-	EC_LPC_CMDR_DATA      = (1 << 0) /* Data ready for host to read */
-	EC_LPC_CMDR_PENDING   = (1 << 1) /* Write pending to EC */
-	EC_LPC_CMDR_BUSY      = (1 << 2) /* EC is busy processing a command */
-	EC_LPC_CMDR_CMD       = (1 << 3) /* Last host write was a command */
-	EC_LPC_CMDR_ACPI_BRST = (1 << 4) /* Burst mode (not used) */
-	EC_LPC_CMDR_SCI       = (1 << 5) /* SCI event is pending */
-	EC_LPC_CMDR_SMI       = (1 << 6) /* SMI event is pending */
+	ecLpcCmdrData     = (1 << 0) /* Data ready for host to read */
+	ecLpcCmdrPending  = (1 << 1) /* Write pending to EC */
+	ecLpcCmdrBusy     = (1 << 2) /* EC is busy processing a command */
+	ecLpcCmdrCmd      = (1 << 3) /* Last host write was a command */
+	ecLpcCmdrAcpiBrst = (1 << 4) /* Burst mode (not used) */
+	ecLpcCmdrSci      = (1 << 5) /* SCI event is pending */
+	ecLpcCmdrSmi      = (1 << 6) /* SMI event is pending */
 
-	EC_LPC_ADDR_MEMMAP = 0x900
-	EC_MEMMAP_SIZE     = 255 /* ACPI IO buffer max is 255 bytes */
-	EC_MEMMAP_TEXT_MAX = 8   /* Size of a string in the memory map */
+	ecLpcAddrMemmap = 0x900
+	ecMemmapSize    = 255 /* ACPI IO buffer max is 255 bytes */
+	ecMemmapTextMax = 8   /* Size of a string in the memory map */
 
 	/* The offset address of each type of data in mapped memory. */
-	EC_MEMMAP_TEMP_SENSOR      = 0x00 /* Temp sensors 0x00 - 0x0f */
-	EC_MEMMAP_FAN              = 0x10 /* Fan speeds 0x10 - 0x17 */
-	EC_MEMMAP_TEMP_SENSOR_B    = 0x18 /* More temp sensors 0x18 - 0x1f */
-	EC_MEMMAP_ID               = 0x20 /* 0x20 == 'E', 0x21 == 'C' */
-	EC_MEMMAP_ID_VERSION       = 0x22 /* Version of data in 0x20 - 0x2f */
-	EC_MEMMAP_THERMAL_VERSION  = 0x23 /* Version of data in 0x00 - 0x1f */
-	EC_MEMMAP_BATTERY_VERSION  = 0x24 /* Version of data in 0x40 - 0x7f */
-	EC_MEMMAP_SWITCHES_VERSION = 0x25 /* Version of data in 0x30 - 0x33 */
-	EC_MEMMAP_EVENTS_VERSION   = 0x26 /* Version of data in 0x34 - 0x3f */
-	EC_MEMMAP_HOST_CMD_FLAGS   = 0x27 /* Host cmd interface flags (8 bits) */
+	ecMemmapTempSensor      = 0x00 /* Temp sensors 0x00 - 0x0f */
+	ecMemmapFan             = 0x10 /* Fan speeds 0x10 - 0x17 */
+	ecMemmapTempSensorB     = 0x18 /* More temp sensors 0x18 - 0x1f */
+	ecMemmapID              = 0x20 /* 0x20 == 'E', 0x21 == 'C' */
+	ecMemmapIDVersion       = 0x22 /* Version of data in 0x20 - 0x2f */
+	ecMemmapThermalVersion  = 0x23 /* Version of data in 0x00 - 0x1f */
+	ecMemmapBatteryVersion  = 0x24 /* Version of data in 0x40 - 0x7f */
+	ecMemmapSwitchesVersion = 0x25 /* Version of data in 0x30 - 0x33 */
+	ecMemmapEventsVersion   = 0x26 /* Version of data in 0x34 - 0x3f */
+	ecMemmapHostCmdFlags    = 0x27 /* Host cmd interface flags (8 bits) */
 	/* Unused 0x28 - 0x2f */
-	EC_MEMMAP_SWITCHES = 0x30 /* 8 bits */
+	ecMemmapSwitches = 0x30 /* 8 bits */
 	/* Unused 0x31 - 0x33 */
-	EC_MEMMAP_HOST_EVENTS = 0x34 /* 32 bits */
+	ecMemmapHostEvents = 0x34 /* 32 bits */
 	/* Reserve 0x38 - 0x3f for additional host event-related stuff */
 	/* Battery values are all 32 bits */
-	EC_MEMMAP_BATT_VOLT = 0x40 /* Battery Present Voltage */
-	EC_MEMMAP_BATT_RATE = 0x44 /* Battery Present Rate */
-	EC_MEMMAP_BATT_CAP  = 0x48 /* Battery Remaining Capacity */
-	EC_MEMMAP_BATT_FLAG = 0x4c /* Battery State, defined below */
-	EC_MEMMAP_BATT_DCAP = 0x50 /* Battery Design Capacity */
-	EC_MEMMAP_BATT_DVLT = 0x54 /* Battery Design Voltage */
-	EC_MEMMAP_BATT_LFCC = 0x58 /* Battery Last Full Charge Capacity */
-	EC_MEMMAP_BATT_CCNT = 0x5c /* Battery Cycle Count */
-	/* Strings are all 8 bytes (EC_MEMMAP_TEXT_MAX) */
-	EC_MEMMAP_BATT_MFGR   = 0x60 /* Battery Manufacturer String */
-	EC_MEMMAP_BATT_MODEL  = 0x68 /* Battery Model Number String */
-	EC_MEMMAP_BATT_SERIAL = 0x70 /* Battery Serial Number String */
-	EC_MEMMAP_BATT_TYPE   = 0x78 /* Battery Type String */
-	EC_MEMMAP_ALS         = 0x80 /* ALS readings in lux (2 X 16 bits) */
+	ecMemmapBattVolt = 0x40 /* Battery Present Voltage */
+	ecMemmapBattRate = 0x44 /* Battery Present Rate */
+	ecMemmapBattCap  = 0x48 /* Battery Remaining Capacity */
+	ecMemmapBattFlag = 0x4c /* Battery State, defined below */
+	ecMemmapBattDcap = 0x50 /* Battery Design Capacity */
+	ecMemmapBattDvlt = 0x54 /* Battery Design Voltage */
+	ecMemmapBattLfcc = 0x58 /* Battery Last Full Charge Capacity */
+	ecMemmapBattCcnt = 0x5c /* Battery Cycle Count */
+	/* Strings are all 8 bytes (ecMemmapTextMax) */
+	ecMemmapBattMfgr   = 0x60 /* Battery Manufacturer String */
+	ecMemmapBattModel  = 0x68 /* Battery Model Number String */
+	ecMemmapBattSerial = 0x70 /* Battery Serial Number String */
+	ecMemmapBattType   = 0x78 /* Battery Type String */
+	ecMemmapAls        = 0x80 /* ALS readings in lux (2 X 16 bits) */
 	/* Unused 0x84 - 0x8f */
-	EC_MEMMAP_ACC_STATUS = 0x90 /* Accelerometer status (8 bits )*/
+	ecMemmapAccStatus = 0x90 /* Accelerometer status (8 bits )*/
 	/* Unused 0x91 */
-	EC_MEMMAP_ACC_DATA  = 0x92 /* Accelerometer data 0x92 - 0x9f */
-	EC_MEMMAP_GYRO_DATA = 0xa0 /* Gyroscope data 0xa0 - 0xa5 */
+	ecMemmapAccData  = 0x92 /* Accelerometer data 0x92 - 0x9f */
+	ecMemmapGyroData = 0xa0 /* Gyroscope data 0xa0 - 0xa5 */
 	/* Unused 0xa6 - 0xdf */
 
 	/*
@@ -97,79 +97,79 @@ const (
 	 * limitations of the ACPI protocol. Do not place data in the range 0xe0 - 0xfe
 	 * which might be needed by ACPI.
 	 */
-	EC_MEMMAP_NO_ACPI = 0xe0
+	ecMemmapNoAcpi = 0xe0
 
 	/* Define the format of the accelerometer mapped memory status byte. */
-	EC_MEMMAP_ACC_STATUS_SAMPLE_ID_MASK = 0x0f
-	EC_MEMMAP_ACC_STATUS_BUSY_BIT       = (1 << 4)
-	EC_MEMMAP_ACC_STATUS_PRESENCE_BIT   = (1 << 7)
+	ecMemmapAccStatusSampleIDMask = 0x0f
+	ecMemmapAccStatusBusyBit      = (1 << 4)
+	ecMemmapAccStatusPresenceBit  = (1 << 7)
 
-	/* Number of temp sensors at EC_MEMMAP_TEMP_SENSOR */
-	EC_TEMP_SENSOR_ENTRIES = 16
+	/* Number of temp sensors at ecMemmapTempSensor */
+	ecTempSensorEntries = 16
 	/*
-	 * Number of temp sensors at EC_MEMMAP_TEMP_SENSOR_B.
+	 * Number of temp sensors at ecMemmapTempSensorB.
 	 *
-	 * Valid only if EC_MEMMAP_THERMAL_VERSION returns >= 2.
+	 * Valid only if ecMemmapThermalVersion returns >= 2.
 	 */
-	EC_TEMP_SENSOR_B_ENTRIES = 8
+	ecTempSensorBEntries = 8
 
 	/* Special values for mapped temperature sensors */
-	EC_TEMP_SENSOR_NOT_PRESENT    = 0xff
-	EC_TEMP_SENSOR_ERROR          = 0xfe
-	EC_TEMP_SENSOR_NOT_POWERED    = 0xfd
-	EC_TEMP_SENSOR_NOT_CALIBRATED = 0xfc
+	ecTempSensorNotPresent    = 0xff
+	ecTempSensorError         = 0xfe
+	ecTempSensorNotPowered    = 0xfd
+	ecTempSensorNotCalibrated = 0xfc
 	/*
 	 * The offset of temperature value stored in mapped memory.  This allows
 	 * reporting a temperature range of 200K to 454K = -73C to 181C.
 	 */
-	EC_TEMP_SENSOR_OFFSET = 200
+	ecTempSensorOffset = 200
 
 	/*
-	 * Number of ALS readings at EC_MEMMAP_ALS
+	 * Number of ALS readings at ecMemmapAls
 	 */
-	EC_ALS_ENTRIES = 2
+	ecAlsEntries = 2
 
 	/*
 	 * The default value a temperature sensor will return when it is present but
 	 * has not been read this boot.  This is a reasonable number to avoid
 	 * triggering alarms on the host.
 	 */
-	EC_TEMP_SENSOR_DEFAULT = (296 - EC_TEMP_SENSOR_OFFSET)
+	ecTempSensorDefault = (296 - ecTempSensorOffset)
 
-	EC_FAN_SPEED_ENTRIES     = 4      /* Number of fans at EC_MEMMAP_FAN */
-	EC_FAN_SPEED_NOT_PRESENT = 0xffff /* Entry not present */
-	EC_FAN_SPEED_STALLED     = 0xfffe /* Fan stalled */
+	ecFanSpeedEntries    = 4      /* Number of fans at ecMemmapFan */
+	ecFanSpeedNotPresent = 0xffff /* Entry not present */
+	ecFanSpeedStalled    = 0xfffe /* Fan stalled */
 
-	/* Battery bit flags at EC_MEMMAP_BATT_FLAG. */
-	EC_BATT_FLAG_AC_PRESENT     = 0x01
-	EC_BATT_FLAG_BATT_PRESENT   = 0x02
-	EC_BATT_FLAG_DISCHARGING    = 0x04
-	EC_BATT_FLAG_CHARGING       = 0x08
-	EC_BATT_FLAG_LEVEL_CRITICAL = 0x10
+	/* Battery bit flags at ecMemmapBattFlag. */
+	ecBattFlagAcPresent     = 0x01
+	ecBattFlagBattPresent   = 0x02
+	ecBattFlagDischarging   = 0x04
+	ecBattFlagCharging      = 0x08
+	ecBattFlagLevelCritical = 0x10
 
-	/* Switch flags at EC_MEMMAP_SWITCHES */
-	EC_SWITCH_LID_OPEN               = 0x01
-	EC_SWITCH_POWER_BUTTON_PRESSED   = 0x02
-	EC_SWITCH_WRITE_PROTECT_DISABLED = 0x04
+	/* Switch flags at ecMemmapSwitches */
+	ecSwitchLidOpen              = 0x01
+	ecSwitchPowerButtonPressed   = 0x02
+	ecSwitchWriteProtectDisabled = 0x04
 	/* Was recovery requested via keyboard; now unused. */
-	EC_SWITCH_IGNORE1 = 0x08
+	ecSwitchIgnore1 = 0x08
 	/* Recovery requested via dedicated signal (from servo board) */
-	EC_SWITCH_DEDICATED_RECOVERY = 0x10
+	ecSwitchDedicatedRecovery = 0x10
 	/* Was fake developer mode switch; now unused.  Remove in next refactor. */
-	EC_SWITCH_IGNORE0 = 0x20
+	ecSwitchIgnore0 = 0x20
 
 	/* Host command interface flags */
 	/* Host command interface supports LPC args (LPC interface only) */
-	EC_HOST_CMD_FLAG_LPC_ARGS_SUPPORTED = 0x01
+	ecHostCmdFlagLpcArgsSupported = 0x01
 	/* Host command interface supports version 3 protocol */
-	EC_HOST_CMD_FLAG_VERSION_3 = 0x02
+	ecHostCmdFlagVersion3 = 0x02
 
 	/* Wireless switch flags */
-	EC_WIRELESS_SWITCH_ALL        = ^0x00 /* All flags */
-	EC_WIRELESS_SWITCH_WLAN       = 0x01  /* WLAN radio */
-	EC_WIRELESS_SWITCH_BLUETOOTH  = 0x02  /* Bluetooth radio */
-	EC_WIRELESS_SWITCH_WWAN       = 0x04  /* WWAN power */
-	EC_WIRELESS_SWITCH_WLAN_POWER = 0x08  /* WLAN power */
+	ecWirelessSwitchAll       = ^0x00 /* All flags */
+	ecWirelessSwitchWlan      = 0x01  /* WLAN radio */
+	ecWirelessSwitchBluetooth = 0x02  /* Bluetooth radio */
+	ecWirelessSwitchWwan      = 0x04  /* WWAN power */
+	ecWirelessSwitchWlanPower = 0x08  /* WLAN power */
 
 	/*****************************************************************************/
 	/*
@@ -181,32 +181,32 @@ const (
 	/*
 	 * ACPI Read Embedded Controller
 	 *
-	 * This reads from ACPI memory space on the EC (EC_ACPI_MEM_*).
+	 * This reads from ACPI memory space on the EC (ecAcpiMem_*).
 	 *
 	 * Use the following sequence:
 	 *
-	 *    - Write EC_CMD_ACPI_READ to EC_LPC_ADDR_ACPI_CMD
-	 *    - Wait for EC_LPC_CMDR_PENDING bit to clear
-	 *    - Write address to EC_LPC_ADDR_ACPI_DATA
-	 *    - Wait for EC_LPC_CMDR_DATA bit to set
-	 *    - Read value from EC_LPC_ADDR_ACPI_DATA
+	 *    - Write ecCmdAcpiRead to ecLpcAddrAcpiCmd
+	 *    - Wait for ecLpcCmdrPending bit to clear
+	 *    - Write address to ecLpcAddrAcpiData
+	 *    - Wait for ecLpcCmdrData bit to set
+	 *    - Read value from ecLpcAddrAcpiData
 	 */
-	EC_CMD_ACPI_READ = 0x80
+	ecCmdAcpiRead = 0x80
 
 	/*
 	 * ACPI Write Embedded Controller
 	 *
-	 * This reads from ACPI memory space on the EC (EC_ACPI_MEM_*).
+	 * This reads from ACPI memory space on the EC (ecAcpiMem_*).
 	 *
 	 * Use the following sequence:
 	 *
-	 *    - Write EC_CMD_ACPI_WRITE to EC_LPC_ADDR_ACPI_CMD
-	 *    - Wait for EC_LPC_CMDR_PENDING bit to clear
-	 *    - Write address to EC_LPC_ADDR_ACPI_DATA
-	 *    - Wait for EC_LPC_CMDR_PENDING bit to clear
-	 *    - Write value to EC_LPC_ADDR_ACPI_DATA
+	 *    - Write ecCmdAcpiWrite to ecLpcAddrAcpiCmd
+	 *    - Wait for ecLpcCmdrPending bit to clear
+	 *    - Write address to ecLpcAddrAcpiData
+	 *    - Wait for ecLpcCmdrPending bit to clear
+	 *    - Write value to ecLpcAddrAcpiData
 	 */
-	EC_CMD_ACPI_WRITE = 0x81
+	ecCmdAcpiWrite = 0x81
 
 	/*
 	 * ACPI Burst Enable Embedded Controller
@@ -215,7 +215,7 @@ const (
 	 * commands back-to-back. While in this mode, writes to mapped multi-byte
 	 * data are locked out to ensure data consistency.
 	 */
-	EC_CMD_ACPI_BURST_ENABLE = 0x82
+	ecCmdAcpiBurstEnable = 0x82
 
 	/*
 	 * ACPI Burst Disable Embedded Controller
@@ -223,7 +223,7 @@ const (
 	 * This disables burst mode on the EC and stops preventing EC writes to mapped
 	 * multi-byte data.
 	 */
-	EC_CMD_ACPI_BURST_DISABLE = 0x83
+	ecCmdAcpiBurstDisable = 0x83
 
 	/*
 	 * ACPI Query Embedded Controller
@@ -232,30 +232,30 @@ const (
 	 * sets the result code to the 1-based index of the bit (event 0x00000001 = 1
 	 * event 0x80000000 = 32), or 0 if no event was pending.
 	 */
-	EC_CMD_ACPI_QUERY_EVENT = 0x84
+	ecCmdAcpiQueryEvent = 0x84
 
 	/* Valid addresses in ACPI memory space, for read/write commands */
 
-	/* Memory space version; set to EC_ACPI_MEM_VERSION_CURRENT */
-	EC_ACPI_MEM_VERSION = 0x00
+	/* Memory space version; set to ecAcpiMemVersionCurrent */
+	ecAcpiMemVersion = 0x00
 	/*
 	 * Test location; writing value here updates test compliment byte to (0xff -
 	 * value).
 	 */
-	EC_ACPI_MEM_TEST = 0x01
+	ecAcpiMemTest = 0x01
 	/* Test compliment; writes here are ignored. */
-	EC_ACPI_MEM_TEST_COMPLIMENT = 0x02
+	ecAcpiMemTestCompliment = 0x02
 
 	/* Keyboard backlight brightness percent (0 - 100) */
-	EC_ACPI_MEM_KEYBOARD_BACKLIGHT = 0x03
+	ecAcpiMemKeyboardBacklight = 0x03
 	/* DPTF Target Fan Duty (0-100, 0xff for auto/none) */
-	EC_ACPI_MEM_FAN_DUTY = 0x04
+	ecAcpiMemFanDuty = 0x04
 
 	/*
 	 * DPTF temp thresholds. Any of the EC's temp sensors can have up to two
 	 * independent thresholds attached to them. The current value of the ID
 	 * register determines which sensor is affected by the THRESHOLD and COMMIT
-	 * registers. The THRESHOLD register uses the same EC_TEMP_SENSOR_OFFSET scheme
+	 * registers. The THRESHOLD register uses the same ecTempSensorOffset scheme
 	 * as the memory-mapped sensors. The COMMIT register applies those settings.
 	 *
 	 * The spec does not mandate any way to read back the threshold settings
@@ -266,25 +266,25 @@ const (
 	 * have tripped". Setting or enabling the thresholds for a sensor will clear
 	 * the unread event count for that sensor.
 	 */
-	EC_ACPI_MEM_TEMP_ID        = 0x05
-	EC_ACPI_MEM_TEMP_THRESHOLD = 0x06
-	EC_ACPI_MEM_TEMP_COMMIT    = 0x07
+	ecAcpiMemTempID        = 0x05
+	ecAcpiMemTempThreshold = 0x06
+	ecAcpiMemTempCommit    = 0x07
 	/*
 	 * Here are the bits for the COMMIT register:
 	 *   bit 0 selects the threshold index for the chosen sensor (0/1)
 	 *   bit 1 enables/disables the selected threshold (0 = off, 1 = on)
 	 * Each write to the commit register affects one threshold.
 	 */
-	EC_ACPI_MEM_TEMP_COMMIT_SELECT_MASK = (1 << 0)
-	EC_ACPI_MEM_TEMP_COMMIT_ENABLE_MASK = (1 << 1)
+	ecAcpiMemTempCommitSelectMask = (1 << 0)
+	ecAcpiMemTempCommitEnableMask = (1 << 1)
 	/*
 	 * Example:
 	 *
 	 * Set the thresholds for sensor 2 to 50 C and 60 C:
 	 *   write 2 to [0x05]      --  select temp sensor 2
-	 *   write 0x7b to [0x06]   --  C_TO_K(50) - EC_TEMP_SENSOR_OFFSET
+	 *   write 0x7b to [0x06]   --  CToK(50) - ecTempSensorOffset
 	 *   write 0x2 to [0x07]    --  enable threshold 0 with this value
-	 *   write 0x85 to [0x06]   --  C_TO_K(60) - EC_TEMP_SENSOR_OFFSET
+	 *   write 0x85 to [0x06]   --  CToK(60) - ecTempSensorOffset
 	 *   write 0x3 to [0x07]    --  enable threshold 1 with this value
 	 *
 	 * Disable the 60 C threshold, leaving the 50 C threshold unchanged:
@@ -293,22 +293,22 @@ const (
 	 */
 
 	/* DPTF battery charging current limit */
-	EC_ACPI_MEM_CHARGING_LIMIT = 0x08
+	ecAcpiMemChargingLimit = 0x08
 
 	/* Charging limit is specified in 64 mA steps */
-	EC_ACPI_MEM_CHARGING_LIMIT_STEP_MA = 64
+	ecAcpiMemChargingLimitStepMa = 64
 	/* Value to disable DPTF battery charging limit */
-	EC_ACPI_MEM_CHARGING_LIMIT_DISABLED = 0xff
+	ecAcpiMemChargingLimitDisabled = 0xff
 
 	/*
-	 * ACPI addresses 0x20 - 0xff map to EC_MEMMAP offset 0x00 - 0xdf.  This data
-	 * is read-only from the AP.  Added in EC_ACPI_MEM_VERSION 2.
+	 * ACPI addresses 0x20 - 0xff map to ecMemmap offset 0x00 - 0xdf.  This data
+	 * is read-only from the AP.  Added in ecAcpiMemVersion 2.
 	 */
-	EC_ACPI_MEM_MAPPED_BEGIN = 0x20
-	EC_ACPI_MEM_MAPPED_SIZE  = 0xe0
+	ecAcpiMemMappedBegin = 0x20
+	ecAcpiMemMappedSize  = 0xe0
 
 	/* Current version of ACPI memory address space */
-	EC_ACPI_MEM_VERSION_CURRENT = 2
+	ecAcpiMemVersionCurrent = 2
 
 	/*
 	 * This header file is used in coreboot both in C and ACPI code.  The ACPI code
@@ -318,50 +318,50 @@ const (
 
 	/* LPC command status byte masks */
 	/* EC has written a byte in the data register and host hasn't read it yet */
-	EC_LPC_STATUS_TO_HOST = 0x01
+	ecLpcStatusToHost = 0x01
 	/* Host has written a command/data byte and the EC hasn't read it yet */
-	EC_LPC_STATUS_FROM_HOST = 0x02
+	ecLpcStatusFromHost = 0x02
 	/* EC is processing a command */
-	EC_LPC_STATUS_PROCESSING = 0x04
+	ecLpcStatusProcessing = 0x04
 	/* Last write to EC was a command, not data */
-	EC_LPC_STATUS_LAST_CMD = 0x08
+	ecLpcStatusLastCmd = 0x08
 	/* EC is in burst mode */
-	EC_LPC_STATUS_BURST_MODE = 0x10
+	ecLpcStatusBurstMode = 0x10
 	/* SCI event is pending (requesting SCI query) */
-	EC_LPC_STATUS_SCI_PENDING = 0x20
+	ecLpcStatusSciPending = 0x20
 	/* SMI event is pending (requesting SMI query) */
-	EC_LPC_STATUS_SMI_PENDING = 0x40
+	ecLpcStatusSmiPending = 0x40
 	/* (reserved) */
-	EC_LPC_STATUS_RESERVED = 0x80
+	ecLpcStatusReserved = 0x80
 
 	/*
 	 * EC is busy.  This covers both the EC processing a command, and the host has
 	 * written a new command but the EC hasn't picked it up yet.
 	 */
-	EC_LPC_STATUS_BUSY_MASK = (EC_LPC_STATUS_FROM_HOST | EC_LPC_STATUS_PROCESSING)
+	ecLpcStatusBusyMask = (ecLpcStatusFromHost | ecLpcStatusProcessing)
 )
 
 /* Host command response codes */
-type ec_status uint8
+type ecStatus uint8
 
 const (
-	EC_RES_SUCCESS           ec_status = 0
-	EC_RES_INVALID_COMMAND             = 1
-	EC_RES_ERROR                       = 2
-	EC_RES_INVALID_PARAM               = 3
-	EC_RES_ACCESS_DENIED               = 4
-	EC_RES_INVALID_RESPONSE            = 5
-	EC_RES_INVALID_VERSION             = 6
-	EC_RES_INVALID_CHECKSUM            = 7
-	EC_RES_IN_PROGRESS                 = 8  /* Accepted, command in progress */
-	EC_RES_UNAVAILABLE                 = 9  /* No response available */
-	EC_RES_TIMEOUT                     = 10 /* We got a timeout */
-	EC_RES_OVERFLOW                    = 11 /* Table / data overflow */
-	EC_RES_INVALID_HEADER              = 12 /* Header contains invalid data */
-	EC_RES_REQUEST_TRUNCATED           = 13 /* Didn't get the entire request */
-	EC_RES_RESPONSE_TOO_BIG            = 14 /* Response was too big to handle */
-	EC_RES_BUS_ERROR                   = 15 /* Communications bus error */
-	EC_RES_BUSY                        = 16 /* Up but too busy.  Should retry */
+	ecResSuccess          ecStatus = 0
+	ecResInvalidCommand            = 1
+	ecResError                     = 2
+	ecResInvalidParam              = 3
+	ecResAccessDenied              = 4
+	ecResInvalidResponse           = 5
+	ecResInvalidVersion            = 6
+	ecResInvalidChecksum           = 7
+	ecResInProgress                = 8  /* Accepted, command in progress */
+	ecResUnavailable               = 9  /* No response available */
+	ecResTimeout                   = 10 /* We got a timeout */
+	ecResOverflow                  = 11 /* Table / data overflow */
+	ecResInvalidHeader             = 12 /* Header contains invalid data */
+	ecResRequestTruncated          = 13 /* Didn't get the entire request */
+	ecResResponseTooBig            = 14 /* Response was too big to handle */
+	ecResBusError                  = 15 /* Communications bus error */
+	ecResBusy                      = 16 /* Up but too busy.  Should retry */
 )
 
 /*
@@ -371,103 +371,103 @@ const (
  * item or rearrange the list (it needs to be stable across platforms, not
  * just within a single compiled instance).
  */
-type host_event_code uint8
+type hostEventCode uint8
 
 const (
-	EC_HOST_EVENT_LID_CLOSED        host_event_code = 1
-	EC_HOST_EVENT_LID_OPEN                          = 2
-	EC_HOST_EVENT_POWER_BUTTON                      = 3
-	EC_HOST_EVENT_AC_CONNECTED                      = 4
-	EC_HOST_EVENT_AC_DISCONNECTED                   = 5
-	EC_HOST_EVENT_BATTERY_LOW                       = 6
-	EC_HOST_EVENT_BATTERY_CRITICAL                  = 7
-	EC_HOST_EVENT_BATTERY                           = 8
-	EC_HOST_EVENT_THERMAL_THRESHOLD                 = 9
-	EC_HOST_EVENT_THERMAL_OVERLOAD                  = 10
-	EC_HOST_EVENT_THERMAL                           = 11
-	EC_HOST_EVENT_USB_CHARGER                       = 12
-	EC_HOST_EVENT_KEY_PRESSED                       = 13
+	ecHostEventLidClosed        hostEventCode = 1
+	ecHostEventLidOpen                        = 2
+	ecHostEventPowerButton                    = 3
+	ecHostEventAcConnected                    = 4
+	ecHostEventAcDisconnected                 = 5
+	ecHostEventBatteryLow                     = 6
+	ecHostEventBatteryCritical                = 7
+	ecHostEventBattery                        = 8
+	ecHostEventThermalThreshold               = 9
+	ecHostEventThermalOverload                = 10
+	ecHostEventThermal                        = 11
+	ecHostEventUsbCharger                     = 12
+	ecHostEventKeyPressed                     = 13
 	/*
 	 * EC has finished initializing the host interface.  The host can check
-	 * for this event following sending a EC_CMD_REBOOT_EC command to
+	 * for this event following sending a ecCmdRebootEc command to
 	 * determine when the EC is ready to accept subsequent commands.
 	 */
-	EC_HOST_EVENT_INTERFACE_READY = 14
+	ecHostEventInterfaceReady = 14
 	/* Keyboard recovery combo has been pressed */
-	EC_HOST_EVENT_KEYBOARD_RECOVERY = 15
+	ecHostEventKeyboardRecovery = 15
 
 	/* Shutdown due to thermal overload */
-	EC_HOST_EVENT_THERMAL_SHUTDOWN = 16
+	ecHostEventThermalShutdown = 16
 	/* Shutdown due to battery level too low */
-	EC_HOST_EVENT_BATTERY_SHUTDOWN = 17
+	ecHostEventBatteryShutdown = 17
 
 	/* Suggest that the AP throttle itself */
-	EC_HOST_EVENT_THROTTLE_START = 18
+	ecHostEventThrottleStart = 18
 	/* Suggest that the AP resume normal speed */
-	EC_HOST_EVENT_THROTTLE_STOP = 19
+	ecHostEventThrottleStop = 19
 
 	/* Hang detect logic detected a hang and host event timeout expired */
-	EC_HOST_EVENT_HANG_DETECT = 20
+	ecHostEventHangDetect = 20
 	/* Hang detect logic detected a hang and warm rebooted the AP */
-	EC_HOST_EVENT_HANG_REBOOT = 21
+	ecHostEventHangReboot = 21
 
 	/* PD MCU triggering host event */
-	EC_HOST_EVENT_PD_MCU = 22
+	ecHostEventPdMcu = 22
 
 	/* Battery Status flags have changed */
-	EC_HOST_EVENT_BATTERY_STATUS = 23
+	ecHostEventBatteryStatus = 23
 
 	/* EC encountered a panic, triggering a reset */
-	EC_HOST_EVENT_PANIC = 24
+	ecHostEventPanic = 24
 
 	/*
 	 * The high bit of the event mask is not used as a host event code.  If
 	 * it reads back as set, then the entire event mask should be
 	 * considered invalid by the host.  This can happen when reading the
-	 * raw event status via EC_MEMMAP_HOST_EVENTS but the LPC interface is
+	 * raw event status via ecMemmapHostEvents but the LPC interface is
 	 * not initialized on the EC, or improperly configured on the host.
 	 */
-	EC_HOST_EVENT_INVALID = 32
+	ecHostEventInvalid = 32
 )
 
 /* Host event mask */
-func ec_host_event_mask(event_code uint8) uint8 {
-	return 1 << ((event_code) - 1)
+func ecHostEventMask(eventCode uint8) uint8 {
+	return 1 << ((eventCode) - 1)
 }
 
 /* TYPE */
-/* Arguments at EC_LPC_ADDR_HOST_ARGS */
-type ec_lpc_host_args struct {
-	flags           uint8
-	command_version uint8
-	data_size       uint8
+/* Arguments at ecLpcAddrHostArgs */
+type ecLpcHostArgs struct {
+	flags          uint8
+	commandVersion uint8
+	dataSize       uint8
 	/*
-	 * Checksum; sum of command + flags + command_version + data_size +
+	 * Checksum; sum of command + flags + commandVersion + dataSize +
 	 * all params/response data bytes.
 	 */
 	checksum uint8
 }
 
-/* Flags for ec_lpc_host_args.flags */
+/* Flags for ecLpcHostArgs.flags */
 /*
- * Args are from host.  Data area at EC_LPC_ADDR_HOST_PARAM contains command
+ * Args are from host.  Data area at ecLpcAddrHostParam contains command
  * params.
  *
  * If EC gets a command and this flag is not set, this is an old-style command.
- * Command version is 0 and params from host are at EC_LPC_ADDR_OLD_PARAM with
+ * Command version is 0 and params from host are at ecLpcAddrOldParam with
  * unknown length.  EC must respond with an old-style response (that is
- * withouth setting EC_HOST_ARGS_FLAG_TO_HOST).
+ * withouth setting ecHostArgsFlagToHost).
  */
-const EC_HOST_ARGS_FLAG_FROM_HOST = 0x01
+const ecHostArgsFlagFromHost = 0x01
 
 /*
- * Args are from EC.  Data area at EC_LPC_ADDR_HOST_PARAM contains response.
+ * Args are from EC.  Data area at ecLpcAddrHostParam contains response.
  *
  * If EC responds to a command and this flag is not set, this is an old-style
  * response.  Command version is 0 and response data from EC is at
- * EC_LPC_ADDR_OLD_PARAM with unknown length.
+ * ecLpcAddrOldParam with unknown length.
  */
-const EC_HOST_ARGS_FLAG_TO_HOST = 0x02
+const ecHostArgsFlagToHost = 0x02
 
 /*****************************************************************************/
 /*
@@ -479,28 +479,28 @@ const EC_HOST_ARGS_FLAG_TO_HOST = 0x02
  *
  * Example of sequence of bytes read from EC for a current good transfer:
  *   1. -                  - AP asserts chip select (CS#)
- *   2. EC_SPI_OLD_READY   - AP sends first byte(s) of request
+ *   2. ecSpiOldReady      - AP sends first byte(s) of request
  *   3. -                  - EC starts handling CS# interrupt
- *   4. EC_SPI_RECEIVING   - AP sends remaining byte(s) of request
- *   5. EC_SPI_PROCESSING  - EC starts processing request; AP is clocking in
- *                           bytes looking for EC_SPI_FRAME_START
+ *   4. ecSpiReceiving     - AP sends remaining byte(s) of request
+ *   5. ecSpiProcessing    - EC starts processing request; AP is clocking in
+ *                           bytes looking for ecSpiFrameStart
  *   6. -                  - EC finishes processing and sets up response
- *   7. EC_SPI_FRAME_START - AP reads frame byte
+ *   7. ecSpiFrameStart    - AP reads frame byte
  *   8. (response packet)  - AP reads response packet
- *   9. EC_SPI_PAST_END    - Any additional bytes read by AP
+ *   9. ecSpiPastEnd       - Any additional bytes read by AP
  *   10 -                  - AP deasserts chip select
  *   11 -                  - EC processes CS# interrupt and sets up DMA for
  *                           next request
  *
- * If the AP is waiting for EC_SPI_FRAME_START and sees any value other than
+ * If the AP is waiting for ecSpiFrameStart and sees any value other than
  * the following byte values:
- *   EC_SPI_OLD_READY
- *   EC_SPI_RX_READY
- *   EC_SPI_RECEIVING
- *   EC_SPI_PROCESSING
+ *   ecSpiOldReady
+ *   ecSpiRxReady
+ *   ecSpiReceiving
+ *   ecSpiProcessing
  *
  * Then the EC found an error in the request, or was not ready for the request
- * and lost data.  The AP should give up waiting for EC_SPI_FRAME_START
+ * and lost data.  The AP should give up waiting for ecSpiFrameStart
  * because the EC is unable to tell when the AP is done sending its request.
  */
 
@@ -510,55 +510,55 @@ const EC_HOST_ARGS_FLAG_TO_HOST = 0x02
  * clock in the response packet.
  */
 const (
-	EC_SPI_FRAME_START = 0xec
+	ecSpiFrameStart = 0xec
 
 	/*
 	 * Padding bytes which are clocked out after the end of a response packet.
 	 */
-	EC_SPI_PAST_END = 0xed
+	ecSpiPastEnd = 0xed
 
 	/*
 	 * EC is ready to receive, and has ignored the byte sent by the AP.  EC expects
 	 * that the AP will send a valid packet header (starting with
-	 * EC_COMMAND_PROTOCOL_3) in the next 32 bytes.
+	 * ecCommandProtocol3) in the next 32 bytes.
 	 */
-	EC_SPI_RX_READY = 0xf8
+	ecSpiRxReady = 0xf8
 
 	/*
 	 * EC has started receiving the request from the AP, but hasn't started
 	 * processing it yet.
 	 */
-	EC_SPI_RECEIVING = 0xf9
+	ecSpiReceiving = 0xf9
 
 	/* EC has received the entire request from the AP and is processing it. */
-	EC_SPI_PROCESSING = 0xfa
+	ecSpiProcessing = 0xfa
 
 	/*
 	 * EC received bad data from the AP, such as a packet header with an invalid
 	 * length.  EC will ignore all data until chip select deasserts.
 	 */
-	EC_SPI_RX_BAD_DATA = 0xfb
+	ecSpiRxBadData = 0xfb
 
 	/*
 	 * EC received data from the AP before it was ready.  That is, the AP asserted
 	 * chip select and started clocking data before the EC was ready to receive it.
 	 * EC will ignore all data until chip select deasserts.
 	 */
-	EC_SPI_NOT_READY = 0xfc
+	ecSpiNotReady = 0xfc
 
 	/*
 	 * EC was ready to receive a request from the AP.  EC has treated the byte sent
 	 * by the AP as part of a request packet, or (for old-style ECs) is processing
 	 * a fully received packet but is not ready to respond yet.
 	 */
-	EC_SPI_OLD_READY = 0xfd
+	ecSpiOldReady = 0xfd
 
 	/*****************************************************************************/
 
 	/*
 	 * Protocol version 2 for I2C and SPI send a request this way:
 	 *
-	 *	0	EC_CMD_VERSION0 + (command version)
+	 *	0	ecCmdVersion0 + (command version)
 	 *	1	Command number
 	 *	2	Length of params = N
 	 *	3..N+2	Params, if any
@@ -566,29 +566,29 @@ const (
 	 *
 	 * The corresponding response is:
 	 *
-	 *	0	Result code (EC_RES_*)
+	 *	0	Result code (ecRes_*)
 	 *	1	Length of params = M
 	 *	2..M+1	Params, if any
 	 *	M+2	8-bit checksum of bytes 0..M+1
 	 */
-	EC_PROTO2_REQUEST_HEADER_BYTES  = 3
-	EC_PROTO2_REQUEST_TRAILER_BYTES = 1
-	EC_PROTO2_REQUEST_OVERHEAD      = (EC_PROTO2_REQUEST_HEADER_BYTES +
-		EC_PROTO2_REQUEST_TRAILER_BYTES)
+	ecProto2RequestHeaderBytes  = 3
+	ecProto2RequestTrailerBytes = 1
+	ecProto2RequestOverhead     = (ecProto2RequestHeaderBytes +
+		ecProto2RequestTrailerBytes)
 
-	EC_PROTO2_RESPONSE_HEADER_BYTES  = 2
-	EC_PROTO2_RESPONSE_TRAILER_BYTES = 1
-	EC_PROTO2_RESPONSE_OVERHEAD      = (EC_PROTO2_RESPONSE_HEADER_BYTES +
-		EC_PROTO2_RESPONSE_TRAILER_BYTES)
+	ecProto2ResponseHeaderBytes  = 2
+	ecProto2ResponseTrailerBytes = 1
+	ecProto2ResponseOverhead     = (ecProto2ResponseHeaderBytes +
+		ecProto2ResponseTrailerBytes)
 
 	/* Parameter length was limited by the LPC interface */
-	EC_PROTO2_MAX_PARAM_SIZE = 0xfc
+	ecProto2MaxParamSize = 0xfc
 
 	/* Maximum request and response packet sizes for protocol version 2 */
-	EC_PROTO2_MAX_REQUEST_SIZE = (EC_PROTO2_REQUEST_OVERHEAD +
-		EC_PROTO2_MAX_PARAM_SIZE)
-	EC_PROTO2_MAX_RESPONSE_SIZE = (EC_PROTO2_RESPONSE_OVERHEAD +
-		EC_PROTO2_MAX_PARAM_SIZE)
+	ecProto2MaxRequestSize = (ecProto2RequestOverhead +
+		ecProto2MaxParamSize)
+	ecProto2MaxResponseSize = (ecProto2ResponseOverhead +
+		ecProto2MaxParamSize)
 
 	/*****************************************************************************/
 
@@ -596,20 +596,20 @@ const (
 	 * Value written to legacy command port / prefix byte to indicate protocol
 	 * 3+ structs are being used.  Usage is bus-dependent.
 	 */
-	EC_COMMAND_PROTOCOL_3 = 0xda
+	ecCommandProtocol3 = 0xda
 
-	EC_HOST_REQUEST_VERSION = 3
+	ecHostRequestVersion = 3
 )
 
 /* TYPE */
 /* Version 3 request from host */
-type ec_host_request struct {
+type ecHostRequest struct {
 	/* Struct version (=3)
 	 *
-	 * EC will return EC_RES_INVALID_HEADER if it receives a header with a
+	 * EC will return ecResInvalidHeader if it receives a header with a
 	 * version it doesn't know how to parse.
 	 */
-	struct_version uint8
+	structVersion uint8
 
 	/*
 	 * Checksum of request and data; sum of all bytes including checksum
@@ -621,22 +621,22 @@ type ec_host_request struct {
 	command uint16
 
 	/* Command version */
-	command_version uint8
+	commandVersion uint8
 
 	/* Unused byte in current protocol version; set to 0 */
 	reserved uint8
 
 	/* Length of data which follows this header */
-	data_len uint16
+	dataLen uint16
 }
 
-const EC_HOST_RESPONSE_VERSION = 3
+const ecHostResponseVersion = 3
 
 /* TYPE */
 /* Version 3 response from EC */
-type ec_host_response struct {
+type ecHostResponse struct {
 	/* Struct version (=3) */
-	struct_version uint8
+	structVersion uint8
 
 	/*
 	 * Checksum of response and data; sum of all bytes including checksum
@@ -644,11 +644,11 @@ type ec_host_response struct {
 	 */
 	checksum uint8
 
-	/* Result code (EC_RES_*) */
+	/* Result code (ecRes_*) */
 	result uint16
 
 	/* Length of data which follows this header */
-	data_len uint16
+	dataLen uint16
 
 	/* Unused bytes in current protocol version; set to 0 */
 	reserved uint16
@@ -673,10 +673,10 @@ type ec_host_response struct {
  * Get protocol version, used to deal with non-backward compatible protocol
  * changes.
  */
-const EC_CMD_PROTO_VERSION = 0x00
+const ecCmdProtoVersion = 0x00
 
 /* TYPE */
-type ec_response_proto_version struct {
+type ecResponseProtoVersion struct {
 	version uint32
 }
 
@@ -685,54 +685,54 @@ const (
 	 * Hello.  This is a simple command to test the EC is responsive to
 	 * commands.
 	 */
-	EC_CMD_HELLO = 0x01
+	ecCmdHello = 0x01
 )
 
 /* TYPE */
-type ec_params_hello struct {
-	in_data uint32 /* Pass anything here */
+type ecParamsHello struct {
+	inData uint32 /* Pass anything here */
 }
 
 /* TYPE */
-type ec_response_hello struct {
-	out_data uint32 /* Output will be in_data + 0x01020304 */
+type ecResponseHello struct {
+	outData uint32 /* Output will be inData + 0x01020304 */
 }
 
 const (
 	/* Get version number */
-	EC_CMD_GET_VERSION = 0x02
+	ecCmdGetVersion = 0x02
 )
 
-type ec_current_image uint8
+type ecCurrentImage uint8
 
 const (
-	EC_IMAGE_UNKNOWN ec_current_image = 0
-	EC_IMAGE_RO
-	EC_IMAGE_RW
+	ecImageUnknown ecCurrentImage = 0
+	ecImageRo
+	ecImageRw
 )
 
 /* TYPE */
-type ec_response_get_version struct {
+type ecResponseGetVersion struct {
 	/* Null-terminated version strings for RO, RW */
-	version_string_ro [32]byte
-	version_string_rw [32]byte
-	reserved          [32]byte /* Was previously RW-B string */
-	current_image     uint32   /* One of ec_current_image */
+	versionStringRo [32]byte
+	versionStringRw [32]byte
+	reserved        [32]byte /* Was previously RW-B string */
+	currentImage    uint32   /* One of ecCurrentImage */
 }
 
 const (
 	/* Read test */
-	EC_CMD_READ_TEST = 0x03
+	ecCmdReadTest = 0x03
 )
 
 /* TYPE */
-type ec_params_read_test struct {
+type ecParamsReadTest struct {
 	offset uint32 /* Starting value for read buffer */
 	size   uint32 /* Size to read in bytes */
 }
 
 /* TYPE */
-type ec_response_read_test struct {
+type ecResponseReadTest struct {
 	data [32]uint32
 }
 
@@ -742,14 +742,14 @@ const (
 	 *
 	 * Response is null-terminated string.
 	 */
-	EC_CMD_GET_BUILD_INFO = 0x04
+	ecCmdGetBuildInfo = 0x04
 
 	/* Get chip info */
-	EC_CMD_GET_CHIP_INFO = 0x05
+	ecCmdGetChipInfo = 0x05
 )
 
 /* TYPE */
-type ec_response_get_chip_info struct {
+type ecResponseGetChipInfo struct {
 	/* Null-terminated strings */
 	vendor   [32]byte
 	name     [32]byte
@@ -758,12 +758,12 @@ type ec_response_get_chip_info struct {
 
 const (
 	/* Get board HW version */
-	EC_CMD_GET_BOARD_VERSION = 0x06
+	ecCmdGetBoardVersion = 0x06
 )
 
 /* TYPE */
-type ec_response_board_version struct {
-	board_version uint16 /* A monotonously incrementing number. */
+type ecResponseBoardVersion struct {
+	boardVersion uint16 /* A monotonously incrementing number. */
 }
 
 /*
@@ -775,35 +775,35 @@ type ec_response_board_version struct {
  * Response is params.size bytes of data.
  */
 const (
-	EC_CMD_READ_MEMMAP = 0x07
+	ecCmdReadMemmap = 0x07
 )
 
 /* TYPE */
-type ec_params_read_memmap struct {
-	offset uint8 /* Offset in memmap (EC_MEMMAP_*) */
+type ecParamsReadMemmap struct {
+	offset uint8 /* Offset in memmap (ecMemmap_*) */
 	size   uint8 /* Size to read in bytes */
 }
 
 /* Read versions supported for a command */
-const EC_CMD_GET_CMD_VERSIONS = 0x08
+const ecCmdGetCmdVersions = 0x08
 
 /* TYPE */
-type ec_params_get_cmd_versions struct {
+type ecParamsGetCmdVersions struct {
 	cmd uint8 /* Command to check */
 }
 
 /* TYPE */
-type ec_params_get_cmd_versions_v1 struct {
+type ecParamsGetCmdVersionsV1 struct {
 	cmd uint16 /* Command to check */
 }
 
 /* TYPE */
-type ec_response_get_cmd_versions struct {
+type ecResponseGetCmdVersions struct {
 	/*
-	 * Mask of supported versions; use EC_VER_MASK() to compare with a
+	 * Mask of supported versions; use ecVerMask() to compare with a
 	 * desired version.
 	 */
-	version_mask uint32
+	versionMask uint32
 }
 
 /*
@@ -813,60 +813,60 @@ type ec_response_get_cmd_versions struct {
  * lpc must read the status from the command register. Attempting this on
  * lpc will overwrite the args/parameter space and corrupt its data.
  */
-const EC_CMD_GET_COMMS_STATUS = 0x09
+const ecCmdGetCommsStatus = 0x09
 
-/* Avoid using ec_status which is for return values */
-type ec_comms_status uint8
+/* Avoid using ecStatus which is for return values */
+type ecCommsStatus uint8
 
 const (
-	EC_COMMS_STATUS_PROCESSING ec_comms_status = 1 << 0 /* Processing cmd */
+	ecCommsStatusProcessing ecCommsStatus = 1 << 0 /* Processing cmd */
 )
 
 /* TYPE */
-type ec_response_get_comms_status struct {
-	flags uint32 /* Mask of enum ec_comms_status */
+type ecResponseGetCommsStatus struct {
+	flags uint32 /* Mask of enum ecCommsStatus */
 }
 
 const (
 	/* Fake a variety of responses, purely for testing purposes. */
-	EC_CMD_TEST_PROTOCOL = 0x0a
+	ecCmdTestProtocol = 0x0a
 )
 
 /* TYPE */
 /* Tell the EC what to send back to us. */
-type ec_params_test_protocol struct {
-	ec_result uint32
-	ret_len   uint32
-	buf       [32]uint8
+type ecParamsTestProtocol struct {
+	ecResult uint32
+	retLen   uint32
+	buf      [32]uint8
 }
 
 /* TYPE */
 /* Here it comes... */
-type ec_response_test_protocol struct {
+type ecResponseTestProtocol struct {
 	buf [32]uint8
 }
 
 /* Get prococol information */
-const EC_CMD_GET_PROTOCOL_INFO = 0x0b
+const ecCmdGetProtocolInfo = 0x0b
 
-/* Flags for ec_response_get_protocol_info.flags */
-/* EC_RES_IN_PROGRESS may be returned if a command is slow */
-const EC_PROTOCOL_INFO_IN_PROGRESS_SUPPORTED = (1 << 0)
+/* Flags for ecResponseGetProtocolInfo.flags */
+/* ecResInProgress may be returned if a command is slow */
+const ecProtocolInfoInProgressSupported = (1 << 0)
 
 /* TYPE */
-type ec_response_get_protocol_info struct {
+type ecResponseGetProtocolInfo struct {
 	/* Fields which exist if at least protocol version 3 supported */
 
 	/* Bitmask of protocol versions supported (1 << n means version n)*/
-	protocol_versions uint32
+	protocolVersions uint32
 
 	/* Maximum request packet size, in bytes */
-	max_request_packet_size uint16
+	maxRequestPacketSize uint16
 
 	/* Maximum response packet size, in bytes */
-	max_response_packet_size uint16
+	maxResponsePacketSize uint16
 
-	/* Flags; see EC_PROTOCOL_INFO_* */
+	/* Flags; see ecProtocolInfo_* */
 	flags uint32
 }
 
@@ -874,59 +874,59 @@ type ec_response_get_protocol_info struct {
 /* Get/Set miscellaneous values */
 const (
 	/* The upper byte of .flags tells what to do (nothing means "get") */
-	EC_GSV_SET = 0x80000000
+	ecGsvSet = 0x80000000
 
 	/* The lower three bytes of .flags identifies the parameter, if that has
 	   meaning for an individual command. */
-	EC_GSV_PARAM_MASK = 0x00ffffff
+	ecGsvParamMask = 0x00ffffff
 )
 
 /* TYPE */
-type ec_params_get_set_value struct {
+type ecParamsGetSetValue struct {
 	flags uint32
 	value uint32
 }
 
 /* TYPE */
-type ec_response_get_set_value struct {
+type ecResponseGetSetValue struct {
 	flags uint32
 	value uint32
 }
 
 /* More than one command can use these structs to get/set parameters. */
-const EC_CMD_GSV_PAUSE_IN_S5 = 0x0c
+const ecCmdGsvPauseInS5 = 0x0c
 
 /*****************************************************************************/
 /* Flash commands */
 
 /* Get flash info */
-const EC_CMD_FLASH_INFO = 0x10
+const ecCmdFlashInfo = 0x10
 
 /* TYPE */
 /* Version 0 returns these fields */
-type ec_response_flash_info struct {
+type ecResponseFlashInfo struct {
 	/* Usable flash size, in bytes */
-	flash_size uint32
+	flashSize uint32
 	/*
 	 * Write block size.  Write offset and size must be a multiple
 	 * of this.
 	 */
-	write_block_size uint32
+	writeBlockSize uint32
 	/*
 	 * Erase block size.  Erase offset and size must be a multiple
 	 * of this.
 	 */
-	erase_block_size uint32
+	eraseBlockSize uint32
 	/*
 	 * Protection block size.  Protection offset and size must be a
 	 * multiple of this.
 	 */
-	protect_block_size uint32
+	protectBlockSize uint32
 }
 
 /* Flags for version 1+ flash info command */
 /* EC flash erases bits to 0 instead of 1 */
-const EC_FLASH_INFO_ERASE_TO_0 = (1 << 0)
+const ecFlashInfoEraseTo0 = (1 << 0)
 
 /* TYPE */
 /*
@@ -936,12 +936,12 @@ const EC_FLASH_INFO_ERASE_TO_0 = (1 << 0)
  * gcc anonymous structs don't seem to get along with the  directive;
  * if they did we'd define the version 0 struct as a sub-struct of this one.
  */
-type ec_response_flash_info_1 struct {
+type ecResponseFlashInfo1 struct {
 	/* Version 0 fields; see above for description */
-	flash_size         uint32
-	write_block_size   uint32
-	erase_block_size   uint32
-	protect_block_size uint32
+	flashSize        uint32
+	writeBlockSize   uint32
+	eraseBlockSize   uint32
+	protectBlockSize uint32
 
 	/* Version 1 adds these fields: */
 	/*
@@ -950,9 +950,9 @@ type ec_response_flash_info_1 struct {
 	 * may have a write buffer which can do half-page operations if data is
 	 * aligned, and a slower word-at-a-time write mode.
 	 */
-	write_ideal_size uint32
+	writeIdealSize uint32
 
-	/* Flags; see EC_FLASH_INFO_* */
+	/* Flags; see ecFlashInfo_* */
 	flags uint32
 }
 
@@ -961,35 +961,35 @@ type ec_response_flash_info_1 struct {
  *
  * Response is params.size bytes of data.
  */
-const EC_CMD_FLASH_READ = 0x11
+const ecCmdFlashRead = 0x11
 
 /* TYPE */
-type ec_params_flash_read struct {
+type ecParamsFlashRead struct {
 	offset uint32 /* Byte offset to read */
 	size   uint32 /* Size to read in bytes */
 }
 
 const (
 	/* Write flash */
-	EC_CMD_FLASH_WRITE = 0x12
-	EC_VER_FLASH_WRITE = 1
+	ecCmdFlashWrite = 0x12
+	ecVerFlashWrite = 1
 
 	/* Version 0 of the flash command supported only 64 bytes of data */
-	EC_FLASH_WRITE_VER0_SIZE = 64
+	ecFlashWriteVer0Size = 64
 )
 
 /* TYPE */
-type ec_params_flash_write struct {
+type ecParamsFlashWrite struct {
 	offset uint32 /* Byte offset to write */
 	size   uint32 /* Size to write in bytes */
 	/* Followed by data to write */
 }
 
 /* Erase flash */
-const EC_CMD_FLASH_ERASE = 0x13
+const ecCmdFlashErase = 0x13
 
 /* TYPE */
-type ec_params_flash_erase struct {
+type ecParamsFlashErase struct {
 	offset uint32 /* Byte offset to erase */
 	size   uint32 /* Size to erase in bytes */
 }
@@ -1005,41 +1005,41 @@ const (
 	 *
 	 * If mask=0, simply returns the current flags state.
 	 */
-	EC_CMD_FLASH_PROTECT = 0x15
-	EC_VER_FLASH_PROTECT = 1 /* Command version 1 */
+	ecCmdFlashProtect = 0x15
+	ecVerFlashProtect = 1 /* Command version 1 */
 
 	/* Flags for flash protection */
 	/* RO flash code protected when the EC boots */
-	EC_FLASH_PROTECT_RO_AT_BOOT = (1 << 0)
+	ecFlashProtectRoAtBoot = (1 << 0)
 	/*
 	 * RO flash code protected now.  If this bit is set, at-boot status cannot
 	 * be changed.
 	 */
-	EC_FLASH_PROTECT_RO_NOW = (1 << 1)
+	ecFlashProtectRoNow = (1 << 1)
 	/* Entire flash code protected now, until reboot. */
-	EC_FLASH_PROTECT_ALL_NOW = (1 << 2)
+	ecFlashProtectAllNow = (1 << 2)
 	/* Flash write protect GPIO is asserted now */
-	EC_FLASH_PROTECT_GPIO_ASSERTED = (1 << 3)
+	ecFlashProtectGpioAsserted = (1 << 3)
 	/* Error - at least one bank of flash is stuck locked, and cannot be unlocked */
-	EC_FLASH_PROTECT_ERROR_STUCK = (1 << 4)
+	ecFlashProtectErrorStuck = (1 << 4)
 	/*
 	 * Error - flash protection is in inconsistent state.  At least one bank of
 	 * flash which should be protected is not protected.  Usually fixed by
 	 * re-requesting the desired flags, or by a hard reset if that fails.
 	 */
-	EC_FLASH_PROTECT_ERROR_INCONSISTENT = (1 << 5)
+	ecFlashProtectErrorInconsistent = (1 << 5)
 	/* Entire flash code protected when the EC boots */
-	EC_FLASH_PROTECT_ALL_AT_BOOT = (1 << 6)
+	ecFlashProtectAllAtBoot = (1 << 6)
 )
 
 /* TYPE */
-type ec_params_flash_protect struct {
+type ecParamsFlashProtect struct {
 	mask  uint32 /* Bits in flags to apply */
 	flags uint32 /* New flags to apply */
 }
 
 /* TYPE */
-type ec_response_flash_protect struct {
+type ecResponseFlashProtect struct {
 	/* Current value of flash protect flags */
 	flags uint32
 	/*
@@ -1047,9 +1047,9 @@ type ec_response_flash_protect struct {
 	 * to distinguish between flags which aren't set vs. flags which can't
 	 * be set on this platform.
 	 */
-	valid_flags uint32
+	validFlags uint32
 	/* Flags which can be changed given the current protection state */
-	writable_flags uint32
+	writableFlags uint32
 }
 
 /*
@@ -1058,119 +1058,119 @@ type ec_response_flash_protect struct {
  */
 
 /* Get the region offset/size */
-const EC_CMD_FLASH_REGION_INFO = 0x16
-const EC_VER_FLASH_REGION_INFO = 1
+const ecCmdFlashRegionInfo = 0x16
+const ecVerFlashRegionInfo = 1
 
-type ec_flash_region uint8
+type ecFlashRegion uint8
 
 const (
 	/* Region which holds read-only EC image */
-	EC_FLASH_REGION_RO ec_flash_region = iota
+	ecFlashRegionRo ecFlashRegion = iota
 	/* Region which holds rewritable EC image */
-	EC_FLASH_REGION_RW
+	ecFlashRegionRw
 	/*
 	 * Region which should be write-protected in the factory (a superset of
-	 * EC_FLASH_REGION_RO)
+	 * ecFlashRegionRo)
 	 */
-	EC_FLASH_REGION_WP_RO
+	ecFlashRegionWpRo
 	/* Number of regions */
-	EC_FLASH_REGION_COUNT
+	ecFlashRegionCount
 )
 
 /* TYPE */
-type ec_params_flash_region_info struct {
-	region uint32 /* enum ec_flash_region */
+type ecParamsFlashRegionInfo struct {
+	region uint32 /* enum ecFlashRegion */
 }
 
 /* TYPE */
-type ec_response_flash_region_info struct {
+type ecResponseFlashRegionInfo struct {
 	offset uint32
 	size   uint32
 }
 
 const (
 	/* Read/write VbNvContext */
-	EC_CMD_VBNV_CONTEXT = 0x17
-	EC_VER_VBNV_CONTEXT = 1
-	EC_VBNV_BLOCK_SIZE  = 16
+	ecCmdVbnvContext = 0x17
+	ecVerVbnvContext = 1
+	ecVbnvBlockSize  = 16
 )
 
-type ec_vbnvcontext_op uint8
+type ecVbnvcontextOp uint8
 
 const (
-	EC_VBNV_CONTEXT_OP_READ ec_vbnvcontext_op = iota
-	EC_VBNV_CONTEXT_OP_WRITE
+	ecVbnvContextOpRead ecVbnvcontextOp = iota
+	ecVbnvContextOpWrite
 )
 
 /* TYPE */
-type ec_params_vbnvcontext struct {
+type ecParamsVbnvcontext struct {
 	op    uint32
-	block [EC_VBNV_BLOCK_SIZE]uint8
+	block [ecVbnvBlockSize]uint8
 }
 
 /* TYPE */
-type ec_response_vbnvcontext struct {
-	block [EC_VBNV_BLOCK_SIZE]uint8
+type ecResponseVbnvcontext struct {
+	block [ecVbnvBlockSize]uint8
 }
 
 /*****************************************************************************/
 /* PWM commands */
 
 /* Get fan target RPM */
-const EC_CMD_PWM_GET_FAN_TARGET_RPM = 0x20
+const ecCmdPwmGetFanTargetRpm = 0x20
 
 /* TYPE */
-type ec_response_pwm_get_fan_rpm struct {
+type ecResponsePwmGetFanRpm struct {
 	rpm uint32
 }
 
 /* Set target fan RPM */
-const EC_CMD_PWM_SET_FAN_TARGET_RPM = 0x21
+const ecCmdPwmSetFanTargetRpm = 0x21
 
 /* TYPE */
 /* Version 0 of input params */
-type ec_params_pwm_set_fan_target_rpm_v0 struct {
+type ecParamsPwmSetFanTargetRpmV0 struct {
 	rpm uint32
 }
 
 /* TYPE */
 /* Version 1 of input params */
-type ec_params_pwm_set_fan_target_rpm_v1 struct {
-	rpm     uint32
-	fan_idx uint8
+type ecParamsPwmSetFanTargetRpmV1 struct {
+	rpm    uint32
+	fanIdx uint8
 }
 
 /* Get keyboard backlight */
-const EC_CMD_PWM_GET_KEYBOARD_BACKLIGHT = 0x22
+const ecCmdPwmGetKeyboardBacklight = 0x22
 
 /* TYPE */
-type ec_response_pwm_get_keyboard_backlight struct {
+type ecResponsePwmGetKeyboardBacklight struct {
 	percent uint8
 	enabled uint8
 }
 
 /* Set keyboard backlight */
-const EC_CMD_PWM_SET_KEYBOARD_BACKLIGHT = 0x23
+const ecCmdPwmSetKeyboardBacklight = 0x23
 
 /* TYPE */
-type ec_params_pwm_set_keyboard_backlight struct {
+type ecParamsPwmSetKeyboardBacklight struct {
 	percent uint8
 }
 
 /* Set target fan PWM duty cycle */
-const EC_CMD_PWM_SET_FAN_DUTY = 0x24
+const ecCmdPwmSetFanDuty = 0x24
 
 /* TYPE */
 /* Version 0 of input params */
-type ec_params_pwm_set_fan_duty_v0 struct {
+type ecParamsPwmSetFanDutyV0 struct {
 	percent uint32
 }
 
 /* TYPE */
 /* Version 1 of input params */
-type ec_params_pwm_set_fan_duty_v1 struct {
+type ecParamsPwmSetFanDutyV1 struct {
 	percent uint32
-	fan_idx uint8
+	fanIdx  uint8
 }
 
 /*****************************************************************************/
@@ -1180,202 +1180,202 @@ type ec_params_pwm_set_fan_duty_v1 struct {
  * into a subcommand. We'll make separate structs for subcommands with
  * different input args, so that we know how much to expect.
  */
-const EC_CMD_LIGHTBAR_CMD = 0x28
+const ecCmdLightbarCmd = 0x28
 
 /* TYPE */
-type rgb_s struct {
+type rgbS struct {
 	r, g, b uint8
 }
 
-const LB_BATTERY_LEVELS = 4
+const lbBatteryLevels = 4
 
 /* TYPE */
 /* List of tweakable parameters. NOTE: It's  so it can be sent in a
  * host command, but the alignment is the same regardless. Keep it that way.
  */
-type lightbar_params_v0 struct {
+type lightbarParamsV0 struct {
 	/* Timing */
-	google_ramp_up   int32
-	google_ramp_down int32
-	s3s0_ramp_up     int32
-	s0_tick_delay    [2]int32 /* AC=0/1 */
-	s0a_tick_delay   [2]int32 /* AC=0/1 */
-	s0s3_ramp_down   int32
-	s3_sleep_for     int32
-	s3_ramp_up       int32
-	s3_ramp_down     int32
+	googleRampUp   int32
+	googleRampDown int32
+	s3s0RampUp     int32
+	s0TickDelay    [2]int32 /* AC=0/1 */
+	s0aTickDelay   [2]int32 /* AC=0/1 */
+	s0s3RampDown   int32
+	s3SleepFor     int32
+	s3RampUp       int32
+	s3RampDown     int32
 
 	/* Oscillation */
-	new_s0  uint8
-	osc_min [2]uint8 /* AC=0/1 */
-	osc_max [2]uint8 /* AC=0/1 */
-	w_ofs   [2]uint8 /* AC=0/1 */
+	newS0  uint8
+	oscMin [2]uint8 /* AC=0/1 */
+	oscMax [2]uint8 /* AC=0/1 */
+	wOfs   [2]uint8 /* AC=0/1 */
 
 	/* Brightness limits based on the backlight and AC. */
-	bright_bl_off_fixed [2]uint8 /* AC=0/1 */
-	bright_bl_on_min    [2]uint8 /* AC=0/1 */
-	bright_bl_on_max    [2]uint8 /* AC=0/1 */
+	brightBlOffFixed [2]uint8 /* AC=0/1 */
+	brightBlOnMin    [2]uint8 /* AC=0/1 */
+	brightBlOnMax    [2]uint8 /* AC=0/1 */
 
 	/* Battery level thresholds */
-	batteryhreshold [LB_BATTERY_LEVELS - 1]uint8
+	batteryhreshold [lbBatteryLevels - 1]uint8
 
-	/* Map [AC][battery_level] to color index */
-	s0_idx [2][LB_BATTERY_LEVELS]uint8 /* AP is running */
-	s3_idx [2][LB_BATTERY_LEVELS]uint8 /* AP is sleeping */
+	/* Map [AC][batteryLevel] to color index */
+	s0Idx [2][lbBatteryLevels]uint8 /* AP is running */
+	s3Idx [2][lbBatteryLevels]uint8 /* AP is sleeping */
 
 	/* Color palette */
-	color [8]rgb_s /* 0-3 are Google colors */
+	color [8]rgbS /* 0-3 are Google colors */
 }
 
 /* TYPE */
-type lightbar_params_v1 struct {
+type lightbarParamsV1 struct {
 	/* Timing */
-	google_ramp_up   int32
-	google_ramp_down int32
-	s3s0_ramp_up     int32
-	s0_tick_delay    [2]int32 /* AC=0/1 */
-	s0a_tick_delay   [2]int32 /* AC=0/1 */
-	s0s3_ramp_down   int32
-	s3_sleep_for     int32
-	s3_ramp_up       int32
-	s3_ramp_down     int32
-	s5_ramp_up       int32
-	s5_ramp_down     int32
-	tap_tick_delay   int32
-	tap_gate_delay   int32
-	tap_display_time int32
+	googleRampUp   int32
+	googleRampDown int32
+	s3s0RampUp     int32
+	s0TickDelay    [2]int32 /* AC=0/1 */
+	s0aTickDelay   [2]int32 /* AC=0/1 */
+	s0s3RampDown   int32
+	s3SleepFor     int32
+	s3RampUp       int32
+	s3RampDown     int32
+	s5RampUp       int32
+	s5RampDown     int32
+	tapTickDelay   int32
+	tapGateDelay   int32
+	tapDisplayTime int32
 
 	/* Tap-for-battery params */
-	tap_pct_red    uint8
-	tap_pct_green  uint8
-	tap_seg_min_on uint8
-	tap_seg_max_on uint8
-	tap_seg_osc    uint8
-	tap_idx        [3]uint8
+	tapPctRed   uint8
+	tapPctGreen uint8
+	tapSegMinOn uint8
+	tapSegMaxOn uint8
+	tapSegOsc   uint8
+	tapIdx      [3]uint8
 
 	/* Oscillation */
-	osc_min [2]uint8 /* AC=0/1 */
-	osc_max [2]uint8 /* AC=0/1 */
-	w_ofs   [2]uint8 /* AC=0/1 */
+	oscMin [2]uint8 /* AC=0/1 */
+	oscMax [2]uint8 /* AC=0/1 */
+	wOfs   [2]uint8 /* AC=0/1 */
 
 	/* Brightness limits based on the backlight and AC. */
-	bright_bl_off_fixed [2]uint8 /* AC=0/1 */
-	bright_bl_on_min    [2]uint8 /* AC=0/1 */
-	bright_bl_on_max    [2]uint8 /* AC=0/1 */
+	brightBlOffFixed [2]uint8 /* AC=0/1 */
+	brightBlOnMin    [2]uint8 /* AC=0/1 */
+	brightBlOnMax    [2]uint8 /* AC=0/1 */
 
 	/* Battery level thresholds */
-	batteryhreshold [LB_BATTERY_LEVELS - 1]uint8
+	batteryhreshold [lbBatteryLevels - 1]uint8
 
-	/* Map [AC][battery_level] to color index */
-	s0_idx [2][LB_BATTERY_LEVELS]uint8 /* AP is running */
-	s3_idx [2][LB_BATTERY_LEVELS]uint8 /* AP is sleeping */
+	/* Map [AC][batteryLevel] to color index */
+	s0Idx [2][lbBatteryLevels]uint8 /* AP is running */
+	s3Idx [2][lbBatteryLevels]uint8 /* AP is sleeping */
 
 	/* s5: single color pulse on inhibited power-up */
-	s5_idx uint8
+	s5Idx uint8
 
 	/* Color palette */
-	color [8]rgb_s /* 0-3 are Google colors */
+	color [8]rgbS /* 0-3 are Google colors */
 }
 
 /* TYPE */
 /* Lightbar command params v2
  * crbug.com/467716
  *
- * lightbar_parms_v1 was too big for i2c, therefore in v2, we split them up by
+ * lightbarParmsV1 was too big for i2c, therefore in v2, we split them up by
  * logical groups to make it more manageable ( < 120 bytes).
  *
  * NOTE: Each of these groups must be less than 120 bytes.
  */
 
-type lightbar_params_v2_timing struct {
+type lightbarParamsV2Timing struct {
 	/* Timing */
-	google_ramp_up   int32
-	google_ramp_down int32
-	s3s0_ramp_up     int32
-	s0_tick_delay    [2]int32 /* AC=0/1 */
-	s0a_tick_delay   [2]int32 /* AC=0/1 */
-	s0s3_ramp_down   int32
-	s3_sleep_for     int32
-	s3_ramp_up       int32
-	s3_ramp_down     int32
-	s5_ramp_up       int32
-	s5_ramp_down     int32
-	tap_tick_delay   int32
-	tap_gate_delay   int32
-	tap_display_time int32
+	googleRampUp   int32
+	googleRampDown int32
+	s3s0RampUp     int32
+	s0TickDelay    [2]int32 /* AC=0/1 */
+	s0aTickDelay   [2]int32 /* AC=0/1 */
+	s0s3RampDown   int32
+	s3SleepFor     int32
+	s3RampUp       int32
+	s3RampDown     int32
+	s5RampUp       int32
+	s5RampDown     int32
+	tapTickDelay   int32
+	tapGateDelay   int32
+	tapDisplayTime int32
 }
 
 /* TYPE */
-type lightbar_params_v2_tap struct {
+type lightbarParamsV2Tap struct {
 	/* Tap-for-battery params */
-	tap_pct_red    uint8
-	tap_pct_green  uint8
-	tap_seg_min_on uint8
-	tap_seg_max_on uint8
-	tap_seg_osc    uint8
-	tap_idx        [3]uint8
+	tapPctRed   uint8
+	tapPctGreen uint8
+	tapSegMinOn uint8
+	tapSegMaxOn uint8
+	tapSegOsc   uint8
+	tapIdx      [3]uint8
 }
 
 /* TYPE */
-type lightbar_params_v2_oscillation struct {
+type lightbarParamsV2Oscillation struct {
 	/* Oscillation */
-	osc_min [2]uint8 /* AC=0/1 */
-	osc_max [2]uint8 /* AC=0/1 */
-	w_ofs   [2]uint8 /* AC=0/1 */
+	oscMin [2]uint8 /* AC=0/1 */
+	oscMax [2]uint8 /* AC=0/1 */
+	wOfs   [2]uint8 /* AC=0/1 */
 }
 
 /* TYPE */
-type lightbar_params_v2_brightness struct {
+type lightbarParamsV2Brightness struct {
 	/* Brightness limits based on the backlight and AC. */
-	bright_bl_off_fixed [2]uint8 /* AC=0/1 */
-	bright_bl_on_min    [2]uint8 /* AC=0/1 */
-	bright_bl_on_max    [2]uint8 /* AC=0/1 */
+	brightBlOffFixed [2]uint8 /* AC=0/1 */
+	brightBlOnMin    [2]uint8 /* AC=0/1 */
+	brightBlOnMax    [2]uint8 /* AC=0/1 */
 }
 
 /* TYPE */
-type lightbar_params_v2_thresholds struct {
+type lightbarParamsV2Thresholds struct {
 	/* Battery level thresholds */
-	batteryhreshold [LB_BATTERY_LEVELS - 1]uint8
+	batteryhreshold [lbBatteryLevels - 1]uint8
 }
 
 /* TYPE */
-type lightbar_params_v2_colors struct {
-	/* Map [AC][battery_level] to color index */
-	s0_idx [2][LB_BATTERY_LEVELS]uint8 /* AP is running */
-	s3_idx [2][LB_BATTERY_LEVELS]uint8 /* AP is sleeping */
+type lightbarParamsV2Colors struct {
+	/* Map [AC][batteryLevel] to color index */
+	s0Idx [2][lbBatteryLevels]uint8 /* AP is running */
+	s3Idx [2][lbBatteryLevels]uint8 /* AP is sleeping */
 
 	/* s5: single color pulse on inhibited power-up */
-	s5_idx uint8
+	s5Idx uint8
 
 	/* Color palette */
-	color [8]rgb_s /* 0-3 are Google colors */
+	color [8]rgbS /* 0-3 are Google colors */
 }
 
 /* Lightbyte program. */
-const EC_LB_PROG_LEN = 192
+const ecLbProgLen = 192
 
 /* TYPE */
-type lightbar_program struct {
+type lightbarProgram struct {
 	size uint8
-	data [EC_LB_PROG_LEN]uint8
+	data [ecLbProgLen]uint8
 }
 
 /* TYPE */
 /* this one is messy
-type ec_params_lightbar struct {
-cmd uint8		      /* Command (see enum lightbar_command)
+type ecParamsLightbar struct {
+cmd uint8		      /* Command (see enum lightbarCommand)
 	union {
 		struct {
 			/* no args
-		} dump, off, on, init, get_seq, get_params_v0, get_params_v1
-			version, get_brightness, get_demo, suspend, resume
-			get_params_v2_timing, get_params_v2_tap
-			get_params_v2_osc, get_params_v2_bright
-			get_params_v2_thlds, get_params_v2_colors;
+		} dump, off, on, init, getSeq, getParamsV0, getParamsV1
+			version, getBrightness, getDemo, suspend, resume
+			getParamsV2Timing, getParamsV2Tap
+			getParamsV2Osc, getParamsV2Bright
+			getParamsV2Thlds, getParamsV2Colors;
 
 		struct {
 		uint8 num;
-		} set_brightness, seq, demo;
+		} setBrightness, seq, demo;
 
 		struct {
 		uint8 ctrl, reg, value;
@@ -1383,33 +1383,33 @@ cmd uint8		      /* Command (see enum lightbar_command)
 
 		struct {
 		uint8 led, red, green, blue;
-		} set_rgb;
+		} setRgb;
 
 		struct {
 		uint8 led;
-		} get_rgb;
+		} getRgb;
 
 		struct {
 		uint8 enable;
-		} manual_suspend_ctrl;
+		} manualSuspendCtrl;
 
-		struct lightbar_params_v0 set_params_v0;
-		struct lightbar_params_v1 set_params_v1;
+		struct lightbarParamsV0 setParamsV0;
+		struct lightbarParamsV1 setParamsV1;
 
-		struct lightbar_params_v2_timing set_v2par_timing;
-		struct lightbar_params_v2_tap set_v2par_tap;
-		struct lightbar_params_v2_oscillation set_v2par_osc;
-		struct lightbar_params_v2_brightness set_v2par_bright;
-		struct lightbar_params_v2_thresholds set_v2par_thlds;
-		struct lightbar_params_v2_colors set_v2par_colors;
+		struct lightbarParamsV2Timing setV2parTiming;
+		struct lightbarParamsV2Tap setV2parTap;
+		struct lightbarParamsV2Oscillation setV2parOsc;
+		struct lightbarParamsV2Brightness setV2parBright;
+		struct lightbarParamsV2Thresholds setV2parThlds;
+		struct lightbarParamsV2Colors setV2parColors;
 
-		struct lightbar_program set_program;
+		struct lightbarProgram setProgram;
 	};
 } ;
 */
 /* TYPE */
 /*
-type ec_response_lightbar struct {
+type ecResponseLightbar struct {
 	union {
 		struct {
 			struct {
@@ -1421,18 +1421,18 @@ type ec_response_lightbar struct {
 
 		struct  {
 		uint8 num;
-		} get_seq, get_brightness, get_demo;
+		} getSeq, getBrightness, getDemo;
 
-		struct lightbar_params_v0 get_params_v0;
-		struct lightbar_params_v1 get_params_v1;
+		struct lightbarParamsV0 getParamsV0;
+		struct lightbarParamsV1 getParamsV1;
 
 
-		struct lightbar_params_v2_timing get_params_v2_timing;
-		struct lightbar_params_v2_tap get_params_v2_tap;
-		struct lightbar_params_v2_oscillation get_params_v2_osc;
-		struct lightbar_params_v2_brightness get_params_v2_bright;
-		struct lightbar_params_v2_thresholds get_params_v2_thlds;
-		struct lightbar_params_v2_colors get_params_v2_colors;
+		struct lightbarParamsV2Timing getParamsV2Timing;
+		struct lightbarParamsV2Tap getParamsV2Tap;
+		struct lightbarParamsV2Oscillation getParamsV2Osc;
+		struct lightbarParamsV2Brightness getParamsV2Bright;
+		struct lightbarParamsV2Thresholds getParamsV2Thlds;
+		struct lightbarParamsV2Colors getParamsV2Colors;
 
 		struct {
 		uint32 num;
@@ -1441,108 +1441,108 @@ type ec_response_lightbar struct {
 
 		struct {
 		uint8 red, green, blue;
-		} get_rgb;
+		} getRgb;
 
 		struct {
 			/* no return params *
-		} off, on, init, set_brightness, seq, reg, set_rgb
-			demo, set_params_v0, set_params_v1
-			set_program, manual_suspend_ctrl, suspend, resume
-			set_v2par_timing, set_v2par_tap
-			set_v2par_osc, set_v2par_bright, set_v2par_thlds
-			set_v2par_colors;
+		} off, on, init, setBrightness, seq, reg, setRgb
+			demo, setParamsV0, setParamsV1
+			setProgram, manualSuspendCtrl, suspend, resume
+			setV2parTiming, setV2parTap
+			setV2parOsc, setV2parBright, setV2parThlds
+			setV2parColors;
 	};
 } ;
 */
 /* Lightbar commands */
-type lightbar_command uint8
+type lightbarCommand uint8
 
 const (
-	LIGHTBAR_CMD_DUMP                      lightbar_command = 0
-	LIGHTBAR_CMD_OFF                                        = 1
-	LIGHTBAR_CMD_ON                                         = 2
-	LIGHTBAR_CMD_INIT                                       = 3
-	LIGHTBAR_CMD_SET_BRIGHTNESS                             = 4
-	LIGHTBAR_CMD_SEQ                                        = 5
-	LIGHTBAR_CMD_REG                                        = 6
-	LIGHTBAR_CMD_SET_RGB                                    = 7
-	LIGHTBAR_CMD_GET_SEQ                                    = 8
-	LIGHTBAR_CMD_DEMO                                       = 9
-	LIGHTBAR_CMD_GET_PARAMS_V0                              = 10
-	LIGHTBAR_CMD_SET_PARAMS_V0                              = 11
-	LIGHTBAR_CMD_VERSION                                    = 12
-	LIGHTBAR_CMD_GET_BRIGHTNESS                             = 13
-	LIGHTBAR_CMD_GET_RGB                                    = 14
-	LIGHTBAR_CMD_GET_DEMO                                   = 15
-	LIGHTBAR_CMD_GET_PARAMS_V1                              = 16
-	LIGHTBAR_CMD_SET_PARAMS_V1                              = 17
-	LIGHTBAR_CMD_SET_PROGRAM                                = 18
-	LIGHTBAR_CMD_MANUAL_SUSPEND_CTRL                        = 19
-	LIGHTBAR_CMD_SUSPEND                                    = 20
-	LIGHTBAR_CMD_RESUME                                     = 21
-	LIGHTBAR_CMD_GET_PARAMS_V2_TIMING                       = 22
-	LIGHTBAR_CMD_SET_PARAMS_V2_TIMING                       = 23
-	LIGHTBAR_CMD_GET_PARAMS_V2_TAP                          = 24
-	LIGHTBAR_CMD_SET_PARAMS_V2_TAP                          = 25
-	LIGHTBAR_CMD_GET_PARAMS_V2_OSCILLATION                  = 26
-	LIGHTBAR_CMD_SET_PARAMS_V2_OSCILLATION                  = 27
-	LIGHTBAR_CMD_GET_PARAMS_V2_BRIGHTNESS                   = 28
-	LIGHTBAR_CMD_SET_PARAMS_V2_BRIGHTNESS                   = 29
-	LIGHTBAR_CMD_GET_PARAMS_V2_THRESHOLDS                   = 30
-	LIGHTBAR_CMD_SET_PARAMS_V2_THRESHOLDS                   = 31
-	LIGHTBAR_CMD_GET_PARAMS_V2_COLORS                       = 32
-	LIGHTBAR_CMD_SET_PARAMS_V2_COLORS                       = 33
-	LIGHTBAR_NUM_CMDS
+	lightbarCmdDump                   lightbarCommand = 0
+	lightbarCmdOff                                    = 1
+	lightbarCmdOn                                     = 2
+	lightbarCmdInit                                   = 3
+	lightbarCmdSetBrightness                          = 4
+	lightbarCmdSeq                                    = 5
+	lightbarCmdReg                                    = 6
+	lightbarCmdSetRgb                                 = 7
+	lightbarCmdGetSeq                                 = 8
+	lightbarCmdDemo                                   = 9
+	lightbarCmdGetParamsV0                            = 10
+	lightbarCmdSetParamsV0                            = 11
+	lightbarCmdVersion                                = 12
+	lightbarCmdGetBrightness                          = 13
+	lightbarCmdGetRgb                                 = 14
+	lightbarCmdGetDemo                                = 15
+	lightbarCmdGetParamsV1                            = 16
+	lightbarCmdSetParamsV1                            = 17
+	lightbarCmdSetProgram                             = 18
+	lightbarCmdManualSuspendCtrl                      = 19
+	lightbarCmdSuspend                                = 20
+	lightbarCmdResume                                 = 21
+	lightbarCmdGetParamsV2Timing                      = 22
+	lightbarCmdSetParamsV2Timing                      = 23
+	lightbarCmdGetParamsV2Tap                         = 24
+	lightbarCmdSetParamsV2Tap                         = 25
+	lightbarCmdGetParamsV2Oscillation                 = 26
+	lightbarCmdSetParamsV2Oscillation                 = 27
+	lightbarCmdGetParamsV2Brightness                  = 28
+	lightbarCmdSetParamsV2Brightness                  = 29
+	lightbarCmdGetParamsV2Thresholds                  = 30
+	lightbarCmdSetParamsV2Thresholds                  = 31
+	lightbarCmdGetParamsV2Colors                      = 32
+	lightbarCmdSetParamsV2Colors                      = 33
+	lightbarNumCmds
 )
 
 /*****************************************************************************/
 /* LED control commands */
 
-const EC_CMD_LED_CONTROL = 0x29
+const ecCmdLedControl = 0x29
 
-type ec_led_id uint8
+type ecLedID uint8
 
 const (
 	/* LED to indicate battery state of charge */
-	EC_LED_ID_BATTERY_LED ec_led_id = 0
+	ecLedIDBatteryLed ecLedID = 0
 	/*
 	 * LED to indicate system power state (on or in suspend).
 	 * May be on power button or on C-panel.
 	 */
-	EC_LED_ID_POWER_LED
+	ecLedIDPowerLed
 	/* LED on power adapter or its plug */
-	EC_LED_ID_ADAPTER_LED
+	ecLedIDAdapterLed
 
-	EC_LED_ID_COUNT
+	ecLedIDCount
 )
 const (
 	/* LED control flags */
-	EC_LED_FLAGS_QUERY = (1 << iota) /* Query LED capability only */
-	EC_LED_FLAGS_AUTO                /* Switch LED back to automatic control */
+	ecLedFlagsQuery = (1 << iota) /* Query LED capability only */
+	ecLedFlagsAuto                /* Switch LED back to automatic control */
 )
 
-type ec_led_colors uint8
+type ecLedColors uint8
 
 const (
-	EC_LED_COLOR_RED ec_led_colors = 0
-	EC_LED_COLOR_GREEN
-	EC_LED_COLOR_BLUE
-	EC_LED_COLOR_YELLOW
-	EC_LED_COLOR_WHITE
+	ecLedColorRed ecLedColors = 0
+	ecLedColorGreen
+	ecLedColorBlue
+	ecLedColorYellow
+	ecLedColorWhite
 
-	EC_LED_COLOR_COUNT
+	ecLedColorCount
 )
 
 /* TYPE */
-type ec_params_led_control struct {
-	led_id uint8 /* Which LED to control */
-	flags  uint8 /* Control flags */
+type ecParamsLedControl struct {
+	ledID uint8 /* Which LED to control */
+	flags uint8 /* Control flags */
 
-	brightness [EC_LED_COLOR_COUNT]uint8
+	brightness [ecLedColorCount]uint8
 }
 
 /* TYPE */
-type ec_response_led_control struct {
+type ecResponseLedControl struct {
 	/*
 	 * Available brightness value range.
 	 *
@@ -1550,113 +1550,113 @@ type ec_response_led_control struct {
 	 * Range 1 means on/off control.
 	 * Other values means the LED is control by PWM.
 	 */
-	brightness_range [EC_LED_COLOR_COUNT]uint8
+	brightnessRange [ecLedColorCount]uint8
 }
 
 /*****************************************************************************/
 /* Verified boot commands */
 
 /*
- * Note: command code 0x29 version 0 was VBOOT_CMD in Link EVT; it may be
+ * Note: command code 0x29 version 0 was VBOOTCmd in Link EVT; it may be
  * reused for other purposes with version > 0.
  */
 
 /* Verified boot hash command */
-const EC_CMD_VBOOT_HASH = 0x2A
+const ecCmdVbootHash = 0x2A
 
 /* TYPE */
-type ec_params_vboot_hash struct {
-	cmd        uint8     /* enum ec_vboot_hash_cmd */
-	hashype    uint8     /* enum ec_vboot_hash_type */
-	nonce_size uint8     /* Nonce size; may be 0 */
-	reserved0  uint8     /* Reserved; set 0 */
-	offset     uint32    /* Offset in flash to hash */
-	size       uint32    /* Number of bytes to hash */
-	nonce_data [64]uint8 /* Nonce data; ignored if nonce_size=0 */
+type ecParamsVbootHash struct {
+	cmd       uint8     /* enum ecVbootHashCmd */
+	hashype   uint8     /* enum ecVbootHashType */
+	nonceSize uint8     /* Nonce size; may be 0 */
+	reserved0 uint8     /* Reserved; set 0 */
+	offset    uint32    /* Offset in flash to hash */
+	size      uint32    /* Number of bytes to hash */
+	nonceData [64]uint8 /* Nonce data; ignored if nonceSize=0 */
 }
 
 /* TYPE */
-type ec_response_vboot_hash struct {
-	status      uint8     /* enum ec_vboot_hash_status */
-	hashype     uint8     /* enum ec_vboot_hash_type */
-	digest_size uint8     /* Size of hash digest in bytes */
-	reserved0   uint8     /* Ignore; will be 0 */
-	offset      uint32    /* Offset in flash which was hashed */
-	size        uint32    /* Number of bytes hashed */
-	hash_digest [64]uint8 /* Hash digest data */
+type ecResponseVbootHash struct {
+	status     uint8     /* enum ecVbootHashStatus */
+	hashype    uint8     /* enum ecVbootHashType */
+	digestSize uint8     /* Size of hash digest in bytes */
+	reserved0  uint8     /* Ignore; will be 0 */
+	offset     uint32    /* Offset in flash which was hashed */
+	size       uint32    /* Number of bytes hashed */
+	hashDigest [64]uint8 /* Hash digest data */
 }
 
-type ec_vboot_hash_cmd uint8
+type ecVbootHashCmd uint8
 
 const (
-	EC_VBOOT_HASH_GET    ec_vboot_hash_cmd = 0 /* Get current hash status */
-	EC_VBOOT_HASH_ABORT                    = 1 /* Abort calculating current hash */
-	EC_VBOOT_HASH_START                    = 2 /* Start computing a new hash */
-	EC_VBOOT_HASH_RECALC                   = 3 /* Synchronously compute a new hash */
+	ecVbootHashGet    ecVbootHashCmd = 0 /* Get current hash status */
+	ecVbootHashAbort                 = 1 /* Abort calculating current hash */
+	ecVbootHashStart                 = 2 /* Start computing a new hash */
+	ecVbootHashRecalc                = 3 /* Synchronously compute a new hash */
 )
 
-type ec_vboot_hash_type uint8
+type ecVbootHashType uint8
 
 const (
-	EC_VBOOT_HASH_TYPE_SHA256 ec_vboot_hash_type = 0 /* SHA-256 */
+	ecVbootHashTypeSha256 ecVbootHashType = 0 /* SHA-256 */
 )
 
-type ec_vboot_hash_status uint8
+type ecVbootHashStatus uint8
 
 const (
-	EC_VBOOT_HASH_STATUS_NONE ec_vboot_hash_status = 0 /* No hash (not started, or aborted) */
-	EC_VBOOT_HASH_STATUS_DONE                      = 1 /* Finished computing a hash */
-	EC_VBOOT_HASH_STATUS_BUSY                      = 2 /* Busy computing a hash */
+	ecVbootHashStatusNone ecVbootHashStatus = 0 /* No hash (not started, or aborted) */
+	ecVbootHashStatusDone                   = 1 /* Finished computing a hash */
+	ecVbootHashStatusBusy                   = 2 /* Busy computing a hash */
 )
 
 /*
- * Special values for offset for EC_VBOOT_HASH_START and EC_VBOOT_HASH_RECALC.
+ * Special values for offset for ecVbootHashStart and ecVbootHashRecalc.
  * If one of these is specified, the EC will automatically update offset and
  * size to the correct values for the specified image (RO or RW).
  */
-const EC_VBOOT_HASH_OFFSET_RO = 0xfffffffe
-const EC_VBOOT_HASH_OFFSET_RW = 0xfffffffd
+const ecVbootHashOffsetRo = 0xfffffffe
+const ecVbootHashOffsetRw = 0xfffffffd
 
 /*****************************************************************************/
 /*
  * Motion sense commands. We'll make separate structs for sub-commands with
  * different input args, so that we know how much to expect.
  */
-const EC_CMD_MOTION_SENSE_CMD = 0x2B
+const ecCmdMotionSenseCmd = 0x2B
 
 /* Motion sense commands */
-type motionsense_command uint8
+type motionsenseCommand uint8
 
 const (
 	/* Dump command returns all motion sensor data including motion sense
 	 * module flags and individual sensor flags.
 	 */
-	MOTIONSENSE_CMD_DUMP motionsense_command = iota
+	motionsenseCmdDump motionsenseCommand = iota
 
 	/*
 	 * Info command returns data describing the details of a given sensor
-	 * including enum motionsensor_type, enum motionsensor_location, and
-	 * enum motionsensor_chip.
+	 * including enum motionsensorType, enum motionsensorLocation, and
+	 * enum motionsensorChip.
 	 */
-	MOTIONSENSE_CMD_INFO
+	motionsenseCmdInfo
 
 	/*
 	 * EC Rate command is a setter/getter command for the EC sampling rate
 	 * of all motion sensors in milliseconds.
 	 */
-	MOTIONSENSE_CMD_EC_RATE
+	motionsenseCmdEcRate
 
 	/*
 	 * Sensor ODR command is a setter/getter command for the output data
 	 * rate of a specific motion sensor in millihertz.
 	 */
-	MOTIONSENSE_CMD_SENSOR_ODR
+	motionsenseCmdSensorOdr
 
 	/*
 	 * Sensor range command is a setter/getter command for the range of
 	 * a specified motion sensor in +/-G's or +/- deg/s.
 	 */
-	MOTIONSENSE_CMD_SENSOR_RANGE
+	motionsenseCmdSensorRange
 
 	/*
 	 * Setter/getter command for the keyboard wake angle. When the lid
@@ -1665,97 +1665,97 @@ const (
 	 * enabled. Note, the lid angle measurement is an approximate
 	 * un-calibrated value, hence the wake angle isn't exact.
 	 */
-	MOTIONSENSE_CMD_KB_WAKE_ANGLE
+	motionsenseCmdKbWakeAngle
 
 	/* Number of motionsense sub-commands. */
-	MOTIONSENSE_NUM_CMDS
+	motionsenseNumCmds
 )
 
 /* List of motion sensor types. */
-type motionsensor_type uint8
+type motionsensorType uint8
 
 const (
-	MOTIONSENSE_TYPE_ACCEL motionsensor_type = 0
-	MOTIONSENSE_TYPE_GYRO                    = 1
+	motionsenseTypeAccel motionsensorType = 0
+	motionsenseTypeGyro                   = 1
 )
 
 /* List of motion sensor locations. */
-type motionsensor_location uint8
+type motionsensorLocation uint8
 
 const (
-	MOTIONSENSE_LOC_BASE motionsensor_location = 0
-	MOTIONSENSE_LOC_LID                        = 1
+	motionsenseLocBase motionsensorLocation = 0
+	motionsenseLocLid                       = 1
 )
 
 /* List of motion sensor chips. */
-type motionsensor_chip uint8
+type motionsensorChip uint8
 
 const (
-	MOTIONSENSE_CHIP_KXCJ9   motionsensor_chip = 0
-	MOTIONSENSE_CHIP_LSM6DS0                   = 1
+	motionsenseChipKxcj9   motionsensorChip = 0
+	motionsenseChipLsm6ds0                  = 1
 )
 
 /* Module flag masks used for the dump sub-command. */
-const MOTIONSENSE_MODULE_FLAG_ACTIVE = (1 << 0)
+const motionsenseModuleFlagActive = (1 << 0)
 
 /* Sensor flag masks used for the dump sub-command. */
-const MOTIONSENSE_SENSOR_FLAG_PRESENT = (1 << 0)
+const motionsenseSensorFlagPresent = (1 << 0)
 
 /*
  * Send this value for the data element to only perform a read. If you
  * send any other value, the EC will interpret it as data to set and will
  * return the actual value set.
  */
-const EC_MOTION_SENSE_NO_VALUE = -1
+const ecMotionSenseNoValue = -1
 
 /* some other time
-type ec_params_motion_sense struct {
+type ecParamsMotionSense struct {
 cmd uint8
 	union {
-		/* Used for MOTIONSENSE_CMD_DUMP * /
+		/* Used for MOTIONSENSECmdDump * /
 		struct {
 			/*
 			 * Maximal number of sensor the host is expecting.
 			 * 0 means the host is only interested in the number
 			 * of sensors controlled by the EC.
 			 * /
-		uint8 max_sensor_count;
+		uint8 maxSensorCount;
 		} dump;
 
 		/*
-		 * Used for MOTIONSENSE_CMD_EC_RATE and
-		 * MOTIONSENSE_CMD_KB_WAKE_ANGLE.
+		 * Used for MOTIONSENSECmdEcRate and
+		 * MOTIONSENSECmdKbWakeAngle.
 		 * /
 		struct {
-			/* Data to set or EC_MOTION_SENSE_NO_VALUE to read. * /
+			/* Data to set or ecMotionSenseNoValue to read. * /
 			data int16
-		} ec_rate, kb_wake_angle;
+		} ecRate, kbWakeAngle;
 
-		/* Used for MOTIONSENSE_CMD_INFO. * /
+		/* Used for MOTIONSENSECmdInfo. * /
 		struct {
-		uint8 sensor_num;
+		uint8 sensorNum;
 		} info;
 
 		/*
-		 * Used for MOTIONSENSE_CMD_SENSOR_ODR and
-		 * MOTIONSENSE_CMD_SENSOR_RANGE.
+		 * Used for MOTIONSENSECmdSensorOdr and
+		 * MOTIONSENSECmdSensorRange.
 		 * /
 		struct {
-		uint8 sensor_num;
+		uint8 sensorNum;
 
 			/* Rounding flag, true for round-up, false for down. * /
 		uint8 roundup;
 
 		uint16 reserved;
 
-			/* Data to set or EC_MOTION_SENSE_NO_VALUE to read. * /
+			/* Data to set or ecMotionSenseNoValue to read. * /
 			data int32
-		} sensor_odr, sensor_range;
+		} sensorOdr, sensorRange;
 	};
 } ;
 */
 /* TYPE */
-type ec_response_motion_sensor_data struct {
+type ecResponseMotionSensorData struct {
 	/* Flags for each sensor. */
 	flags   uint8
 	padding uint8
@@ -1767,44 +1767,44 @@ type ec_response_motion_sensor_data struct {
 /* TYPE */
 /* some other time
 
-type ec_response_motion_sense struct {
+type ecResponseMotionSense struct {
 	union {
-		/* Used for MOTIONSENSE_CMD_DUMP * /
+		/* Used for MOTIONSENSECmdDump * /
 		struct {
 			/* Flags representing the motion sensor module. * /
-		uint8 module_flags;
+		uint8 moduleFlags;
 
 			/* Number of sensors managed directly by the EC * /
-		uint8 sensor_count;
+		uint8 sensorCount;
 
 			/*
-			 * sensor data is truncated if response_max is too small
+			 * sensor data is truncated if responseMax is too small
 			 * for holding all the data.
 			 * /
-			struct ec_response_motion_sensor_data sensor[0];
+			struct ecResponseMotionSensorData sensor[0];
 		} dump;
 
-		/* Used for MOTIONSENSE_CMD_INFO. * /
+		/* Used for MOTIONSENSECmdInfo. * /
 		struct {
-			/* Should be element of enum motionsensor_type. * /
+			/* Should be element of enum motionsensorType. * /
 		uint8 type;
 
-			/* Should be element of enum motionsensor_location. * /
+			/* Should be element of enum motionsensorLocation. * /
 		uint8 location;
 
-			/* Should be element of enum motionsensor_chip. * /
+			/* Should be element of enum motionsensorChip. * /
 		uint8 chip;
 		} info;
 
 		/*
-		 * Used for MOTIONSENSE_CMD_EC_RATE, MOTIONSENSE_CMD_SENSOR_ODR
-		 * MOTIONSENSE_CMD_SENSOR_RANGE, and
-		 * MOTIONSENSE_CMD_KB_WAKE_ANGLE.
+		 * Used for MOTIONSENSECmdEcRate, MOTIONSENSECmdSensorOdr
+		 * MOTIONSENSECmdSensorRange, and
+		 * MOTIONSENSECmdKbWakeAngle.
 		 * /
 		struct {
 			/* Current value of the parameter queried. * /
 			ret int32
-		} ec_rate, sensor_odr, sensor_range, kb_wake_angle;
+		} ecRate, sensorOdr, sensorRange, kbWakeAngle;
 	};
 } ;
 */
@@ -1812,10 +1812,10 @@ type ec_response_motion_sense struct {
 /* Force lid open command */
 
 /* Make lid event always open */
-const EC_CMD_FORCE_LID_OPEN = 0x2c
+const ecCmdForceLidOpen = 0x2c
 
 /* TYPE */
-type ec_params_force_lid_open struct {
+type ecParamsForceLidOpen struct {
 	enabled uint8
 }
 
@@ -1823,29 +1823,29 @@ type ec_params_force_lid_open struct {
 /* USB charging control commands */
 
 /* Set USB port charging mode */
-const EC_CMD_USB_CHARGE_SET_MODE = 0x30
+const ecCmdUsbChargeSetMode = 0x30
 
 /* TYPE */
-type ec_params_usb_charge_set_mode struct {
-	usb_port_id uint8
-	mode        uint8
+type ecParamsUsbChargeSetMode struct {
+	usbPortID uint8
+	mode      uint8
 }
 
 /*****************************************************************************/
 /* Persistent storage for host */
 
 /* Maximum bytes that can be read/written in a single command */
-const EC_PSTORE_SIZE_MAX = 64
+const ecPstoreSizeMax = 64
 
 /* Get persistent storage info */
-const EC_CMD_PSTORE_INFO = 0x40
+const ecCmdPstoreInfo = 0x40
 
 /* TYPE */
-type ec_response_pstore_info struct {
+type ecResponsePstoreInfo struct {
 	/* Persistent storage size, in bytes */
-	pstore_size uint32
+	pstoreSize uint32
 	/* Access size; read/write offset and size must be a multiple of this */
-	access_size uint32
+	accessSize uint32
 }
 
 /*
@@ -1853,22 +1853,22 @@ type ec_response_pstore_info struct {
  *
  * Response is params.size bytes of data.
  */
-const EC_CMD_PSTORE_READ = 0x41
+const ecCmdPstoreRead = 0x41
 
 /* TYPE */
-type ec_params_pstore_read struct {
+type ecParamsPstoreRead struct {
 	offset uint32 /* Byte offset to read */
 	size   uint32 /* Size to read in bytes */
 }
 
 /* Write persistent storage */
-const EC_CMD_PSTORE_WRITE = 0x42
+const ecCmdPstoreWrite = 0x42
 
 /* TYPE */
-type ec_params_pstore_write struct {
+type ecParamsPstoreWrite struct {
 	offset uint32 /* Byte offset to write */
 	size   uint32 /* Size to write in bytes */
-	data   [EC_PSTORE_SIZE_MAX]uint8
+	data   [ecPstoreSizeMax]uint8
 }
 
 /* TYPE */
@@ -1876,61 +1876,61 @@ type ec_params_pstore_write struct {
 /* Real-time clock */
 
 /* RTC params and response structures */
-type ec_params_rtc struct {
+type ecParamsRtc struct {
 	time uint32
 }
 
 /* TYPE */
-type ec_response_rtc struct {
+type ecResponseRtc struct {
 	time uint32
 }
 
-/* These use ec_response_rtc */
-const EC_CMD_RTC_GET_VALUE = 0x44
-const EC_CMD_RTC_GET_ALARM = 0x45
+/* These use ecResponseRtc */
+const ecCmdRtcGetValue = 0x44
+const ecCmdRtcGetAlarm = 0x45
 
-/* These all use ec_params_rtc */
-const EC_CMD_RTC_SET_VALUE = 0x46
-const EC_CMD_RTC_SET_ALARM = 0x47
+/* These all use ecParamsRtc */
+const ecCmdRtcSetValue = 0x46
+const ecCmdRtcSetAlarm = 0x47
 
 /*****************************************************************************/
 /* Port80 log access */
 
 /* Maximum entries that can be read/written in a single command */
-const EC_PORT80_SIZE_MAX = 32
+const ecPort80SizeMax = 32
 
 /* Get last port80 code from previous boot */
-const EC_CMD_PORT80_LAST_BOOT = 0x48
-const EC_CMD_PORT80_READ = 0x48
+const ecCmdPort80LastBoot = 0x48
+const ecCmdPort80Read = 0x48
 
-type ec_port80_subcmd uint8
+type ecPort80Subcmd uint8
 
 const (
-	EC_PORT80_GET_INFO ec_port80_subcmd = 0
-	EC_PORT80_READ_BUFFER
+	ecPort80GetInfo ecPort80Subcmd = 0
+	ecPort80ReadBuffer
 )
 
 /* TYPE */
-type ec_params_port80_read struct {
-	subcmd      uint16
-	offset      uint32
-	num_entries uint32
+type ecParamsPort80Read struct {
+	subcmd     uint16
+	offset     uint32
+	numEntries uint32
 }
 
 /* TYPE */
-type ec_response_port80_read struct {
+type ecResponsePort80Read struct {
 	/*
 		struct {
 		uint32 writes;
-		uint32 history_size;
-		uint32 last_boot;
-		} get_info;*/
+		uint32 historySize;
+		uint32 lastBoot;
+		} getInfo;*/
 
-	codes [EC_PORT80_SIZE_MAX]uint16
+	codes [ecPort80SizeMax]uint16
 }
 
 /* TYPE */
-type ec_response_port80_last_boot struct {
+type ecResponsePort80LastBoot struct {
 	code uint16
 }
 
@@ -1941,8 +1941,8 @@ type ec_response_port80_last_boot struct {
  * Version 1 separates the CPU thermal limits from the fan control.
  */
 
-const EC_CMD_THERMAL_SET_THRESHOLD = 0x50
-const EC_CMD_THERMAL_GET_THRESHOLD = 0x51
+const ecCmdThermalSetThreshold = 0x50
+const ecCmdThermalGetThreshold = 0x51
 
 /* TYPE */
 /* The version 0 structs are opaque. You have to know what they are for
@@ -1950,59 +1950,59 @@ const EC_CMD_THERMAL_GET_THRESHOLD = 0x51
  */
 
 /* Version 0 - set */
-type ec_params_thermal_set_threshold struct {
-	sensorype    uint8
-	threshold_id uint8
-	value        uint16
+type ecParamsThermalSetThreshold struct {
+	sensorype   uint8
+	thresholdID uint8
+	value       uint16
 }
 
 /* TYPE */
 /* Version 0 - get */
-type ec_params_thermal_get_threshold struct {
-	sensorype    uint8
-	threshold_id uint8
+type ecParamsThermalGetThreshold struct {
+	sensorype   uint8
+	thresholdID uint8
 }
 
 /* TYPE */
-type ec_response_thermal_get_threshold struct {
+type ecResponseThermalGetThreshold struct {
 	value uint16
 }
 
 /* The version 1 structs are visible. */
-type ec_temp_thresholds uint8
+type ecTempThresholds uint8
 
 const (
-	EC_TEMP_THRESH_WARN ec_temp_thresholds = 0
-	EC_TEMP_THRESH_HIGH
-	EC_TEMP_THRESH_HALT
+	ecTempThreshWarn ecTempThresholds = 0
+	ecTempThreshHigh
+	ecTempThreshHalt
 
-	EC_TEMP_THRESH_COUNT
+	ecTempThreshCount
 )
 
 /* TYPE */
 /* Thermal configuration for one temperature sensor. Temps are in degrees K.
  * Zero values will be silently ignored by the thermal task.
  */
-type ec_thermal_config struct {
-	temp_host    [EC_TEMP_THRESH_COUNT]uint32 /* levels of hotness */
-	temp_fan_off uint32                       /* no active cooling needed */
-	temp_fan_max uint32                       /* max active cooling needed */
+type ecThermalConfig struct {
+	tempHost   [ecTempThreshCount]uint32 /* levels of hotness */
+	tempFanOff uint32                    /* no active cooling needed */
+	tempFanMax uint32                    /* max active cooling needed */
 }
 
 /* TYPE */
 /* Version 1 - get config for one sensor. */
-type ec_params_thermal_get_threshold_v1 struct {
-	sensor_num uint32
+type ecParamsThermalGetThresholdV1 struct {
+	sensorNum uint32
 }
 
 /* TYPE */
-/* This returns a struct ec_thermal_config */
+/* This returns a struct ecThermalConfig */
 
 /* Version 1 - set config for one sensor.
  * Use read-modify-write for best results! */
-type ec_params_thermal_set_threshold_v1 struct {
-	sensor_num uint32
-	cfg        ec_thermal_config
+type ecParamsThermalSetThresholdV1 struct {
+	sensorNum uint32
+	cfg       ecThermalConfig
 }
 
 /* This returns no data */
@@ -2010,17 +2010,17 @@ type ec_params_thermal_set_threshold_v1 struct {
 /****************************************************************************/
 
 /* Toggle automatic fan control */
-const EC_CMD_THERMAL_AUTO_FAN_CTRL = 0x52
+const ecCmdThermalAutoFanCtrl = 0x52
 
 /* TYPE */
 /* Version 1 of input params */
-type ec_params_auto_fan_ctrl_v1 struct {
-	fan_idx uint8
+type ecParamsAutoFanCtrlV1 struct {
+	fanIdx uint8
 }
 
 /* Get/Set TMP006 calibration data */
-const EC_CMD_TMP006_GET_CALIBRATION = 0x53
-const EC_CMD_TMP006_SET_CALIBRATION = 0x54
+const ecCmdTmp006GetCalibration = 0x53
+const ecCmdTmp006SetCalibration = 0x54
 
 /* TYPE */
 /*
@@ -2033,18 +2033,18 @@ const EC_CMD_TMP006_SET_CALIBRATION = 0x54
  */
 
 /* This is the same struct for both v0 and v1. */
-type ec_params_tmp006_get_calibration struct {
+type ecParamsTmp006GetCalibration struct {
 	index uint8
 }
 
 /* TYPE */
 /* Version 0 */
-type ec_response_tmp006_get_calibration_v0 struct {
+type ecResponseTmp006GetCalibrationV0 struct {
 	s0, b0, b1, bw float32
 }
 
 /* TYPE */
-type ec_params_tmp006_set_calibration_v0 struct {
+type ecParamsTmp006SetCalibrationV0 struct {
 	index          uint8
 	reserved       [3]uint8
 	s0, b0, b1, b2 float32
@@ -2052,32 +2052,32 @@ type ec_params_tmp006_set_calibration_v0 struct {
 
 /* TYPE */
 /* Version 1 */
-type ec_response_tmp006_get_calibration_v1 struct {
-	algorithm  uint8
-	num_params uint8
-	reserved   [2]uint8
-	val        []float32
+type ecResponseTmp006GetCalibrationV1 struct {
+	algorithm uint8
+	numParams uint8
+	reserved  [2]uint8
+	val       []float32
 }
 
 /* TYPE */
-type ec_params_tmp006_set_calibration_v1 struct {
-	index      uint8
-	algorithm  uint8
-	num_params uint8
-	reserved   uint8
-	val        []float32
+type ecParamsTmp006SetCalibrationV1 struct {
+	index     uint8
+	algorithm uint8
+	numParams uint8
+	reserved  uint8
+	val       []float32
 }
 
 /* Read raw TMP006 data */
-const EC_CMD_TMP006_GET_RAW = 0x55
+const ecCmdTmp006GetRaw = 0x55
 
 /* TYPE */
-type ec_params_tmp006_get_raw struct {
+type ecParamsTmp006GetRaw struct {
 	index uint8
 }
 
 /* TYPE */
-type ec_response_tmp006_get_raw struct {
+type ecResponseTmp006GetRaw struct {
 	t int32 /* In 1/100 K */
 	v int32 /* In nV */
 }
@@ -2088,148 +2088,148 @@ type ec_response_tmp006_get_raw struct {
 /*
  * Read key state
  *
- * Returns raw data for keyboard cols; see ec_response_mkbp_info.cols for
+ * Returns raw data for keyboard cols; see ecResponseMkbpInfo.cols for
  * expected response size.
  */
-const EC_CMD_MKBP_STATE = 0x60
+const ecCmdMkbpState = 0x60
 
 /* Provide information about the matrix : number of rows and columns */
-const EC_CMD_MKBP_INFO = 0x61
+const ecCmdMkbpInfo = 0x61
 
 /* TYPE */
-type ec_response_mkbp_info struct {
+type ecResponseMkbpInfo struct {
 	rows     uint32
 	cols     uint32
 	switches uint8
 }
 
 /* Simulate key press */
-const EC_CMD_MKBP_SIMULATE_KEY = 0x62
+const ecCmdMkbpSimulateKey = 0x62
 
 /* TYPE */
-type ec_params_mkbp_simulate_key struct {
+type ecParamsMkbpSimulateKey struct {
 	col     uint8
 	row     uint8
 	pressed uint8
 }
 
 /* Configure keyboard scanning */
-const EC_CMD_MKBP_SET_CONFIG = 0x64
-const EC_CMD_MKBP_GET_CONFIG = 0x65
+const ecCmdMkbpSetConfig = 0x64
+const ecCmdMkbpGetConfig = 0x65
 
 /* flags */
-type mkbp_config_flags uint8
+type mkbpConfigFlags uint8
 
 const (
-	EC_MKBP_FLAGS_ENABLE mkbp_config_flags = 1 /* Enable keyboard scanning */
+	ecMkbpFlagsEnable mkbpConfigFlags = 1 /* Enable keyboard scanning */
 )
 
-type mkbp_config_valid uint8
+type mkbpConfigValid uint8
 
 const (
-	EC_MKBP_VALID_SCAN_PERIOD         mkbp_config_valid = 1 << 0
-	EC_MKBP_VALID_POLL_TIMEOUT                          = 1 << 1
-	EC_MKBP_VALID_MIN_POST_SCAN_DELAY                   = 1 << 3
-	EC_MKBP_VALID_OUTPUT_SETTLE                         = 1 << 4
-	EC_MKBP_VALID_DEBOUNCE_DOWN                         = 1 << 5
-	EC_MKBP_VALID_DEBOUNCE_UP                           = 1 << 6
-	EC_MKBP_VALID_FIFO_MAX_DEPTH                        = 1 << 7
+	ecMkbpValidScanPeriod       mkbpConfigValid = 1 << 0
+	ecMkbpValidPollTimeout                      = 1 << 1
+	ecMkbpValidMinPostScanDelay                 = 1 << 3
+	ecMkbpValidOutputSettle                     = 1 << 4
+	ecMkbpValidDebounceDown                     = 1 << 5
+	ecMkbpValidDebounceUp                       = 1 << 6
+	ecMkbpValidFifoMaxDepth                     = 1 << 7
 )
 
 /* TYPE */
 /* Configuration for our key scanning algorithm */
-type ec_mkbp_config struct {
-	valid_mask     uint32 /* valid fields */
-	flags          uint8  /* some flags (enum mkbp_config_flags) */
-	valid_flags    uint8  /* which flags are valid */
-	scan_period_us uint16 /* period between start of scans */
+type ecMkbpConfig struct {
+	validMask    uint32 /* valid fields */
+	flags        uint8  /* some flags (enum mkbpConfigFlags) */
+	validFlags   uint8  /* which flags are valid */
+	scanPeriodUs uint16 /* period between start of scans */
 	/* revert to interrupt mode after no activity for this long */
-	pollimeout_us uint32
+	pollimeoutUs uint32
 	/*
 	 * minimum post-scan relax time. Once we finish a scan we check
 	 * the time until we are due to start the next one. If this time is
 	 * shorter this field, we use this instead.
 	 */
-	min_post_scan_delay_us uint16
+	minPostScanDelayUs uint16
 	/* delay between setting up output and waiting for it to settle */
-	output_settle_us uint16
-	debounce_down_us uint16 /* time for debounce on key down */
-	debounce_up_us   uint16 /* time for debounce on key up */
+	outputSettleUs uint16
+	debounceDownUs uint16 /* time for debounce on key down */
+	debounceUpUs   uint16 /* time for debounce on key up */
 	/* maximum depth to allow for fifo (0 = no keyscan output) */
-	fifo_max_depth uint8
+	fifoMaxDepth uint8
 }
 
 /* TYPE */
-type ec_params_mkbp_set_config struct {
-	config ec_mkbp_config
+type ecParamsMkbpSetConfig struct {
+	config ecMkbpConfig
 }
 
 /* TYPE */
-type ec_response_mkbp_get_config struct {
-	config ec_mkbp_config
+type ecResponseMkbpGetConfig struct {
+	config ecMkbpConfig
 }
 
 /* Run the key scan emulation */
-const EC_CMD_KEYSCAN_SEQ_CTRL = 0x66
+const ecCmdKeyscanSeqCtrl = 0x66
 
-type ec_keyscan_seq_cmd uint8
+type ecKeyscanSeqCmd uint8
 
 const (
-	EC_KEYSCAN_SEQ_STATUS  ec_keyscan_seq_cmd = 0 /* Get status information */
-	EC_KEYSCAN_SEQ_CLEAR                      = 1 /* Clear sequence */
-	EC_KEYSCAN_SEQ_ADD                        = 2 /* Add item to sequence */
-	EC_KEYSCAN_SEQ_START                      = 3 /* Start running sequence */
-	EC_KEYSCAN_SEQ_COLLECT                    = 4 /* Collect sequence summary data */
+	ecKeyscanSeqStatus  ecKeyscanSeqCmd = 0 /* Get status information */
+	ecKeyscanSeqClear                   = 1 /* Clear sequence */
+	ecKeyscanSeqAdd                     = 2 /* Add item to sequence */
+	ecKeyscanSeqStart                   = 3 /* Start running sequence */
+	ecKeyscanSeqCollect                 = 4 /* Collect sequence summary data */
 )
 
-type ec_collect_flags uint8
+type ecCollectFlags uint8
 
 const (
 	/* Indicates this scan was processed by the EC. Due to timing, some
 	 * scans may be skipped.
 	 */
-	EC_KEYSCAN_SEQ_FLAG_DONE ec_collect_flags = 1 << iota
+	ecKeyscanSeqFlagDone ecCollectFlags = 1 << iota
 )
 
 /* TYPE */
-type ec_collect_item struct {
-	flags uint8 /* some flags (enum ec_collect_flags) */
+type ecCollectItem struct {
+	flags uint8 /* some flags (enum ecCollectFlags) */
 }
 
 /* TYPE */
 /* later
-type ec_params_keyscan_seq_ctrl struct {
-cmd uint8	/* Command to send (enum ec_keyscan_seq_cmd) * /
+type ecParamsKeyscanSeqCtrl struct {
+cmd uint8	/* Command to send (enum ecKeyscanSeqCmd) * /
 	union {
 		struct {
 		uint8 active;		/* still active * /
-		uint8 num_items;	/* number of items * /
+		uint8 numItems;	/* number of items * /
 			/* Current item being presented * /
-		uint8 cur_item;
+		uint8 curItem;
 		} status;
 		struct {
 			/*
 			 * Absolute time for this scan, measured from the
 			 * start of the sequence.
 			 * /
-		uint32 time_us;
+		uint32 timeUs;
 		uint8 scan[0];	/* keyscan data * /
 		} add;
 		struct {
-		uint8 start_item;	/* First item to return * /
-		uint8 num_items;	/* Number of items to return * /
+		uint8 startItem;	/* First item to return * /
+		uint8 numItems;	/* Number of items to return * /
 		} collect;
 	};
 } ;
 */
 /* TYPE */
 /* lter
-type ec_result_keyscan_seq_ctrl struct {
+type ecResultKeyscanSeqCtrl struct {
 	union {
 		struct {
-		uint8 num_items;	/* Number of items *
+		uint8 numItems;	/* Number of items *
 			/* Data for each item *
-			struct ec_collect_item item[0]
+			struct ecCollectItem item[0]
 		} collect;
 	};
 } ;
@@ -2237,25 +2237,25 @@ type ec_result_keyscan_seq_ctrl struct {
 /*
  * Get the next pending MKBP event.
  *
- * Returns EC_RES_UNAVAILABLE if there is no event pending.
+ * Returns ecResUnavailable if there is no event pending.
  */
-const EC_CMD_GET_NEXT_EVENT = 0x67
+const ecCmdGetNextEvent = 0x67
 
-type ec_mkbp_event uint8
+type ecMkbpEvent uint8
 
 const (
 	/* Keyboard matrix changed. The event data is the new matrix state. */
-	EC_MKBP_EVENT_KEY_MATRIX = iota
+	ecMkbpEventKeyMatrix = iota
 
 	/* New host event. The event data is 4 bytes of host event flags. */
-	EC_MKBP_EVENT_HOST_EVENT
+	ecMkbpEventHostEvent
 
 	/* Number of MKBP events */
-	EC_MKBP_EVENT_COUNT
+	ecMkbpEventCount
 )
 
 /* TYPE */
-type ec_response_get_next_event struct {
+type ecResponseGetNextEvent struct {
 	eventype uint8
 	/* Followed by event data if any */
 }
@@ -2264,17 +2264,17 @@ type ec_response_get_next_event struct {
 /* Temperature sensor commands */
 
 /* Read temperature sensor info */
-const EC_CMD_TEMP_SENSOR_GET_INFO = 0x70
+const ecCmdTempSensorGetInfo = 0x70
 
 /* TYPE */
-type ec_params_temp_sensor_get_info struct {
+type ecParamsTempSensorGetInfo struct {
 	id uint8
 }
 
 /* TYPE */
-type ec_response_temp_sensor_get_info struct {
-	sensor_name [32]byte
-	sensorype   uint8
+type ecResponseTempSensorGetInfo struct {
+	sensorName [32]byte
+	sensorype  uint8
 }
 
 /* TYPE */
@@ -2293,133 +2293,133 @@ type ec_response_temp_sensor_get_info struct {
  * Host event mask params and response structures, shared by all of the host
  * event commands below.
  */
-type ec_params_host_event_mask struct {
+type ecParamsHostEventMask struct {
 	mask uint32
 }
 
 /* TYPE */
-type ec_response_host_event_mask struct {
+type ecResponseHostEventMask struct {
 	mask uint32
 }
 
-/* These all use ec_response_host_event_mask */
-const EC_CMD_HOST_EVENT_GET_B = 0x87
-const EC_CMD_HOST_EVENT_GET_SMI_MASK = 0x88
-const EC_CMD_HOST_EVENT_GET_SCI_MASK = 0x89
-const EC_CMD_HOST_EVENT_GET_WAKE_MASK = 0x8d
+/* These all use ecResponseHostEventMask */
+const ecCmdHostEventGetB = 0x87
+const ecCmdHostEventGetSmiMask = 0x88
+const ecCmdHostEventGetSciMask = 0x89
+const ecCmdHostEventGetWakeMask = 0x8d
 
-/* These all use ec_params_host_event_mask */
-const EC_CMD_HOST_EVENT_SET_SMI_MASK = 0x8a
-const EC_CMD_HOST_EVENT_SET_SCI_MASK = 0x8b
-const EC_CMD_HOST_EVENT_CLEAR = 0x8c
-const EC_CMD_HOST_EVENT_SET_WAKE_MASK = 0x8e
-const EC_CMD_HOST_EVENT_CLEAR_B = 0x8f
+/* These all use ecParamsHostEventMask */
+const ecCmdHostEventSetSmiMask = 0x8a
+const ecCmdHostEventSetSciMask = 0x8b
+const ecCmdHostEventClear = 0x8c
+const ecCmdHostEventSetWakeMask = 0x8e
+const ecCmdHostEventClearB = 0x8f
 
 /*****************************************************************************/
 /* Switch commands */
 
 /* Enable/disable LCD backlight */
-const EC_CMD_SWITCH_ENABLE_BKLIGHT = 0x90
+const ecCmdSwitchEnableBklight = 0x90
 
 /* TYPE */
-type ec_params_switch_enable_backlight struct {
+type ecParamsSwitchEnableBacklight struct {
 	enabled uint8
 }
 
 /* Enable/disable WLAN/Bluetooth */
-const EC_CMD_SWITCH_ENABLE_WIRELESS = 0x91
-const EC_VER_SWITCH_ENABLE_WIRELESS = 1
+const ecCmdSwitchEnableWireless = 0x91
+const ecVerSwitchEnableWireless = 1
 
 /* TYPE */
 /* Version 0 params; no response */
-type ec_params_switch_enable_wireless_v0 struct {
+type ecParamsSwitchEnableWirelessV0 struct {
 	enabled uint8
 }
 
 /* TYPE */
 /* Version 1 params */
-type ec_params_switch_enable_wireless_v1 struct {
+type ecParamsSwitchEnableWirelessV1 struct {
 	/* Flags to enable now */
-	now_flags uint8
+	nowFlags uint8
 
-	/* Which flags to copy from now_flags */
-	now_mask uint8
+	/* Which flags to copy from nowFlags */
+	nowMask uint8
 
 	/*
 	 * Flags to leave enabled in S3, if they're on at the S0->S3
 	 * transition.  (Other flags will be disabled by the S0->S3
 	 * transition.)
 	 */
-	suspend_flags uint8
+	suspendFlags uint8
 
-	/* Which flags to copy from suspend_flags */
-	suspend_mask uint8
+	/* Which flags to copy from suspendFlags */
+	suspendMask uint8
 }
 
 /* TYPE */
 /* Version 1 response */
-type ec_response_switch_enable_wireless_v1 struct {
+type ecResponseSwitchEnableWirelessV1 struct {
 	/* Flags to enable now */
-	now_flags uint8
+	nowFlags uint8
 
 	/* Flags to leave enabled in S3 */
-	suspend_flags uint8
+	suspendFlags uint8
 }
 
 /*****************************************************************************/
 /* GPIO commands. Only available on EC if write protect has been disabled. */
 
 /* Set GPIO output value */
-const EC_CMD_GPIO_SET = 0x92
+const ecCmdGpioSet = 0x92
 
 /* TYPE */
-type ec_params_gpio_set struct {
+type ecParamsGpioSet struct {
 	name [32]byte
 	val  uint8
 }
 
 /* Get GPIO value */
-const EC_CMD_GPIO_GET = 0x93
+const ecCmdGpioGet = 0x93
 
 /* TYPE */
 /* Version 0 of input params and response */
-type ec_params_gpio_get struct {
+type ecParamsGpioGet struct {
 	name [32]byte
 }
 
 /* TYPE */
-type ec_response_gpio_get struct {
+type ecResponseGpioGet struct {
 	val uint8
 }
 
 /* TYPE */
 /* Version 1 of input params and response */
-type ec_params_gpio_get_v1 struct {
+type ecParamsGpioGetV1 struct {
 	subcmd uint8
 	data   [32]byte
 }
 
 /* TYPE */
 /* later
-type ec_response_gpio_get_v1 struct {
+type ecResponseGpioGetV1 struct {
 	union {
 		struct {
 		uint8 val;
-		} get_value_by_name, get_count;
+		} getValueByName, getCount;
 		struct {
 		uint8 val;
 			char name[32];
 		uint32 flags;
-		} get_info;
+		} getInfo;
 	};
 } ;
 */
-type gpio_get_subcmd uint8
+type gpioGetSubcmd uint8
 
 const (
-	EC_GPIO_GET_BY_NAME gpio_get_subcmd = 0
-	EC_GPIO_GET_COUNT                   = 1
-	EC_GPIO_GET_INFO                    = 2
+	ecGpioGetByName gpioGetSubcmd = 0
+	ecGpioGetCount                = 1
+	ecGpioGetInfo                 = 2
 )
 
 /*****************************************************************************/
@@ -2427,35 +2427,35 @@ const (
 
 /*
  * TODO(crosbug.com/p/23570): These commands are deprecated, and will be
- * removed soon.  Use EC_CMD_I2C_XFER instead.
+ * removed soon.  Use ecCmdI2cXfer instead.
  */
 
 /* Read I2C bus */
-const EC_CMD_I2C_READ = 0x94
+const ecCmdI2cRead = 0x94
 
 /* TYPE */
-type ec_params_i2c_read struct {
-	addr      uint16 /* 8-bit address (7-bit shifted << 1) */
-	read_size uint8  /* Either 8 or 16. */
-	port      uint8
-	offset    uint8
+type ecParamsI2cRead struct {
+	addr     uint16 /* 8-bit address (7-bit shifted << 1) */
+	readSize uint8  /* Either 8 or 16. */
+	port     uint8
+	offset   uint8
 }
 
 /* TYPE */
-type ec_response_i2c_read struct {
+type ecResponseI2cRead struct {
 	data uint16
 }
 
 /* Write I2C bus */
-const EC_CMD_I2C_WRITE = 0x95
+const ecCmdI2cWrite = 0x95
 
 /* TYPE */
-type ec_params_i2c_write struct {
-	data       uint16
-	addr       uint16 /* 8-bit address (7-bit shifted << 1) */
-	write_size uint8  /* Either 8 or 16. */
-	port       uint8
-	offset     uint8
+type ecParamsI2cWrite struct {
+	data      uint16
+	addr      uint16 /* 8-bit address (7-bit shifted << 1) */
+	writeSize uint8  /* Either 8 or 16. */
+	port      uint8
+	offset    uint8
 }
 
 /*****************************************************************************/
@@ -2464,27 +2464,27 @@ type ec_params_i2c_write struct {
 /* Force charge state machine to stop charging the battery or force it to
  * discharge the battery.
  */
-const EC_CMD_CHARGE_CONTROL = 0x96
-const EC_VER_CHARGE_CONTROL = 1
+const ecCmdChargeControl = 0x96
+const ecVerChargeControl = 1
 
-type ec_charge_control_mode uint8
+type ecChargeControlMode uint8
 
 const (
-	CHARGE_CONTROL_NORMAL ec_charge_control_mode = 0
-	CHARGE_CONTROL_IDLE
-	CHARGE_CONTROL_DISCHARGE
+	chargeControlNormal ecChargeControlMode = 0
+	chargeControlIdle
+	chargeControlDischarge
 )
 
 /* TYPE */
-type ec_params_charge_control struct {
-	mode uint32 /* enum charge_control_mode */
+type ecParamsChargeControl struct {
+	mode uint32 /* enum chargeControlMode */
 }
 
 /*****************************************************************************/
 /* Console commands. Only available when flash write protect is unlocked. */
 
-/* Snapshot console output buffer for use by EC_CMD_CONSOLE_READ. */
-const EC_CMD_CONSOLE_SNAPSHOT = 0x97
+/* Snapshot console output buffer for use by ecCmdConsoleRead. */
+const ecCmdConsoleSnapshot = 0x97
 
 /*
  * Read next chunk of data from saved snapshot.
@@ -2492,23 +2492,23 @@ const EC_CMD_CONSOLE_SNAPSHOT = 0x97
  * Response is null-terminated string.  Empty string, if there is no more
  * remaining output.
  */
-const EC_CMD_CONSOLE_READ = 0x98
+const ecCmdConsoleRead = 0x98
 
 /*****************************************************************************/
 
 /*
  * Cut off battery power immediately or after the host has shut down.
  *
- * return EC_RES_INVALID_COMMAND if unsupported by a board/battery.
- *	  EC_RES_SUCCESS if the command was successful.
- *	  EC_RES_ERROR if the cut off command failed.
+ * return ecResInvalidCommand if unsupported by a board/battery.
+ *	  ecResSuccess if the command was successful.
+ *	  ecResError if the cut off command failed.
  */
-const EC_CMD_BATTERY_CUT_OFF = 0x99
+const ecCmdBatteryCutOff = 0x99
 
-const EC_BATTERY_CUTOFF_FLAG_AT_SHUTDOWN = (1 << 0)
+const ecBatteryCutoffFlagAtShutdown = (1 << 0)
 
 /* TYPE */
-type ec_params_battery_cutoff struct {
+type ecParamsBatteryCutoff struct {
 	flags uint8
 }
 
@@ -2518,30 +2518,30 @@ type ec_params_battery_cutoff struct {
 /*
  * Switch USB mux or return to automatic switching.
  */
-const EC_CMD_USB_MUX = 0x9a
+const ecCmdUsbMux = 0x9a
 
 /* TYPE */
-type ec_params_usb_mux struct {
+type ecParamsUsbMux struct {
 	mux uint8
 }
 
 /*****************************************************************************/
 /* LDOs / FETs control. */
 
-type ec_ldo_state uint8
+type ecLdoState uint8
 
 const (
-	EC_LDO_STATE_OFF ec_ldo_state = 0 /* the LDO / FET is shut down */
-	EC_LDO_STATE_ON               = 1 /* the LDO / FET is ON / providing power */
+	ecLdoStateOff ecLdoState = 0 /* the LDO / FET is shut down */
+	ecLdoStateOn             = 1 /* the LDO / FET is ON / providing power */
 )
 
 /*
  * Switch on/off a LDO.
  */
-const EC_CMD_LDO_SET = 0x9b
+const ecCmdLdoSet = 0x9b
 
 /* TYPE */
-type ec_params_ldo_set struct {
+type ecParamsLdoSet struct {
 	index uint8
 	state uint8
 }
@@ -2549,15 +2549,15 @@ type ec_params_ldo_set struct {
 /*
  * Get LDO state.
  */
-const EC_CMD_LDO_GET = 0x9c
+const ecCmdLdoGet = 0x9c
 
 /* TYPE */
-type ec_params_ldo_get struct {
+type ecParamsLdoGet struct {
 	index uint8
 }
 
 /* TYPE */
-type ec_response_ldo_get struct {
+type ecResponseLdoGet struct {
 	state uint8
 }
 
@@ -2567,83 +2567,83 @@ type ec_response_ldo_get struct {
 /*
  * Get power info.
  */
-const EC_CMD_POWER_INFO = 0x9d
+const ecCmdPowerInfo = 0x9d
 
 /* TYPE */
-type ec_response_power_info struct {
-	usb_devype        uint32
-	voltage_ac        uint16
-	voltage_system    uint16
-	current_system    uint16
-	usb_current_limit uint16
+type ecResponsePowerInfo struct {
+	usbDevype       uint32
+	voltageAc       uint16
+	voltageSystem   uint16
+	currentSystem   uint16
+	usbCurrentLimit uint16
 }
 
 /*****************************************************************************/
 /* I2C passthru command */
 
-const EC_CMD_I2C_PASSTHRU = 0x9e
+const ecCmdI2cPassthru = 0x9e
 
 /* Read data; if not present, message is a write */
-const EC_I2C_FLAG_READ = (1 << 15)
+const ecI2cFlagRead = (1 << 15)
 
 /* Mask for address */
-const EC_I2C_ADDR_MASK = 0x3ff
+const ecI2cAddrMask = 0x3ff
 
-const EC_I2C_STATUS_NAK = (1 << 0)     /* Transfer was not acknowledged */
-const EC_I2C_STATUS_TIMEOUT = (1 << 1) /* Timeout during transfer */
+const ecI2cStatusNak = (1 << 0)     /* Transfer was not acknowledged */
+const ecI2cStatusTimeout = (1 << 1) /* Timeout during transfer */
 
 /* Any error */
-const EC_I2C_STATUS_ERROR = (EC_I2C_STATUS_NAK | EC_I2C_STATUS_TIMEOUT)
+const ecI2cStatusError = (ecI2cStatusNak | ecI2cStatusTimeout)
 
 /* TYPE */
-type ec_params_i2c_passthru_msg struct {
-	addr_flags uint16 /* I2C slave address (7 or 10 bits) and flags */
-	len        uint16 /* Number of bytes to read or write */
+type ecParamsI2cPassthruMsg struct {
+	addrFlags uint16 /* I2C slave address (7 or 10 bits) and flags */
+	len       uint16 /* Number of bytes to read or write */
 }
 
 /* TYPE */
-type ec_params_i2c_passthru struct {
-	port     uint8 /* I2C port number */
-	num_msgs uint8 /* Number of messages */
-	msg      []ec_params_i2c_passthru_msg
+type ecParamsI2cPassthru struct {
+	port    uint8 /* I2C port number */
+	numMsgs uint8 /* Number of messages */
+	msg     []ecParamsI2cPassthruMsg
 	/* Data to write for all messages is concatenated here */
 }
 
 /* TYPE */
-type ec_response_i2c_passthru struct {
-	i2c_status uint8   /* Status flags (EC_I2C_STATUS_...) */
-	num_msgs   uint8   /* Number of messages processed */
-	data       []uint8 /* Data read by messages concatenated here */
+type ecResponseI2cPassthru struct {
+	i2cStatus uint8   /* Status flags (ecI2cStatus_...) */
+	numMsgs   uint8   /* Number of messages processed */
+	data      []uint8 /* Data read by messages concatenated here */
 }
 
 /*****************************************************************************/
 /* Power button hang detect */
 
-const EC_CMD_HANG_DETECT = 0x9f
+const ecCmdHangDetect = 0x9f
 
 /* Reasons to start hang detection timer */
 /* Power button pressed */
-const EC_HANG_START_ON_POWER_PRESS = (1 << 0)
+const ecHangStartOnPowerPress = (1 << 0)
 
 /* Lid closed */
-const EC_HANG_START_ON_LID_CLOSE = (1 << 1)
+const ecHangStartOnLidClose = (1 << 1)
 
 /* Lid opened */
-const EC_HANG_START_ON_LID_OPEN = (1 << 2)
+const ecHangStartOnLidOpen = (1 << 2)
 
 /* Start of AP S3->S0 transition (booting or resuming from suspend) */
-const EC_HANG_START_ON_RESUME = (1 << 3)
+const ecHangStartOnResume = (1 << 3)
 
 /* Reasons to cancel hang detection */
 
 /* Power button released */
-const EC_HANG_STOP_ON_POWER_RELEASE = (1 << 8)
+const ecHangStopOnPowerRelease = (1 << 8)
 
 /* Any host command from AP received */
-const EC_HANG_STOP_ON_HOST_COMMAND = (1 << 9)
+const ecHangStopOnHostCommand = (1 << 9)
 
 /* Stop on end of AP S0->S3 transition (suspending or shutting down) */
-const EC_HANG_STOP_ON_SUSPEND = (1 << 10)
+const ecHangStopOnSuspend = (1 << 10)
 
 /*
  * If this flag is set, all the other fields are ignored, and the hang detect
@@ -2651,25 +2651,25 @@ const EC_HANG_STOP_ON_SUSPEND = (1 << 10)
  * without reconfiguring any of the other hang detect settings.  Note that
  * you must previously have configured the timeouts.
  */
-const EC_HANG_START_NOW = (1 << 30)
+const ecHangStartNow = (1 << 30)
 
 /*
  * If this flag is set, all the other fields are ignored (including
- * EC_HANG_START_NOW).  This provides the AP a way to stop the hang timer
+ * ecHangStartNow).  This provides the AP a way to stop the hang timer
  * without reconfiguring any of the other hang detect settings.
  */
-const EC_HANG_STOP_NOW = (1 << 31)
+const ecHangStopNow = (1 << 31)
 
 /* TYPE */
-type ec_params_hang_detect struct {
-	/* Flags; see EC_HANG_* */
+type ecParamsHangDetect struct {
+	/* Flags; see ecHang_* */
 	flags uint32
 
 	/* Timeout in msec before generating host event, if enabled */
-	host_eventimeout_msec uint16
+	hostEventimeoutMsec uint16
 
 	/* Timeout in msec before generating warm reboot, if enabled */
-	warm_rebootimeout_msec uint16
+	warmRebootimeoutMsec uint16
 }
 
 /*****************************************************************************/
@@ -2679,78 +2679,78 @@ type ec_params_hang_detect struct {
  * This is the single catch-all host command to exchange data regarding the
  * charge state machine (v2 and up).
  */
-const EC_CMD_CHARGE_STATE = 0xa0
+const ecCmdChargeState = 0xa0
 
 /* Subcommands for this host command */
-type charge_state_command uint8
+type chargeStateCommand uint8
 
 const (
-	CHARGE_STATE_CMD_GET_STATE charge_state_command = iota
-	CHARGE_STATE_CMD_GET_PARAM
-	CHARGE_STATE_CMD_SET_PARAM
-	CHARGE_STATE_NUM_CMDS
+	chargeStateCmdGetState chargeStateCommand = iota
+	chargeStateCmdGetParam
+	chargeStateCmdSetParam
+	chargeStateNumCmds
 )
 
 /*
  * Known param numbers are defined here. Ranges are reserved for board-specific
  * params, which are handled by the particular implementations.
  */
-type charge_state_params uint8
+type chargeStateParams uint8
 
 const (
-	CS_PARAM_CHG_VOLTAGE       charge_state_params = iota /* charger voltage limit */
-	CS_PARAM_CHG_CURRENT                                  /* charger current limit */
-	CS_PARAM_CHG_INPUT_CURRENT                            /* charger input current limit */
-	CS_PARAM_CHG_STATUS                                   /* charger-specific status */
-	CS_PARAM_CHG_OPTION                                   /* charger-specific options */
+	csParamChgVoltage      chargeStateParams = iota /* charger voltage limit */
+	csParamChgCurrent                               /* charger current limit */
+	csParamChgInputCurrent                          /* charger input current limit */
+	csParamChgStatus                                /* charger-specific status */
+	csParamChgOption                                /* charger-specific options */
 	/* How many so far? */
-	CS_NUM_BASE_PARAMS
+	csNumBaseParams
 
-	/* Range for CONFIG_CHARGER_PROFILE_OVERRIDE params */
-	CS_PARAM_CUSTOM_PROFILE_MIN = 0x10000
-	CS_PARAM_CUSTOM_PROFILE_MAX = 0x1ffff
+	/* Range for CONFIGChargerProfileOverride params */
+	csParamCustomProfileMin = 0x10000
+	csParamCustomProfileMax = 0x1ffff
 
 	/* Other custom param ranges go here... */
 )
 
 /* TYPE */
 /* ler
-type ec_params_charge_state struct {
-cmd uint8				/* enum charge_state_command * /
+type ecParamsChargeState struct {
+cmd uint8				/* enum chargeStateCommand * /
 	union {
 		struct {
 			/* no args * /
-		} get_state;
+		} getState;
 
 		struct {
-		uint32 param;		/* enum charge_state_param * /
-		} get_param;
+		uint32 param;		/* enum chargeStateParam * /
+		} getParam;
 
 		struct {
 		uint32 param;		/* param to set * /
 		uint32 value;		/* value to set * /
-		} set_param;
+		} setParam;
 	};
 } ;
 
 /* TYPE */
 /* later
-type ec_response_charge_state struct {
+type ecResponseChargeState struct {
 	union {
 		struct {
 			int ac;
-			int chg_voltage;
-			int chg_current;
-			int chg_input_current;
-			int batt_state_of_charge;
-		} get_state;
+			int chgVoltage;
+			int chgCurrent;
+			int chgInputCurrent;
+			int battStateOfCharge;
+		} getState;
 
 		struct {
 		uint32 value;
-		} get_param;
+		} getParam;
 		struct {
 			/* no return values *
-		} set_param;
+		} setParam;
 	};
 } ;
 */
@@ -2758,20 +2758,20 @@ type ec_response_charge_state struct {
 /*
  * Set maximum battery charging current.
  */
-const EC_CMD_CHARGE_CURRENT_LIMIT = 0xa1
+const ecCmdChargeCurrentLimit = 0xa1
 
 /* TYPE */
-type ec_params_current_limit struct {
+type ecParamsCurrentLimit struct {
 	limit uint32 /* in mA */
 }
 
 /*
  * Set maximum external power current.
  */
-const EC_CMD_EXT_POWER_CURRENT_LIMIT = 0xa2
+const ecCmdExtPowerCurrentLimit = 0xa2
 
 /* TYPE */
-type ec_params_ext_power_current_limit struct {
+type ecParamsExtPowerCurrentLimit struct {
 	limit uint32 /* in mA */
 }
 
@@ -2779,38 +2779,38 @@ type ec_params_ext_power_current_limit struct {
 /* Smart battery pass-through */
 
 /* Get / Set 16-bit smart battery registers */
-const EC_CMD_SB_READ_WORD = 0xb0
-const EC_CMD_SB_WRITE_WORD = 0xb1
+const ecCmdSbReadWord = 0xb0
+const ecCmdSbWriteWord = 0xb1
 
 /* Get / Set string smart battery parameters
  * formatted as SMBUS "block".
  */
-const EC_CMD_SB_READ_BLOCK = 0xb2
-const EC_CMD_SB_WRITE_BLOCK = 0xb3
+const ecCmdSbReadBlock = 0xb2
+const ecCmdSbWriteBlock = 0xb3
 
 /* TYPE */
-type ec_params_sb_rd struct {
+type ecParamsSbRd struct {
 	reg uint8
 }
 
 /* TYPE */
-type ec_response_sb_rd_word struct {
+type ecResponseSbRdWord struct {
 	value uint16
 }
 
 /* TYPE */
-type ec_params_sb_wr_word struct {
+type ecParamsSbWrWord struct {
 	reg   uint8
 	value uint16
 }
 
 /* TYPE */
-type ec_response_sb_rd_block struct {
+type ecResponseSbRdBlock struct {
 	data [32]uint8
 }
 
 /* TYPE */
-type ec_params_sb_wr_block struct {
+type ecParamsSbWrBlock struct {
 	reg  uint8
 	data [32]uint16
 }
@@ -2824,24 +2824,24 @@ type ec_params_sb_wr_block struct {
  * requested value.
  */
 
-const EC_CMD_BATTERY_VENDOR_PARAM = 0xb4
+const ecCmdBatteryVendorParam = 0xb4
 
-type ec_battery_vendor_param_mode uint8
+type ecBatteryVendorParamMode uint8
 
 const (
-	BATTERY_VENDOR_PARAM_MODE_GET ec_battery_vendor_param_mode = 0
-	BATTERY_VENDOR_PARAM_MODE_SET
+	batteryVendorParamModeGet ecBatteryVendorParamMode = 0
+	batteryVendorParamModeSet
 )
 
 /* TYPE */
-type ec_params_battery_vendor_param struct {
+type ecParamsBatteryVendorParam struct {
 	param uint32
 	value uint32
 	mode  uint8
 }
 
 /* TYPE */
-type ec_response_battery_vendor_param struct {
+type ecResponseBatteryVendorParam struct {
 	value uint32
 }
 
@@ -2849,70 +2849,70 @@ type ec_response_battery_vendor_param struct {
 /*
  * Smart Battery Firmware Update Commands
  */
-const EC_CMD_SB_FW_UPDATE = 0xb5
+const ecCmdSbFwUpdate = 0xb5
 
-type ec_sb_fw_update_subcmd uint8
+type ecSbFwUpdateSubcmd uint8
 
 const (
-	EC_SB_FW_UPDATE_PREPARE ec_sb_fw_update_subcmd = 0x0
-	EC_SB_FW_UPDATE_INFO                           = 0x1 /*query sb info */
-	EC_SB_FW_UPDATE_BEGIN                          = 0x2 /*check if protected */
-	EC_SB_FW_UPDATE_WRITE                          = 0x3 /*check if protected */
-	EC_SB_FW_UPDATE_END                            = 0x4
-	EC_SB_FW_UPDATE_STATUS                         = 0x5
-	EC_SB_FW_UPDATE_PROTECT                        = 0x6
-	EC_SB_FW_UPDATE_MAX                            = 0x7
+	ecSbFwUpdatePrepare ecSbFwUpdateSubcmd = 0x0
+	ecSbFwUpdateInfo                       = 0x1 /*query sb info */
+	ecSbFwUpdateBegin                      = 0x2 /*check if protected */
+	ecSbFwUpdateWrite                      = 0x3 /*check if protected */
+	ecSbFwUpdateEnd                        = 0x4
+	ecSbFwUpdateStatus                     = 0x5
+	ecSbFwUpdateProtect                    = 0x6
+	ecSbFwUpdateMax                        = 0x7
 )
 
-const SB_FW_UPDATE_CMD_WRITE_BLOCK_SIZE = 32
-const SB_FW_UPDATE_CMD_STATUS_SIZE = 2
-const SB_FW_UPDATE_CMD_INFO_SIZE = 8
+const sbFwUpdateCmdWriteBlockSize = 32
+const sbFwUpdateCmdStatusSize = 2
+const sbFwUpdateCmdInfoSize = 8
 
 /* TYPE */
-type ec_sb_fw_update_header struct {
-	subcmd uint16 /* enum ec_sb_fw_update_subcmd */
-	fw_id  uint16 /* firmware id */
+type ecSbFwUpdateHeader struct {
+	subcmd uint16 /* enum ecSbFwUpdateSubcmd */
+	fwID   uint16 /* firmware id */
 }
 
 /* TYPE */
-type ec_params_sb_fw_update struct {
-	hdr ec_sb_fw_update_header
+type ecParamsSbFwUpdate struct {
+	hdr ecSbFwUpdateHeader
 	/* no args. */
-	/* EC_SB_FW_UPDATE_PREPARE  = 0x0 */
-	/* EC_SB_FW_UPDATE_INFO     = 0x1 */
-	/* EC_SB_FW_UPDATE_BEGIN    = 0x2 */
-	/* EC_SB_FW_UPDATE_END      = 0x4 */
-	/* EC_SB_FW_UPDATE_STATUS   = 0x5 */
-	/* EC_SB_FW_UPDATE_PROTECT  = 0x6 */
+	/* ecSbFwUpdatePrepare  = 0x0 */
+	/* ecSbFwUpdateInfo     = 0x1 */
+	/* ecSbFwUpdateBegin    = 0x2 */
+	/* ecSbFwUpdateEnd      = 0x4 */
+	/* ecSbFwUpdateStatus   = 0x5 */
+	/* ecSbFwUpdateProtect  = 0x6 */
 	/* or ... */
-	/* EC_SB_FW_UPDATE_WRITE    = 0x3 */
-	data [SB_FW_UPDATE_CMD_WRITE_BLOCK_SIZE]uint8
+	/* ecSbFwUpdateWrite    = 0x3 */
+	data [sbFwUpdateCmdWriteBlockSize]uint8
 }
 
 /* TYPE */
-type ec_response_sb_fw_update struct {
+type ecResponseSbFwUpdate struct {
 	data []uint8
-	/* EC_SB_FW_UPDATE_INFO     = 0x1 */
-	//uint8 data[SB_FW_UPDATE_CMD_INFO_SIZE];
-	/* EC_SB_FW_UPDATE_STATUS   = 0x5 */
-	//uint8 data[SB_FW_UPDATE_CMD_STATUS_SIZE];
+	/* ecSbFwUpdateInfo     = 0x1 */
+	//uint8 data[SBFwUpdateCmdInfoSize];
+	/* ecSbFwUpdateStatus   = 0x5 */
+	//uint8 data[SBFwUpdateCmdStatusSize];
 }
 
 /*
  * Entering Verified Boot Mode Command
- * Default mode is VBOOT_MODE_NORMAL if EC did not receive this command.
+ * Default mode is VBOOTModeNormal if EC did not receive this command.
  * Valid Modes are: normal, developer, and recovery.
  */
-const EC_CMD_ENTERING_MODE = 0xb6
+const ecCmdEnteringMode = 0xb6
 
 /* TYPE */
-type ec_params_entering_mode struct {
-	vboot_mode int
+type ecParamsEnteringMode struct {
+	vbootMode int
 }
 
-const VBOOT_MODE_NORMAL = 0
-const VBOOT_MODE_DEVELOPER = 1
-const VBOOT_MODE_RECOVERY = 2
+const vbootModeNormal = 0
+const vbootModeDeveloper = 1
+const vbootModeRecovery = 2
 
 /*****************************************************************************/
 /* System commands */
@@ -2921,29 +2921,29 @@ const VBOOT_MODE_RECOVERY = 2
  * TODO(crosbug.com/p/23747): This is a confusing name, since it doesn't
  * necessarily reboot the EC.  Rename to "image" or something similar?
  */
-const EC_CMD_REBOOT_EC = 0xd2
+const ecCmdRebootEc = 0xd2
 
 /* Command */
-type ec_reboot_cmd uint8
+type ecRebootCmd uint8
 
 const (
-	EC_REBOOT_CANCEL  ec_reboot_cmd = 0 /* Cancel a pending reboot */
-	EC_REBOOT_JUMP_RO               = 1 /* Jump to RO without rebooting */
-	EC_REBOOT_JUMP_RW               = 2 /* Jump to RW without rebooting */
+	ecRebootCancel ecRebootCmd = 0 /* Cancel a pending reboot */
+	ecRebootJumpRo             = 1 /* Jump to RO without rebooting */
+	ecRebootJumpRw             = 2 /* Jump to RW without rebooting */
 	/* (command 3 was jump to RW-B) */
-	EC_REBOOT_COLD         = 4 /* Cold-reboot */
-	EC_REBOOT_DISABLE_JUMP = 5 /* Disable jump until next reboot */
-	EC_REBOOT_HIBERNATE    = 6 /* Hibernate EC */
+	ecRebootCold        = 4 /* Cold-reboot */
+	ecRebootDisableJump = 5 /* Disable jump until next reboot */
+	ecRebootHibernate   = 6 /* Hibernate EC */
 )
 
-/* Flags for ec_params_reboot_ec.reboot_flags */
-const EC_REBOOT_FLAG_RESERVED0 = (1 << 0)      /* Was recovery request */
-const EC_REBOOT_FLAG_ON_AP_SHUTDOWN = (1 << 1) /* Reboot after AP shutdown */
+/* Flags for ecParamsRebootEc.rebootFlags */
+const ecRebootFlagReserved0 = (1 << 0)    /* Was recovery request */
+const ecRebootFlagOnApShutdown = (1 << 1) /* Reboot after AP shutdown */
 
 /* TYPE */
-type ec_params_reboot_ec struct {
-	cmd   uint8 /* enum ec_reboot_cmd */
-	flags uint8 /* See EC_REBOOT_FLAG_* */
+type ecParamsRebootEc struct {
+	cmd   uint8 /* enum ecRebootCmd */
+	flags uint8 /* See ecRebootFlag_* */
 }
 
 /*
@@ -2952,7 +2952,7 @@ type ec_params_reboot_ec struct {
  * Returns variable-length platform-dependent panic information.  See panic.h
  * for details.
  */
-const EC_CMD_GET_PANIC_INFO = 0xd3
+const ecCmdGetPanicInfo = 0xd3
 
 /*****************************************************************************/
 /*
@@ -2969,18 +2969,18 @@ const EC_CMD_GET_PANIC_INFO = 0xd3
  * reboot command is processed at interrupt level.  Note that when the EC
  * reboots, the host will reboot too, so there is no response to this command.
  *
- * Use EC_CMD_REBOOT_EC to reboot the EC more politely.
+ * Use ecCmdRebootEc to reboot the EC more politely.
  */
-const EC_CMD_REBOOT = 0xd1 /* Think "die" */
+const ecCmdReboot = 0xd1 /* Think "die" */
 
 /*
  * Resend last response (not supported on LPC).
  *
- * Returns EC_RES_UNAVAILABLE if there is no response available - for example
+ * Returns ecResUnavailable if there is no response available - for example
  * there was no previous command, or the previous command's response was too
  * big to save.
  */
-const EC_CMD_RESEND_RESPONSE = 0xdb
+const ecCmdResendResponse = 0xdb
 
 /*
  * This header byte on a command indicate version 0. Any header byte less
@@ -2988,11 +2988,11 @@ const EC_CMD_RESEND_RESPONSE = 0xdb
  * versioning. In that case, we assume version 0.
  *
  * Header bytes greater than this indicate a later version. For example
- * EC_CMD_VERSION0 + 1 means we are using version 1.
+ * ecCmdVersion0 + 1 means we are using version 1.
  *
  * The old EC interface must not use commands 0xdc or higher.
  */
-const EC_CMD_VERSION0 = 0xdc
+const ecCmdVersion0 = 0xdc
 
 /*****************************************************************************/
 /*
@@ -3002,83 +3002,83 @@ const EC_CMD_VERSION0 = 0xdc
  */
 
 /* EC to PD MCU exchange status command */
-const EC_CMD_PD_EXCHANGE_STATUS = 0x100
+const ecCmdPdExchangeStatus = 0x100
 
-type pd_charge_state uint8
+type pdChargeState uint8
 
 const (
-	PD_CHARGE_NO_CHANGE pd_charge_state = 0 /* Don't change charge state */
-	PD_CHARGE_NONE                          /* No charging allowed */
-	PD_CHARGE_5V                            /* 5V charging only */
-	PD_CHARGE_MAX                           /* Charge at max voltage */
+	pdChargeNoChange pdChargeState = 0 /* Don't change charge state */
+	pdChargeNone                       /* No charging allowed */
+	pdCharge5v                         /* 5V charging only */
+	pdChargeMax                        /* Charge at max voltage */
 )
 
 /* TYPE */
 /* Status of EC being sent to PD */
-type ec_params_pd_status struct {
-	batt_soc     int8  /* battery state of charge */
-	charge_state uint8 /* charging state (from enum pd_charge_state) */
+type ecParamsPdStatus struct {
+	battSoc     int8  /* battery state of charge */
+	chargeState uint8 /* charging state (from enum pdChargeState) */
 }
 
 /* Status of PD being sent back to EC */
-const PD_STATUS_HOST_EVENT = (1 << 0)      /* Forward host event to AP */
-const PD_STATUS_IN_RW = (1 << 1)           /* Running RW image */
-const PD_STATUS_JUMPED_TO_IMAGE = (1 << 2) /* Current image was jumped to */
+const pdStatusHostEvent = (1 << 0)     /* Forward host event to AP */
+const pdStatusInRw = (1 << 1)          /* Running RW image */
+const pdStatusJumpedToImage = (1 << 2) /* Current image was jumped to */
 /* TYPE */
-type ec_response_pd_status struct {
-	status             uint32 /* PD MCU status */
-	curr_lim_ma        uint32 /* input current limit */
-	active_charge_port int32  /* active charging port */
+type ecResponsePdStatus struct {
+	status           uint32 /* PD MCU status */
+	currLimMa        uint32 /* input current limit */
+	activeChargePort int32  /* active charging port */
 }
 
 /* AP to PD MCU host event status command, cleared on read */
-const EC_CMD_PD_HOST_EVENT_STATUS = 0x104
+const ecCmdPdHostEventStatus = 0x104
 
 /* PD MCU host event status bits */
-const PD_EVENT_UPDATE_DEVICE = (1 << 0)
-const PD_EVENT_POWER_CHANGE = (1 << 1)
-const PD_EVENT_IDENTITY_RECEIVED = (1 << 2)
+const pdEventUpdateDevice = (1 << 0)
+const pdEventPowerChange = (1 << 1)
+const pdEventIdentityReceived = (1 << 2)
 
 /* TYPE */
-type ec_response_host_event_status struct {
+type ecResponseHostEventStatus struct {
 	status uint32 /* PD MCU host event status */
 }
 
 /* Set USB type-C port role and muxes */
-const EC_CMD_USB_PD_CONTROL = 0x101
+const ecCmdUsbPdControl = 0x101
 
-type usb_pd_control_role uint8
+type usbPdControlRole uint8
 
 const (
-	USB_PD_CTRL_ROLE_NO_CHANGE    usb_pd_control_role = 0
-	USB_PD_CTRL_ROLE_TOGGLE_ON                        = 1 /* == AUTO */
-	USB_PD_CTRL_ROLE_TOGGLE_OFF                       = 2
-	USB_PD_CTRL_ROLE_FORCE_SINK                       = 3
-	USB_PD_CTRL_ROLE_FORCE_SOURCE                     = 4
-	USB_PD_CTRL_ROLE_COUNT
+	usbPdCtrlRoleNoChange    usbPdControlRole = 0
+	usbPdCtrlRoleToggleOn                     = 1 /* == AUTO */
+	usbPdCtrlRoleToggleOff                    = 2
+	usbPdCtrlRoleForceSink                    = 3
+	usbPdCtrlRoleForceSource                  = 4
+	usbPdCtrlRoleCount
 )
 
-type usb_pd_control_mux uint8
+type usbPdControlMux uint8
 
 const (
-	USB_PD_CTRL_MUX_NO_CHANGE usb_pd_control_mux = 0
-	USB_PD_CTRL_MUX_NONE                         = 1
-	USB_PD_CTRL_MUX_USB                          = 2
-	USB_PD_CTRL_MUX_DP                           = 3
-	USB_PD_CTRL_MUX_DOCK                         = 4
-	USB_PD_CTRL_MUX_AUTO                         = 5
-	USB_PD_CTRL_MUX_COUNT
+	usbPdCtrlMuxNoChange usbPdControlMux = 0
+	usbPdCtrlMuxNone                     = 1
+	usbPdCtrlMuxUsb                      = 2
+	usbPdCtrlMuxDp                       = 3
+	usbPdCtrlMuxDock                     = 4
+	usbPdCtrlMuxAuto                     = 5
+	usbPdCtrlMuxCount
 )
 
 /* TYPE */
-type ec_params_usb_pd_control struct {
+type ecParamsUsbPdControl struct {
 	port uint8
 	role uint8
 	mux  uint8
 }
 
 /* TYPE */
-type ec_response_usb_pd_control struct {
+type ecResponseUsbPdControl struct {
 	enabled  uint8
 	role     uint8
 	polarity uint8
@@ -3086,294 +3086,294 @@ type ec_response_usb_pd_control struct {
 }
 
 /* TYPE */
-type ec_response_usb_pd_control_v1 struct {
+type ecResponseUsbPdControlV1 struct {
 	enabled  uint8
 	role     uint8 /* [0] power: 0=SNK/1=SRC [1] data: 0=UFP/1=DFP */
 	polarity uint8
 	state    [32]byte
 }
 
-const EC_CMD_USB_PD_PORTS = 0x102
+const ecCmdUsbPdPorts = 0x102
 
 /* TYPE */
-type ec_response_usb_pd_ports struct {
-	num_ports uint8
+type ecResponseUsbPdPorts struct {
+	numPorts uint8
 }
 
-const EC_CMD_USB_PD_POWER_INFO = 0x103
+const ecCmdUsbPdPowerInfo = 0x103
 
-const PD_POWER_CHARGING_PORT = 0xff
+const pdPowerChargingPort = 0xff
 
 /* TYPE */
-type ec_params_usb_pd_power_info struct {
+type ecParamsUsbPdPowerInfo struct {
 	port uint8
 }
 
-type usb_chg_type uint8
+type usbChgType uint8
 
 const (
-	USB_CHG_TYPE_NONE usb_chg_type = iota
-	USB_CHG_TYPE_PD
-	USB_CHG_TYPE_C
-	USB_CHG_TYPE_PROPRIETARY
-	USB_CHG_TYPE_BC12_DCP
-	USB_CHG_TYPE_BC12_CDP
-	USB_CHG_TYPE_BC12_SDP
-	USB_CHG_TYPE_OTHER
-	USB_CHG_TYPE_VBUS
-	USB_CHG_TYPE_UNKNOWN
+	usbChgTypeNone usbChgType = iota
+	usbChgTypePd
+	usbChgTypeC
+	usbChgTypeProprietary
+	usbChgTypeBc12Dcp
+	usbChgTypeBc12Cdp
+	usbChgTypeBc12Sdp
+	usbChgTypeOther
+	usbChgTypeVbus
+	usbChgTypeUnknown
 )
 
-type usb_power_roles uint8
+type usbPowerRoles uint8
 
 const (
-	USB_PD_PORT_POWER_DISCONNECTED usb_power_roles = iota
-	USB_PD_PORT_POWER_SOURCE
-	USB_PD_PORT_POWER_SINK
-	USB_PD_PORT_POWER_SINK_NOT_CHARGING
+	usbPdPortPowerDisconnected usbPowerRoles = iota
+	usbPdPortPowerSource
+	usbPdPortPowerSink
+	usbPdPortPowerSinkNotCharging
 )
 
 /* TYPE */
-type usb_chg_measures struct {
-	voltage_max uint16
-	voltage_now uint16
-	current_max uint16
-	current_lim uint16
+type usbChgMeasures struct {
+	voltageMax uint16
+	voltageNow uint16
+	currentMax uint16
+	currentLim uint16
 }
 
 /* TYPE */
-type ec_response_usb_pd_power_info struct {
+type ecResponseUsbPdPowerInfo struct {
 	role      uint8
 	etype     uint8
 	dualrole  uint8
 	reserved1 uint8
-	meas      usb_chg_measures
-	max_power uint32
+	meas      usbChgMeasures
+	maxPower  uint32
 }
 
 /* Write USB-PD device FW */
-const EC_CMD_USB_PD_FW_UPDATE = 0x110
+const ecCmdUsbPdFwUpdate = 0x110
 
-type usb_pd_fw_update_cmds uint8
+type usbPdFwUpdateCmds uint8
 
 const (
-	USB_PD_FW_REBOOT usb_pd_fw_update_cmds = iota
-	USB_PD_FW_FLASH_ERASE
-	USB_PD_FW_FLASH_WRITE
-	USB_PD_FW_ERASE_SIG
+	usbPdFwReboot usbPdFwUpdateCmds = iota
+	usbPdFwFlashErase
+	usbPdFwFlashWrite
+	usbPdFwEraseSig
 )
 
 /* TYPE */
-type ec_params_usb_pd_fw_update struct {
-	dev_id uint16
-	cmd    uint8
-	port   uint8
-	size   uint32 /* Size to write in bytes */
+type ecParamsUsbPdFwUpdate struct {
+	devID uint16
+	cmd   uint8
+	port  uint8
+	size  uint32 /* Size to write in bytes */
 	/* Followed by data to write */
 }
 
-/* Write USB-PD Accessory RW_HASH table entry */
-const EC_CMD_USB_PD_RW_HASH_ENTRY = 0x111
+/* Write USB-PD Accessory RWHash table entry */
+const ecCmdUsbPdRwHashEntry = 0x111
 
 /* RW hash is first 20 bytes of SHA-256 of RW section */
-const PD_RW_HASH_SIZE = 20
+const pdRwHashSize = 20
 
 /* TYPE */
-type ec_params_usb_pd_rw_hash_entry struct {
-	dev_id        uint16
-	dev_rw_hash   [PD_RW_HASH_SIZE]uint8
-	reserved      uint8  /* For alignment of current_image */
-	current_image uint32 /* One of ec_current_image */
+type ecParamsUsbPdRwHashEntry struct {
+	devID        uint16
+	devRwHash    [pdRwHashSize]uint8
+	reserved     uint8  /* For alignment of currentImage */
+	currentImage uint32 /* One of ecCurrentImage */
 }
 
 /* Read USB-PD Accessory info */
-const EC_CMD_USB_PD_DEV_INFO = 0x112
+const ecCmdUsbPdDevInfo = 0x112
 
 /* TYPE */
-type ec_params_usb_pd_info_request struct {
+type ecParamsUsbPdInfoRequest struct {
 	port uint8
 }
 
 /* Read USB-PD Device discovery info */
-const EC_CMD_USB_PD_DISCOVERY = 0x113
+const ecCmdUsbPdDiscovery = 0x113
 
 /* TYPE */
-type ec_params_usb_pd_discovery_entry struct {
+type ecParamsUsbPdDiscoveryEntry struct {
 	vid   uint16 /* USB-IF VID */
 	pid   uint16 /* USB-IF PID */
 	ptype uint8  /* product type (hub,periph,cable,ama) */
 }
 
 /* Override default charge behavior */
-const EC_CMD_PD_CHARGE_PORT_OVERRIDE = 0x114
+const ecCmdPdChargePortOverride = 0x114
 
 /* Negative port parameters have special meaning */
-type usb_pd_override_ports int8
+type usbPdOverridePorts int8
 
 const (
-	OVERRIDE_DONT_CHARGE usb_pd_override_ports = -2
-	OVERRIDE_OFF                               = -1
-	/* [0, PD_PORT_COUNT): Port# */
+	overrideDontCharge usbPdOverridePorts = -2
+	overrideOff                           = -1
+	/* [0, pdPortCount): Port# */
 )
 
 /* TYPE */
-type ec_params_charge_port_override struct {
-	override_port int16 /* Override port# */
+type ecParamsChargePortOverride struct {
+	overridePort int16 /* Override port# */
 }
 
 /* Read (and delete) one entry of PD event log */
-const EC_CMD_PD_GET_LOG_ENTRY = 0x115
+const ecCmdPdGetLogEntry = 0x115
 
 /* TYPE */
-type ec_response_pd_log struct {
+type ecResponsePdLog struct {
 	timestamp uint32  /* relative timestamp in milliseconds */
-	etype     uint8   /* event type : see PD_EVENT_xx below */
-	size_port uint8   /* [7:5] port number [4:0] payload size in bytes */
+	etype     uint8   /* event type : see pdEventXx below */
+	sizePort  uint8   /* [7:5] port number [4:0] payload size in bytes */
 	data      uint16  /* type-defined data payload */
 	payload   []uint8 /* optional additional data payload: 0..16 bytes */
 }
 
 /* The timestamp is the microsecond counter shifted to get about a ms. */
-const PD_LOG_TIMESTAMP_SHIFT = 10 /* 1 LSB = 1024us */
+const pdLogTimestampShift = 10 /* 1 LSB = 1024us */
 
-const PD_LOG_SIZE_MASK = 0x1F
-const PD_LOG_PORT_MASK = 0xE0
-const PD_LOG_PORT_SHIFT = 5
+const pdLogSizeMask = 0x1F
+const pdLogPortMask = 0xE0
+const pdLogPortShift = 5
 
-func pd_log_port_size(port, size uint8) uint8 {
-	return (port << PD_LOG_PORT_SHIFT) | (size & PD_LOG_SIZE_MASK)
+func pdLogPortSize(port, size uint8) uint8 {
+	return (port << pdLogPortShift) | (size & pdLogSizeMask)
 }
 
-func pd_log_port(size_port uint8) uint8 {
-	return size_port >> PD_LOG_PORT_SHIFT
+func pdLogPort(sizePort uint8) uint8 {
+	return sizePort >> pdLogPortShift
 }
-func pd_log_size(size_port uint8) uint8 {
-	return size_port & PD_LOG_SIZE_MASK
+func pdLogSize(sizePort uint8) uint8 {
+	return sizePort & pdLogSizeMask
 }
 
 /* PD event log : entry types */
 /* PD MCU events */
-const PD_EVENT_MCU_BASE = 0x00
-const PD_EVENT_MCU_CHARGE = (PD_EVENT_MCU_BASE + 0)
-const PD_EVENT_MCU_CONNECT = (PD_EVENT_MCU_BASE + 1)
+const pdEventMcuBase = 0x00
+const pdEventMcuCharge = (pdEventMcuBase + 0)
+const pdEventMcuConnect = (pdEventMcuBase + 1)
 
 /* Reserved for custom board event */
-const PD_EVENT_MCU_BOARD_CUSTOM = (PD_EVENT_MCU_BASE + 2)
+const pdEventMcuBoardCustom = (pdEventMcuBase + 2)
 
 /* PD generic accessory events */
-const PD_EVENT_ACC_BASE = 0x20
-const PD_EVENT_ACC_RW_FAIL = (PD_EVENT_ACC_BASE + 0)
-const PD_EVENT_ACC_RW_ERASE = (PD_EVENT_ACC_BASE + 1)
+const pdEventAccBase = 0x20
+const pdEventAccRwFail = (pdEventAccBase + 0)
+const pdEventAccRwErase = (pdEventAccBase + 1)
 
 /* PD power supply events */
-const PD_EVENT_PS_BASE = 0x40
-const PD_EVENT_PS_FAULT = (PD_EVENT_PS_BASE + 0)
+const pdEventPsBase = 0x40
+const pdEventPsFault = (pdEventPsBase + 0)
 
 /* PD video dongles events */
-const PD_EVENT_VIDEO_BASE = 0x60
-const PD_EVENT_VIDEO_DP_MODE = (PD_EVENT_VIDEO_BASE + 0)
-const PD_EVENT_VIDEO_CODEC = (PD_EVENT_VIDEO_BASE + 1)
+const pdEventVideoBase = 0x60
+const pdEventVideoDpMode = (pdEventVideoBase + 0)
+const pdEventVideoCodec = (pdEventVideoBase + 1)
 
 /* Returned in the "type" field, when there is no entry available */
-const PD_EVENT_NO_ENTRY = 0xFF
+const pdEventNoEntry = 0xFF
 
 /*
- * PD_EVENT_MCU_CHARGE event definition :
- * the payload is "struct usb_chg_measures"
+ * pdEventMcuCharge event definition :
+ * the payload is "struct usbChgMeasures"
  * the data field contains the port state flags as defined below :
  */
 /* Port partner is a dual role device */
-const CHARGE_FLAGS_DUAL_ROLE = (1 << 15)
+const chargeFlagsDualRole = (1 << 15)
 
 /* Port is the pending override port */
-const CHARGE_FLAGS_DELAYED_OVERRIDE = (1 << 14)
+const chargeFlagsDelayedOverride = (1 << 14)
 
 /* Port is the override port */
-const CHARGE_FLAGS_OVERRIDE = (1 << 13)
+const chargeFlagsOverride = (1 << 13)
 
 /* Charger type */
-const CHARGE_FLAGS_TYPE_SHIFT = 3
-const CHARGE_FLAGS_TYPE_MASK = (0xF << CHARGE_FLAGS_TYPE_SHIFT)
+const chargeFlagsTypeShift = 3
+const chargeFlagsTypeMask = (0xF << chargeFlagsTypeShift)
 
 /* Power delivery role */
-const CHARGE_FLAGS_ROLE_MASK = (7 << 0)
+const chargeFlagsRoleMask = (7 << 0)
 
 /*
- * PD_EVENT_PS_FAULT data field flags definition :
+ * pdEventPsFault data field flags definition :
  */
-const PS_FAULT_OCP = 1
-const PS_FAULT_FAST_OCP = 2
-const PS_FAULT_OVP = 3
-const PS_FAULT_DISCH = 4
+const psFaultOcp = 1
+const psFaultFastOcp = 2
+const psFaultOvp = 3
+const psFaultDisch = 4
 
 /* TYPE */
 /*
- * PD_EVENT_VIDEO_CODEC payload is "struct mcdp_info".
+ * pdEventVideoCodec payload is "struct mcdpInfo".
  */
-type mcdp_version struct {
+type mcdpVersion struct {
 	major uint8
 	minor uint8
 	build uint16
 }
 
 /* TYPE */
-type mcdp_info struct {
+type mcdpInfo struct {
 	family [2]uint8
 	chipid [2]uint8
-	irom   mcdp_version
-	fw     mcdp_version
+	irom   mcdpVersion
+	fw     mcdpVersion
 }
 
-/* struct mcdp_info field decoding */
-func mcdp_chipid(chipid []uint8) uint16 {
+/* struct mcdpInfo field decoding */
+func mcdpChipid(chipid []uint8) uint16 {
 	return (uint16(chipid[0]) << 8) | uint16(chipid[1])
 }
 
-func mcdp_family(family []uint8) uint16 {
+func mcdpFamily(family []uint8) uint16 {
 	return (uint16(family[0]) << 8) | uint16(family[1])
 }
 
 /* Get/Set USB-PD Alternate mode info */
-const EC_CMD_USB_PD_GET_AMODE = 0x116
+const ecCmdUsbPdGetAmode = 0x116
 
 /* TYPE */
-type ec_params_usb_pd_get_mode_request struct {
-	svid_idx uint16 /* SVID index to get */
-	port     uint8  /* port */
+type ecParamsUsbPdGetModeRequest struct {
+	svidIdx uint16 /* SVID index to get */
+	port    uint8  /* port */
 }
 
 /* TYPE */
-type ec_params_usb_pd_get_mode_response struct {
+type ecParamsUsbPdGetModeResponse struct {
 	svid uint16    /* SVID */
 	opos uint16    /* Object Position */
 	vdo  [6]uint32 /* Mode VDOs */
 }
 
-const EC_CMD_USB_PD_SET_AMODE = 0x117
+const ecCmdUsbPdSetAmode = 0x117
 
-type pd_mode_cmd uint8
+type pdModeCmd uint8
 
 const (
-	PD_EXIT_MODE  pd_mode_cmd = 0
-	PD_ENTER_MODE             = 1
+	pdExitMode  pdModeCmd = 0
+	pdEnterMode           = 1
 	/* Not a command.  Do NOT remove. */
-	PD_MODE_CMD_COUNT
+	pdModeCmdCount
 )
 
 /* TYPE */
-type ec_params_usb_pd_set_mode_request struct {
-	cmd  uint32 /* enum pd_mode_cmd */
+type ecParamsUsbPdSetModeRequest struct {
+	cmd  uint32 /* enum pdModeCmd */
 	svid uint16 /* SVID to set */
 	opos uint8  /* Object Position */
 	port uint8  /* port */
 }
 
 /* Ask the PD MCU to record a log of a requested type */
-const EC_CMD_PD_WRITE_LOG_ENTRY = 0x118
+const ecCmdPdWriteLogEntry = 0x118
 
 /* TYPE */
-type ec_params_pd_write_log_entry struct {
-	etype uint8 /* event type : see PD_EVENT_xx above */
+type ecParamsPdWriteLogEntry struct {
+	etype uint8 /* event type : see pdEventXx above */
 	port  uint8 /* port#, or 0 for events unrelated to a given port */
 }
 
@@ -3401,12 +3401,12 @@ type ec_params_pd_write_log_entry struct {
  */
 
 /* Offset and max command number for sub-device n */
-func ec_cmd_passthru_offset(n uint) uint {
+func ecCmdPassthruOffset(n uint) uint {
 	return 0x4000 * n
 }
 
-func ec_cmd_passthru_max(n uint) uint {
-	return ec_cmd_passthru_offset(n) + 0x3fff
+func ecCmdPassthruMax(n uint) uint {
+	return ecCmdPassthruOffset(n) + 0x3fff
 }
 
 /*****************************************************************************/
@@ -3416,11 +3416,11 @@ func ec_cmd_passthru_max(n uint) uint {
  * switch to the new names soon, as the old names may not be carried forward
  * forever.
  */
-const EC_HOST_PARAM_SIZE = EC_PROTO2_MAX_PARAM_SIZE
-const EC_LPC_ADDR_OLD_PARAM = EC_HOST_CMD_REGION1
-const EC_OLD_PARAM_SIZE = EC_HOST_CMD_REGION_SIZE
+const ecHostParamSize = ecProto2MaxParamSize
+const ecLpcAddrOldParam = ecHostCmdRegion1
+const ecOldParamSize = ecHostCmdRegionSize
 
-func ec_ver_mask(version uint8) uint8 {
+func ecVerMask(version uint8) uint8 {
 	/* Command version mask */
 	return 1 << version
 }

--- a/cmds/ectool/eclib.go
+++ b/cmds/ectool/eclib.go
@@ -5,13 +5,13 @@ import (
 )
 
 type (
-	Command int
-	Version int
+	command int
+	version int
 )
 
 type ec interface {
 	Probe(timeout time.Duration) error
 	Cleanup(timeout time.Duration) error
 	Wait(timeout time.Duration) error
-	Command(command Command, version Version, idata []byte, outsize int, timeout time.Duration) ([]byte, error)
+	Command(command command, version version, idata []byte, outsize int, timeout time.Duration) ([]byte, error)
 }

--- a/cmds/ectool/ectool.go
+++ b/cmds/ectool/ectool.go
@@ -16,7 +16,7 @@ var (
 	lpcdebug    = flag.Bool("lpcdebug", true, "Enable lpc debug prints")
 	chips       = make(map[string]func(ioport, ioaddr, time.Duration, time.Duration, debugf) ec)
 	defaultChip = flag.String("chip", "lpc", "Which chip to use")
-	chip        = NewLPC
+	chip        = newLPC
 )
 
 func debug(s string, v ...interface{}) {
@@ -29,7 +29,7 @@ func main() {
 	if !*lpcdebug {
 		d = nil
 	}
-	p, err := NewDevPorts(d)
+	p, err := newDevPorts(d)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v", err)
 	}
@@ -41,7 +41,7 @@ func main() {
 		chip = c
 	}
 
-	ec := chip(p, EC_LPC_ADDR_HOST_CMD, time.Second*10, time.Second*10, d)
+	ec := chip(p, ecLpcAddrHostCmd, time.Second*10, time.Second*10, d)
 	// valid command?
 	// TODO: use the command table for real? But what should the type be? interface{}, err?
 	a := flag.Args()

--- a/cmds/ectool/info.go
+++ b/cmds/ectool/info.go
@@ -5,5 +5,5 @@ import (
 )
 
 func info(ec ec) ([]byte, error) {
-	return ec.Command(EC_CMD_GET_CHIP_INFO, 0, []byte{}, 96 /*len(_ ec_response_get_chip_info)*/, time.Duration(10*time.Second))
+	return ec.Command(ecCmdGetChipInfo, 0, []byte{}, 96 /*len(_ ecResponseGetChipInfo)*/, time.Duration(10*time.Second))
 }

--- a/cmds/ectool/io.go
+++ b/cmds/ectool/io.go
@@ -32,7 +32,7 @@ type devports struct {
 	debugf
 }
 
-func NewDevPorts(d debugf) (ioport, error) {
+func newDevPorts(d debugf) (ioport, error) {
 	f, err := os.Create("/dev/port")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This removes a huge chunk of warnings from our go report card. Only changes in identifiers and comments. The only test I performed was compiling + running `ectool --help`. 

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>