### PR TITLE
installcommand: use os.Exec unless told not to by INSTALLCOMMAND_NOEXEC

### DIFF
--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -101,7 +101,7 @@ func parseCommandLine() form {
 // it should never return in any other case. Hence, if all goes well
 // at the end, we os.Exit(0)
 func run(n string, form form) {
-	if os.Getenv("INSTALLCOMMAND_NOFORK") == "1" {
+	if os.Getenv("INSTALLCOMMAND_NOEXEC") == "" {
 		err := syscall.Exec(n, append([]string{form.cmdName}, form.cmdArgs...), os.Environ())
 		// Regardless of whether err is nil, if Exec returns at all, it failed
 		// at its job. Print an error and then let's see if a normal run can succeed.


### PR DESCRIPTION
Because of uncertainties about os.Exec, we biased towards not exec'ing
unless told otherwise. With this change, we bias towards having
installcommand use os.Exec unless INSTALLCOMMAND_NOEXEC is set.
This leads to a much tidier process tree.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>