### PR TITLE
ls: fix display of information

### DIFF
--- a/cmds/ls/ls.go
+++ b/cmds/ls/ls.go
@@ -52,7 +52,7 @@ func listDir(d string, w io.Writer) error {
 			return nil
 		}
 
-		fi := extractImportantParts(osfi)
+		fi := extractImportantParts(path, osfi)
 
 		if *recurse {
 			// Mimic find command


### PR DESCRIPTION
somewhere along the line ls stopped displaying anything useful about symlinks.
Fix it.

TODO: The tests here are really bad.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>