### PR TITLE
fix busybox mode init() and argument error processing

### DIFF
--- a/cmds/rush/rush.go
+++ b/cmds/rush/rush.go
@@ -206,7 +206,9 @@ func main() {
 		}
 		_, _, _ = getCommand(b)
 	}()
-	if f, ok := forkBuiltins[os.Args[0]]; ok {
+
+	// we use path.Base in case they type something like ./cmd
+	if f, ok := forkBuiltins[path.Base(os.Args[0])]; ok {
 		if err := f(&Command{cmd: os.Args[0], Cmd: &exec.Cmd{Stdin: os.Stdin, Stdout: os.Stdout, Stderr: os.Stderr}, argv: os.Args[1:]}); err != nil {
 			log.Fatalf("%v", err)
 		}


### PR DESCRIPTION
Change init() -> Init() for every command.

Create a map of command names to init functions.

In the init() function, if os.Args[0] is in the map, then
run its Init().

The startup code now only runs one init, not all of them for all
commands.

For tools that don't set their own usage, the usage is now usable, e.g.:
ls -q
flag provided but not defined: -ls.q
Usage: ls:
        Flag Q: 'quoted', Default false, Value false
        Flag R: 'equivalent to findutil's find', Default false, Value false
        Flag l: 'long form', Default false, Value false

the 'flag provided but not defined .... '
text ought to go away at some point however.

That said, this is a big improvement; it's also one Russ
also suggested we use, so we independently reached this
same point.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>