### PR TITLE
Convert pkg/termios to use x/sys/unix

### DIFF
--- a/cmds/pflask/pflask.go
+++ b/cmds/pflask/pflask.go
@@ -19,6 +19,9 @@ import (
 	"time"
 
 	"unsafe"
+
+	// "github.com/u-root/u-root/pkg/termios"
+	"golang.org/x/sys/unix"
 )
 
 // pty support. We used to import github.com/kr/pty but what we need is not that complex.
@@ -333,14 +336,14 @@ func main() {
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
-		//t, err := getTermios(1)
+		//t, err := termios.GetTermios(1)
 		//if err != nil {
 		//	log.Fatalf("Can't get termios on fd 1: %v", err)
 		//}
 		if err := c.Run(); err != nil {
 			log.Printf(err.Error())
 		}
-		//if err := t.set(1); err != nil {
+		//if err := termios.SetTermios(1, t); err != nil {
 		//	log.Printf("Can't reset termios on fd1: %v", err)
 		//}
 		os.Exit(1)

--- a/cmds/pflask/pflask.go
+++ b/cmds/pflask/pflask.go
@@ -176,9 +176,9 @@ func modedev(st os.FileInfo) (uint32, int) {
 	return uint32(st.Sys().(*syscall.Stat_t).Mode), dev
 }
 
-// make_console sets the right modes for the real console, then creates
+// makeConsole sets the right modes for the real console, then creates
 // a /dev/console in the chroot.
-func make_console(base, console string, unprivileged bool) {
+func makeConsole(base, console string, unprivileged bool) {
 	if err := os.Chmod(console, 0600); err != nil {
 		log.Printf("%v", err)
 	}
@@ -213,8 +213,8 @@ func make_console(base, console string, unprivileged bool) {
 
 }
 
-// copy_nodes makes copies of needed nodes in the chroot.
-func copy_nodes(base string) {
+// copyNodes makes copies of needed nodes in the chroot.
+func copyNodes(base string) {
 	nodes := []string{
 		"/dev/tty",
 		"/dev/full",
@@ -236,9 +236,9 @@ func copy_nodes(base string) {
 	}
 }
 
-// make_ptmx creates /dev/ptmx in the root. Because of order of operations
-// it has to happen at a different time than copy_nodes.
-func make_ptmx(base string) {
+// makePtmx creates /dev/ptmx in the root. Because of order of operations
+// it has to happen at a different time than copyNodes.
+func makePtmx(base string) {
 	dst := filepath.Join(base, "/dev/ptmx")
 
 	if _, err := os.Stat(dst); err == nil {
@@ -250,8 +250,8 @@ func make_ptmx(base string) {
 	}
 }
 
-// make_symlinks sets up standard symlinks as found in /dev.
-func make_symlinks(base string) {
+// makeSymlinks sets up standard symlinks as found in /dev.
+func makeSymlinks(base string) {
 	linkit := []struct {
 		src, dst string
 	}{
@@ -375,14 +375,14 @@ func main() {
 	MountAll(*chroot, unprivileged)
 
 	if !unprivileged {
-		copy_nodes(*chroot)
+		copyNodes(*chroot)
 	}
 
-	make_ptmx(*chroot)
+	makePtmx(*chroot)
 
-	make_symlinks(*chroot)
+	makeSymlinks(*chroot)
 
-	make_console(*chroot, sname, unprivileged)
+	makeConsole(*chroot, sname, unprivileged)
 
 	//umask(0022);
 

--- a/cmds/pflask/pflask.go
+++ b/cmds/pflask/pflask.go
@@ -51,12 +51,11 @@ func ptsopen() (pty, tty *os.File, slavename string, err error) {
 }
 
 func ptsname(f *os.File) (string, error) {
-	var n uintptr
-	_, _, err := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), syscall.TIOCGPTN, uintptr(unsafe.Pointer(&n)))
-	if err != 0 {
+	n, err := unix.IoctlGetInt(int(f.Fd()), unix.TIOCGPTN)
+	if err != nil {
 		return "", err
 	}
-	return "/dev/pts/" + strconv.Itoa(int(n)), nil
+	return "/dev/pts/" + strconv.Itoa(n), nil
 }
 
 func ptsunlock(f *os.File) error {

--- a/cmds/pflask/termios.go
+++ b/cmds/pflask/termios.go
@@ -5,146 +5,19 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"syscall"
-	"unsafe"
+
+	"github.com/u-root/u-root/pkg/termios"
 )
-
-const NCCS = 32
-
-type (
-	cc_t     byte
-	speed_t  uint32
-	tcflag_t uint32
-
-	termios struct {
-		c_iflag, c_oflag, c_cflag, c_lflag tcflag_t
-		c_line                             cc_t
-		c_cc                               [NCCS]cc_t
-		c_ispeed, c_ospeed                 speed_t
-	}
-
-	winsize struct {
-		ws_row, ws_col       uint16
-		ws_xpixel, ws_ypixel uint16
-	}
-)
-
-// termios constants
-const (
-	t_IGNBRK = tcflag_t(0000001)
-	t_BRKINT = tcflag_t(0000002)
-	t_PARMRK = tcflag_t(0000010)
-	t_ISTRIP = tcflag_t(0000040)
-	t_INLCR  = tcflag_t(0000100)
-	t_IGNCR  = tcflag_t(0000200)
-	t_ICRNL  = tcflag_t(0000400)
-	t_IXON   = tcflag_t(0002000)
-	t_OPOST  = tcflag_t(0000001)
-	t_ECHO   = tcflag_t(0000010)
-	t_ECHONL = tcflag_t(0000100)
-	t_ICANON = tcflag_t(0000002)
-	t_ISIG   = tcflag_t(0000001)
-	t_IEXTEN = tcflag_t(0100000)
-	t_CSIZE  = tcflag_t(0000060)
-	t_CS8    = tcflag_t(0000060)
-	t_PARENB = tcflag_t(0000400)
-	t_VTIME  = 5
-	t_VMIN   = 6
-)
-
-// ioctl constants
-const (
-	i_TCGETS     = 0x5401
-	i_TCSETS     = 0x5402
-	i_TIOCGWINSZ = 0x5413
-	i_TIOCSWINSZ = 0x5414
-)
-
-func getTermios(fd uintptr) (*termios, error) {
-	term := new(termios)
-	if err := term.get(fd); err != nil {
-		return nil, err
-	}
-
-	return term, nil
-}
-
-func (self *termios) get(fd uintptr) error {
-	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		fd, uintptr(i_TCGETS),
-		uintptr(unsafe.Pointer(self)))
-
-	if errno != 0 || r1 != 0 {
-		return fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
-	}
-	return nil
-}
-
-func (self *termios) set(fd uintptr) error {
-	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		fd, uintptr(i_TCSETS),
-		uintptr(unsafe.Pointer(self)))
-	if errno != 0 || r1 != 0 {
-		return fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
-	}
-
-	return nil
-}
-
-func (self *termios) setRaw(fd uintptr) error {
-	self.c_iflag &= ^(t_IGNBRK | t_BRKINT | t_PARMRK | t_ISTRIP |
-		t_INLCR | t_IGNCR | t_ICRNL | t_IXON)
-	self.c_oflag &= ^t_OPOST
-	self.c_lflag &= ^(t_ECHO | t_ECHONL | t_ICANON | t_ISIG | t_IEXTEN)
-	self.c_cflag &= ^(t_CSIZE | t_PARENB)
-	self.c_cflag |= t_CS8
-
-	self.c_cc[t_VMIN] = 1
-	self.c_cc[t_VTIME] = 0
-
-	return self.set(fd)
-}
-
-func getWinsize(fd uintptr) (*winsize, error) {
-	size := new(winsize)
-	if err := size.get(fd); err != nil {
-		return nil, err
-	}
-
-	return size, nil
-}
-
-func (self *winsize) get(fd uintptr) error {
-	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		fd, uintptr(i_TIOCGWINSZ),
-		uintptr(unsafe.Pointer(self)))
-	if errno != 0 || r1 != 0 {
-		return fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
-	}
-
-	return nil
-}
-
-func (self *winsize) set(fd uintptr) error {
-	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL,
-		fd, uintptr(i_TIOCSWINSZ),
-		uintptr(unsafe.Pointer(self)))
-	if errno != 0 || r1 != 0 {
-		return fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
-	}
-
-	return nil
-}
 
 func raw() {
 	// we don't set raw until the very last, so if they see an issue they can hit ^C
-	t, err := getTermios(1)
+	t, err := termios.GetTermios(1)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
-	if err = t.setRaw(1); err != nil {
+	raw := termios.MakeRaw(t)
+	if err = termios.SetTermios(1, raw); err != nil {
 		log.Fatalf(err.Error())
 	}
 }

--- a/pkg/pty/pty.go
+++ b/pkg/pty/pty.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 
 	"github.com/u-root/u-root/pkg/termios"
+	"golang.org/x/sys/unix"
 )
 
 type Pty struct {
@@ -27,8 +28,8 @@ type Pty struct {
 	Sname    string
 	Kid      int
 	TTY      *termios.TTY
-	WS       *termios.WinSize
-	Restorer *termios.Termios
+	WS       *unix.Winsize
+	Restorer *unix.Termios
 }
 
 func (p *Pty) Start() error {

--- a/pkg/termios/termios.go
+++ b/pkg/termios/termios.go
@@ -13,7 +13,11 @@
 // tty.Set(restorer)
 package termios
 
-func (t *TTY) Raw() (*Termios, error) {
+import (
+	"golang.org/x/sys/unix"
+)
+
+func (t *TTY) Raw() (*unix.Termios, error) {
 	restorer, err := t.Get()
 	if err != nil {
 		return nil, err

--- a/pkg/termios/termios_linux.go
+++ b/pkg/termios/termios_linux.go
@@ -5,68 +5,14 @@
 package termios
 
 import (
-	"fmt"
 	"os"
-	"syscall"
-	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
 
-// NCCS is the size of the control character array, which is basically
-// ^@ to ^Z.
-const NCCS = 32
-
-type (
-	ControlChar byte
-	Speed       uint32
-	TCFlag      uint32
-
-	Termios struct {
-		Iflag, Oflag, Cflag, Lflag TCFlag
-		Line                       uint8
-		CC                         [NCCS]ControlChar
-		Ispeed, Ospeed             Speed
-	}
-
-	WinSize struct {
-		Row, Col       uint16
-		Xpixel, Ypixel uint16
-	}
-
-	TTY struct {
-		f *os.File
-	}
-)
-
-// termios constants
-const (
-	IGNBRK = TCFlag(0000001)
-	BRKINT = TCFlag(0000002)
-	PARMRK = TCFlag(0000010)
-	ISTRIP = TCFlag(0000040)
-	INLCR  = TCFlag(0000100)
-	IGNCR  = TCFlag(0000200)
-	ICRNL  = TCFlag(0000400)
-	IXON   = TCFlag(0002000)
-	OPOST  = TCFlag(0000001)
-	ECHO   = TCFlag(0000010)
-	ECHONL = TCFlag(0000100)
-	ICANON = TCFlag(0000002)
-	ISIG   = TCFlag(0000001)
-	IEXTEN = TCFlag(0100000)
-	CSIZE  = TCFlag(0000060)
-	CS8    = TCFlag(0000060)
-	PARENB = TCFlag(0000400)
-	VTIME  = 5
-	VMIN   = 6
-)
-
-// ioctl constants
-const (
-	TCGETS     = 0x5401
-	TCSETS     = 0x5402
-	TIOCGWINSZ = 0x5413
-	TIOCSWINSZ = 0x5414
-)
+type TTY struct {
+	f *os.File
+}
 
 func New() (*TTY, error) {
 	f, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
@@ -78,58 +24,48 @@ func New() (*TTY, error) {
 	return t, nil
 }
 
-func (t *TTY) Get() (*Termios, error) {
-	var ti = &Termios{}
-	r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL, t.f.Fd(), uintptr(TCGETS), uintptr(unsafe.Pointer(ti)))
-	if errno != 0 || r1 != 0 {
-		return nil, fmt.Errorf("termios.get: r1 %v, errno %v", r1, errno)
-	}
-	return ti, nil
+func GetTermios(fd uintptr) (*unix.Termios, error) {
+	return unix.IoctlGetTermios(int(fd), unix.TCGETS)
 }
 
-func (t *TTY) Set(ti *Termios) error {
-	if r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL, t.f.Fd(), uintptr(TCSETS), uintptr(unsafe.Pointer(ti))); errno != 0 || r1 != 0 {
-		return fmt.Errorf("Termios.Set: r1 %v, errno %v", r1, errno)
-	}
-
-	return nil
+func (t *TTY) Get() (*unix.Termios, error) {
+	return GetTermios(t.f.Fd())
 }
 
-func MakeRaw(term *Termios) *Termios {
+func SetTermios(fd uintptr, ti *unix.Termios) error {
+	return unix.IoctlSetTermios(int(fd), unix.TCSETS, ti)
+}
+
+func (t *TTY) Set(ti *unix.Termios) error {
+	return SetTermios(t.f.Fd(), ti)
+}
+
+func MakeRaw(term *unix.Termios) *unix.Termios {
 	raw := *term
-	raw.Iflag &= ^(IGNBRK | BRKINT | PARMRK | ISTRIP | INLCR | IGNCR | ICRNL | IXON)
-	raw.Oflag &= ^OPOST
-	raw.Lflag &= ^(ECHO | ECHONL | ICANON | ISIG | IEXTEN)
-	raw.Cflag &= ^(CSIZE | PARENB)
-	raw.Cflag |= CS8
+	raw.Iflag &^= unix.IGNBRK | unix.BRKINT | unix.PARMRK | unix.ISTRIP | unix.INLCR | unix.IGNCR | unix.ICRNL | unix.IXON
+	raw.Oflag &^= unix.OPOST
+	raw.Lflag &^= unix.ECHO | unix.ECHONL | unix.ICANON | unix.ISIG | unix.IEXTEN
+	raw.Cflag &^= unix.CSIZE | unix.PARENB
+	raw.Cflag |= unix.CS8
 
-	raw.CC[VMIN] = 1
-	raw.CC[VTIME] = 0
+	raw.Cc[unix.VMIN] = 1
+	raw.Cc[unix.VTIME] = 0
 
 	return &raw
 }
 
-func GetWinSize(fd uintptr) (*WinSize, error) {
-	var w = &WinSize{}
-	if r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(TIOCGWINSZ), uintptr(unsafe.Pointer(w))); errno != 0 || r1 != 0 {
-		return nil, fmt.Errorf("WinSize.Get: r1 %v, errno %v", r1, errno)
-	}
-
-	return w, nil
+func GetWinSize(fd uintptr) (*unix.Winsize, error) {
+	return unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
 }
 
-func (t *TTY) GetWinSize() (*WinSize, error) {
+func (t *TTY) GetWinSize() (*unix.Winsize, error) {
 	return GetWinSize(t.f.Fd())
 }
 
-func SetWinSize(fd uintptr, w *WinSize) error {
-	if r1, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(TIOCSWINSZ), uintptr(unsafe.Pointer(w))); errno != 0 || r1 != 0 {
-		return fmt.Errorf("WinSize.Set: r1 %v, errno %v", r1, errno)
-	}
-
-	return nil
+func SetWinSize(fd uintptr, w *unix.Winsize) error {
+	return unix.IoctlSetWinsize(int(fd), unix.TIOCSWINSZ, w)
 }
 
-func (t *TTY) SetWinSize(w *WinSize) error {
+func (t *TTY) SetWinSize(w *unix.Winsize) error {
 	return SetWinSize(t.f.Fd(), w)
 }


### PR DESCRIPTION
Follow up on #429 and convert pkg/termios to use functions, types and constants from golang.org/x/sys/unix. Also convert cmds/pflask to use the updated termios package instead of locally duplicating its functionality.

The last commit fixes some golint warnings in cmds/pflask (already present before this PR), which I encountered while checking my changes.