### PR TITLE
Use syscall numbers from x/sys/unix

### DIFF
--- a/pkg/kexec/kexec_linux_amd64.go
+++ b/pkg/kexec/kexec_linux_amd64.go
@@ -7,12 +7,10 @@ package kexec
 import (
 	"fmt"
 	"os"
-	"syscall"
 	"unsafe"
-)
 
-// Syscall number for kexec_file_load(2).
-const _SYS_KEXEC_FILE_LOAD = 320
+	"golang.org/x/sys/unix"
+)
 
 // kexec_file_load(2) syscall flags.
 const (
@@ -34,13 +32,13 @@ func FileLoad(kernel, ramfs *os.File, cmdline string) error {
 		flags |= _KEXEC_FILE_NO_INITRAMFS
 	}
 
-	cmdPtr, err := syscall.BytePtrFromString(cmdline)
+	cmdPtr, err := unix.BytePtrFromString(cmdline)
 	if err != nil {
 		return fmt.Errorf("could not use cmdline %q: %v", cmdline, err)
 	}
 
-	if _, _, errno := syscall.Syscall6(
-		_SYS_KEXEC_FILE_LOAD,
+	if _, _, errno := unix.Syscall6(
+		unix.SYS_KEXEC_FILE_LOAD,
 		kernel.Fd(),
 		ramfsfd,
 		uintptr(len(cmdline)),

--- a/pkg/kmodule/kmodule_linux_amd64.go
+++ b/pkg/kmodule/kmodule_linux_amd64.go
@@ -1,6 +1,0 @@
-package kmodule
-
-const (
-	// x86-64 syscall number for finit_module(2).
-	_SYS_FINIT_MODULE = 313
-)

--- a/pkg/kmodule/kmodule_linux_arm64.go
+++ b/pkg/kmodule/kmodule_linux_arm64.go
@@ -1,6 +1,0 @@
-package kmodule
-
-const (
-	// arm64 syscall number for finit_module(2).
-	_SYS_FINIT_MODULE = 379
-)

--- a/pkg/kmodule/kmodule_linux_ppc64le.go
+++ b/pkg/kmodule/kmodule_linux_ppc64le.go
@@ -1,6 +1,0 @@
-package kmodule
-
-const (
-	// powerpc syscall number for finit_module(2).
-	_SYS_FINIT_MODULE = 353
-)


### PR DESCRIPTION
Use the architecture-specific syscall numbers for kexec_file_load(2) and finit_module(2) from golang.org/x/sys/unix instead of locally duplicating them. Also switch the packages to use functions from x/sys/unix instead of syscall (as per the comment in https://github.com/golang/go/blob/master/src/syscall/syscall.go#L21-L28).