### PR TITLE
msr command

### DIFF
--- a/cmds/msr/msr.go
+++ b/cmds/msr/msr.go
@@ -1,0 +1,86 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+// +build amd64
+
+// msr lets you read and write an msr for one or more cores.
+// The cores are specified via a filepath.Glob string.
+// The string should be for core number only, with no
+// surrounding paths, e.g. you use 0 for core 0, not
+// /dev/cpu/0/msr.
+// To specify all cores, use '*'
+// To specify all cores with two digits, use '??'
+// To specify all odd cores, use '*[13579]'
+// To specify, e.g., all the even cores, use '*[02468]'.
+// Usage:
+// msr r glob 32-bit-msr-number
+// msr w glob 32-bit-msr-number 64-bit-value
+// For each MSR operation msr will print an error if any.
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+)
+
+const usage = `msr r glob register
+msr w glob register value`
+
+func main() {
+	a := os.Args[1:]
+	if len(a) < 3 {
+		log.Fatal(usage)
+	}
+
+	m := msrList(a[1])
+
+	reg, err := strconv.ParseUint(a[2], 0, 32)
+	if err != nil {
+		log.Fatalf("%v: %v", a[2], err)
+	}
+	switch a[0] {
+	case "r":
+		data, errs := rdmsr(m, uint32(reg))
+		for i := range m {
+			if errs[i] != nil {
+				fmt.Printf("%v: %v\n", m[i], errs[i])
+			} else {
+				fmt.Printf("%v: %#016x\n", m[i], data[i])
+			}
+		}
+
+	case "w":
+		// Sadly, we don't get an error on write if the values
+		// don't match.  Reading it back to check it is
+		// not always going to work. There are many write-only
+		// MSRs. If there are no errors there is still no
+		// guarantee that it worked, or if we read it we would
+		// see what we wrote, or that vmware did not do
+		// something stupid, or the x86 did not do something really
+		// stupid, or the particular implementation of the x86
+		// that we are on did not do something really stupid.
+		// Why is it this way? Because vendors hide proprietary
+		// information in hidden MSRs, or in hidden fields in MSRs.
+		// Checking is just not an option. There, feel better now?
+		if len(a) < 4 {
+			log.Fatal(usage)
+		}
+		v, err := strconv.ParseUint(a[3], 0, 64)
+		if err != nil {
+			log.Fatalf("%v: %v", a, err)
+		}
+		errs := wrmsr(m, uint32(reg), v)
+		for i := range errs {
+			if errs[i] != nil {
+				fmt.Printf("%v: %v\n", m[i], errs[i])
+			}
+		}
+
+	default:
+		log.Fatalf(usage)
+	}
+}

--- a/cmds/msr/msr_linux.go
+++ b/cmds/msr/msr_linux.go
@@ -1,0 +1,76 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build amd64
+
+// This file contains support functions for msr access for x86 Linux.
+package main
+
+import (
+	"encoding/binary"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+func msrList(n string) []string {
+	m, err := filepath.Glob(filepath.Join("/dev/cpu", n, "msr"))
+	// This err will be if the glob was bad.
+	if err != nil {
+		log.Fatalf("No MSRs matched %v: %v", n, err)
+	}
+	// len will be zero for any of a number of reasons.
+	if len(m) == 0 {
+		log.Fatalf("No msrs found. Make sure your kernel is compiled with msrs, and you may need to 'sudo modprobe msr'. To see available msrs, ls /dev/cpu.")
+	}
+	return m
+}
+
+func openAll(m []string, o int) ([]*os.File, []error) {
+	var (
+		f    = make([]*os.File, len(m))
+		errs = make([]error, len(m))
+	)
+	for i := range m {
+		f[i], errs[i] = os.OpenFile(m[i], o, 0)
+	}
+	return f, errs
+}
+
+func doio(msr *os.File, addr uint32, f func(*os.File) error) error {
+	if _, err := msr.Seek(int64(addr), 0); err != nil {
+		return fmt.Errorf("Bad address %v: %v", addr, err)
+	}
+	return f(msr)
+}
+
+func rdmsr(m []string, addr uint32) ([]uint64, []error) {
+	var regs = make([]uint64, len(m))
+
+	f, errs := openAll(m, os.O_RDONLY)
+	for i := range m {
+		if errs[i] != nil {
+			continue
+		}
+		errs[i] = doio(f[i], addr, func(port *os.File) error {
+			return binary.Read(port, binary.LittleEndian, &regs[i])
+		})
+	}
+	return regs, errs
+}
+
+func wrmsr(m []string, addr uint32, data uint64) []error {
+	f, errs := openAll(m, os.O_RDWR)
+
+	for i := range m {
+		if errs[i] != nil {
+			continue
+		}
+		errs[i] = doio(f[i], addr, func(port *os.File) error {
+			return binary.Write(port, binary.LittleEndian, data)
+		})
+	}
+	return errs
+}


### PR DESCRIPTION
usage:
msr r glob 32-bit-number
msr w glob 32-bit number 64-bit value

Unlike the rdmsr/wrmsr commands, this one lets you do a whole bunch
of processors in one pass. It accumulates a list of errors, one per msr
operation. If there is an error,
it will print an error for that one operation. If there is not an
error, for read, it prints the msr value.

I tried several approaches for the specification of the set of cores
and the glob was by far the most convenient. It's possible we'll have
an OS where a string will not suffice to name an MSR but we can cross
that bridge when we come to it.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>