### PR TITLE
usage: fix up usage so we can keep using flag.Usage

### DIFF
--- a/cmds/comm/comm.go
+++ b/cmds/comm/comm.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 )
 
+const cmd = "comm [-123i] file1 file2\n"
+
 var (
 	s1   = flag.Bool("1", false, "suppress printing of column 1")
 	s2   = flag.Bool("2", false, "suppress printing of column 2")
@@ -36,10 +38,13 @@ var (
 	help = flag.Bool("h", false, "print this help message and exit")
 )
 
-func usage() {
-	log.Printf("Usage: %s [-123i] file1 file2\n", os.Args[0])
-	flag.PrintDefaults()
-	os.Exit(1)
+func init() {
+	flag.Usage = func(f func()) func() {
+		return func() {
+			os.Args[0] = cmd
+			f()
+		}
+	}(flag.Usage)
 }
 
 func reader(f *os.File, c chan string) {
@@ -90,7 +95,6 @@ func outer(c1, c2 chan string, c chan out) {
 }
 
 func main() {
-	flag.Usage = usage
 	flag.Parse()
 	if flag.NArg() != 2 || *help {
 		flag.Usage()

--- a/cmds/date/date.go
+++ b/cmds/date/date.go
@@ -49,15 +49,14 @@ var (
 	z     = time.Local
 )
 
-func usage() {
-	fmt.Fprintln(os.Stderr, "Usage:", cmd)
-	flag.PrintDefaults()
-	os.Exit(1)
-}
-
 func init() {
 	flag.BoolVar(&flags.universal, "u", false, "Coordinated Universal Time (UTC)")
-	flag.Usage = usage
+	flag.Usage = func(f func()) func() {
+		return func() {
+			os.Args[0] = cmd
+			f()
+		}
+	}(flag.Usage)
 	flag.Parse()
 	if flags.universal {
 		z = time.UTC
@@ -232,6 +231,6 @@ func main() {
 			}
 		}
 	default:
-		usage()
+		flag.Usage()
 	}
 }

--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -39,14 +39,13 @@ var (
 	mainPID = os.Getpid()
 )
 
-func usage() {
-	fmt.Fprintln(os.Stderr, "Usage:", cmd)
-	flag.PrintDefaults()
-	os.Exit(1)
-}
-
 func init() {
-	flag.Usage = usage
+	flag.Usage = func(f func()) func() {
+		return func() {
+			os.Args[0] = cmd
+			f()
+		}
+	}(flag.Usage)
 	flag.BoolVar(&flags.all, "A", false, "Select all processes.  Identical to -e.")
 	flag.BoolVar(&flags.all, "e", false, "Select all processes.  Identical to -A.")
 	flag.BoolVar(&flags.x, "x", false, "BSD-Like style, with STAT Column and long CommandLine")

--- a/cmds/pwd/pwd.go
+++ b/cmds/pwd/pwd.go
@@ -29,14 +29,14 @@ var (
 	cmd      = "pwd [-LP]"
 )
 
-func usage() {
-	fmt.Printf("Usage: %v\n", cmd)
-	flag.PrintDefaults()
-}
-
 func init() {
+	flag.Usage = func(f func()) func() {
+		return func() {
+			os.Args[0] = cmd
+			f()
+		}
+	}(flag.Usage)
 	args := os.Args[1:]
-	flag.Usage = usage
 	flag.Parse()
 	for _, flag := range args {
 		switch flag {

--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -31,19 +31,18 @@ var (
 	cmd = "rm [-Rrvi] file..."
 )
 
-func usage() {
-	fmt.Fprintln(os.Stderr, "Usage:", cmd)
-	flag.PrintDefaults()
-	os.Exit(1)
-}
-
 func init() {
+	flag.Usage = func(f func()) func() {
+		return func() {
+			os.Args[0] = cmd
+			f()
+		}
+	}(flag.Usage)
 	flag.BoolVar(&flags.i, "i", false, "Interactive mode.")
 	flag.BoolVar(&flags.v, "v", false, "Verbose mode.")
 	flag.BoolVar(&flags.r, "R", false, "Remove file hierarchies")
 	flag.BoolVar(&flags.r, "r", false, "Equivalent to -R.")
 	flag.Parse()
-	flag.Usage = usage
 }
 
 func rm(files []string) error {
@@ -84,7 +83,7 @@ func rm(files []string) error {
 
 func main() {
 	if flag.NArg() < 1 {
-		usage()
+		flag.Usage()
 	}
 
 	if err := rm(flag.Args()); err != nil {

--- a/cmds/seq/seq.go
+++ b/cmds/seq/seq.go
@@ -40,14 +40,13 @@ var (
 	cmd = "seq [-f format] [-w] [-s separator] [start [step [end]]]"
 )
 
-func usage() {
-	fmt.Fprintf(os.Stdout, "Usage: %v\n", cmd)
-	flag.PrintDefaults()
-	os.Exit(1)
-}
-
 func init() {
-	flag.Usage = usage
+	flag.Usage = func(f func()) func() {
+		return func() {
+			os.Args[0] = cmd
+			f()
+		}
+	}(flag.Usage)
 	flag.StringVar(&flags.format, "f", "%v", "use printf style floating-point FORMAT")
 	flag.StringVar(&flags.separator, "s", "\n", "use STRING to separate numbers")
 	flag.BoolVar(&flags.widthEqual, "w", false, "equalize width by padding with leading zeroes")


### PR DESCRIPTION
In some cases we had been writing our own usage function,
which leads to awkward looking output. It turns out that
if one wants more information than just os.Args[0], one
can set os.Args[0] before calling flag.Usage.

This change uses a function literal to create closure
to be assigned to flag.Usage such that we can set os.Args[0]
and get more natural looking output, e.g.

date -z
flag provided but not defined: -z
Usage of date [-u] [+format] | date [-u] [MMDDhhmm[CC]YY[.ss]]:
  -u    Coordinated Universal Time (UTC)

This will also allow us to better use the busybox mode. It provides
its own usage function but this design will let us provide our additional
text while still using the busybox functtion too.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>