### PR TITLE
Fix bug in rm -i and streamline how -i is handled

### DIFF
--- a/cmds/cp/cp.go
+++ b/cmds/cp/cp.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 // buffSize is the length of buffer during
@@ -72,7 +73,7 @@ func promptOverwrite(dst string) (bool, error) {
 		return false, err
 	}
 
-	if answer[0] != 'y' {
+	if strings.ToLower(answer)[0] != 'y' {
 		return false, nil
 	}
 

--- a/cmds/ln/ln.go
+++ b/cmds/ln/ln.go
@@ -23,11 +23,13 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type config struct {
@@ -45,11 +47,8 @@ type config struct {
 // promptOverwrite ask for overwrite destination
 func promptOverwrite(fname string) bool {
 	fmt.Printf("ln: overwrite '%v'? ", fname)
-	var txt string
-	if fmt.Scanln(&txt); txt != "y" {
-		return false
-	}
-	return true
+	answer, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	return err == nil && strings.ToLower(answer)[0] == 'y'
 }
 
 // exists verify if a fname exists

--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 )
 
 var (
@@ -56,12 +57,12 @@ func rm(files []string) error {
 		return err
 	}
 
-	input := bufio.NewScanner(os.Stdin)
+	input := bufio.NewReader(os.Stdin)
 	for _, file := range files {
 		if flags.i {
 			fmt.Printf("rm: remove '%v'? ", file)
-			input.Scan()
-			if input.Text()[0] != 'y' {
+			answer, err := input.ReadString('\n')
+			if err != nil || strings.ToLower(answer)[0] != 'y' {
 				continue
 			}
 		}


### PR DESCRIPTION
The first commit is an actual bugfix (index out of bounds). The second one unifies how answers to '-i' are handled.  So far every command did that slightly different, where some strictly only accepted 'y', where some accepted 'y'something, some used Scanner, some ReadString, some fmt.Scanln().

So this is a fist step to unify them: Use ReadString and accept what coreutils accept as "yes".

If you want me to move that AskYes() in its own package, just tell me. Could be a follow up or an update to this PR. If so, suggestions for a pkg name? "utils"? :-P. Any preferences on strings.ToLower() vs. == 'y' || == 'Y'?