### PR TITLE
Move flag.Parse() to main

### DIFF
--- a/cmds/field/field.go
+++ b/cmds/field/field.go
@@ -55,10 +55,11 @@ func init() {
 	flag.BoolVar(&flags.discardEmpty, "E", false, "discard empty input fields")
 	flag.StringVar(&flags.insep, "F", "[ \t\v\r]+", "Input separator characters (regular expression)")
 	flag.StringVar(&flags.outsep, "O", " ", "Output separater (string)")
-	flag.Parse()
 }
 
 func main() {
+	flag.Parse()
+
 	fstate := make(map[string]bool)
 	flag.Visit(func(f *flag.Flag) { fstate[f.Name] = true })
 	if fstate["e"] && fstate["E"] {

--- a/cmds/pwd/pwd.go
+++ b/cmds/pwd/pwd.go
@@ -35,16 +35,6 @@ func init() {
 		os.Args[0] = cmd
 		defUsage()
 	}
-	args := os.Args[1:]
-	flag.Parse()
-	for _, flag := range args {
-		switch flag {
-		case "-L":
-			*physical = false
-		case "-P":
-			*physical = true
-		}
-	}
 }
 
 func pwd() error {
@@ -61,6 +51,17 @@ func pwd() error {
 }
 
 func main() {
+	args := os.Args[1:]
+	flag.Parse()
+	for _, flag := range args {
+		switch flag {
+		case "-L":
+			*physical = false
+		case "-P":
+			*physical = true
+		}
+	}
+
 	if err := pwd(); err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -43,7 +43,6 @@ func init() {
 	flag.BoolVar(&flags.v, "v", false, "Verbose mode.")
 	flag.BoolVar(&flags.r, "R", false, "Remove file hierarchies")
 	flag.BoolVar(&flags.r, "r", false, "Equivalent to -R.")
-	flag.Parse()
 }
 
 func rm(files []string) error {
@@ -83,6 +82,7 @@ func rm(files []string) error {
 }
 
 func main() {
+	flag.Parse()
 	if flag.NArg() < 1 {
 		flag.Usage()
 		os.Exit(1)

--- a/cmds/seq/seq.go
+++ b/cmds/seq/seq.go
@@ -49,7 +49,6 @@ func init() {
 	flag.StringVar(&flags.format, "f", "%v", "use printf style floating-point FORMAT")
 	flag.StringVar(&flags.separator, "s", "\n", "use STRING to separate numbers")
 	flag.BoolVar(&flags.widthEqual, "w", false, "equalize width by padding with leading zeroes")
-	flag.Parse()
 }
 
 func seq(w io.Writer, args []string) error {
@@ -110,6 +109,8 @@ func seq(w io.Writer, args []string) error {
 }
 
 func main() {
+	flag.Parse()
+
 	if err := seq(os.Stdout, flag.Args()); err != nil {
 		log.Println(err)
 		flag.Usage()

--- a/cmds/uname/uname.go
+++ b/cmds/uname/uname.go
@@ -36,9 +36,7 @@ var (
 	domain  = flag.Bool("d", false, "print your domain name")
 )
 
-func handle_flags(u *uroot.Utsname) string {
-
-	flag.Parse()
+func handleFlags(u *uroot.Utsname) string {
 	info := make([]string, 0, 6)
 
 	if *all || flag.NFlag() == 0 {
@@ -69,11 +67,12 @@ end:
 }
 
 func main() {
+	flag.Parse()
 
 	if u, err := uroot.Uname(); err != nil {
 		log.Fatalf("%v", err)
 	} else {
-		info := handle_flags(u)
+		info := handleFlags(u)
 		fmt.Printf("%v\n", info)
 	}
 }


### PR DESCRIPTION
As stated by Chris in the truncate PR, this should always happen in main().

Found them with some git grep -A5 -B5. Maybe I missed some, but this is a start. I don't see how this should break something. I ran the tests, and tried the ones that do not have a _test.go manually.