### PR TITLE
Crappy uinit.go

### DIFF
--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -127,7 +127,7 @@ func main() {
 	// Perhaps we should stat inito first.
 	// inito is always first and we set default flags for it.
 	cloneFlags := uintptr(syscall.CLONE_NEWPID)
-	for _, v := range []string{"/inito", "/buildbin/rush"} {
+	for _, v := range []string{"/inito", "/buildbin/uinit", "/buildbin/rush"} {
 		cmd = exec.Command(v)
 		cmd.Env = envs
 		cmd.Stdin = os.Stdin

--- a/cmds/uinit/uinit.go
+++ b/cmds/uinit/uinit.go
@@ -1,0 +1,40 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This is a basic init script.
+package main
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+var (
+	commands = []string{
+		"/buildbin/date",
+		"/buildbin/ls -l",
+	}
+)
+
+func main() {
+	for _, line := range commands {
+		log.Printf("Executing Command: %v", line)
+		cmdSplit := strings.Split(line, " ")
+		if len(cmdSplit) == 0 {
+			continue
+		}
+
+		cmd := exec.Command(cmdSplit[0], cmdSplit[1:]...)
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+		cmd.Stdout = os.Stdout
+		if err := cmd.Run(); err != nil {
+			log.Print(err)
+		}
+
+	}
+	log.Print("Uinit Done!")
+}


### PR DESCRIPTION
This acts as a shitty init script that we can use to run commands before
starting the shell.

Signed-off-by: Gan Shun Lim <ganshun@google.com>