### PR TITLE
cmds/pci: Enable numbers argument

### DIFF
--- a/cmds/pci/pci_linux.go
+++ b/cmds/pci/pci_linux.go
@@ -28,7 +28,9 @@ func onePCI(dir string) (*PCI, error) {
 		// Linux never understood /proc.
 		reflect.ValueOf(&pci).Elem().Field(ix).SetString(string(s[2 : len(s)-1]))
 	}
-	pci.VendorName, pci.DeviceName = lookup(pci.Vendor, pci.Device)
+	if !*numbers {
+		pci.VendorName, pci.DeviceName = lookup(pci.Vendor, pci.Device)
+	}
 	return &pci, nil
 }
 

--- a/cmds/pci/types.go
+++ b/cmds/pci/types.go
@@ -21,7 +21,8 @@ type PCI struct {
 }
 
 func (p *PCI) String() string {
-	return fmt.Sprintf("%s:", p.Addr) +
-		fmt.Sprintf(" %v", p.VendorName) +
-		fmt.Sprintf(" %v", p.DeviceName)
+	if *numbers {
+		return fmt.Sprintf("%s: %s:%s", p.Addr, p.Vendor, p.Device)
+	} 
+	return fmt.Sprintf("%s: %v %v", p.Addr, p.VendorName, p.DeviceName)
 }


### PR DESCRIPTION
Enable the use of the "-n" argument to show vendor and device ID.

Signed-off-by: Ben Allen <bensallen@me.com>