### PR TITLE
unshare: add chroot option, break out kernel-dependent code

### DIFF
--- a/cmds/unshare/unshare.go
+++ b/cmds/unshare/unshare.go
@@ -21,15 +21,8 @@
 //     expectation of success.
 //
 //     If PROGRAM is not specified, unshare defaults to /ubin/rush.
-//
-// Options:
-//     -ipc:           Unshare the IPC namespace
-//     -mount:         Unshare the mount namespace
-//     -pid:           Unshare the pid namespace
-//     -net:           Unshare the net namespace
-//     -uts:           Unshare the uts namespace
-//     -user:          Unshare the user namespace
-//     -map-root-user: Map current uid to root. Not working
+//     The unsharing options are highly kernel dependent, but most kernels
+//     support at least one of them.
 package main
 
 import (
@@ -37,18 +30,9 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"syscall"
 )
 
-var (
-	ipc     = flag.Bool("ipc", false, "Unshare the IPC namespace")
-	mount   = flag.Bool("mount", false, "Unshare the mount namespace")
-	pid     = flag.Bool("pid", false, "Unshare the pid namespace")
-	net     = flag.Bool("net", false, "Unshare the net namespace")
-	uts     = flag.Bool("uts", false, "Unshare the uts namespace")
-	user    = flag.Bool("user", false, "Unshare the user namespace")
-	maproot = flag.Bool("map-root-user", false, "Map current uid to root. Not working")
-)
+var fatal= log.Fatalf
 
 func main() {
 	flag.Parse()
@@ -59,31 +43,10 @@ func main() {
 	}
 
 	c := exec.Command(a[0], a[1:]...)
-	c.SysProcAttr = &syscall.SysProcAttr{}
-	if *mount {
-		c.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNS
-	}
-	if *uts {
-		c.SysProcAttr.Cloneflags |= syscall.CLONE_NEWUTS
-	}
-	if *ipc {
-		c.SysProcAttr.Cloneflags |= syscall.CLONE_NEWIPC
-	}
-	if *net {
-		c.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNET
-	}
-	if *pid {
-		c.SysProcAttr.Cloneflags |= syscall.CLONE_NEWPID
-	}
-	if *user {
-		c.SysProcAttr.Cloneflags |= syscall.CLONE_NEWUSER
-	}
-
-	c.Stdin = os.Stdin
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	setSysProcAttr(c)
 
 	if err := c.Run(); err != nil {
-		log.Printf(err.Error())
+		fatal(err.Error())
 	}
 }

--- a/cmds/unshare/unshare_linux.go
+++ b/cmds/unshare/unshare_linux.go
@@ -1,0 +1,58 @@
+// Copyright 2016-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//
+// Options:
+//     -ipc:           Unshare the IPC namespace
+//     -mount:         Unshare the mount namespace
+//     -pid:           Unshare the pid namespace
+//     -net:           Unshare the net namespace
+//     -uts:           Unshare the uts namespace
+//     -user:          Unshare the user namespace
+//     -map-root-user  Map current uid to root. Not working
+//     -chroot         Chroot to the place specified by the argument
+package main
+
+import (
+	"flag"
+	"os/exec"
+	"syscall"
+)
+
+var (
+	ipc     = flag.Bool("ipc", false, "Unshare the IPC namespace")
+	mount   = flag.Bool("mount", false, "Unshare the mount namespace")
+	pid     = flag.Bool("pid", false, "Unshare the pid namespace")
+	net     = flag.Bool("net", false, "Unshare the net namespace")
+	uts     = flag.Bool("uts", false, "Unshare the uts namespace")
+	user    = flag.Bool("user", false, "Unshare the user namespace")
+	maproot = flag.Bool("map-root-user", false, "Map current uid to root. Not working")
+	chroot  = flag.String("chroot", "", "Chroot to the argument before running")
+)
+
+func setSysProcAttr(c *exec.Cmd) {
+	c.SysProcAttr = &syscall.SysProcAttr{}
+	if *mount {
+		c.SysProcAttr.Unshareflags |= syscall.CLONE_NEWNS
+	}
+	if *uts {
+		c.SysProcAttr.Unshareflags |= syscall.CLONE_NEWUTS
+	}
+	if *ipc {
+		c.SysProcAttr.Unshareflags |= syscall.CLONE_NEWIPC
+	}
+	if *net {
+		c.SysProcAttr.Unshareflags |= syscall.CLONE_NEWNET
+	}
+	if *pid {
+		c.SysProcAttr.Unshareflags |= syscall.CLONE_NEWPID
+	}
+	if *user {
+		c.SysProcAttr.Unshareflags |= syscall.CLONE_NEWUSER
+	}
+
+	if *chroot != "" {
+		c.SysProcAttr.Chroot = *chroot
+	}
+}

--- a/cmds/unshare/unshare_test.go
+++ b/cmds/unshare/unshare_test.go
@@ -1,0 +1,54 @@
+// Copyright 2016-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+	
+	"github.com/u-root/u-root/shared/testutil"
+)
+
+var (
+	testPath = "."
+	// if true removeAll the testPath on the end
+	remove = true
+)
+
+type test struct {
+	args    []string
+	expects string
+}
+
+// TODO: well, there's a lot todo. And it's easy with this test to
+// really mess up your system, what with all the mounting it has to do,
+// so ... not sure.
+// Also, note, this is basically a wrapper for exec, and all the tests done there
+// need not be repeated here. So it's not quite clear what a test should do.
+func init() {
+	fatal = func(s string, i ...interface{}) {
+		fmt.Printf(s, i...)
+	}
+	fatal("HI THERE!")
+}
+
+func run(c *exec.Cmd) (string, string, error) {
+	var o, e bytes.Buffer
+	c.Stdout, c.Stderr = &o, &e
+	err := c.Run()
+	return o.String(), e.String(), err
+}
+
+func TestUnshareSimple(t *testing.T) {
+	tmpDir, xPath := testutil.CompileInTempDir(t)
+	if remove {
+		defer os.RemoveAll(tmpDir)
+	}
+	t.Logf("tmpDir %v, xPath %v", tmpDir, xPath)
+}
+


### PR DESCRIPTION
Actual writing of tests is blocked on a CL I have pending
for Go upstream.

This *should* now let us test intramfs with a pid 1.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>