### PR TITLE
tcz: add options so we can fetch all the tcz files

### DIFF
--- a/cmds/tcz/tcz.go
+++ b/cmds/tcz/tcz.go
@@ -47,6 +47,8 @@ var (
 	version            = flag.String("v", "8.x", "tinycore version")
 	arch               = flag.String("a", "x86_64", "tinycore architecture")
 	port               = flag.String("p", "80", "Host port")
+	install            = flag.Bool("i", true, "Install the packages, i.e. mount and create symlinks")
+	tczRoot            = flag.String("r", "/tcz", "tcz root directory")
 	debugPrint         = flag.Bool("d", false, "Enable debug prints")
 	debug              = func(f string, s ...interface{}) {}
 	tczServerDir       string
@@ -141,7 +143,7 @@ func fetch(p string) error {
 
 		debug("resp %v err %v\n", resp, err)
 		// we have the whole tcz in resp.Body.
-		// First, save it to /tcz/name
+		// First, save it to /tczRoot/name
 		f, err := os.Create(fullpath)
 		if err != nil {
 			l.Fatalf("Create of :%v: failed: %v\n", fullpath, err)
@@ -261,7 +263,7 @@ func main() {
 	flag.Parse()
 	needPackages := make(map[string]bool)
 	tczServerDir = filepath.Join("/", *version, *arch, "/tcz")
-	tczLocalPackageDir = filepath.Join("/tcz", tczServerDir)
+	tczLocalPackageDir = filepath.Join(*tczRoot, tczServerDir)
 
 	if *debugPrint {
 		debug = l.Printf
@@ -292,8 +294,10 @@ func main() {
 
 		debug("After installpackages: needPackages %v\n", needPackages)
 
-		if err := setupPackages(tczName, needPackages); err != nil {
-			l.Fatal(err)
+		if *install {
+			if err := setupPackages(tczName, needPackages); err != nil {
+				l.Fatal(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This will allow us to build a NiChrome image ahead of time
that contains all the packages,
i.e. avoid the need to fetch the images after we boot.

Note that fetching after boot will still work. If we
want a package after boot and it's not there, and the
net is up, tcz will fetch it. But if it's there, there's
no need to fetch and tcz won't.

Hence, we don't need to change xinit
one bit, but we can make its life much easier by preloading
a set of tcz's on the usb stick.

The -i switch, which defaults to true, determines whether we
install the packages, i.e. do the loopback mount and create
symlinks.

The -r switch, which defaults to /tcz, lets us determine where the
packages go.

Suppose in NiChrome we have a list of packages we want to
make available on ROOT-A. Suppose it's just bash
and opera-12. To start, in the NiChrome usb program, we do this:

tcz -r `pwd`/tcz -i=false base opera-12

This will give us a tcz directory in $pwd that has structure we need for
eventual setup in the ramfs, i.e. files like this
tcz/8.x/x86_64/tcz/bash.tcz

The eventual thing I'm going to try is that ROOT-A won't even
be a file system; it will be a cpio archive containing tcz/ and
anything else we need in the ramfs. This is nice since it
means we don't need DM-verity; we can just sign the cpio archive
and test it on boot. There's also no fsck or other issues
to worry about. We'll see how it goes. I'll be testing more and more
of this next week.

But these changes are useful not matter what we do on NiChrome.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>