### PR TITLE
dhclient: fix error pointed out by Chris

### DIFF
--- a/cmds/dhclient/dhclient.go
+++ b/cmds/dhclient/dhclient.go
@@ -152,6 +152,7 @@ func dhclient(ifname string, timeout time.Duration, iList []string, done chan er
 				return
 			}
 			done <- fmt.Errorf("error: %v", err)
+			return
 		}
 
 		if !success {


### PR DESCRIPTION
missing return.

We'll take on the cleanup he suggested later. This is simple and gets it done.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>