### PR TITLE
busybox init; test against pid 1

### DIFF
--- a/bb/bb.go
+++ b/bb/bb.go
@@ -73,9 +73,14 @@ import (
 )
 
 func init() {
-	// This one stat adds a bit of cost to each invocation (not much really)
+	// This getpid adds a bit of cost to each invocation (not much really)
 	// but it allows us to merge init and sh. The 600K we save is worth it.
-	if _, err := os.Stat("/proc/self"); err == nil {
+	if os.Args[0] != "/init" {
+		log.Printf("Skipping root file system setup since we are not /init")
+		return
+	}
+	if os.Getpid() != 1 {
+		log.Printf("Skipping root file system setup since /init is not pid 1")
 		return
 	}
 	uroot.Rootfs()


### PR DESCRIPTION
realistically, we should be pid 1, and if we're not, we should not
set things up. This makes some aspects of testing in a chroot harder
but it's probably the right thing to do anyway.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>