### PR TITLE
bb: correctly create cpio archives

### DIFF
--- a/pkg/cpio/types.go
+++ b/pkg/cpio/types.go
@@ -52,6 +52,7 @@ func NewReadCloser(r io.Reader) io.ReadCloser {
 }
 
 func EmptyRecord(info Info) Record {
+	info.FileSize = 0
 	return Record{
 		ioutil.NopCloser(bytes.NewReader(nil)),
 		info,


### PR DESCRIPTION
Turns out the linux cpio processor won't accept paths with
missing things in the middle, e.g. /a/b/c/d fails silently
if /a/b/c does not exist.

Change copyCommands to create records for intermediate directories.
This currently adds a bunch of redundant zero-length directories
but it seems to harm nothing.

Also fix EmptyRecord to set the FileSize to 0, otherwise we create
directory entries with non-zero size which confuses cpio parsers.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>