### PR TITLE
ramfs:Fixing multiple spaces between commands and merging cmds and extra flag into just cmds

### DIFF
--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -29,7 +29,7 @@ var (
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
 	paths     = map[string][]string{}
-	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
+	extraCmds = flag.String("cmds", "", "Extra commands or directories to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
 
@@ -39,7 +39,7 @@ func sanity() {
 	if err == nil {
 		config.Go = goBinGo
 	}
-	// but does the one in go/bin/OS_ARCH exist too?
+	// But does the one in go/bin/OS_ARCH exist too?
 	goBinGo = filepath.Join(config.Goroot, fmt.Sprintf("bin/%s_%s/go", config.Goos, config.Arch))
 	_, err = os.Stat(goBinGo)
 	if err == nil {
@@ -87,11 +87,9 @@ func ramfs() {
 
 	if *extraCmds != "" {
 		copyc := strings.Fields(*extraCmds)
-		// check if the path is a file or directory
 		for _, eachPath := range copyc {
-			fmt.Printf("each path is %s\n", eachPath)
+			debug("each path is %s\n", eachPath)
 			// Must not include ~ in path
-			//TODO throw an error if there is more than 1 :
 			if strings.Count(eachPath, ":") > 1 {
 				log.Fatalf(" Input has more than one :")
 			}

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -28,7 +28,7 @@ var (
 	// e.g., /lib/modules/4.04, you would do add the root as / and the
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
-	paths = map[string][]string{}
+	paths     = map[string][]string{}
 	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
@@ -91,10 +91,10 @@ func ramfs() {
 		for _, eachPath := range copyc {
 			fmt.Printf("each path is %s\n", eachPath)
 			// Must not include ~ in path
-			//TODO throw an error if there is more than 1 : 
-			if (strings.Count(eachPath, ":") > 1){
+			//TODO throw an error if there is more than 1 :
+			if strings.Count(eachPath, ":") > 1 {
 				log.Fatalf(" Input has more than one :")
-			}		
+			}
 			modPath := strings.Replace(eachPath, ":", "/", 1)
 			fmt.Printf("modpath is %s\n", modPath)
 			statval, err := os.Stat(modPath)
@@ -110,10 +110,10 @@ func ramfs() {
 			paths[p[0]] = append(paths[p[0]], p[1])
 			debug("putps")
 			fmt.Printf("Paths currently is %v\n", paths)
-			if !statval.IsDir(){
+			if !statval.IsDir() {
 				tmpSlice := []string{modPath}
 				libs, err := uroot.LddList(tmpSlice)
-				if err != nil{
+				if err != nil {
 					log.Fatalf("%v", err)
 				}
 				paths["/"] = append(paths["/"], libs...)
@@ -121,7 +121,6 @@ func ramfs() {
 			}
 		}
 	}
-	
 
 	if *extraCpio != "" {
 		extras := strings.Fields(*extraCpio)

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -29,9 +29,6 @@ var (
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
 	paths = map[string][]string{}
-	/*extraPaths = flag.String("extra", "", `Extra paths to add in the form root:start, e.g. /:etc/hosts.
-	The path before the : is used as a starting point for a walk; the path after the : selects what things to put
-	into the initramfs starting at /. E.g., /tmp/prototype:/ will install the prototype file system into / of the initramfs`)*/	
 	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -29,9 +29,9 @@ var (
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
 	paths = map[string][]string{}
-	extraPaths = flag.String("extra", "", `Extra paths to add in the form root:start, e.g. /:etc/hosts.
+	/*extraPaths = flag.String("extra", "", `Extra paths to add in the form root:start, e.g. /:etc/hosts.
 	The path before the : is used as a starting point for a walk; the path after the : selects what things to put
-	into the initramfs starting at /. E.g., /tmp/prototype:/ will install the prototype file system into / of the initramfs`)
+	into the initramfs starting at /. E.g., /tmp/prototype:/ will install the prototype file system into / of the initramfs`)*/	
 	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
@@ -70,11 +70,11 @@ func dirComponents(dir string) []string {
 
 // copyCommands takes a list of commands, generates the list of libs,
 // and creates cpio records, including directory records.
-func copyCommands(w cpio.Writer, cmds string) {
-	debug("copyCommands: start with %v", cmds)
+func copyCommands(w cpio.Writer, cmd string) {
+	debug("copyCommands: start with %v", cmd)
 	var recs []cpio.Record
 	//introduced the tmpSlice variable to be the dependency slice for the cmd string
-	tmpSlice := []string{cmds}
+	tmpSlice := []string{cmd}
 	libs, err := uroot.LddList(tmpSlice)
 	if err != nil {
 		log.Fatalf("%v\n", err)

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -31,7 +31,7 @@ var (
 	paths = map[string][]string{}
 	/*extraPaths = flag.String("extra", "", `Extra paths to add in the form root:start, e.g. /:etc/hosts.
 	The path before the : is used as a starting point for a walk; the path after the : selects what things to put
-	into the initramfs starting at /. E.g., /tmp/prototype:/ will install the prototype file system into / of the initramfs`)*/	
+	into the initramfs starting at /. E.g., /tmp/prototype:/ will install the prototype file system into / of the initramfs`)*/
 	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
@@ -142,7 +142,7 @@ func ramfs() {
 			}
 		}
 	}
-	
+
 	if *extraPaths != "" {
 		extras := strings.Split(strings.TrimSpace(*extraPaths), " ")
 		for _, x := range extras {
@@ -153,7 +153,6 @@ func ramfs() {
 			paths[p[0]] = append(paths[p[0]], p[1])
 		}
 	}
-
 
 	if *extraCpio != "" {
 		extras := strings.Fields(*extraCpio)

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -113,10 +113,9 @@ func ramfs() {
 
 	if *extraCmds != "" {
 		copyc := strings.Fields(*extraCmds)
-		//check if the path is a file or directory
+		// check if the path is a file or directory
 		for _, eachPath := range copyc {
-			//must not include ~ in path
-			//replace only the first : with //
+			// Must not include ~ in path
 			modPath := strings.Replace(eachPath, ":", "", 1)
 			statval, err := os.Stat(modPath)
 			if err != nil {
@@ -165,7 +164,7 @@ func ramfs() {
 	debug("PATHS: %v", paths)
 	for r, list := range paths {
 		debug("PATHS: root %v", r)
-		// we need to make all the path prefix directories.
+		// We need to make all the path prefix directories.
 		for _, n := range list {
 			debug("\troot %v, name %v", r, n)
 			for _, d := range dirComponents(n) {

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -29,7 +29,7 @@ var (
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
 	paths     = map[string][]string{}
-	extraCmds = flag.String("cmds", "", "Extra commands or directories to add (full path, comma-separated string)")
+	extraAdd = flag.String("add", "", "Extra commands or directories to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
 
@@ -85,8 +85,8 @@ func ramfs() {
 
 	paths[filepath.Join(config.Gopath, "src/github.com/u-root/u-root/bb/bbsh")] = []string{"init", "ubin"}
 
-	if *extraCmds != "" {
-		copyc := strings.Fields(*extraCmds)
+	if *extraAdd != "" {
+		copyc := strings.Fields(*extraAdd)
 		for _, eachPath := range copyc {
 			debug("each path is %s\n", eachPath)
 			// Must not include ~ in path
@@ -94,7 +94,7 @@ func ramfs() {
 				log.Fatalf(" Input has more than one :")
 			}
 			modPath := strings.Replace(eachPath, ":", "/", 1)
-			fmt.Printf("modpath is %s\n", modPath)
+			debug("modpath is %s\n", modPath)
 			statval, err := os.Stat(modPath)
 			if err != nil {
 				log.Fatalf("%v", err)
@@ -103,11 +103,11 @@ func ramfs() {
 			if len(p) != 2 {
 				p = append([]string{"/"}, p...)
 			}
-			fmt.Printf("P is %v\n", p)
-			fmt.Printf("Paths currently is %v\n", paths)
+			debug("P is %v\n", p)
+			debug("Paths currently is %v\n", paths)
 			paths[p[0]] = append(paths[p[0]], p[1])
 			debug("putps")
-			fmt.Printf("Paths currently is %v\n", paths)
+			debug("Paths currently is %v\n", paths)
 			if !statval.IsDir() {
 				tmpSlice := []string{modPath}
 				libs, err := uroot.LddList(tmpSlice)
@@ -115,7 +115,7 @@ func ramfs() {
 					log.Fatalf("%v", err)
 				}
 				paths["/"] = append(paths["/"], libs...)
-				fmt.Printf("Paths currently is (because command) %v\n", paths)
+				debug("Paths currently is (because command) %v\n", paths)
 			}
 		}
 	}
@@ -145,14 +145,14 @@ func ramfs() {
 	}
 	//append the ldd'd files to /
 	// For all the 'roots' in paths, start walking at the name.
-	fmt.Printf("PATHS: %v", paths)
+	debug("PATHS: %v", paths)
 	for r, list := range paths {
-		fmt.Printf("PATHS: root %v", r)
+		debug("PATHS: root %v", r)
 		// We need to make all the path prefix directories.
 		for _, n := range list {
-			fmt.Printf("\troot %v, name %v", r, n)
+			debug("\troot %v, name %v", r, n)
 			for _, d := range dirComponents(n) {
-				fmt.Printf("\t\troot %v, name %v, component %v", r, n, d)
+				debug("\t\troot %v, name %v, component %v", r, n, d)
 				rec, err := cpio.GetRecord(d)
 				if err != nil {
 					log.Fatalf("Getting record of %q failed: %v", d, err)
@@ -173,7 +173,7 @@ func ramfs() {
 				if err != nil {
 					log.Fatalf("filepath.Rel(%v, %v): %v", r, name, err)
 				}
-				fmt.Printf("%v\n", cn)
+				debug("%v\n", cn)
 				rec, err := cpio.GetRecord(name)
 				if err != nil {
 					log.Fatalf("Getting record of %q failed: %v", cn, err)

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -28,7 +28,7 @@ var (
 	// e.g., /lib/modules/4.04, you would do add the root as / and the
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
-	paths = map[string][]string
+	paths = map[string][]string{}
 	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
@@ -65,12 +65,9 @@ func dirComponents(dir string) []string {
 	return dirlist
 }
 
-// copyCommands takes a list of commands, generates the list of libs,
-// and creates cpio records, including directory records.
 func copyCommands(w cpio.Writer, cmd string) {
 	debug("copyCommands: start with %v", cmd)
 	var recs []cpio.Record
-	//introduced the tmpSlice variable to be the dependency slice for the cmd string
 	tmpSlice := []string{cmd}
 	libs, err := uroot.LddList(tmpSlice)
 	if err != nil {

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -31,7 +31,7 @@ var (
 	paths = map[string][]string{}
 	/*extraPaths = flag.String("extra", "", `Extra paths to add in the form root:start, e.g. /:etc/hosts.
 	The path before the : is used as a starting point for a walk; the path after the : selects what things to put
-	into the initramfs starting at /. E.g., /tmp/prototype:/ will install the prototype file system into / of the initramfs`)*/
+	into the initramfs starting at /. E.g., /tmp/prototype:/ will install the prototype file system into / of the initramfs`)*/	
 	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
@@ -142,17 +142,7 @@ func ramfs() {
 			}
 		}
 	}
-
-	if *extraPaths != "" {
-		extras := strings.Split(strings.TrimSpace(*extraPaths), " ")
-		for _, x := range extras {
-			p := strings.Split(x, ":")
-			if len(p) != 2 {
-				p = append([]string{"/"}, p...)
-			}
-			paths[p[0]] = append(paths[p[0]], p[1])
-		}
-	}
+	
 
 	if *extraCpio != "" {
 		extras := strings.Fields(*extraCpio)

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -28,7 +28,7 @@ var (
 	// e.g., /lib/modules/4.04, you would do add the root as / and the
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
-	paths = map[string][]string{}
+	paths = map[string][]string
 	extraCmds = flag.String("cmds", "", "Extra commands to add (full path, comma-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
@@ -74,7 +74,7 @@ func copyCommands(w cpio.Writer, cmd string) {
 	tmpSlice := []string{cmd}
 	libs, err := uroot.LddList(tmpSlice)
 	if err != nil {
-		log.Fatalf("%v\n", err)
+		log.Fatalf("%v", err)
 	}
 	tmpSlice = append(tmpSlice, libs...)
 	for _, n := range tmpSlice {
@@ -90,7 +90,7 @@ func copyCommands(w cpio.Writer, cmd string) {
 	}
 	cpio.MakeReproducible(recs)
 	if err := w.WriteRecords(recs); err != nil {
-		log.Fatalf("%v\n", err)
+		log.Fatalf("%v", err)
 	}
 }
 
@@ -103,13 +103,13 @@ func ramfs() {
 	oname := fmt.Sprintf("/tmp/initramfs.%v_%v.cpio", config.Goos, config.Arch)
 	f, err := os.Create(oname)
 	if err != nil {
-		log.Fatalf("%v\n", err)
+		log.Fatalf("%v", err)
 	}
 
 	w := archiver.Writer(f)
 	cpio.MakeReproducible(devCPIO[:])
 	if err := w.WriteRecords(devCPIO[:]); err != nil {
-		log.Fatalf("%v\n", err)
+		log.Fatalf("%v", err)
 	}
 
 	paths[filepath.Join(config.Gopath, "src/github.com/u-root/u-root/bb/bbsh")] = []string{"init", "ubin"}
@@ -121,10 +121,9 @@ func ramfs() {
 			//must not include ~ in path
 			//replace only the first : with //
 			modPath := strings.Replace(eachPath, ":", "", 1)
-			fmt.Println("this is the path", modPath)
 			statval, err := os.Stat(modPath)
 			if err != nil {
-				log.Fatalf("%v\n", err)
+				log.Fatalf("%v", err)
 			}
 			if statval.IsDir() {
 				// If the file is a directory, append all the files in the directory to the path
@@ -160,13 +159,13 @@ func ramfs() {
 			}
 			cpio.MakeReproducible(recs)
 			if err := w.WriteRecords(recs); err != nil {
-				log.Fatalf("%v\n", err)
+				log.Fatalf("%v", err)
 			}
 		}
 	}
 
 	// For all the 'roots' in paths, start walking at the name.
-	fmt.Printf("PATHS: %v", paths)
+	debug("PATHS: %v", paths)
 	for r, list := range paths {
 		debug("PATHS: root %v", r)
 		// we need to make all the path prefix directories.
@@ -181,7 +180,7 @@ func ramfs() {
 				recs := []cpio.Record{rec}
 				cpio.MakeReproducible(recs)
 				if err := w.WriteRecords(recs); err != nil {
-					log.Fatalf("%v\n", err)
+					log.Fatalf("%v", err)
 				}
 			}
 		}
@@ -204,7 +203,7 @@ func ramfs() {
 				recs := []cpio.Record{rec}
 				cpio.MakeReproducible(recs)
 				if err := w.WriteRecords(recs); err != nil {
-					log.Fatalf("%v\n", err)
+					log.Fatalf("%v", err)
 				}
 				return nil
 			}); err != nil {

--- a/bb/ramfs.go
+++ b/bb/ramfs.go
@@ -29,7 +29,7 @@ var (
 	// starting point for the walk as lib/modules/4.04. That way we only preserve
 	// as much of the path as we need, but we can preserve it all.
 	paths     = map[string][]string{}
-	extraAdd = flag.String("add", "", "Extra commands or directories to add (full path, comma-separated string)")
+	extraAdd = flag.String("add", "", "Extra commands or directories to add (full path, space-separated string)")
 	extraCpio = flag.String("cpio", "", "A list of cpio archives to include in the output")
 )
 


### PR DESCRIPTION
1. Allows for multiple spaces ex: "a    (4 spaces) b c d" will  be interpreted as [a,b,c,d]
2.Combine cmd and extra flag so it is just cmd