### PR TITLE
Create a "switch_root" script

### DIFF
--- a/cmds/uinit/uinit.go
+++ b/cmds/uinit/uinit.go
@@ -14,27 +14,68 @@ import (
 
 var (
 	commands = []string{
-		"/buildbin/date",
-		"/buildbin/ls -l",
+		"/bin/bash",
 	}
 )
 
-func main() {
-	for _, line := range commands {
-		log.Printf("Executing Command: %v", line)
-		cmdSplit := strings.Split(line, " ")
-		if len(cmdSplit) == 0 {
-			continue
-		}
+func start() {
+	flag.Usage = usage
+	// This getpid adds a bit of cost to each invocation (not much really)
+	// but it allows us to merge init and sh. The 600K we save is worth it.
+	// Figure out which init to run. We must always do this.
 
-		cmd := exec.Command(cmdSplit[0], cmdSplit[1:]...)
-		cmd.Stdin = os.Stdin
-		cmd.Stderr = os.Stderr
-		cmd.Stdout = os.Stdout
-		if err := cmd.Run(); err != nil {
-			log.Print(err)
-		}
+	// log.Printf("init: os is %v, initMap %v", filepath.Base(os.Args[0]), initMap)
+	// we use filepath.Base in case they type something like ./cmd
 
+	log.Printf("init: Making mount directory")
+
+	if err := syscall.Mkdir("/mnt", 0777); err != nil {
+		log.Printf("init: error %v", err)
 	}
-	log.Print("Uinit Done!")
+
+	log.Printf("init: Mounting filesystem")
+
+	if err := syscall.Mount("/dev/mmcblk0p1", "/mnt", "ext4", 0, ""); err != nil {
+		log.Printf("init: error %v", err)
+	}
+
+	log.Printf("init: Changing directory")
+
+	syscall.Chdir("/mnt")
+
+	log.Printf("init: Overmounting on /")
+
+	if err := syscall.Mount(".", "/", "ext4", syscall.MS_MOVE, ""); err != nil {
+		log.Printf("init: error %v", err)
+	}
+
+	log.Printf("init: Changing root!")
+
+	if err := syscall.Chroot("."); err != nil {
+		log.Printf("Change root: error %v", err)
+	}
+
+	log.Printf("init: returning to slash")
+	syscall.Chdir("/")
+
+	log.Printf("Exec init!")
+
+	cmd := exec.Command("/bin/bash")
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	var fd int
+	cmd.SysProcAttr = &syscall.SysProcAttr{Ctty: fd, Setctty: true, Setsid: true, Cloneflags: uintptr(0)}
+	log.Printf("Run %v", cmd)
+
+	if err := cmd.Run(); err != nil {
+		log.Print(err)
+	}
+
+}
+
+func main() {
+
+	start()
+
 }


### PR DESCRIPTION
This commit contains the basic workflow of a script that changes the
root filesystem of the current process and all child processes.

There are the following issues:
1. It needs to auto detect hardware somehow
2. It does not clear the initial ram filesystem
 
   * As such RAM is being used by an unusable filesytem

3. The new root does not contain anything usable

   * Perhaps it should be populated by uroot.rootfs if empty?