### PR TITLE
Dhcpv6 timeout

### DIFF
--- a/cmds/dhclient/dhclient.go
+++ b/cmds/dhclient/dhclient.go
@@ -72,7 +72,7 @@ func dhclient4(iface netlink.Link, numRenewals int, timeout time.Duration) error
 
 	var packet dhcp4.Packet
 	for i := 0; numRenewals < 0 || i < numRenewals+1; i++ {
-		debug("Start getting or renewing lease")
+		debug("Start getting or renewing DHCPv4 lease")
 
 		var success bool
 		if packet == nil {
@@ -154,9 +154,10 @@ func dhclient6(iface netlink.Link, numRenewals int, timeout time.Duration) error
 	if err != nil {
 		return fmt.Errorf("client conection generation: %v", err)
 	}
-	client := dhcp6client.New(iface.Attrs().HardwareAddr, conn)
+	client := dhcp6client.New(iface.Attrs().HardwareAddr, conn, timeout)
 
 	for i := 0; numRenewals < 0 || i < numRenewals+1; i++ {
+		debug("Start getting or renewing DHCPv6 lease")
 		iaAddrs, packet, err := client.Solicit()
 		if err != nil {
 			return fmt.Errorf("error: %v", err)

--- a/pkg/dhcp6client/packetSock.go
+++ b/pkg/dhcp6client/packetSock.go
@@ -3,6 +3,7 @@ package dhcp6client
 import (
 	"net"
 	"syscall"
+	"time"
 )
 
 // TODO: Make packetSock implement net.PacketConn?
@@ -30,7 +31,7 @@ func NewPacketSock(ifindex int) (*packetSock, error) {
 	}, nil
 }
 
-// Writes a packet.
+// Write a packet.
 func (pc packetSock) WriteTo(p []byte, mac net.HardwareAddr) error {
 	lladdr := syscall.SockaddrLinklayer{
 		Ifindex:  pc.ifindex,
@@ -52,6 +53,12 @@ func (pc packetSock) ReadFrom(p []byte) (int, error) {
 // Close socket.
 func (pc packetSock) Close() error {
 	return syscall.Close(pc.fd)
+}
+
+// Set a read timeout
+func (pc *packetSock) SetReadTimeout(t time.Duration) error {
+	tv := syscall.NsecToTimeval(t.Nanoseconds())
+	return syscall.SetsockoptTimeval(pc.fd, syscall.SOL_SOCKET, syscall.SO_RCVTIMEO, &tv)
 }
 
 func swap16(x uint16) uint16 {


### PR DESCRIPTION
If DHCPv6 client has not been receiving packets for a certain amount of time after it sends out a DHCPv6 solicit message, it will try to resend the solicit message. This handles the situation when interface is not even up, or some other unknown issues probably