### PR TITLE
ps: add more info

### DIFF
--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -177,8 +177,8 @@ func ps(pT ProcessTable) error {
 	sort.Sort(pT)
 
 	if flags.x {
-		pT.headers = []string{"PID", "TTY", "STAT", "TIME", "COMMAND"}
-		pT.fields = []string{"Pid", "Ctty", "State", "Time", "Cmd"}
+		pT.headers = []string{"PID", "PGRP", "SID", "TTY", "STAT", "TIME", "COMMAND"}
+		pT.fields = []string{"Pid", "Pgrp", "Sid", "Ctty", "State", "Time", "Cmd"}
 	} else {
 		pT.headers = []string{"PID", "TTY", "TIME", "CMD"}
 		pT.fields = []string{"Pid", "Ctty", "Time", "Cmd"}


### PR DESCRIPTION
with -x you can now see pgrp, sid, tty, which has been invaluable in debugging.

At some point this needs to be redone to let you specify your display but this
is very helpful for now.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>