### PR TITLE
Clean up overriding of flag.Usage functions.

### DIFF
--- a/cmds/comm/comm.go
+++ b/cmds/comm/comm.go
@@ -39,12 +39,11 @@ var (
 )
 
 func init() {
-	flag.Usage = func(f func()) func() {
-		return func() {
-			os.Args[0] = cmd
-			f()
-		}
-	}(flag.Usage)
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = cmd
+		defUsage()
+	}
 }
 
 func reader(f *os.File, c chan string) {

--- a/cmds/cp/cp.go
+++ b/cmds/cp/cp.go
@@ -48,6 +48,11 @@ var (
 )
 
 func init() {
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = "cp [-wRrifvP] file[s] ... dest"
+		defUsage()
+	}
 	flag.IntVar(&nwork, "w", runtime.NumCPU(), "number of worker goroutines")
 	flag.BoolVar(&recursive, "R", false, "copy file hierarchies")
 	flag.BoolVar(&recursive, "r", false, "alias to -R recursive mode")

--- a/cmds/date/date.go
+++ b/cmds/date/date.go
@@ -45,18 +45,18 @@ var fmtMap = map[string]string{
 
 var (
 	flags struct{ universal bool }
-	cmd   = "date [-u] [+format] | date [-u] [MMDDhhmm[CC]YY[.ss]]"
 	z     = time.Local
 )
 
+const cmd = "date [-u] [+format] | date [-u] [MMDDhhmm[CC]YY[.ss]]"
+
 func init() {
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = cmd
+		defUsage()
+	}
 	flag.BoolVar(&flags.universal, "u", false, "Coordinated Universal Time (UTC)")
-	flag.Usage = func(f func()) func() {
-		return func() {
-			os.Args[0] = cmd
-			f()
-		}
-	}(flag.Usage)
 	flag.Parse()
 	if flags.universal {
 		z = time.UTC

--- a/cmds/field/field.go
+++ b/cmds/field/field.go
@@ -45,12 +45,11 @@ var (
 )
 
 func init() {
-	flag.Usage = func(f func()) func() {
-		return func() {
-			os.Args[0] = cmd
-			f()
-		}
-	}(flag.Usage)
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = cmd
+		defUsage()
+	}
 	flag.BoolVar(&flags.nuloutsep, "0", false, "use the NUL character ('\\0') as output separator")
 	flag.BoolVar(&flags.preserveEmpty, "e", false, "preseve empty input fields")
 	flag.BoolVar(&flags.discardEmpty, "E", false, "discard empty input fields")

--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -40,12 +40,11 @@ var (
 )
 
 func init() {
-	flag.Usage = func(f func()) func() {
-		return func() {
-			os.Args[0] = cmd
-			f()
-		}
-	}(flag.Usage)
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = cmd
+		defUsage()
+	}
 	flag.BoolVar(&flags.all, "A", false, "Select all processes.  Identical to -e.")
 	flag.BoolVar(&flags.all, "e", false, "Select all processes.  Identical to -A.")
 	flag.BoolVar(&flags.x, "x", false, "BSD-Like style, with STAT Column and long CommandLine")

--- a/cmds/pwd/pwd.go
+++ b/cmds/pwd/pwd.go
@@ -30,12 +30,11 @@ var (
 )
 
 func init() {
-	flag.Usage = func(f func()) func() {
-		return func() {
-			os.Args[0] = cmd
-			f()
-		}
-	}(flag.Usage)
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = cmd
+		defUsage()
+	}
 	args := os.Args[1:]
 	flag.Parse()
 	for _, flag := range args {

--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -32,12 +32,11 @@ var (
 )
 
 func init() {
-	flag.Usage = func(f func()) func() {
-		return func() {
-			os.Args[0] = cmd
-			f()
-		}
-	}(flag.Usage)
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = cmd
+		defUsage()
+	}
 	flag.BoolVar(&flags.i, "i", false, "Interactive mode.")
 	flag.BoolVar(&flags.v, "v", false, "Verbose mode.")
 	flag.BoolVar(&flags.r, "R", false, "Remove file hierarchies")

--- a/cmds/seq/seq.go
+++ b/cmds/seq/seq.go
@@ -41,12 +41,11 @@ var (
 )
 
 func init() {
-	flag.Usage = func(f func()) func() {
-		return func() {
-			os.Args[0] = cmd
-			f()
-		}
-	}(flag.Usage)
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = cmd
+		defUsage()
+	}
 	flag.StringVar(&flags.format, "f", "%v", "use printf style floating-point FORMAT")
 	flag.StringVar(&flags.separator, "s", "\n", "use STRING to separate numbers")
 	flag.BoolVar(&flags.widthEqual, "w", false, "equalize width by padding with leading zeroes")


### PR DESCRIPTION
The code to set up the chaining of calls to flag.Usage was
just a bit too clever for it's own good: it created a lambda
that took the old value as an argument, but all that lambda
did was set up a closure over that same old value that invoked
it with the right argument string.

It seems simpler and more easier to understand to just copy
the old value into a new variable and close over that.

Signed-off-by: Dan Cross <cross@gajendra.net>