### PR TITLE
dd: make it a bit better at IO.

### DIFF
--- a/cmds/dd/dd.go
+++ b/cmds/dd/dd.go
@@ -25,7 +25,6 @@ package main
 import (
 	"bytes"
 	"flag"
-	"fmt"
 	"io"
 	"log"
 	"math"
@@ -33,48 +32,77 @@ import (
 	"strings"
 )
 
+type data struct {
+	sz   int64
+	data []byte
+}
+
 var (
 	ibs     = flag.Int64("ibs", 1, "Default input block size")
 	obs     = flag.Int64("obs", 1, "Default output block size")
 	bs      = flag.Int64("bs", 0, "Default input and output block size")
 	skip    = flag.Int64("skip", 0, "skip n bytes before reading")
 	seek    = flag.Int64("seek", 0, "seek output when writing")
-	conv    = flag.String("conv", "", "Convert the file on a specific way, like notrunc")
+	conv    = flag.String("conv", "none", "Convert the file on a specific way, like notrunc")
 	count   = flag.Int64("count", math.MaxInt64, "Max output of data to copy")
 	inName  = flag.String("if", "", "Input file")
 	outName = flag.String("of", "", "Output file")
+	convs   = map[string]func([]byte) []byte{
+		"none":  func(b []byte) []byte { return b },
+		"ucase": bytes.ToUpper,
+		"lcase": bytes.ToLower,
+	}
+	convert func([]byte) []byte
 )
 
-func pass(r io.Reader, w io.Writer, ibs, obs int64, conv string) {
-	var b = &bytes.Buffer{}
-	for {
-		b.Reset()
-		n, err := io.CopyN(b, r, ibs)
-		if n == 0 {
-			break
-		}
-		if err != nil && err != io.EOF {
-			log.Fatalf("Reading from input: %v", err)
-		}
-		var out *bytes.Buffer
-		switch conv {
-		case "ucase":
-			out = bytes.NewBuffer(bytes.ToUpper(b.Bytes()))
-		case "lcase":
-			out = bytes.NewBuffer(bytes.ToLower(b.Bytes()))
-		default:
-			out = bytes.NewBuffer(b.Bytes())
-		}
-		for n := int64(0); n < int64(out.Len()); {
-			amt, err := io.CopyN(w, out, obs)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "pass: %v\n", err)
-				break
+func pass(r io.Reader, w io.Writer, ibs, obs int64) {
+	// make the channels deep enough for 1 GiB
+	depth := (1024 * 1048576) / ibs 
+	// but keep it reasonable!
+	if depth > 8192 {
+		depth = 8192
+	}
+	bufs := make(chan *data, depth)
+	i := make(chan *data, depth)
+	go func() {
+		var d *data
+		for {
+			select {
+			case d = <-bufs:
+			default:
+				d = &data{ibs, make([]byte, ibs, ibs)}
 			}
-			n += int64(amt)
+			amt, err := r.Read(d.data)
+			if amt > 0 {
+				d.sz = int64(amt)
+				i <- d
+			}
+			if err == io.EOF || amt == 0 {
+				close(i)
+				return
+			}
+			if err != nil {
+				close(i)
+				log.Fatalf("input: %v", err)
+			}
 		}
-		if err == io.EOF {
-			break
+	}()
+
+	for b := range i {
+		for i := int64(0); i < b.sz; {
+			amt := obs
+			if b.sz-i < obs {
+				amt = b.sz - i
+			}
+			got, err := w.Write(convert(b.data[i:amt]))
+			if err != nil || got < int(amt) {
+				log.Fatalf("output: got %d, wanted %d, err %v", got, amt, err)
+			}
+			i += amt
+		}
+		select {
+		case bufs <- b:
+		default:
 		}
 	}
 }
@@ -152,12 +180,29 @@ func openFiles() (io.Reader, io.Writer) {
 	return io.LimitReader(i, maxRead), o
 }
 
+func usage() {
+	// If the conversions get more complex we can dump
+	// the convs map. For now, it's not really worth it.
+	log.Fatal(`Usage: dd [if=file] [of=file] [conv=lcase|ucase] [seek=#] [skip=#] [count=#] [bs=#] [ibs=#] [obs=#]
+		options may also be invoked Go-style as -opt value or -opt=value
+		bs, if specified, overrides ibs and obs`)
+}
+
 // rather than, in essence, recreating all the apparatus of flag.xxxx with the if= bits,
 // including dup checking, conversion, etc. we just convert the arguments and then
 // run flag.Parse. Gross, but hey, it works.
 func main() {
 	os.Args = splitArgs()
 	flag.Parse()
+
+	if len(flag.Args()) > 0 {
+		usage()
+	}
+	var ok bool
+	if convert, ok = convs[*conv]; !ok {
+		usage()
+	}
+
 	i, o := openFiles()
-	pass(i, o, *obs, *obs, *conv)
+	pass(i, o, *obs, *obs)
 }


### PR DESCRIPTION
It now reads and writes at the blocksize, e.g. 1M.

Sadly, however, the performance is really not catching up with dd.

The test fails, but that is because of a bug in the test. When you take
string(out) it's adding three nulls. Ryan, help!

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>