### PR TITLE
Add "aux" option to ps and correct output for "-x"

### DIFF
--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -5,7 +5,7 @@
 // Print process information.
 //
 // Synopsis:
-//     ps [-Aaex]
+//     ps [-Aaex] [aux]
 //
 // Description:
 //     ps reads the /proc filesystem and prints nice things about what it
@@ -17,6 +17,7 @@
 //     -e: select all processes. Identical to -A.
 //     -x: BSD-Like style, with STAT Column and long CommandLine
 //     -a: print all process except whose are session leaders or unlinked with terminal
+//    aux: see every process on the system using BSD syntax
 package main
 
 import (
@@ -24,8 +25,10 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"reflect"
 	"sort"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -174,44 +177,14 @@ func (pT *ProcessTable) PrepareString() {
 	pT.fstring = fstring
 }
 
-func mapSubset(check map[byte]int, ref map[byte]int) bool {
-	for cLet, cNum := range check {
-		if rNum, ok := ref[cLet]; ok {
-			if cNum != rNum {
-				return false
-			}
-		} else {
-			return false
-		}
-	}
-	return true
-}
-
 func isPermutation(check string, ref string) bool {
+	checkArray := strings.Split(check, "")
+	refArray := strings.Split(ref, "")
 
-	checkMap := make(map[byte]int)
-	refMap := make(map[byte]int)
+	sort.Strings(checkArray)
+	sort.Strings(refArray)
 
-	if len(check) != len(ref) {
-		return false
-	}
-
-	for i := 0; i < len(check); i++ {
-		if _, ok := checkMap[check[i]]; ok {
-			checkMap[check[i]] += 1
-		} else {
-			checkMap[check[i]] = 0
-		}
-
-		if _, ok := refMap[ref[i]]; ok {
-			refMap[ref[i]] += 1
-		} else {
-			refMap[ref[i]] = 0
-		}
-	}
-
-	return mapSubset(checkMap, refMap) && mapSubset(refMap, checkMap)
-
+	return reflect.DeepEqual(check, ref)
 }
 
 // For now, just read /proc/pid/stat and dump its brains.

--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -55,8 +54,10 @@ func init() {
 	flag.BoolVar(&flags.nSidTty, "a", false, "Print all process except whose are session leaders or unlinked with terminal")
 
 	if len(os.Args) > 1 {
-		flags.all = true
-		flags.aux = isPermutation(os.Args[1], "aux")
+		if isPermutation(os.Args[1], "aux") {
+			flags.aux = true
+			flags.all = true
+		}
 	}
 }
 
@@ -178,13 +179,21 @@ func (pT *ProcessTable) PrepareString() {
 }
 
 func isPermutation(check string, ref string) bool {
+	if len(check) != len(ref) {
+		return false
+	}
 	checkArray := strings.Split(check, "")
 	refArray := strings.Split(ref, "")
 
 	sort.Strings(checkArray)
 	sort.Strings(refArray)
 
-	return reflect.DeepEqual(check, ref)
+	for i, _ := range check {
+		if checkArray[i] != refArray[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // For now, just read /proc/pid/stat and dump its brains.


### PR DESCRIPTION
Now ps can accept any permutation of "aux" as its first argument and it
will return the GNU ps output for "axu". "-x" now returns the
appropriate categories.