### PR TITLE
Fix and Upgrade TCZ

### DIFF
--- a/cmds/tcz/tcz.go
+++ b/cmds/tcz/tcz.go
@@ -51,7 +51,6 @@ var (
 	debug              = func(f string, s ...interface{}) {}
 	tczServerDir       string
 	tczLocalPackageDir string
-	debug              = func(f string, s ...interface{}) {}
 )
 
 // consider making this a goroutine which pushes the string down the channel.
@@ -124,8 +123,6 @@ func fetch(p string) error {
 		debug("package %s is downloaded\n", fullpath)
 		return nil
 	}
-
-	packageName := path.Join(tczServerDir, p)
 
 	if _, err := os.Stat(fullpath); err != nil {
 		cmd := fmt.Sprintf("http://%s:%s/%s", *host, *port, packageName)

--- a/cmds/tcz/tcz.go
+++ b/cmds/tcz/tcz.go
@@ -239,6 +239,8 @@ func setupPackages(tczName string, deps map[string]bool) error {
 
 }
 
+func debug(f string, s ...interface{}) {}
+
 func main() {
 	flag.Parse()
 	needPackages := make(map[string]bool)
@@ -250,7 +252,6 @@ func main() {
 	if len(os.Args) < 2 {
 		os.Exit(1)
 	}
-
 
 	cmdName := flag.Args()[0]
 	tczName := cmdName + ".tcz"

--- a/cmds/tcz/tcz.go
+++ b/cmds/tcz/tcz.go
@@ -216,9 +216,7 @@ func setupPackages(tczName string, deps map[string]bool) error {
 		}
 
 		if err := os.MkdirAll(packagePath, 0700); err != nil {
-			l.Printf("overwriting %s", packagePath)
-			//l.Fatal(err)
-
+			l.Fatalf("Package directory %s at %s, can not be created: %v", tczName, packagePath, err)
 		}
 
 		loopname, err := findloop()
@@ -236,13 +234,10 @@ func setupPackages(tczName string, deps map[string]bool) error {
 			l.Fatalf("%v: %v\n", loopname, err)
 		}
 		debug("ffd %v lfd %v\n", ffd, lfd)
+
 		a, b, errno := syscall.Syscall(SYS_ioctl, uintptr(lfd), LOOP_SET_FD, uintptr(ffd))
 		if errno != 0 {
 			l.Fatalf("loop set fd ioctl: pkgpath :%v:, loop :%v:, %v, %v, %v\n", pkgpath, loopname, a, b, errno)
-		}
-
-		if err != nil {
-			l.Fatalf("Error opening %s: %v", packagePath, err)
 		}
 
 		/* now mount it. The convention is the mount is in /tmp/tcloop/packagename */
@@ -258,6 +253,10 @@ func setupPackages(tczName string, deps map[string]bool) error {
 
 }
 
+func usage() string {
+	return "tcz [-v version] [-a architecture] [-h hostname] [-p host port] [-d debug prints] PROGRAM..."
+}
+
 func main() {
 	flag.Parse()
 	needPackages := make(map[string]bool)
@@ -271,6 +270,7 @@ func main() {
 	packages := flag.Args()
 
 	if len(packages) == 0 {
+		fmt.Println(usage())
 		os.Exit(1)
 	}
 

--- a/cmds/tcz/tcz.go
+++ b/cmds/tcz/tcz.go
@@ -249,12 +249,12 @@ func main() {
 	if *debugPrint {
 		debug = l.Printf
 	}
-	if len(os.Args) < 2 {
+
+	packages := flag.Args()
+
+	if len(packages) == 0 {
 		os.Exit(1)
 	}
-
-	cmdName := flag.Args()[0]
-	tczName := cmdName + ".tcz"
 
 	if err := os.MkdirAll(tczLocalPackageDir, 0700); err != nil {
 		l.Fatal(err)
@@ -264,12 +264,18 @@ func main() {
 		l.Fatal(err)
 	}
 
-	if err := installPackage(tczName, needPackages); err != nil {
-		l.Fatal(err)
-	}
-	debug("After installpackages: needPackages %v\n", needPackages)
+	for cmdName := range packages {
 
-	if err := setupPackages(tczName, needPackages); err != nil {
-		l.Fatal(err)
+		tczName := cmdName + ".tcz"
+
+		if err := installPackage(tczName, needPackages); err != nil {
+			l.Fatal(err)
+		}
+
+		debug("After installpackages: needPackages %v\n", needPackages)
+
+		if err := setupPackages(tczName, needPackages); err != nil {
+			l.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
1. It downloads tcz packages that already exist
2. It will mount on top of older versions
3. It does not create tcloop directories correctly
   - It spltis on "." instead of removing ".tcz" from the command names
   - This causes packages to be mounted in the same place i.e. "Xorg-7.7.tcz" and "Xorg-7.7-bin.tcz" both mount to "Xorg-7"
4. It needs a debug flag "-d" to enable/disable print statements

All code written with @ananion-cation 