### PR TITLE
pkg/cpio: create dir when creating files/specials/symlinks

### DIFF
--- a/pkg/cpio/cpio.go
+++ b/pkg/cpio/cpio.go
@@ -81,7 +81,7 @@ type Writer struct {
 	// There seems to be no harm done in stripping
 	// duplicate names when the record is written,
 	// and lots of harm done if we don't do it.
-	alreadyWritten map[string] struct{}
+	alreadyWritten map[string]struct{}
 }
 
 func (w Writer) WriteRecord(rec Record) error {


### PR DESCRIPTION
It turns out cpio files are not required to specify the
directories for files, i.e. if you have
a/b/c/d
you don't need records for a, a/b, and a/b/c. This is
kind of nuts because when you unpack the archive
you've got no idea as to ownership and modes of
a, a/b, or a/b/c. But I did not write the spec.

So, we'll do our best. For each file/special/symlink,
we split out the dir and do a MkdirAll with mode 755.

Note that if the directory existed with a different mode
we may change that mode. The go runtime doesn't actually
check if the directory exists before trying to make it.
I don't think this matters: cpio is a dead
format save for the kernel initramfs.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>