### PR TITLE
onehot package: add onehot package

### DIFF
--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -5,13 +5,14 @@
 package cpio
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/u-root/u-root/pkg/onehot"
 )
 
 // Linux mode_t bits.
@@ -186,17 +187,11 @@ func GetRecord(path string) (Record, error) {
 		if done {
 			return Record{nil, info}, nil
 		}
-		osfile, err := os.Open(path)
+		f, err := onehot.Open(path)
 		if err != nil {
 			return Record{}, err
 		}
-		defer osfile.Close()
-
-		contents, err := ioutil.ReadAll(osfile)
-		if err != nil {
-			return Record{}, err
-		}
-		return Record{bytes.NewReader(contents), info}, nil
+		return Record{f, info}, nil
 
 	case os.ModeSymlink:
 		linkname, err := os.Readlink(path)

--- a/pkg/onehot/onehot.go
+++ b/pkg/onehot/onehot.go
@@ -1,0 +1,98 @@
+// Copyright 2013-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// package onehot implements a "one hot" struct that implements
+// Reader but defers the open until the first read. It should be
+// used in packages, like cpio, that want to set up lots of
+// Readers and read them later. Just reading the files in
+// is impractical for many reasons:
+// o they might be named pipes on Plan9
+// o they might be so large they won't fit in memory
+// o there might be so many of them they might not all
+//   fit in memory.
+// But just opening them and returning an io.Reader is also
+// impractical as, seen in practice, we might get EMFILE.
+// Hence, we keep track of the file, but don't open it.
+// We considered doing a test open but it seems a bit pointless;
+// the file might go away by the time we get around to opening
+// it for I/O and, on some systems, opening and then closing
+// the file can make it go away, even if we don't read it.
+// The name onehot may be a misnomer but we're keeping open
+// the possibility of adding state such that only one onehot
+// file can be open at a time. We will see if we need that.
+// Since our first use case is cpio, that seems unlikely.
+package onehot
+
+import (
+	"io"
+	"os"
+	"sync"
+)
+
+type OneHot struct {
+	m sync.Mutex
+	name string
+	f    *os.File
+	dead bool
+	err  error
+}
+
+// Open returns a new OneHot with the name filled in.
+func Open(name string) (io.ReadCloser, error) {
+	return &OneHot{name: name}, nil
+}
+
+// Read reads from a OneHot. If it is dead, it returns
+// -1 and the last error, which is sticky. If it is
+// not open, it opens it; if the open fails, it marks
+// the OneHot as dead and records the error.
+// If the open works, it calls the Read on the
+// underlying Reader; if there is an error there
+// the OneHot is marked dead and the error is recorded.
+func (f *OneHot) Read(b []byte) (int, error) {
+	var err error
+	f.m.Lock()
+	defer f.m.Unlock()
+	if f.dead {
+		return -1, f.err
+	}
+	if f.f == nil {
+		f.f, err = os.Open(f.name)
+		if err != nil {
+			f.dead = true
+			f.err = err
+			return -1, err
+		}
+	}
+	n, err := f.f.Read(b)
+
+	if n < 0 || err != nil {
+		f.dead = true
+		f.err = err
+	}
+	return n, err
+}
+
+// Close closes the OneNot. It always calls f.f.Close()
+// then sets f.f to nil, retains the error if any, and
+// makes the OneHot as dead.
+func (f *OneHot) Close() error {
+	f.m.Lock()
+	defer f.m.Unlock()
+	// This is a bit tricky. If f.f is nil
+	// but it's not dead, it has not been opened.
+	// Return no error, but mark it dead.
+	if ! f.dead && f.f == nil {
+		f.dead = true
+		f.err = nil
+		return nil
+	}
+	// calling Close on nil Files is OK.
+	// This way we are sure to get the right error
+	err := f.f.Close()
+	f.dead = true
+	f.err = err
+	f.f = nil
+	return err
+}

--- a/pkg/onehot/onehot_test.go
+++ b/pkg/onehot/onehot_test.go
@@ -5,6 +5,8 @@
 package onehot
 
 import (
+	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -87,6 +89,91 @@ func TestOneHotFail(t *testing.T) {
 	var b [1]byte
 	if _, err := f.Read(b[:]); err == nil {
 		t.Fatalf("Writing test data: got nil, want err")
+	}
+
+}
+
+func TestOneHotTooMany(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "TestOneHot")
+	if err != nil {
+		t.Fatal("TempDir failed: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	// This is kinda weird, but basically we make files until we get E2MANY.
+	// Then we close the last one that worked, meaning we can only have one open.
+	// Then we use onehot to iterate through them all, which should not fail.
+	var closeme *os.File
+	var names []string
+	var nfiles int
+	for ; ; nfiles++ {
+		n := filepath.Join(tmpDir, fmt.Sprintf("%d", nfiles))
+		f, err := os.Create(n)
+		t.Logf("%v: %v, %v", n, f, err)
+		// I can't believe there's not a better way to do this but ...
+		want := fmt.Sprintf("open %v: too many open files", n)
+		if err != nil && err.Error() != want {
+			t.Fatalf("Creating the %d'th file: want %v, got %v", nfiles, want, err.Error())
+		}
+		if err != nil {
+			break
+		}
+		// write one byte into it to verify we can read it
+		if n, err := f.Write([]byte{1}); err != nil || n != 1 {
+			t.Fatalf("Trying to write one byte to %v: want [1, nil] , got [%v, %v]", f, n, err)
+		}
+		t.Logf("Opened %v", n)
+		closeme = f
+		names = append(names, n)
+	}
+
+	t.Logf("Opened %d files", nfiles)
+
+	if err := closeme.Close(); err != nil {
+		t.Fatalf("Closing the closeme file, %v: want nil, got %v", closeme, err)
+	}
+
+	var onehots []io.ReadCloser
+
+	for _, n := range names {
+		f, err := Open(n)
+		t.Logf("onehot open %v", n)
+		if err != nil {
+			t.Fatalf("Opening %v: got %v, want nil", n, err)
+		}
+		onehots = append(onehots, f)
+	}
+
+	t.Logf("opened them all")
+	for _, f := range onehots {
+		var b [1]byte
+		if n, err := f.Read(b[:]); err != nil || n != 1 {
+			t.Fatalf("Reading test data: want [1, nil], got [%v, %v]", n, err)
+		}
+		t.Logf("Read 1 byte from %v", f)
+	}
+
+	// Go around again. This tests interleaved reads.
+	for _, f := range onehots {
+		var b [1]byte
+		if n, err := f.Read(b[:]); err != nil || n != 1 {
+			t.Fatalf("Reading test data: want [1, nil], got [%v, %v]", n, err)
+		}
+		t.Logf("Read 1 byte from %v", f)
+	}
+
+	for _, f := range onehots {
+		if err := f.Close(); err != nil {
+			t.Fatalf("Closing onehot , %v: want nil, got %v", f, err)
+		}
+	}
+
+	// Go around again. This tests read after close.
+	for _, f := range onehots {
+		var b [1]byte
+		if n, err := f.Read(b[:]); err != io.EOF || n != -1 {
+			t.Fatalf("Reading test data: want [-1, io.EOF], got [%v, %v]", n, err)
+		}
+		t.Logf("Read 1 byte from %v", f)
 	}
 
 }

--- a/pkg/onehot/onehot_test.go
+++ b/pkg/onehot/onehot_test.go
@@ -65,6 +65,9 @@ func TestOneHotFile(t *testing.T) {
 	if string(b) != tval {
 		t.Fatalf("Reading back file: got %s, want %s", string(b), tval)
 	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Closing %v: want nil, got %v", name, err)
+	}
 }
 
 func TestOneHotFail(t *testing.T) {
@@ -74,13 +77,16 @@ func TestOneHotFail(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	bad := filepath.Join(tmpDir, "bad")
+	if err := ioutil.WriteFile(bad, []byte{}, 0644); err != nil {
+		t.Fatalf("Writing test data: got %v, want nil", err)
+	}
 	f, err := Open(bad)
 	if err != nil {
-		t.Fatalf("Opening %v: got %v, want nil", err)
+		t.Fatalf("Opening %v: got %v, want nil", bad, err)
 	}
 	var b [1]byte
 	if _, err := f.Read(b[:]); err == nil {
-		t.Fatalf("Writing test data: got %v, want nil", err)
+		t.Fatalf("Writing test data: got nil, want err")
 	}
 
 }

--- a/pkg/onehot/onehot_test.go
+++ b/pkg/onehot/onehot_test.go
@@ -1,0 +1,86 @@
+// Copyright 2016 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package onehot
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const tval = "testing"
+
+func TestOneHotFileClose(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "TestOneHot")
+	if err != nil {
+		t.Fatal("TempDir failed: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	name := filepath.Join(tmpDir, "test")
+	if err := ioutil.WriteFile(name, []byte(tval), 0644); err != nil {
+		t.Fatalf("Writing test data: got %v, want nil", err)
+	}
+
+	f, err := Open(name)
+	if err != nil {
+		t.Fatalf("Opening %v after writing it: got %v, want nil", name, err)
+	}
+	err = f.Close()
+	if err != nil {
+		t.Fatalf("Closing %v after opening it: got %v, want nil", name, err)
+	}
+	err = f.Close()
+	if err == nil {
+		t.Fatalf("Closing %v after closing it: got nil, want err", name)
+	}
+}
+
+func TestOneHotFile(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "TestOneHot")
+	if err != nil {
+		t.Fatal("TempDir failed: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	name := filepath.Join(tmpDir, "test")
+	if err := ioutil.WriteFile(name, []byte(tval), 0644); err != nil {
+		t.Fatalf("Writing test data: got %v, want nil", err)
+	}
+
+	f, err := Open(name)
+	if err != nil {
+		t.Fatalf("Opening %v after writing it: got %v, want nil", name, err)
+	}
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("Writing test data: got %v, want nil", err)
+	}
+	if len(b) != 7 {
+		t.Fatalf("Reading back file: got len %d, want %d", len(b), len(tval))
+	}
+	if string(b) != tval {
+		t.Fatalf("Reading back file: got %s, want %s", string(b), tval)
+	}
+}
+
+func TestOneHotFail(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "TestOneHot")
+	if err != nil {
+		t.Fatal("TempDir failed: ", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	bad := filepath.Join(tmpDir, "bad")
+	f, err := Open(bad)
+	if err != nil {
+		t.Fatalf("Opening %v: got %v, want nil", err)
+	}
+	var b [1]byte
+	if _, err := f.Read(b[:]); err == nil {
+		t.Fatalf("Writing test data: got %v, want nil", err)
+	}
+
+}


### PR DESCRIPTION
onehot implements io.Reader for files you open. It defers
opening the file until the first read.

onehot refers to a possible eventual need to only have one file
open at a time, and also to the planned usage pattern, as in
cpio, to only have one file "hot" at a time as we are sequentially
reading from a list of files.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>