### PR TITLE
Mknod /dev/urandom

### DIFF
--- a/uroot/root.go
+++ b/uroot/root.go
@@ -85,6 +85,7 @@ var (
 		//{name: "/dev/null", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0103},
 		//{name: "/dev/console", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0501},
 		{name: "/dev/tty", mode: uint32(syscall.S_IFCHR) | 0666, dev: 0x0501},
+		{name: "/dev/urandom", mode: uint32(syscall.S_IFCHR) | 0444, dev: 0x0109},
 	}
 	namespace = []mount{
 		{source: "proc", target: "/proc", fstype: "proc", flags: syscall.MS_MGC_VAL, opts: ""},


### PR DESCRIPTION
Create /dev/urandom during initialization, so as to provide alternative if booting up happens earlier than random number generator getting prepared.

Signed-off-by: xchenan <xchenan@gmail.com>