### PR TITLE
pkg/uroot: remove bbsh before regenerating.

### DIFF
--- a/pkg/uroot/bb.go
+++ b/pkg/uroot/bb.go
@@ -150,6 +150,10 @@ func BBBuild(opts BuildOpts) (ArchiveFiles, error) {
 	}
 
 	bbshDir := filepath.Join(urootDir, "bbsh")
+	// Blow bbsh away before trying to re-create it.
+	if err := os.RemoveAll(bbshDir); err != nil {
+		return ArchiveFiles{}, err
+	}
 	if err := os.MkdirAll(bbshDir, 0755); err != nil {
 		return ArchiveFiles{}, err
 	}


### PR DESCRIPTION
Fixes #447.

Signed-off-by: Christopher Koch <c@chrisko.ch>