### PR TITLE
Extend bb so we can add existing commands

### DIFF
--- a/bb/bb.go
+++ b/bb/bb.go
@@ -328,7 +328,7 @@ func oneCmd(c Command) {
 	}
 	initMap += "\n\t\"" + c.CmdName + "\":" + c.CmdName + "Init,"
 	// In the bb case, the commands are built. In some cases, we want to
-	// specify init= for a u-root command on boot. Hence, it now makes sense
+	// specify init= to be a u-root command on boot. Hence, it now makes sense
 	// to have the ubin directory populated on boot, not by /init.
 	l := filepath.Join(config.Bbsh, "ubin", c.CmdName)
 	if err := os.Symlink("/init", l); err != nil {

--- a/bb/bb.go
+++ b/bb/bb.go
@@ -327,6 +327,13 @@ func oneCmd(c Command) {
 		}
 	}
 	initMap += "\n\t\"" + c.CmdName + "\":" + c.CmdName + "Init,"
+	// In the bb case, the commands are built. In some cases, we want to
+	// specify init= for a u-root command on boot. Hence, it now makes sense
+	// to have the ubin directory populated on boot, not by /init.
+	l := filepath.Join(config.Bbsh, "ubin", c.CmdName)
+	if err := os.Symlink("/init", l); err != nil {
+		log.Fatalf("Symlinking %v -> /init: %v", l, err)
+	}
 }
 func main() {
 	var err error
@@ -384,14 +391,6 @@ func main() {
 		}
 		c.CmdName = filepath.Base(c.CmdPath)
 		oneCmd(c)
-		// In the bb case, the commands are built. In some cases, we want to
-		// specify init= for a u-root command on boot. Hence, it now makes sense
-		// to have the ubin directory populated on boot, not by /init.
-		l := filepath.Join(config.Bbsh, "ubin", c.CmdName)
-		err := os.Symlink("/init", l)
-		if err != nil {
-			log.Fatalf("Symlinking %v -> /init: %v", l, err)
-		}
 	}
 
 	if err := ioutil.WriteFile(filepath.Join(config.Bbsh, "init.go"), []byte(initGo), 0644); err != nil {

--- a/bb/devCPIO.go
+++ b/bb/devCPIO.go
@@ -31,6 +31,7 @@ var devCPIO = []cpio.Record{
 	{Info: cpio.Info{Name: "tcz", Mode: d | 0755}},
 	{Info: cpio.Info{Name: "etc", Mode: d | 0755}},
 	{Info: cpio.Info{Name: "dev", Mode: d | 0755}},
+	{Info: cpio.Info{Name: "ubin", Mode: d | 0755}},
 	{Info: cpio.Info{Name: "usr", Mode: d | 0755}},
 	{Info: cpio.Info{Name: "usr/lib", Mode: d | 0755}},
 	{Info: cpio.Info{Name: "lib64", Mode: d | 0755}},

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -54,10 +54,7 @@ func sanity() {
 // and creates cpio records, including directory records.
 func copyCommands(w cpio.Writer, cmds []string) {
 	debug("copyCommands: start with %v", cmds)
-	var (
-		recs []cpio.Record
-		done = make(map[string]bool)
-	)
+	var recs []cpio.Record
 	libs, err := uroot.LddList(cmds)
 	if err != nil {
 		log.Fatalf("%v\n", err)
@@ -67,11 +64,7 @@ func copyCommands(w cpio.Writer, cmds []string) {
 		debug("copyCommands: file %v", n)
 		var dirlist []string
 		for d := filepath.Dir(n); d != "/"; d = filepath.Dir(d) {
-			if done[d] {
-				continue
-			}
 			dirlist = append([]string{d}, dirlist...)
-			done[d] = true
 		}
 		dirlist = append(dirlist, n)
 		for _, n := range dirlist {

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -29,8 +29,10 @@ var (
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
 	paths      = map[string][]string{}
-	extraPaths = flag.String("extra", "", "Extra paths to add in the form root:start, e.g. /:etc/hosts")
-	extraCmds  = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
+	extraPaths = flag.String("extra", "", `Extra paths to add in the form root:start, e.g. /:etc/hosts.
+The path before the : is used as a starting point for a walk; the path after the : selects what things to put
+into the initramfs starting at /. E.g., /tmp/prototype:/ will install the prototype file system into / of the initramfs`)
+	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
 )
 
 func sanity() {
@@ -115,7 +117,11 @@ func ramfs() {
 	if *extraPaths != "" {
 		extras := strings.Split(*extraPaths, " ")
 		for _, x := range extras {
-			paths["/"] = append(paths["/"], x)
+			p := strings.Split(x, ":")
+			if len(p) != 2 {
+				p = append([]string{"/"}, p...)
+			}
+			paths[p[0]] = append(paths[p[0]], p[1])
 		}
 	}
 

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -50,6 +50,21 @@ func sanity() {
 	}
 }
 
+// dirComponents takes a string and returns an array of strings,
+// such that we can create the directory records for intermediate
+// directories.
+func dirComponents(dir string) []string {
+	var dirlist []string
+	if filepath.Dir(dir) == "." {
+		return []string{}
+	}
+	for d := filepath.Dir(dir); d != "/"; d = filepath.Dir(d) {
+		dirlist = append([]string{d}, dirlist...)
+	}
+	dirlist = append(dirlist, dir)
+	return dirlist
+}
+
 // copyCommands takes a list of commands, generates the list of libs,
 // and creates cpio records, including directory records.
 func copyCommands(w cpio.Writer, cmds []string) {
@@ -62,12 +77,7 @@ func copyCommands(w cpio.Writer, cmds []string) {
 	cmds = append(cmds, libs...)
 	for _, n := range cmds {
 		debug("copyCommands: file %v", n)
-		var dirlist []string
-		for d := filepath.Dir(n); d != "/"; d = filepath.Dir(d) {
-			dirlist = append([]string{d}, dirlist...)
-		}
-		dirlist = append(dirlist, n)
-		for _, n := range dirlist {
+		for _, n := range dirComponents(n) {
 			debug("copyCommands: %v", n)
 			r, err := cpio.GetRecord(n)
 			if err != nil {
@@ -116,6 +126,23 @@ func ramfs() {
 	// For all the 'roots' in paths, start walking at the name.
 	debug("PATHS: %v", paths)
 	for r, list := range paths {
+		debug("PATHS: root %v", r)
+		// we need to make all the path prefix directories.
+		for _, n := range list {
+			debug("\troot %v, name %v", r, n)
+			for _, d := range dirComponents(n) {
+				debug("\t\troot %v, name %v, component %v", r, n, d)
+				rec, err := cpio.GetRecord(d)
+				if err != nil {
+					log.Fatalf("Getting record of %q failed: %v", d, err)
+				}
+				recs := []cpio.Record{rec}
+				cpio.MakeReproducible(recs)
+				if err := w.WriteRecords(recs); err != nil {
+					log.Fatalf("%v\n", err)
+				}
+			}
+		}
 		for _, n := range list {
 			if err := filepath.Walk(filepath.Join(r, n), func(name string, fi os.FileInfo, err error) error {
 				if err != nil {

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -51,7 +51,7 @@ func sanity() {
 }
 
 // copyCommands takes a list of commands, generates the list of libs,
-// and creates cpio records, including directory records. 
+// and creates cpio records, including directory records.
 func copyCommands(w cpio.Writer, cmds []string) {
 	debug("copyCommands: start with %v", cmds)
 	var (
@@ -107,15 +107,13 @@ func ramfs() {
 		log.Fatalf("%v\n", err)
 	}
 
-	paths[filepath.Join(config.Gopath, "src/github.com/u-root/u-root/bb/bbsh")] = []string{"init","ubin"}
+	paths[filepath.Join(config.Gopath, "src/github.com/u-root/u-root/bb/bbsh")] = []string{"init", "ubin"}
 
-	// For now, just one added path.
 	if *extraPaths != "" {
-		x := strings.Split(*extraPaths, ":")
-		if len(x) != 2 {
-			log.Fatalf("extraPaths requires two : separated pathnames")
+		extras := strings.Split(*extraPaths, " ")
+		for _, x := range extras {
+			paths["/"] = append(paths["/"], x)
 		}
-		paths[x[0]] = append(paths[x[0]], x[1])
 	}
 
 	if *extraCmds != "" {

--- a/pkg/cpio/cpio.go
+++ b/pkg/cpio/cpio.go
@@ -43,7 +43,7 @@ func (a Archiver) Reader(r io.ReaderAt) Reader {
 }
 
 func (a Archiver) Writer(w io.Writer) Writer {
-	return Writer{rw: a.RecordFormat.Writer(w), alreadyWritten: make(map[string]bool)}
+	return Writer{rw: a.RecordFormat.Writer(w), alreadyWritten: make(map[string]struct{})}
 }
 
 type Reader struct {
@@ -81,7 +81,7 @@ type Writer struct {
 	// There seems to be no harm done in stripping
 	// duplicate names when the record is written,
 	// and lots of harm done if we don't do it.
-	alreadyWritten map[string] bool
+	alreadyWritten map[string] struct{}
 }
 
 func (w Writer) WriteRecord(rec Record) error {
@@ -96,10 +96,10 @@ func (w Writer) WriteRecord(rec Record) error {
 		rec.Name = rel
 	}
 
-	if w.alreadyWritten[rec.Name] {
+	if _, ok := w.alreadyWritten[rec.Name]; ok {
 		return nil
 	}
-	w.alreadyWritten[rec.Name] = true
+	w.alreadyWritten[rec.Name] = struct{}{}
 	return w.rw.WriteRecord(rec)
 }
 

--- a/pkg/cpio/cpio.go
+++ b/pkg/cpio/cpio.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"path/filepath"
 )
 
 var (
@@ -80,6 +81,16 @@ type Writer struct {
 }
 
 func (w Writer) WriteRecord(rec Record) error {
+	// we do NOT write records with absolute paths.
+	if filepath.IsAbs(rec.Name) {
+		// There's no constant that means "root".
+		// PathSeparator is not really quite right.
+		rel, err := filepath.Rel("/", rec.Name)
+		if err != nil {
+			return fmt.Errorf("Can't make %s relative to /?", rec.Name)
+		}
+		rec.Name = rel
+	}
 	return w.rw.WriteRecord(rec)
 }
 

--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -195,6 +195,6 @@ func GetRecord(path string) (Record, error) {
 		return StaticRecord([]byte(linkname), info), nil
 
 	default:
-		return EmptyRecord(info), nil
+		return StaticRecord(nil, info), nil
 	}
 }

--- a/pkg/cpio/newc/newc.go
+++ b/pkg/cpio/newc/newc.go
@@ -117,6 +117,9 @@ func (w *writer) WriteRecord(f cpio.Record) error {
 
 	buf := &bytes.Buffer{}
 	hdr := headerFromInfo(f.Info)
+	if f.ReadCloser == nil {
+		hdr.FileSize = 0
+	}
 	hdr.CRC = 0
 	if err := binary.Write(buf, binary.BigEndian, hdr); err != nil {
 		return err

--- a/pkg/cpio/types.go
+++ b/pkg/cpio/types.go
@@ -52,6 +52,7 @@ func NewReadCloser(r io.Reader) io.ReadCloser {
 }
 
 func EmptyRecord(info Info) Record {
+	info.FileSize = 0
 	return Record{
 		ioutil.NopCloser(bytes.NewReader(nil)),
 		info,

--- a/pkg/cpio/types.go
+++ b/pkg/cpio/types.go
@@ -20,7 +20,7 @@ type Record struct {
 	Info
 }
 
-var TrailerRecord = EmptyRecord(Info{Name: Trailer})
+var TrailerRecord = StaticRecord(nil, Info{Name: Trailer})
 
 type RecordReader interface {
 	ReadRecord() (Record, error)
@@ -49,14 +49,6 @@ func NewBytesReadCloser(contents []byte) io.ReadCloser {
 
 func NewReadCloser(r io.Reader) io.ReadCloser {
 	return ioutil.NopCloser(r)
-}
-
-func EmptyRecord(info Info) Record {
-	info.FileSize = 0
-	return Record{
-		ioutil.NopCloser(bytes.NewReader(nil)),
-		info,
-	}
 }
 
 type LazyOpen struct {


### PR DESCRIPTION
You can now do this:
bb -cmds /bin/bash 

and it will include bash in the initramfs. It's a space-separated
list so you can, for example, say:
bb -cmds '/bin/bash /usr/bin/git'
and it works.

this will be helpful as we bring u-root up to speed on chromebooks
and minimega