### PR TITLE
Correct duplicate symlink check in TCZ

### DIFF
--- a/cmds/tcz/tcz.go
+++ b/cmds/tcz/tcz.go
@@ -72,9 +72,10 @@ func clonetree(tree string) error {
 	l.Printf("Clone tree %v", tree)
 	lt := len(tree)
 	err := filepath.Walk(tree, func(path string, fi os.FileInfo, err error) error {
+
 		l.Printf("Clone tree with path %s fi %v", path, fi)
 		if fi.IsDir() {
-			l.Printf("walking, dir %v\n", path)
+			l.Printf("Walking, dir %v\n", path)
 			if path[lt:] == "" {
 				return nil
 			}
@@ -87,26 +88,30 @@ func clonetree(tree string) error {
 			return nil
 		}
 		// all else gets a symlink.
-		if link, err := os.Readlink(path); err == nil {
-			if link == path {
+
+		// If the link exists
+		if target, err := os.Readlink(path[lt:]); err == nil {
+			// Confirm that it points to the same path to be symlinked
+			if target == path {
 				return nil
 			}
-			l.Printf("Symlink: need %v -> %v but %v -> %v is already there", path, path[lt:], path, link)
-			return err
+
+			// If it does not, return error because tcz packages are inconsistent
+			return fmt.Errorf("symlink: need %q -> %q, but %q -> %q is already there", path, path[lt:], path, target)
 		}
-		l.Printf("Need to symlnk %v to %v\n", path, path[lt:])
+
+		l.Printf("Need to symlink %v to %v\n", path, path[lt:])
+
 		if err := os.Symlink(path, path[lt:]); err != nil {
-			// TODO: if it's there, and has same value, no error.
-			l.Printf("symlink failed: %v", err)
-			return err
+			return fmt.Errorf("Symlink: %v", err)
 		}
+
 		return nil
 	})
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		l.Fatalf("Clone tree: %v", err)
 	}
-	return err
+	return nil
 }
 
 func fetch(p string) error {


### PR DESCRIPTION
This commit corrects the way TCZ looks for duplicate symlinks when
it is creating symlinks from fetched pacakges. Before, the command
would abort on symlinks that should exist. Now it will safely
ignore existing symlinks. Use correct go error handling.

Signed-off-by: laconicpneumonic <tonyprolland@gmail.com>