### PR TITLE
Dd benchmark

### DIFF
--- a/shared/testutil/testutil.go
+++ b/shared/testutil/testutil.go
@@ -6,6 +6,7 @@ package testutil
 
 import (
 	"io/ioutil"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -13,12 +14,21 @@ import (
 
 // CompileInTempDir creates a temp directory and compiles the main package of
 // the current directory. Remember to delete the directory after the test:
+//
 //     defer os.RemoveAll(tmpDir)
-func CompileInTempDir(t *testing.T) (tmpDir string, execPath string) {
+//
+// The environment variable EXECPATH overrides execPath.
+func CompileInTempDir(t testing.TB) (tmpDir string, execPath string) {
 	// Create temp directory
 	tmpDir, err := ioutil.TempDir("", "Test")
 	if err != nil {
 		t.Fatal("TempDir failed: ", err)
+	}
+
+	// Skip compilation if EXECPATH is set.
+	execPath = os.Getenv("EXECPATH")
+	if execPath != "" {
+		return
 	}
 
 	// Compile the program


### PR DESCRIPTION
Add benchmark for dd command

Example usage:

Benchmarking u-root's dd command:

    $ go test -bench=Dd
    BenchmarkDd-12           10000        16263 ns/op    644.55 MB/s
    PASS
    ok      github.com/u-root/u-root/cmds/dd    4.198s

Benchmarking your system's dd command:

    $ EXECPATH=dd go test -bench=Dd
    BenchmarkDd-12           30000         4809 ns/op    2180.25 MB/s
    PASS
    ok      github.com/u-root/u-root/cmds/dd    2.075s

The "op" unit measures 1 MiB block.