### PR TITLE
Max Number of DHCP Reply Reception Attempts

### DIFF
--- a/pkg/dhcp6client/dhcp6client.go
+++ b/pkg/dhcp6client/dhcp6client.go
@@ -24,12 +24,16 @@ type Client struct {
 
 	// Packet socket to send on.
 	connection *packetSock
+
+	// Max number of attempts to receive a valid DHCPv6 reply from server.
+	attempts int
 }
 
-func New(haddr net.HardwareAddr, packetSock *packetSock) *Client {
+func New(haddr net.HardwareAddr, packetSock *packetSock, n int) *Client {
 	return &Client{
 		srcMAC:     haddr,
 		connection: packetSock,
+		attempts:   n,
 	}
 }
 
@@ -92,7 +96,7 @@ func (p *buffer) remaining() []byte {
 
 func (c *Client) ReadReply() (*dhcp6.Packet, error) {
 	var err error
-	for i := 0; i < 5; i++ { // five attempts
+	for i := 0; i < c.attempts; i++ { // five attempts
 		pb := make([]byte, 1500)
 		var n int
 		n, err = c.connection.ReadFrom(pb)


### PR DESCRIPTION
Added a flag so that a user is able to customize the maximal number of
attempts for DHCP client to receive a valid reply from server. In
default the maximal number of retry is 5.

Signed-off-by: Xuan Chen <xchenan@gmail.com>