### PR TITLE
pkg/cpio: add support for darwin

### DIFF
--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -134,20 +134,7 @@ func GetRecord(path string) (Record, error) {
 	}
 
 	sys := fi.Sys().(*syscall.Stat_t)
-	info := Info{
-		Ino:      sys.Ino,
-		Mode:     uint64(sys.Mode),
-		UID:      uint64(sys.Uid),
-		GID:      uint64(sys.Gid),
-		NLink:    sys.Nlink,
-		MTime:    uint64(sys.Mtim.Sec),
-		FileSize: uint64(sys.Size),
-		Major:    sys.Dev >> 8,
-		Minor:    sys.Dev & 0xff,
-		Rmajor:   sys.Rdev >> 8,
-		Rminor:   sys.Rdev & 0xff,
-		Name:     path,
-	}
+	info := sysInfo(path, sys)
 
 	switch fi.Mode() & os.ModeType {
 	case 0: // Regular file.

--- a/pkg/cpio/sysinfo_darwin.go
+++ b/pkg/cpio/sysinfo_darwin.go
@@ -1,0 +1,26 @@
+// Copyright 2013-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cpio
+
+import (
+	"syscall"
+)
+
+func sysInfo(n string, sys *syscall.Stat_t) Info {
+	return Info{
+		Ino:      sys.Ino,
+		Mode:     uint64(sys.Mode),
+		UID:      uint64(sys.Uid),
+		GID:      uint64(sys.Gid),
+		NLink:    uint64(sys.Nlink),
+		MTime:    uint64(sys.Mtimespec.Sec),
+		FileSize: uint64(sys.Size),
+		Major:    uint64(sys.Dev >> 8),
+		Minor:    uint64(sys.Dev & 0xff),
+		Rmajor:   uint64(sys.Rdev >> 8),
+		Rminor:   uint64(sys.Rdev & 0xff),
+		Name:     n,
+	}
+}

--- a/pkg/cpio/sysinfo_linux.go
+++ b/pkg/cpio/sysinfo_linux.go
@@ -1,0 +1,26 @@
+// Copyright 2013-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cpio
+
+import (
+	"syscall"
+)
+
+func sysInfo(n string, sys *syscall.Stat_t) Info {
+	return Info{
+		Ino:      sys.Ino,
+		Mode:     uint64(sys.Mode),
+		UID:      uint64(sys.Uid),
+		GID:      uint64(sys.Gid),
+		NLink:    sys.Nlink,
+		MTime:    uint64(sys.Mtim.Sec),
+		FileSize: uint64(sys.Size),
+		Major:    sys.Dev >> 8,
+		Minor:    sys.Dev & 0xff,
+		Rmajor:   sys.Rdev >> 8,
+		Rminor:   sys.Rdev & 0xff,
+		Name:     n,
+	}
+}


### PR DESCRIPTION
Stat_t are just different enough that we need a sysInfo function
for each kernel type.

Signed-off-by: Ron Minnich <rminnich@gmail.com>