### PR TITLE
README: provide a working bb invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,17 @@ command line or coreboot config variable.
 binary. Think of it as busy-box mode. This single binary consists of all the
 commands that got specified by a glob pattern on the command line (by default all of
 them). The following command for example includes the elvish shell:
+
+```shell
+$ # Required for elvish.
+$ go get github.com/boltdb/bolt
+$ go get github.com/elves/elvish
+
+$ cd $GOPATH/src/github.com/u-root/u-root/bb
+$ go build github.com/u-root/u-root/bb
+$ ./bb src/github.com/elves/elvish "s*/g*/u*/u*/c*/*"
 ```
-bb src/github.com/elves/elvish s*/g*/u*/u*/c*
-```
+
 Also note that `bb` has an `-add` flag that is handy to include local files in
 the initramfs.
 


### PR DESCRIPTION
The existing invocation is missing a glob on the end that causes a build
failure.

Beyond that it is lacking in context of which directory it must be run
from to work correctly, and the required packages for elvish.

I don't know how best to explain the need to go get boltdb/bolt. It
seems to be a bug in the build tool that it doesn't look in the proper
vendor directories.

Updates #420

Signed-off-by: Michael Pratt <michael@pratt.im>