### PR TITLE
rush: fix bug where ^C seems to go to only one process

### DIFF
--- a/cmds/rush/parse.go
+++ b/cmds/rush/parse.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os/exec"
 	"path"
 	"strings"
@@ -62,7 +63,7 @@ func one(b *bufio.Reader) byte {
 		return 0
 	}
 	if err != nil {
-		panic(fmt.Errorf("reading bufio: %v", err))
+		log.Fatalf("reading bufio: %v", err)
 	}
 	return c
 }


### PR DESCRIPTION
not sure what the deal is here, but as we try to get
control tty stuff right we're seeing issues where one process
in rush manages the ^C just fine, but another does not.
So one process exits, and takes stdin with it somehow;
we get endless bufio errors. It's pretty strange.

This gets us around the infinite loop of error prints for now.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>