### PR TITLE
Replace path.join with filepath.join

### DIFF
--- a/cmds/builtin/builtin.go
+++ b/cmds/builtin/builtin.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"syscall"
 
@@ -86,7 +85,7 @@ func main() {
 		if *debug {
 			log.Printf("\n----FULLCODE---------\n%v\n------FULLCODE----------\n", string(fullCode))
 		}
-		bName := path.Join(rushPath, a[0]+".go")
+		bName := filepath.Join(rushPath, a[0]+".go")
 		filemap[bName] = fullCode
 	}
 

--- a/cmds/ps/ps_linux.go
+++ b/cmds/ps/ps_linux.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -89,7 +88,7 @@ type process struct {
 // Parse all content of stat to a Process Struct
 // by gived the pid (linux)
 func (p *process) readStat(pid int) error {
-	b, err := ioutil.ReadFile(path.Join(proc, fmt.Sprint(pid), "stat"))
+	b, err := ioutil.ReadFile(filepath.Join(proc, fmt.Sprint(pid), "stat"))
 	if err != nil {
 		return err
 	}
@@ -132,7 +131,7 @@ func (p *Process) Parse(pid int) error {
 // ctty returns the ctty or "?" if none can be found.
 // TODO: an right way to get ctty by p.TTYNr and p.TTYPgrp
 func (p process) getCtty() string {
-	if tty, err := os.Readlink(path.Join(proc, p.Pid, "fd/0")); err != nil {
+	if tty, err := os.Readlink(filepath.Join(proc, p.Pid, "fd/0")); err != nil {
 		return "?"
 	} else if p.TTYPgrp != "-1" {
 		if len(tty) > 5 && tty[:5] == "/dev/" {
@@ -157,7 +156,7 @@ func (p Process) Search(field string) string {
 
 // read UID of process based on or
 func (p process) getUid() (int, error) {
-	b, err := ioutil.ReadFile(path.Join(proc, p.Pid, "status"))
+	b, err := ioutil.ReadFile(filepath.Join(proc, p.Pid, "status"))
 
 	var uid int
 	lines := strings.Split(string(b), "\n")
@@ -179,7 +178,7 @@ func (p Process) GetUid() (int, error) {
 
 // change p.Cmd to long command line with args
 func (p process) longCmdLine() (string, error) {
-	b, err := ioutil.ReadFile(path.Join(proc, p.Pid, "cmdline"))
+	b, err := ioutil.ReadFile(filepath.Join(proc, p.Pid, "cmdline"))
 
 	if err != nil {
 		return "", err

--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 )
 
 var (
@@ -72,7 +73,7 @@ func rm(files []string) error {
 		if flags.v {
 			toRemove := file
 			if !path.IsAbs(file) {
-				toRemove = path.Join(workingPath, file)
+				toRemove = filepath.Join(workingPath, file)
 			}
 			fmt.Printf("removed '%v'\n", toRemove)
 		}

--- a/cmds/rm/rm_test.go
+++ b/cmds/rm/rm_test.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 )
 
@@ -46,13 +46,13 @@ func setup() (string, error) {
 		return "", err
 	}
 
-	tmpdir := path.Join(d, "hi.sub.dir")
+	tmpdir := filepath.Join(d, "hi.sub.dir")
 	if err := os.Mkdir(tmpdir, 0777); err != nil {
 		return "", err
 	}
 
 	for i := range tests {
-		if err := ioutil.WriteFile(path.Join(d, tests[i].n), []byte("Go is cool!"), tests[i].m); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(d, tests[i].n), []byte("Go is cool!"), tests[i].m); err != nil {
 			return "", err
 		}
 	}
@@ -69,7 +69,7 @@ func Test_rm_1(t *testing.T) {
 	defer os.RemoveAll(d)
 
 	fmt.Println("== Deleting files and empty folders (no args) ...")
-	files := []string{path.Join(d, "hi1.txt"), path.Join(d, "hi2.txt"), path.Join(d, "go.txt")}
+	files := []string{filepath.Join(d, "hi1.txt"), filepath.Join(d, "hi2.txt"), filepath.Join(d, "go.txt")}
 
 	flags.v = true
 	if err := rm(files); err != nil {

--- a/cmds/rush/parse.go
+++ b/cmds/rush/parse.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -179,7 +180,7 @@ func parsestring(b *bufio.Reader, c *Command) (*Command, string) {
 		switch t {
 		case "ENV":
 			if !path.IsAbs(s) {
-				s = path.Join(envDir, s)
+				s = filepath.Join(envDir, s)
 			}
 			b, err := ioutil.ReadFile(s)
 			if err != nil {

--- a/cmds/rush/rush.go
+++ b/cmds/rush/rush.go
@@ -145,7 +145,7 @@ func doArgs(cmds []*Command) error {
 			if v.mod == "ENV" {
 				e := v.val
 				if !path.IsAbs(v.val) {
-					e = path.Join(envDir, e)
+					e = filepath.Join(envDir, e)
 				}
 				b, err := ioutil.ReadFile(e)
 				if err != nil {

--- a/cmds/validate/validate_test.go
+++ b/cmds/validate/validate_test.go
@@ -8,7 +8,6 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"syscall"
 	"testing"
@@ -43,7 +42,7 @@ ff02::2 ip6-allrouters
 		t.Fatal("TempDir failed: ", err)
 	}
 	defer os.RemoveAll(tmpDir)
-	if err := ioutil.WriteFile(path.Join(tmpDir, "hosts"), data, 0444); err != nil {
+	if err := ioutil.WriteFile(filepath.Join(tmpDir, "hosts"), data, 0444); err != nil {
 		t.Fatalf("Can't set up data file: %v", err)
 	}
 
@@ -55,11 +54,11 @@ ff02::2 ip6-allrouters
 
 	t.Logf("Built %v for test", validatetestpath)
 	for _, v := range tests {
-		if err := ioutil.WriteFile(path.Join(tmpDir, v.name), v.val, 0444); err != nil {
+		if err := ioutil.WriteFile(filepath.Join(tmpDir, v.name), v.val, 0444); err != nil {
 			t.Fatalf("Can't set up hash file: %v", err)
 		}
 
-		c := exec.Command(validatetestpath, path.Join(tmpDir, v.name), path.Join(tmpDir, "hosts"))
+		c := exec.Command(validatetestpath, filepath.Join(tmpDir, v.name), filepath.Join(tmpDir, "hosts"))
 		ep, err := c.StderrPipe()
 		if err != nil {
 			t.Fatalf("Can't start StderrPipe: %v", err)

--- a/cmds/which/which.go
+++ b/cmds/which/which.go
@@ -16,7 +16,7 @@ import (
 	"io"
 	"log"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 )
 
@@ -35,7 +35,7 @@ func which(p string, writer io.Writer, cmds []string) {
 
 	for _, name := range cmds {
 		for i := range pathArray {
-			f := path.Join(pathArray[i], name)
+			f := filepath.Join(pathArray[i], name)
 			if info, err := os.Stat(f); err == nil {
 				// TODO: this test (0111) is not quite right.
 				// Consider a file executable only by root (0100)

--- a/pkg/memmap/memmap.go
+++ b/pkg/memmap/memmap.go
@@ -45,7 +45,7 @@ var (
 )
 
 func mmVal(dir, file string) (uint64, error) {
-	s, err := ioutil.ReadFile(path.Join(dir, file))
+	s, err := ioutil.ReadFile(filepath.Join(dir, file))
 	if err != nil {
 		return 0, err
 	}
@@ -64,7 +64,7 @@ func mmr(name string) (*MemoryRange, error) {
 	if err != nil {
 		return nil, err
 	}
-	s, err := ioutil.ReadFile(path.Join(name, "type"))
+	s, err := ioutil.ReadFile(filepath.Join(name, "type"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/memmap/memmap/memmap.go
+++ b/pkg/memmap/memmap/memmap.go
@@ -45,7 +45,7 @@ var (
 )
 
 func mmVal(dir, file string) (uint64, error) {
-	s, err := ioutil.ReadFile(path.Join(dir, file))
+	s, err := ioutil.ReadFile(filepath.Join(dir, file))
 	if err != nil {
 		return 0, err
 	}
@@ -64,7 +64,7 @@ func mmr(name string) (*MemoryRange, error) {
 	if err != nil {
 		return nil, err
 	}
-	s, err := ioutil.ReadFile(path.Join(name, "type"))
+	s, err := ioutil.ReadFile(filepath.Join(name, "type"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/memmap/memmap/memmap_test.go
+++ b/pkg/memmap/memmap/memmap_test.go
@@ -7,7 +7,6 @@ package memmap
 import (
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 	"unicode"
@@ -32,7 +31,7 @@ func TestSysMemmap(t *testing.T) {
 			return nil
 		}
 		for _, v := range []string{"start", "end", "type"} {
-			s, err := ioutil.ReadFile(path.Join(name, v))
+			s, err := ioutil.ReadFile(filepath.Join(name, v))
 			if err != nil {
 				return err
 			}

--- a/pkg/memmap/memmap_test.go
+++ b/pkg/memmap/memmap_test.go
@@ -7,7 +7,6 @@ package memmap
 import (
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 	"unicode"
@@ -32,7 +31,7 @@ func TestSysMemmap(t *testing.T) {
 			return nil
 		}
 		for _, v := range []string{"start", "end", "type"} {
-			s, err := ioutil.ReadFile(path.Join(name, v))
+			s, err := ioutil.ReadFile(filepath.Join(name, v))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Description
This pull request resolves https://github.com/u-root/u-root/issues/206

## Testing
I ran the `travis.sh` tests inside of a _travis like_ container using the following command.  I expect this pr will run the same but wanted a way to test locally as well.
```
% docker run -e "PATH=/home/travis/gopath/bin:$PATH" --privileged -u travis -it -v /Users/bkochendorfer/go/src/github.com/u-root/u-root:/home/travis/gopath/src/github.com/u-root/u-root quay.io/travisci/travis-go:latest bash
% # setup golang 1.9 using gimme
% bash travis.sh
... output ...
Mon Sep 18 18:49:42 UTC 2017
Did it blend
root@d2a1a53b5130:/home/travis/gopath/src/github.com/u-root/u-root# echo $?
0
root@d2a1a53b5130:/home/travis/gopath/src/github.com/u-root/u-root# exit
```
