### PR TITLE
fix busybox

### DIFF
--- a/bb/bb.go
+++ b/bb/bb.go
@@ -46,8 +46,9 @@ os.Args = fixArgs("{{.CmdName}}", append([]string{c.cmd}, c.argv...))
 return
 }
 
-func init() {
+func {{.CmdName}}Init() {
 	addForkBuiltIn("{{.CmdName}}", _forkbuiltin_{{.CmdName}})
+	{{.Init}}
 }
 `
 	fixArgs = `
@@ -66,15 +67,34 @@ func fixArgs(cmd string, args[]string) (s []string) {
 	initGo = `
 package main
 import (
+	"bytes"
+	"flag"
 	"log"
 	"os"
 	"path"
 	"github.com/u-root/u-root/uroot"
 )
 
+func usage () {
+	var b = &bytes.Buffer{}
+
+	flag.CommandLine.SetOutput(b)
+	flag.CommandLine.PrintDefaults()
+	log.Printf("things went badly for %v: %v", os.Args, b.String())
+}
+
 func init() {
+	flag.Usage = usage
 	// This getpid adds a bit of cost to each invocation (not much really)
 	// but it allows us to merge init and sh. The 600K we save is worth it.
+	// Figure out which init to run. We must always do this.
+
+	log.Printf("init: os is %v, initMap %v", os.Args[0], initMap)
+	if f, ok := initMap[os.Args[0]]; ok {
+		log.Printf("init: run %v", f)
+		f()
+	}
+
 	if os.Args[0] != "/init" {
 		log.Printf("Skipping root file system setup since we are not /init")
 		return
@@ -119,7 +139,7 @@ var (
 		"freq",
 		"grep",
 		"ip",
-		//"kexec",
+		"kexec",
 		"ls",
 		"mkdir",
 		"mount",
@@ -159,12 +179,14 @@ var (
 		"Var":         1,
 	}
 	dumpAST = flag.Bool("D", false, "Dump the AST")
+	initMap = "package main\nvar initMap = map[string] func() {\n"
 )
 
 var config struct {
 	Args     []string
 	CmdName  string
 	FullPath string
+	Init string
 	Src      string
 	Uroot    string
 	Cwd      string
@@ -184,6 +206,8 @@ var config struct {
 func oneFile(dir, s string, fset *token.FileSet, f *ast.File) error {
 	// Inspect the AST and change all instances of main()
 	isMain := false
+	// yeah, this is awful, sorry.
+	config.Init = ""
 	ast.Inspect(f, func(n ast.Node) bool {
 		switch x := n.(type) {
 		case *ast.File:
@@ -194,6 +218,10 @@ func oneFile(dir, s string, fset *token.FileSet, f *ast.File) error {
 				// Append a return.
 				x.Body.List = append(x.Body.List, &ast.ReturnStmt{})
 				isMain = true
+			}
+			if x.Name.Name == "init" {
+				x.Name.Name = fmt.Sprintf("Init")
+				config.Init = config.CmdName + ".Init()"
 			}
 
 		case *ast.CallExpr:
@@ -286,6 +314,7 @@ func oneCmd() {
 			oneFile(packageDir, n, fset, v)
 		}
 	}
+	initMap += "\n\t\"" + config.CmdName + "\":" + config.CmdName + "Init,"
 }
 func main() {
 	var err error
@@ -346,6 +375,12 @@ func main() {
 	if err := ioutil.WriteFile(path.Join(config.Bbsh, "fixargs.go"), []byte(fixArgs), 0644); err != nil {
 		log.Fatalf("%v\n", err)
 	}
+
+	initMap += "\n}"
+	if err := ioutil.WriteFile(path.Join(config.Bbsh, "initmap.go"), []byte(initMap), 0644); err != nil {
+		log.Fatalf("%v\n", err)
+	}
+
 
 	buildinit()
 	ramfs()


### PR DESCRIPTION
Change init() -> Init() for every command.

Create a map of command names to init functions.

In the init() function, if os.Args[0] is in the map, then
run its Init()

we no longer run all the inits, and we maybe have a fix for the mess
with options.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>