### PR TITLE
pkg/uroot: define the command-line interface as a Go API.

### DIFF
--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -6,12 +6,15 @@ package uroot
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
 
 	"github.com/u-root/u-root/pkg/cpio"
 	"github.com/u-root/u-root/pkg/golang"
+	"github.com/u-root/u-root/pkg/ldd"
 )
 
 var (
@@ -26,6 +29,144 @@ var (
 	}
 )
 
+// Opts are the arguments to CreateInitramfs.
+type Opts struct {
+	// Env is the build environment (OS, arch, etc).
+	Env golang.Environ
+
+	// Builder is the build format.
+	//
+	// This can currently be "source" or "bb".
+	Builder Build
+
+	// Archiver is the initramfs archival format.
+	//
+	// Only "cpio" is currently supported.
+	Archiver Archiver
+
+	// Packages are the Go packages to add to the archive.
+	//
+	// Currently allowed formats:
+	//   Go package imports; e.g. github.com/u-root/u-root/cmds/ls
+	//   Paths to Go package directories; e.g. $GOPATH/src/github.com/u-root/u-root/cmds/ls
+	//   Globs of paths to Go package directories; e.g. ./cmds/*
+	Packages []string
+
+	// ExtraFiles are files to add to the archive in addition to the Go
+	// packages.
+	//
+	// Shared library dependencies will automatically also be added to the
+	// archive using ldd.
+	ExtraFiles []string
+
+	// TempDir is a temporary directory for the builder to store files in.
+	TempDir string
+
+	// OutputFile is the archive output file.
+	OutputFile *os.File
+
+	// BaseArchive is an existing initramfs to include in the resulting
+	// initramfs.
+	BaseArchive *os.File
+
+	// UseExistingInit determines whether the existing init from
+	// BaseArchive should be used.
+	//
+	// If this is false, the "init" from BaseArchive will be renamed to
+	// "inito".
+	UseExistingInit bool
+}
+
+// CreateInitramfs creates an initramfs built to `opts`' specifications.
+func CreateInitramfs(opts Opts) error {
+	if _, err := os.Stat(opts.TempDir); os.IsNotExist(err) {
+		return fmt.Errorf("temp dir %q must exist: %v", opts.TempDir, err)
+	}
+	if opts.OutputFile == nil {
+		return fmt.Errorf("must give output file")
+	}
+
+	var importPaths []string
+	// Resolve file system paths to package import paths.
+	for _, pkg := range opts.Packages {
+		matches, err := filepath.Glob(pkg)
+		if len(matches) == 0 || err != nil {
+			if _, perr := opts.Env.ListPackage(pkg); perr != nil {
+				return fmt.Errorf("%q is neither package or path/glob: %v / %v", pkg, err, perr)
+			}
+			importPaths = append(importPaths, pkg)
+		}
+
+		for _, match := range matches {
+			p, err := opts.Env.FindPackageByPath(match)
+			if err != nil {
+				log.Printf("Skipping package %q: %v", match, err)
+			} else {
+				importPaths = append(importPaths, p)
+			}
+		}
+	}
+
+	builderTmpDir, err := ioutil.TempDir(opts.TempDir, "builder")
+	if err != nil {
+		return err
+	}
+
+	// Build the packages.
+	bOpts := BuildOpts{
+		Env:      opts.Env,
+		Packages: importPaths,
+		TempDir:  builderTmpDir,
+	}
+	files, err := opts.Builder(bOpts)
+	if err != nil {
+		return fmt.Errorf("error building %#v: %v", bOpts, err)
+	}
+
+	archiveTmpDir, err := ioutil.TempDir(opts.TempDir, "archive")
+	if err != nil {
+		return err
+	}
+
+	// Open the target initramfs file.
+	archive := ArchiveOpts{
+		ArchiveFiles:    files,
+		OutputFile:      opts.OutputFile,
+		BaseArchive:     opts.BaseArchive,
+		UseExistingInit: opts.UseExistingInit,
+		TempDir:         archiveTmpDir,
+	}
+
+	// Add files from command line.
+	for _, file := range opts.ExtraFiles {
+		path, err := filepath.Abs(file)
+		if err != nil {
+			return fmt.Errorf("couldn't find absolute path for %q: %v", file, err)
+		}
+		if err := archive.AddFile(path, path[1:]); err != nil {
+			return fmt.Errorf("couldn't add %q to archive: %v", file, err)
+		}
+
+		// Pull dependencies in the case of binaries. If `path` is not
+		// a binary, `libs` will just be empty.
+		libs, err := ldd.List([]string{path})
+		if err != nil {
+			return fmt.Errorf("couldn't list ldd dependencies for %q: %v", file, err)
+		}
+		for _, lib := range libs {
+			if err := archive.AddFile(lib, lib[1:]); err != nil {
+				return fmt.Errorf("couldn't add %q to archive: %v", lib, err)
+			}
+		}
+	}
+
+	// Finally, write the archive.
+	if err := opts.Archiver.Archive(archive); err != nil {
+		return fmt.Errorf("error archiving: %v", err)
+	}
+	return nil
+}
+
 // BuildOpts are arguments to the Build function.
 type BuildOpts struct {
 	// Env is the Go environment to use to compile and link packages.
@@ -33,11 +174,15 @@ type BuildOpts struct {
 
 	// Packages are the Go package import paths to compile.
 	//
+	// Builders need not support resolving packages by path.
+	//
 	// E.g. cmd/go or github.com/u-root/u-root/cmds/ls.
 	Packages []string
 
 	// TempDir is a temporary directory where the compilation mode compiled
 	// binaries can be placed.
+	//
+	// TempDir should contain no files.
 	TempDir string
 }
 
@@ -49,6 +194,12 @@ type Build func(BuildOpts) (ArchiveFiles, error)
 type ArchiveOpts struct {
 	// ArchiveFiles are the files to be included.
 	ArchiveFiles
+
+	// TempDir is a temporary directory that can be used at the archiver's
+	// discretion.
+	//
+	// TempDir should contain no files.
+	TempDir string
 
 	// OutputFile is the file to write to.
 	OutputFile *os.File

--- a/u-root.go
+++ b/u-root.go
@@ -10,11 +10,9 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/u-root/u-root/pkg/golang"
-	"github.com/u-root/u-root/pkg/ldd"
 	"github.com/u-root/u-root/pkg/uroot"
 )
 
@@ -36,28 +34,33 @@ var (
 func main() {
 	flag.Parse()
 
+	// Main is in a separate functions so defer's run on return.
+	if err := Main(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func Main() error {
 	env := golang.Default()
 	if env.CgoEnabled {
 		log.Printf("Disabling CGO for u-root...")
 		env.CgoEnabled = false
 	}
 	log.Printf("Build environment: %s", env)
-
-	if err := Build(env, flag.Args(), *build, *format, *tmpDir, *base, *outputPath, strings.Fields(*extraFiles), *useExistingInit); err != nil {
-		log.Fatalf("u-root: %v", err)
+	if env.GOOS != "linux" {
+		log.Printf("GOOS is not linux. Did you mean to set GOOS=linux?")
 	}
-}
 
-func Build(env golang.Environ, pkgs []string, build, format, tempDir, base, outputPath string, extraFiles []string, useExistingInit bool) error {
-	builder, err := uroot.GetBuilder(build)
+	builder, err := uroot.GetBuilder(*build)
 	if err != nil {
 		return err
 	}
-	archiver, err := uroot.GetArchiver(format)
+	archiver, err := uroot.GetArchiver(*format)
 	if err != nil {
 		return err
 	}
 
+	tempDir := *tmpDir
 	if tempDir == "" {
 		var err error
 		tempDir, err = ioutil.TempDir("", "u-root")
@@ -65,6 +68,10 @@ func Build(env golang.Environ, pkgs []string, build, format, tempDir, base, outp
 			return err
 		}
 		defer os.RemoveAll(tempDir)
+	} else if _, err := os.Stat(tempDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(tempDir, 0755); err != nil {
+			return fmt.Errorf("temporary directory %q did not exist; tried to mkdir but failed: %v", tempDir, err)
+		}
 	}
 
 	// Resolve globs into package imports.
@@ -72,6 +79,7 @@ func Build(env golang.Environ, pkgs []string, build, format, tempDir, base, outp
 	// Currently allowed formats:
 	//   Go package imports; e.g. github.com/u-root/u-root/cmds/ls
 	//   Paths to Go package directories; e.g. $GOPATH/src/github.com/u-root/u-root/cmds/*
+	pkgs := flag.Args()
 	if len(pkgs) == 0 {
 		var err error
 		pkgs, err = uroot.DefaultPackageImports(env)
@@ -80,85 +88,41 @@ func Build(env golang.Environ, pkgs []string, build, format, tempDir, base, outp
 		}
 	}
 
-	var importPaths []string
-	// Resolve file system paths to package import paths.
-	for _, pkg := range pkgs {
-		importPath, err := env.FindPackageByPath(pkg)
-		if err != nil {
-			if _, perr := env.FindPackageDir(pkg); perr != nil {
-				return fmt.Errorf("%q is neither package or path: %v / %v", pkg, err, perr)
-			}
-			importPath = pkg
-		}
-		importPaths = append(importPaths, importPath)
-	}
-
-	// Build the packages.
-	bOpts := uroot.BuildOpts{
-		Env:      env,
-		Packages: importPaths,
-		TempDir:  tempDir,
-	}
-	files, err := builder(bOpts)
-	if err != nil {
-		return fmt.Errorf("error building %#v: %v", bOpts, err)
-	}
-
 	// Open the target initramfs file.
-	if outputPath == "" {
-		outputPath = fmt.Sprintf("/tmp/initramfs.%s_%s.%s", env.GOOS, env.GOARCH, archiver.DefaultExtension())
+	filename := *outputPath
+	if filename == "" {
+		filename = fmt.Sprintf("/tmp/initramfs.%s_%s.%s", env.GOOS, env.GOARCH, archiver.DefaultExtension())
 	}
-	f, err := os.OpenFile(outputPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	f, err := os.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		return err
 	}
 	defer f.Close()
 
 	var baseFile *os.File
-	if base != "" {
+	if *base != "" {
 		var err error
-		baseFile, err = os.Open(base)
+		baseFile, err = os.Open(*base)
 		if err != nil {
 			return err
 		}
 		defer baseFile.Close()
 	}
 
-	archive := uroot.ArchiveOpts{
-		ArchiveFiles:    files,
+	opts := uroot.Opts{
+		Env:             env,
+		Builder:         builder,
+		Archiver:        archiver,
+		TempDir:         tempDir,
+		Packages:        pkgs,
+		ExtraFiles:      strings.Fields(*extraFiles),
 		OutputFile:      f,
 		BaseArchive:     baseFile,
-		UseExistingInit: useExistingInit,
+		UseExistingInit: *useExistingInit,
 	}
-
-	// Add files from command line.
-	for _, file := range extraFiles {
-		path, err := filepath.Abs(file)
-		if err != nil {
-			return fmt.Errorf("couldn't find absolute path for %q: %v", file, err)
-		}
-		if err := archive.AddFile(path, path[1:]); err != nil {
-			return fmt.Errorf("couldn't add %q to archive: %v", file, err)
-		}
-
-		// Pull dependencies in the case of binaries. If `path` is not
-		// a binary, `libs` will just be empty.
-		libs, err := ldd.List([]string{path})
-		if err != nil {
-			return fmt.Errorf("couldn't list ldd dependencies for %q: %v", file, err)
-		}
-		for _, lib := range libs {
-			if err := archive.AddFile(lib, lib[1:]); err != nil {
-				return fmt.Errorf("couldn't add %q to archive: %v", lib, err)
-			}
-		}
+	if err := uroot.CreateInitramfs(opts); err != nil {
+		return err
 	}
-
-	// Finally, write the archive.
-	if err := archiver.Archive(archive); err != nil {
-		return fmt.Errorf("error archiving: %v", err)
-	}
-
-	log.Printf("Filename is %s", outputPath)
+	log.Printf("Filename is %s", filename)
 	return nil
 }


### PR DESCRIPTION
This enables people to include pkg/uroot in their own packages and be
met with the same API available on the command-line.

Fixes #440.

Signed-off-by: Christopher Koch <chrisko@google.com>