### PR TITLE
busybox init and cmds/rush: make tty behavior correct, helps minimega

### DIFF
--- a/bb/bb.go
+++ b/bb/bb.go
@@ -130,14 +130,6 @@ func init() {
 		cmd.Stderr = os.Stderr
 		cmd.Stdout = os.Stdout
 		var fd int
-		cons, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-		if err != nil {
-			log.Printf("can't open /dev/tty: %v", err)
-		} else {
-			fd = int(cons.Fd())
-			log.Printf("#### setting 0, 1, 2 to opened tty fd is %v", cons.Fd())
-			cmd.Stdin, cmd.Stdout, cmd.Stderr = cons, cons, cons
-		}
 		cmd.SysProcAttr = &syscall.SysProcAttr{Ctty: fd, Setctty: true, Setsid: true, Cloneflags: cloneFlags}
 		log.Printf("Run %v", cmd)
 		if err := cmd.Run(); err != nil {

--- a/cmds/rush/rush.go
+++ b/cmds/rush/rush.go
@@ -103,6 +103,13 @@ func runit(c *Command) error {
 			return err
 		}
 	} else {
+		c.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+		if c.bg {
+			c.Cmd.SysProcAttr.Setpgid = true
+		} else {
+			c.Cmd.SysProcAttr.Foreground = true
+			c.Cmd.SysProcAttr.Ctty = int(ttyf.Fd())
+		}
 		if err := c.Start(); err != nil {
 			return fmt.Errorf("%v: Path %v", err, os.Getenv("PATH"))
 		}
@@ -172,8 +179,7 @@ func commands(cmds []*Command) error {
 		// Not sure of the issue but this hack will have to do until
 		// we understand it. Barf.
 		if c.cmd == "builtin" {
-			s := &syscall.SysProcAttr{Cloneflags: syscall.CLONE_NEWNS}
-			c.Cmd.SysProcAttr = s
+			c.Cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNS
 		}
 	}
 	return nil

--- a/cmds/rush/tty_linux.go
+++ b/cmds/rush/tty_linux.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	ttypgrp uintptr
-	ttyf *os.File
+	ttyf    *os.File
 )
 
 // tty does whatever needs to be done to set up a tty for GOOS.
@@ -24,6 +24,7 @@ func tty() {
 
 	sigs := make(chan os.Signal, 512)
 	signal.Notify(sigs, os.Interrupt)
+	signal.Ignore(syscall.SIGTTOU)
 	go func() {
 		for i := range sigs {
 			fmt.Println(i)


### PR DESCRIPTION
This set of changes finally makes rush work sanely, for foreground and background processes, and
gets minimega way farther along.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>