### PR TITLE
add stty command

### DIFF
--- a/cmds/rush/tty_linux.go
+++ b/cmds/rush/tty_linux.go
@@ -53,7 +53,7 @@ func foreground() {
 	if ttypgrp != 0 {
 		r1, r2, errno := syscall.RawSyscall(syscall.SYS_IOCTL, ttyf.Fd(), uintptr(syscall.TIOCSPGRP), uintptr(unsafe.Pointer(&ttypgrp)))
 		if errno != 0 {
-			log.Printf("Can't set foreground: %v, %v, %v", r1, r2, errno)
+			log.Printf("rush pid %v: Can't set foreground to %v: %v, %v, %v", os.Getpid(), ttypgrp, r1, r2, errno)
 		}
 	}
 

--- a/cmds/stty/stty.go
+++ b/cmds/stty/stty.go
@@ -1,0 +1,110 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// stty is an stty command in Go.
+// It follows many of the conventions of standard stty.
+// However, it can produce JSON output, for later use, and can
+// read that JSON later to configure it.
+//
+// stty has always had an odd set of flags. -flag means turn flag off;
+// flag means turn flag on. Except for those flags which make an argument;
+// in that case they look like flag <arg>
+// To make the flag package continue to work, we've changed the - to a ~.
+//
+// Programmatically, the options are set with a []string, not lots of magic numbers that
+// are not portable across kernels.
+//
+// The default action is to print in the model of standard stty, which is all most
+// people ever do anyway.
+
+// The command works like this:
+// stty [verb] [options]
+// Verbs are:
+// dump -- dump the json of the struct to stdout
+// load -- read a json file from stdin and use it to set
+// raw -- convenience command to set raw
+// cooked -- convenience command to set cooked
+// In common stty usage, options may be specified without a verb.
+//
+// any other verb, with a ~ or without, is taken to mean standard stty args, e.g.
+// stty ~echo
+// turns off echo. Flags with arguments work too:
+// stty intr 1
+// sets the interrupt character to ^A.
+//
+// The JSON encoding lets you do things like this:
+// stty dump | sed whatever > file
+// stty load file
+// Further, one can easily push and pop state in by storing the current
+// state in a file in JSON, making changes, and restoring it later. This has
+// always been inconvenient in standard stty.
+//
+// While GNU stty can do some of this, its way of doing it is harder to read and not
+// as portable, since the format they use is not self-describing:
+// stty -g
+// 4500:5:bf:8a3b:3:1c:7f:15:4:0:1:0:11:13:1a:0:12:f:17:16:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0
+//
+// We always do our operations on fd 0, as that is standard, and we always do an initial
+// gtty to ensure we have access to fd 0.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+)
+
+func main() {
+	t, err := gtty(0)
+
+	if err != nil {
+		log.Fatalf("gtty: %v", err)
+	}
+
+	if len(os.Args) == 1 {
+		os.Args = append(os.Args, "pretty")
+	}
+
+	switch os.Args[1] {
+	case "pretty":
+		pretty(os.Stdout, t)
+	case "dump":
+		b, err := json.MarshalIndent(t, "", "\t")
+
+		if err != nil {
+			log.Fatalf("json marshal: %v", err)
+		}
+		fmt.Printf("%s\n", b)
+	case "load":
+		if len(os.Args) != 3 {
+			log.Fatalf("arg count")
+		}
+		b, err := ioutil.ReadFile(os.Args[2])
+		if err != nil {
+			log.Fatalf("stty load: %v", err)
+		}
+		if err := json.Unmarshal(b, t); err != nil {
+			log.Fatalf("stty load: %v", err)
+		}
+		if t, err = stty(0, t); err != nil {
+			log.Fatalf("stty: %v", err)
+		}
+		pretty(os.Stdout, t)
+	case "raw":
+		if _, err := setRaw(0); err != nil {
+			log.Fatalf("raw: %v", err)
+		}
+	default:
+		if err := setOpts(t, os.Args[1:]); err != nil {
+			log.Fatalf("setting opts: %v", err)
+		}
+		t, err = stty(0, t)
+		if err != nil {
+			log.Fatalf("stty: %v", err)
+		}
+		pretty(os.Stdout, t)
+	}
+}

--- a/cmds/stty/termios.go
+++ b/cmds/stty/termios.go
@@ -94,7 +94,7 @@ func stty(fd uintptr, t *tty) (*tty, error) {
 	term.Ispeed = uint32(t.Ispeed)
 	term.Ospeed = uint32(t.Ospeed)
 
-	if err := tiSet(0, term); err != nil {
+	if err := tiSet(fd, term); err != nil {
 		return nil, err
 	}
 

--- a/cmds/stty/termios.go
+++ b/cmds/stty/termios.go
@@ -1,0 +1,189 @@
+// Copyright 2015-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"reflect"
+	"strconv"
+)
+
+type (
+	// tty is an os-independent version of the combined info in termios and window size structs.
+	// It is used to get/set info to the termios functions as well as marshal/unmarshal data
+	// in JSON formwt for dump and loading.
+	tty struct {
+		Ispeed int
+		Ospeed int
+		Row    int
+		Col    int
+		Line   int
+		Min    int
+		Time   int
+
+		CC map[string]uint8
+
+		Opts map[string]bool
+	}
+
+	winsize struct {
+		Row, Col       uint16
+		Xpixel, Ypixel uint16
+	}
+)
+
+func gtty(fd uintptr) (*tty, error) {
+	term, err := tiGet(fd)
+	if err != nil {
+		return nil, err
+	}
+	w, err := wsGet(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	var t = tty{Opts: make(map[string]bool), CC: make(map[string]uint8)}
+	for n, b := range boolFields {
+		val := uint32(reflect.ValueOf(term).Elem().Field(b.word).Uint()) & b.mask
+		t.Opts[n] = val != 0
+	}
+
+	for n, c := range cc {
+		t.CC[n] = term.Cc[c]
+	}
+
+	// back in the day, you could have different i and o speeds.
+	// since about 1975, this has not been a thing. It's still in POSIX
+	// evidently. WTF?
+	t.Ispeed = int(term.Ispeed)
+	t.Ospeed = int(term.Ospeed)
+	t.Row = int(w.Row)
+	t.Col = int(w.Col)
+
+	return &t, nil
+}
+
+func stty(fd uintptr, t *tty) (*tty, error) {
+
+	// Get a syscall.Termios
+	// which we can partially fill in.
+	term, err := tiGet(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	for n, b := range boolFields {
+		set := t.Opts[n]
+		i := reflect.ValueOf(term).Elem().Field(b.word).Uint()
+		if set {
+			i |= uint64(b.mask)
+		} else {
+			i &= ^uint64(b.mask)
+		}
+		reflect.ValueOf(term).Elem().Field(b.word).SetUint(i)
+	}
+
+	for n, c := range cc {
+		term.Cc[c] = t.CC[n]
+	}
+
+	term.Ispeed = uint32(t.Ispeed)
+	term.Ospeed = uint32(t.Ospeed)
+
+	if err := tiSet(0, term); err != nil {
+		return nil, err
+	}
+
+	w := &winsize{Row: uint16(t.Row), Col: uint16(t.Col)}
+	if err := wsSet(fd, w); err != nil {
+		return nil, err
+	}
+
+	return gtty(fd)
+}
+
+func pretty(w io.Writer, t *tty) {
+	fmt.Printf("speed: %v ", t.Ispeed)
+	for n, c := range t.CC {
+		fmt.Printf("%v: %#q, ", n, c)
+	}
+	fmt.Fprintf(w, "%d rows, %d cols\n", t.Row, t.Col)
+
+	for n, set := range t.Opts {
+		if set {
+			fmt.Fprintf(w, "%v ", n)
+		} else {
+			fmt.Fprintf(w, "~%v ", n)
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+func intarg(s []string) int {
+	if len(s) < 2 {
+		log.Fatalf("%s requires an arg", s[0])
+	}
+	i, err := strconv.Atoi(s[1])
+	if err != nil {
+		log.Fatalf("%s is not a number", s)
+	}
+	return i
+}
+
+// the arguments are a variety of key-value pairs and booleans.
+// booleans are cleared if the first char is a -, set otherwise.
+func setOpts(t *tty, opts []string) error {
+	for i := 0; i < len(opts); i++ {
+		o := opts[i]
+		switch o {
+		case "row":
+			t.Row = intarg(opts[i:])
+			i++
+			continue
+		case "col":
+			t.Col = intarg(opts[i:])
+			i++
+			continue
+		case "speed":
+			t.Ispeed = intarg(opts[i:])
+			i++
+			continue
+		}
+
+		// see if it's one of the control char options.
+		if _, ok := cc[opts[i]]; ok {
+			t.CC[opts[i]] = uint8(intarg(opts[i:]))
+			i++
+			continue
+		}
+
+		// At this point, it has to be one of the boolean ones
+		// or we're done here.
+		set := true
+		if o[0] == '~' {
+			set = false
+			o = o[1:]
+		}
+		if _, ok := boolFields[o]; !ok {
+			log.Fatalf("%s: unknown option", o)
+		}
+
+		t.Opts[o] = set
+	}
+	return nil
+}
+
+func setRaw(fd uintptr) (*tty, error) {
+	t, err := gtty(fd)
+	if err != nil {
+		return nil, err
+	}
+
+	setOpts(t, []string{"~ignbrk", "~brkint", "~parmrk", "~istrip", "~inlcr", "~igncr", "~icrnl", "~ixon", "~opost", "~echo", "~echonl", "~icanon", "~isig", "~iexten", "~parenb" /*"cs8", */, "min", "1", "time", "0"})
+
+	return stty(fd, t)
+}

--- a/cmds/stty/termios_linux.go
+++ b/cmds/stty/termios_linux.go
@@ -1,0 +1,152 @@
+// Copyright 2015-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+)
+
+type bit struct {
+	word int
+	mask uint32
+}
+
+var (
+	boolFields = map[string]*bit{
+		// Input processing
+		"ignbrk":  &bit{word: I, mask: syscall.IGNBRK},
+		"brkint":  &bit{word: I, mask: syscall.BRKINT},
+		"ignpar":  &bit{word: I, mask: syscall.IGNPAR},
+		"parmrk":  &bit{word: I, mask: syscall.PARMRK},
+		"inpck":   &bit{word: I, mask: syscall.INPCK},
+		"istrip":  &bit{word: I, mask: syscall.ISTRIP},
+		"inlcr":   &bit{word: I, mask: syscall.INLCR},
+		"igncr":   &bit{word: I, mask: syscall.IGNCR},
+		"icrnl":   &bit{word: I, mask: syscall.ICRNL},
+		"iuclc":   &bit{word: I, mask: syscall.IUCLC},
+		"ixon":    &bit{word: I, mask: syscall.IXON},
+		"ixany":   &bit{word: I, mask: syscall.IXANY},
+		"ixoff":   &bit{word: I, mask: syscall.IXOFF},
+		"imaxbel": &bit{word: I, mask: syscall.IMAXBEL},
+		"iutf8":   &bit{word: I, mask: syscall.IUTF8},
+
+		//Outputprocessing
+		"opost":  &bit{word: O, mask: syscall.OPOST},
+		"olcuc":  &bit{word: O, mask: syscall.OLCUC},
+		"onlcr":  &bit{word: O, mask: syscall.ONLCR},
+		"ocrnl":  &bit{word: O, mask: syscall.OCRNL},
+		"onocr":  &bit{word: O, mask: syscall.ONOCR},
+		"onlret": &bit{word: O, mask: syscall.ONLRET},
+		"ofill":  &bit{word: O, mask: syscall.OFILL},
+		"ofdel":  &bit{word: O, mask: syscall.OFDEL},
+
+		//Localprocessing
+		"isig":    &bit{word: L, mask: syscall.ISIG},
+		"icanon":  &bit{word: L, mask: syscall.ICANON},
+		"xcase":   &bit{word: L, mask: syscall.XCASE},
+		"echo":    &bit{word: L, mask: syscall.ECHO},
+		"echoe":   &bit{word: L, mask: syscall.ECHOE},
+		"echok":   &bit{word: L, mask: syscall.ECHOK},
+		"echonl":  &bit{word: L, mask: syscall.ECHONL},
+		"noflsh":  &bit{word: L, mask: syscall.NOFLSH},
+		"tostop":  &bit{word: L, mask: syscall.TOSTOP},
+		"echoctl": &bit{word: L, mask: syscall.ECHOCTL},
+		"echoprt": &bit{word: L, mask: syscall.ECHOPRT},
+		"echoke":  &bit{word: L, mask: syscall.ECHOKE},
+		"flusho":  &bit{word: L, mask: syscall.FLUSHO},
+		"pendin":  &bit{word: L, mask: syscall.PENDIN},
+		"iexten":  &bit{word: L, mask: syscall.IEXTEN},
+
+		//Controlprocessing
+
+		"cstopb": &bit{word: C, mask: syscall.CSTOPB},
+		"cread":  &bit{word: C, mask: syscall.CREAD},
+		"parenb": &bit{word: C, mask: syscall.PARENB},
+		"parodd": &bit{word: C, mask: syscall.PARODD},
+		"hupcl":  &bit{word: C, mask: syscall.HUPCL},
+		"clocal": &bit{word: C, mask: syscall.CLOCAL},
+	}
+	cc = map[string]int{
+		"min":   5,
+		"time":  0,
+		"lnext": syscall.VLNEXT,
+		//"flush": syscall.VFLUSH,
+		"intr":  syscall.VINTR,
+		"quit":  syscall.VQUIT,
+		"erase": syscall.VERASE,
+		"kill":  syscall.VKILL,
+		"eof":   syscall.VEOF,
+		"eol":   syscall.VEOL,
+		"eol2":  syscall.VEOL2,
+		//"swtch": syscall.VSWTCH,
+		"start": syscall.VSTART,
+		"stop":  syscall.VSTOP,
+		"susp":  syscall.VSUSP,
+		//"rprnt": syscall.VRPRNT,
+		"werase": syscall.VWERASE,
+	}
+)
+
+// These consts describe the offsets into the termios struct of various elements.
+const (
+	I = iota // Input control
+	O        // Output control
+	C        // Control
+	L        // Line control
+)
+
+// ioctl constants
+const (
+	syscallTIOCGWINSZ = 0x5413
+	syscallTIOCSWINSZ = 0x5414
+)
+
+func tiGet(fd uintptr) (*syscall.Termios, error) {
+	var term syscall.Termios
+	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		fd, uintptr(syscall.TCGETS),
+		uintptr(unsafe.Pointer(&term)))
+
+	if errno != 0 || r1 != 0 {
+		return nil, fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
+	}
+	return &term, nil
+}
+
+func tiSet(fd uintptr, term *syscall.Termios) error {
+	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		fd, uintptr(syscall.TCSETS),
+		uintptr(unsafe.Pointer(term)))
+	if errno != 0 || r1 != 0 {
+		return fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
+	}
+
+	return nil
+}
+
+func wsGet(fd uintptr) (*winsize, error) {
+	var w winsize
+	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		fd, uintptr(syscallTIOCGWINSZ),
+		uintptr(unsafe.Pointer(&w)))
+	if errno != 0 || r1 != 0 {
+		return nil, fmt.Errorf("wsGet: r1 %v, errno %v", r1, errno)
+	}
+
+	return &w, nil
+}
+
+func wsSet(fd uintptr, w *winsize) error {
+	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
+		fd, uintptr(syscallTIOCSWINSZ),
+		uintptr(unsafe.Pointer(w)))
+	if errno != 0 || r1 != 0 {
+		return fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
+	}
+
+	return nil
+}

--- a/cmds/stty/termios_linux.go
+++ b/cmds/stty/termios_linux.go
@@ -112,7 +112,7 @@ func tiGet(fd uintptr) (*syscall.Termios, error) {
 		uintptr(unsafe.Pointer(&term)))
 
 	if errno != 0 || r1 != 0 {
-		return nil, fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
+		return nil, fmt.Errorf("tiGet: r1 %v, errno %v", r1, errno)
 	}
 	return &term, nil
 }
@@ -122,7 +122,7 @@ func tiSet(fd uintptr, term *syscall.Termios) error {
 		fd, uintptr(syscall.TCSETS),
 		uintptr(unsafe.Pointer(term)))
 	if errno != 0 || r1 != 0 {
-		return fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
+		return fmt.Errorf("tiSet: r1 %v, errno %v", r1, errno)
 	}
 
 	return nil
@@ -145,7 +145,7 @@ func wsSet(fd uintptr, w *winsize) error {
 		fd, uintptr(syscallTIOCSWINSZ),
 		uintptr(unsafe.Pointer(w)))
 	if errno != 0 || r1 != 0 {
-		return fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
+		return fmt.Errorf("wsSet: r1 %v, errno %v", r1, errno)
 	}
 
 	return nil


### PR DESCRIPTION
You can do things like
stty raw

Default is to just print stuff out.

You can say
stty dump
and it will dump JSON. then you can say:
stty load < file.json

and it get restored, or even
stty Save | sed command > load.json
 stty load load.json

and you can have a filter that modifies stty settings.

You can also do this:

stty save > push.json
stty raw

do stuff

stty load  push.json

i.e. stty is more unix-like than it's been.

Also, the stty struct in termios.go is intended to have enough struct members to cover a superset of uses, so it
may nbot fit all cases. I.e. there might be a variable in there that would have no meaning on OSX

Just keep in mind, termios.go is supposed to be sort of OS-agnostic, with nasty bits in termios_os.go. Also, lest anyone
forget, this should be able to work on systems like plan 9 and harvey, in which text is the control, not weird
bits of binary crap.

So make sure that setOpt is always implemented with []string, ok? Not ints or magic bits.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>