### PR TITLE
cpio: fix Record so it implements ReadCloser

### DIFF
--- a/bb/devCPIO.go
+++ b/bb/devCPIO.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"strings"
 	"syscall"
 
 	"github.com/u-root/u-root/pkg/cpio"
@@ -40,8 +39,8 @@ var devCPIO = []cpio.Record{
 	{Info: cpio.Info{Name: "dev/tty", Mode: c | 0666, Rmajor: 5, Rminor: 0}},
 	{Info: cpio.Info{Name: "dev/null", Mode: c | 0666, Rmajor: 1, Rminor: 3}},
 	{Info: cpio.Info{Name: "dev/urandom", Mode: c | 0666, Rmajor: 1, Rminor: 9}},
-	{Info: cpio.Info{Name: "etc/resolv.conf", Mode: f | 0644, FileSize: uint64(len(nameserver))}, Reader: strings.NewReader(nameserver)},
-	{Info: cpio.Info{Name: "etc/localtime", Mode: f | 0644, FileSize: uint64(len(gmt0))}, Reader: strings.NewReader(gmt0)},
+	{Info: cpio.Info{Name: "etc/resolv.conf", Mode: f | 0644, FileSize: uint64(len(nameserver))}, ReadCloser: cpio.NewBytesReadCloser([]byte(nameserver))},
+	{Info: cpio.Info{Name: "etc/localtime", Mode: f | 0644, FileSize: uint64(len(gmt0))}, ReadCloser: cpio.NewBytesReadCloser([]byte(gmt0))},
 }
 
 // not yet implemented, let's wait and see if we still need them:


### PR DESCRIPTION
It's important to not have lots of files open, and
to not read all the files in, and to close files
we open as soon as we are done. So we need to implement
ReadCloser.

We implement a struct that implements ReadCloser with a Close
that always works, since it does nothing;
and another struct that implements Read
by remembering the name and deferring the open until first use.

The assumption here is that our pattern of use is read, then close.
That applies to cpio perfectly.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>