### PR TITLE
Small fix for device id of /dev/tty

### DIFF
--- a/uroot/root.go
+++ b/uroot/root.go
@@ -84,7 +84,7 @@ var (
 		// we will always need dev.cpio or something like it.
 		//{name: "/dev/null", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0103},
 		//{name: "/dev/console", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0501},
-		{name: "/dev/tty", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0501},
+		{name: "/dev/tty", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0500},
 		{name: "/dev/urandom", mode: uint32(syscall.S_IFCHR) | 0444, dev: 0x0109},
 	}
 	namespace = []mount{


### PR DESCRIPTION
A small fix for tty's device id. /dev/console has 0x501, abd /dev/tty has 0x500.

Signed-off-by: xchenan <xchenan@gmail.com>