### PR TITLE
bb: Fix Gopath/Gopaths handling broken in bf8bc

### DIFF
--- a/bb/config.go
+++ b/bb/config.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 )
 
 func guessgoarch() {
@@ -34,8 +35,8 @@ func guessgoroot() {
 func guessgopath() {
 	gopath := os.Getenv("GOPATH")
 	if gopath != "" {
-		config.Gopath = gopath
-		config.Gopaths = []string{gopath}
+		config.Gopaths = strings.Split(gopath, ":")
+		config.Gopath = config.Gopaths[0]
 		return
 	}
 	log.Fatalf("You have to set GOPATH, which is typically ~/go")


### PR DESCRIPTION
That change broke the handling of GOPATH that had multiple
:-separate elements. This gets it back to how it used to
work.

This does not fix the problem reported in #420, with an elvish
build requiring a go get of boltdb.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>