### PR TITLE
`ip` command enhancements

### DIFF
--- a/cmds/ip/ip.go
+++ b/cmds/ip/ip.go
@@ -161,6 +161,11 @@ func linkset() {
 }
 
 func link() {
+	if len(arg) == 1 {
+		linkshow()
+		return
+	}
+
 	cursor++
 	whatIWant = []string{"show", "set"}
 	cmd := arg[cursor]

--- a/cmds/ip/ip.go
+++ b/cmds/ip/ip.go
@@ -6,8 +6,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"io"
 	"io/ioutil"
 	l "log"
+	"math"
 	"os"
 	"strings"
 
@@ -38,6 +41,14 @@ var (
 	arg       []string
 	whatIWant []string
 	log       = l.New(os.Stdout, "ip: ", 0)
+
+	addrScopes = map[netlink.Scope]string{
+		netlink.SCOPE_UNIVERSE: "global",
+		netlink.SCOPE_HOST:     "host",
+		netlink.SCOPE_SITE:     "site",
+		netlink.SCOPE_LINK:     "link",
+		netlink.SCOPE_NOWHERE:  "nowhere",
+	}
 )
 
 // the pattern:
@@ -80,17 +91,63 @@ func dev() netlink.Link {
 	return iface
 }
 
-func showips() {
+func showLinks(w io.Writer, withAddresses bool) {
 	ifaces, err := netlink.LinkList()
 	if err != nil {
 		log.Fatalf("Can't enumerate interfaces? %v", err)
 	}
+
 	for _, v := range ifaces {
-		addrs, err := netlink.AddrList(v, netlink.FAMILY_ALL)
-		if err != nil {
-			log.Printf("Can't enumerate addresses")
+		l := v.Attrs()
+
+		fmt.Fprintf(w, "%d: %s: <%s> mtu %d state %s\n", l.Index, l.Name,
+			strings.Replace(strings.ToUpper(fmt.Sprintf("%s", l.Flags)), "|", ",", -1),
+			l.MTU, strings.ToUpper(l.OperState.String()))
+
+		fmt.Fprintf(w, "    link/%s %s\n", l.EncapType, l.HardwareAddr)
+
+		if withAddresses {
+			showLinkAddresses(w, v)
 		}
-		log.Printf("%v: %v", v, addrs)
+	}
+}
+
+func showLinkAddresses(w io.Writer, link netlink.Link) {
+	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+	if err != nil {
+		log.Printf("Can't enumerate addresses")
+	}
+
+	for _, addr := range addrs {
+
+		var inet string
+		switch len(addr.IPNet.IP) {
+		case 4:
+			inet = "inet"
+		case 16:
+			inet = "inet6"
+		default:
+			log.Fatalf("Can't figure out IP protocol version")
+		}
+
+		fmt.Fprintf(w, "    %s %s", inet, addr.Peer)
+		if addr.Broadcast != nil {
+			fmt.Fprintf(w, " brd %s", addr.Broadcast)
+		}
+		fmt.Fprintf(w, " scope %s %s\n", addrScopes[netlink.Scope(addr.Scope)], addr.Label)
+
+		var validLft, preferredLft string
+		if addr.PreferedLft == math.MaxUint32 {
+			preferredLft = "forever"
+		} else {
+			preferredLft = fmt.Sprintf("%dsec", addr.PreferedLft)
+		}
+		if addr.ValidLft == math.MaxUint32 {
+			validLft = "forever"
+		} else {
+			validLft = fmt.Sprintf("%dsec", addr.ValidLft)
+		}
+		fmt.Fprintf(w, "       valid_lft %s preferred_lft %s\n", validLft, preferredLft)
 	}
 }
 
@@ -98,7 +155,7 @@ func addrip() {
 	var err error
 	var addr *netlink.Addr
 	if len(arg) == 1 {
-		showips()
+		showLinks(os.Stdout, true)
 		return
 	}
 	cursor++
@@ -138,7 +195,7 @@ func linkshow() {
 	cursor++
 	whatIWant = []string{"<nothing>", "<device name>"}
 	if len(arg[cursor:]) == 0 {
-		showips()
+		showLinks(os.Stdout, false)
 	}
 }
 
@@ -188,6 +245,7 @@ func routeshow() {
 		log.Fatalf("Route show failed: %v", err)
 	}
 }
+
 func nodespec() string {
 	cursor++
 	whatIWant = []string{"default", "CIDR"}
@@ -255,6 +313,7 @@ func route() {
 	}
 
 }
+
 func main() {
 	// When this is embedded in busybox we need to reinit some things.
 	whatIWant = []string{"addr", "route", "link"}


### PR DESCRIPTION
Here comes a few enhancements for the `ip` command. Everything in this pull request is done to help the `ip` command to behave like the standard implementation.

* Output formating for `ip addr` and `ip link`
* `ip link` command now print links information like `ip link show` do instead of printing usage
* Command shortcuts (e.g. `ip l sh` for `ip link show`)

#### Before

```
% ip addr

ip: &{{1 65536 1 lo  up|loopback 65609 0 0 <nil>  0xc42007d12c 0 <nil> loopback <nil> unknown}}: [127.0.0.1/8 lo ::1/128]
ip: &{{2 1500 1000 enp0s3 02:19:3b:8a:ad:b3 up|broadcast|multicast 69699 0 0 <nil>  0xc42007d5d0 0 <nil> ether <nil> up}}: [10.0.2.15/24 enp0s3 10.0.2.200/24 enp0s3 fe80::19:3bff:fe8a:adb3/64]
```

```
% ip link show

ip: &{{1 65536 1 lo  up|loopback 65609 0 0 <nil>  0xc42007d12c 0 <nil> loopback <nil> unknown}}: [127.0.0.1/8 lo ::1/128]
ip: &{{2 1500 1000 enp0s3 02:19:3b:8a:ad:b3 up|broadcast|multicast 69699 0 0 <nil>  0xc42007d5d0 0 <nil> ether <nil> up}}: [10.0.2.15/24 enp0s3 10.0.2.200/24 enp0s3 fe80::19:3bff:fe8a:adb3/64]
```

#### Now

```
% ip addr

1: lo: <UP,LOOPBACK> mtu 65536 state UNKNOWN
    link/loopback
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: enp0s3: <UP,BROADCAST,MULTICAST> mtu 1500 state UP
    link/ether 02:19:3b:8a:ad:b3
    inet 10.0.2.15/24 brd 10.0.2.255 scope global enp0s3
       valid_lft forever preferred_lft forever
    inet 10.0.2.200/24 scope global enp0s3
       valid_lft 61722sec preferred_lft 0sec
    inet6 fe80::19:3bff:fe8a:adb3/64 scope link
       valid_lft forever preferred_lft forever
```

```
% ip link show

1: lo: <UP,LOOPBACK> mtu 65536 state UNKNOWN
    link/loopback
2: enp0s3: <UP,BROADCAST,MULTICAST> mtu 1500 state UP
    link/ether 02:19:3b:8a:ad:b3
```
