### PR TITLE
uroot: bring back device creation

### DIFF
--- a/uroot/root.go
+++ b/uroot/root.go
@@ -38,6 +38,12 @@ type file struct {
 }
 
 // TODO: make this a map so it's easier to find dups.
+type dev struct {
+	name    string
+	mode    uint32
+	dev     int
+	howmany int
+}
 type mount struct {
 	source string
 	target string
@@ -72,6 +78,13 @@ var (
 		{name: "/go/pkg/linux_amd64", mode: os.FileMode(0777)},
 		// This is for uroot packages. Is this a good idea? I don't know.
 		{name: "/pkg", mode: os.FileMode(0777)},
+	}
+	devs = []dev{
+		// chicken and egg: these need to be there before you start. So, sadly,
+		// we will always need dev.cpio or something like it.
+		//{name: "/dev/null", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0103},
+		//{name: "/dev/console", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0501},
+		{name: "/dev/tty", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0501},
 	}
 	namespace = []mount{
 		{source: "proc", target: "/proc", fstype: "proc", flags: syscall.MS_MGC_VAL, opts: ""},
@@ -138,6 +151,14 @@ func Rootfs() {
 	for _, m := range dirs {
 		if err := os.MkdirAll(m.name, m.mode); err != nil {
 			log.Printf("mkdir :%s: mode %o: %v\n", m.name, m.mode, err)
+			continue
+		}
+	}
+
+	for _, d := range devs {
+		syscall.Unlink(d.name)
+		if err := syscall.Mknod(d.name, d.mode, d.dev); err != nil {
+			log.Printf("mknod :%q: mode: %#o: magic: %v: %v\n", d.name, d.mode, d.dev, err)
 			continue
 		}
 	}


### PR DESCRIPTION
We need it, and especially need /dev/tty. Plus, it's just
way easier to have it in source like this.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>