### PR TITLE
Disabled CGO in travis.sh

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export GOPATH=/home/travis/gopath
 set -e
- (cd bb && go build . && ./bb)
+ (cd bb && CGO_ENABLED=0 go build . && ./bb)
 mv /tmp/initramfs.linux_amd64.cpio /tmp/i2
 # echo Test for reproducible initramfds in busybox mode
- (cd bb && go build . && ./bb)
+ (cd bb && CGO_ENABLED=0 go build . && ./bb)
 cmp /tmp/initramfs.linux_amd64.cpio /tmp/i2
  which go
- (cd scripts && go run ramfs.go -tmpdir=/tmp/u-root -removedir=false)
+ (cd scripts && CGO_ENABLED=0 go run ramfs.go -tmpdir=/tmp/u-root -removedir=false)
  GOBIN=/tmp/u-root/ubin GOROOT=/tmp/u-root/go GOPATH=/tmp/u-root CGO_ENABLED=0 /tmp/u-root/go/bin/go build  github.com/u-root/u-root/cmds/ip
  (cd cmds && CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags '-s' ./...)
  ls -l cmds/*


### PR DESCRIPTION
A small modification which disables cgo during testing.

Signed-off-by: Xuan Chen <xchenan@gmail.com>