### PR TITLE
wireless: add a simple wifi tool

### DIFF
--- a/cmds/wifi/wifi.go
+++ b/cmds/wifi/wifi.go
@@ -1,0 +1,62 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+)
+
+const cmd = "wifi [options] essid passphrase"
+
+var (
+	iface = flag.String("i", "wlan0", "interface to use")
+	essid string
+	pass  string
+)
+
+func init() {
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		os.Args[0] = cmd
+		defUsage()
+	}
+}
+
+func main() {
+	flag.Parse()
+	a := flag.Args()
+	if len(a) != 2 {
+		flag.Usage()
+	}
+	essid, pass = a[0], a[1]
+
+	conf, err := exec.Command("wpa_passphrase", essid, pass).CombinedOutput()
+	if err != nil {
+		log.Fatalf("%v %v: %v", essid, pass, err)
+	}
+
+	if err := ioutil.WriteFile("/tmp/wifi.conf", []byte(conf), 0444); err != nil {
+		log.Fatalf("/tmp/wifi.conf: %v", err)
+	}
+
+	// There's no telling how long the supplicant will take, but on the other hand,
+	// it's been almost instantaneous. But, further, it needs to keep running.
+	go func() {
+		if o, err := exec.Command("wpa_supplicant", "-i"+*iface, "-c/tmp/wifi.conf").CombinedOutput(); err != nil {
+			log.Fatalf("wpa_supplicant: %v (%v)", o, err)
+		}
+	}()
+
+	cmd := exec.Command("dhclient", "-ipv4=true", "-ipv6=false", "-verbose", *iface)
+	cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("%v: %v", cmd, err)
+	}
+
+}

--- a/cmds/xinit/xinit.go
+++ b/cmds/xinit/xinit.go
@@ -49,6 +49,7 @@ var (
 		"Xorg-7.7",
 		"links",
 		"opera-12",
+		"wifi",
 	}
 	sshdCommands = []string{
 		"Protocol 2",

--- a/cmds/xinit/xinit.go
+++ b/cmds/xinit/xinit.go
@@ -166,13 +166,13 @@ func xSetup() error {
 	time.Sleep(5 * time.Second)
 	for _, f := range []string{"flwm", "opera-12"} {
 		log.Printf("Run %v", f)
-		go func() {
-			cmd := exec.Command(f, "-display", ":0")
+		go func(n string) {
+			cmd := exec.Command(n, "-display", ":0")
 			cmd.Stdout, cmd.Stderr = os.Stdout, os.Stderr
 			if err := cmd.Run(); err != nil {
-				log.Printf("%v: %v", f, err)
+				log.Printf("%v: %v", n, err)
 			}
-		}()
+		}(f)
 	}
 	cmd := exec.Command("aterm", "-display", ":0")
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr

--- a/uroot/root.go
+++ b/uroot/root.go
@@ -21,7 +21,7 @@ import (
 const (
 	// Not all these paths may be populated or even exist but OTOH they might.
 	PATHHEAD = "/ubin"
-	PATHMID  = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin"
+	PATHMID  = "/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/bin:/usr/local/sbin"
 	PATHTAIL = "/buildbin"
 	CmdsPath = "github.com/u-root/u-root/cmds"
 )


### PR DESCRIPTION
I just tested this on the chromebook parrot and it
works.

tcz wifi (assuming you don't automatically load that package)

PATH=$PATH:/usr/local/sbin
wifi essid password

and we're up.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>