### PR TITLE
rush: add tty  support

### DIFF
--- a/cmds/rush/rush.go
+++ b/cmds/rush/rush.go
@@ -204,7 +204,6 @@ func main() {
 		default:
 			log.Fatalf("unexpected panic value: %T(%v)", err, err)
 		}
-		_, _, _ = getCommand(b)
 	}()
 
 	// we use path.Base in case they type something like ./cmd
@@ -220,8 +219,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	tty()
 	fmt.Printf("%% ")
 	for {
+		foreground()
 		cmds, status, err := getCommand(b)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmds/rush/tty_linux.go
+++ b/cmds/rush/tty_linux.go
@@ -1,0 +1,67 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	ttypgrp, pgrpid int
+	ttyf            *os.File
+)
+
+// tty does whatever needs to be done to set up a tty for GOOS.
+func tty() {
+	var err error
+
+	// N.B. We can continue to use this file, in the foreground function,
+	// but the runtime closes it on exec for us.
+	if ttyf, err = os.OpenFile("/dev/tty", os.O_RDWR, 0); err != nil {
+		log.Printf("rush: Can't open a console; no job control in this session")
+		return
+	}
+	sigs := make(chan os.Signal, 512)
+	signal.Notify(sigs, os.Interrupt)
+	go func() {
+		for i := range sigs {
+			fmt.Println(i)
+		}
+	}()
+
+	// Get the current pgrp, and the pgrp on the tty.
+	// get current pgrp
+	r1, r2, errno := syscall.RawSyscall(syscall.SYS_IOCTL, ttyf.Fd(), uintptr(syscall.TIOCGPGRP), uintptr(unsafe.Pointer(&pgrpid)))
+	if errno != 0 {
+		log.Printf("Can't set foreground: %v, %v, %v", r1, r2, errno)
+	}
+
+	pgrpid, err = syscall.Getpgid(0)
+	if err != nil {
+		log.Printf("rush: can't get my own pgid, no job control")
+		return
+	}
+}
+
+func foreground() {
+	// Place process group in foreground.
+	if pgrpid != 0 {
+		if err := syscall.Setpgid(0, pgrpid); err != nil {
+			log.Printf("Warning: failed to set pgid: %v", err)
+		}
+	}
+	if ttyf.Fd() >= 0 {
+		r1, r2, errno := syscall.RawSyscall(syscall.SYS_IOCTL, ttyf.Fd(), uintptr(syscall.TIOCSPGRP), uintptr(unsafe.Pointer(&pgrpid)))
+		if errno != 0 {
+			log.Printf("Can't set foreground: %v, %v, %v", r1, r2, errno)
+		}
+	}
+
+}


### PR DESCRIPTION
We add a tty() function to be called before the main command loop;
and a foreground() function which is called at the top of the loop.

This is basically what ash does and it works fine.

Any new kernels this is ported to will have to define a tty handler.

This will let us test the broken tty setup in our initramfs. We've got something
wrong somehow.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>