### PR TITLE
init: add a test flag

### DIFF
--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -26,6 +26,7 @@ import (
 var (
 	verbose   = flag.Bool("v", false, "print all build commands")
 	ludicrous = flag.Bool("ludicrous", false, "print out information about symlink creation")
+	test      = flag.Bool("test", false, "Test mode: don't try to set control tty")
 	debug     = func(string, ...interface{}) {}
 )
 
@@ -138,9 +139,11 @@ func main() {
 		cmd.Stdin = os.Stdin
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
-		// TODO: figure out why we get EPERM when we use this.
-		//cmd.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true, Cloneflags: cloneFlags}
-		cmd.SysProcAttr = &syscall.SysProcAttr{Cloneflags: cloneFlags}
+		if *test {
+			cmd.SysProcAttr = &syscall.SysProcAttr{Cloneflags: cloneFlags}
+		} else {
+			cmd.SysProcAttr = &syscall.SysProcAttr{Setctty: true, Setsid: true, Cloneflags: cloneFlags}
+		}
 		debug("Run %v", cmd)
 		if err := cmd.Run(); err != nil {
 			log.Print(err)

--- a/scripts/ramfs.go
+++ b/scripts/ramfs.go
@@ -590,7 +590,7 @@ func main() {
 	// Arrange to start init in the directory in a new namespace.
 	// That should make all mounts go away when we're done.
 	// On real kernels you can unshare without being root. Not on Linux.
-	cmd = exec.Command("sudo", "unshare", "-m", "chroot", config.TempDir, "/init")
+	cmd = exec.Command("sudo", "unshare", "-m", "chroot", config.TempDir, "/init", "-test")
 	cmd.Dir = config.TempDir
 	cmd.Stdin, cmd.Stderr, cmd.Stdout = os.Stdin, os.Stderr, os.Stdout
 	debug("Run %v @ %v", cmd, cmd.Dir)


### PR DESCRIPTION
It's becoming more and more clear as Xuan and I try to get control tty working
that init needs to have some idea that it's in a chroot, i.e. test mode.

Add a test flag to init which disables setting Ctty and Setsid in the
command; have ramfs set this flag when it runs the chroot.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>