### PR TITLE
Local testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,12 @@ Of course you have to fetch all those packages first somehow :-)
 
 In the EXAMPLES directory you can see examples of running in a chroot, kernel, and coreboot.
 
+## Testing
 
+You can run tests locally using the standard `go test` pointing at the directory where you would
+like to run tests (e.g. `go test cmds/dd/`).
+
+You can run the entire test suite locally in a Docker container by running `go run scripts/test_local.go`.
 
 ## Using elvish: a more handy shell
 

--- a/scripts/ramfs.go
+++ b/scripts/ramfs.go
@@ -68,7 +68,7 @@ func buildPkg(pkg string, wd string, output string, opts []string) error {
 	}
 	cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 	if o, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("building statically linked go tool info %v: %v, %v", pkg, string(o), err)
+		return fmt.Errorf("Building statically linked go tool info %v: %v, %v", pkg, string(o), err)
 	}
 	return nil
 }

--- a/scripts/test_local.go
+++ b/scripts/test_local.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+)
+
+func main() {
+
+	mountPoint := "/go/src/github.com/u-root/u-root"
+	goVersion := "1.9.2"
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	args := []string{
+		"run",
+		"--privileged",
+		"-v", fmt.Sprintf("%s:%s", cwd, mountPoint),
+		"-t",
+		"-e", "USER=root",
+		"-w", mountPoint,
+		fmt.Sprintf("golang:%s", goVersion),
+		"./travis.sh",
+	}
+
+	cmd := exec.Command("docker", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		os.Exit(1)
+	}
+}

--- a/travis.sh
+++ b/travis.sh
@@ -46,5 +46,5 @@ echo "-----------------------> go vet scripts/ramfs.go"
 # is it go-gettable?
 echo "-----------------------> test go-gettable"
 go get github.com/u-root/u-root
- sudo date
+ date
  echo "Did it blend"


### PR DESCRIPTION
This allows for easy development and testing. I switch between developing on OS X and Linux this adds an easy hook to ensures I can run tests before pushing up changes.

To run execute `go run scripts/local_tests.go`.
