### PR TITLE
pkg/pci, cmd/pci: Parse pci.ids on start and update to use stripped plain text pci.ids

### DIFF
--- a/cmds/pci/pci.go
+++ b/cmds/pci/pci.go
@@ -33,8 +33,12 @@ func main() {
 		log.Fatalf("Read: %v", err)
 	}
 
-	if *numbers {
-		fmt.Print(d.ToString(*numbers))
+	if !*numbers {
+		ids, err := pci.NewIDs()
+		if err != nil {
+			log.Fatalf("pci.NewIDs: %v\n", err)
+		}
+		fmt.Print(d.ToString(*numbers, ids))
 
 	} else {
 		fmt.Print(d)

--- a/pkg/pci/devices.go
+++ b/pkg/pci/devices.go
@@ -4,7 +4,9 @@
 
 package pci
 
-import "bytes"
+import (
+	"bytes"
+)
 
 //Devices contains a slice of one or more PCI devices
 type Devices []*PCI
@@ -12,10 +14,10 @@ type Devices []*PCI
 // ToString concatenates multiple Devices' PCI address, Vendor, and Device
 // to make a useful display for the user. Boolean argument toggles displaying
 // numeric IDs or human readable labels.
-func (d Devices) ToString(n bool) string {
+func (d Devices) ToString(n bool, ids map[string]Vendor) string {
 	var buffer bytes.Buffer
 	for _, pci := range d {
-		buffer.WriteString(pci.ToString(n))
+		buffer.WriteString(pci.ToString(n, ids))
 		buffer.WriteString("\n")
 	}
 	return buffer.String()
@@ -23,5 +25,5 @@ func (d Devices) ToString(n bool) string {
 
 // String is a Stringer for fmt and others' convenience.
 func (d Devices) String() string {
-	return d.ToString(false)
+	return d.ToString(true, nil)
 }

--- a/pkg/pci/ids.go
+++ b/pkg/pci/ids.go
@@ -1,58 +1,41 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// A slice of bytes of the literal plain text of pci.ids has been found
+// to produce the smallest binary compared to a native Go map, marshalled
+// JSON, and go-bindata (gzip'ed bytes). Further runtime of parsing the plain
+// text pci.ids is lower than all options compared. The pciids in this package
+// is stripped of all comments, empty lines, sub-devices, and classes to save
+// on binary size.
+
 package pci
 
-var pciids = []byte(`#
-#	List of PCI ID's
-#
-#	Version: 2017.10.09
-#	Date:    2017-10-09 03:15:02
-#
-#	Maintained by Albert Pool, Martin Mares, and other volunteers from
-#	the PCI ID Project at http://pci-ids.ucw.cz/.
-#
-#	New data are always welcome, especially if they are accurate. If you have
-#	anything to contribute, please follow the instructions at the web site.
-#
-#	This file can be distributed under either the GNU General Public License
-#	(version 2 or higher) or the 3-clause BSD License.
-#
+// NewIDs contains the plain text contents of pci.ids. It returns
+// a map to be used as lookup from hex ID to human readable lable.
+func NewIDs() (map[string]Vendor, error) {
 
-# Vendors, devices and subsystems. Please keep sorted.
-
-# Syntax:
-# vendor  vendor_name
-#	device  device_name				<-- single tab
-#		subvendor subdevice  subsystem_name	<-- two tabs
-
-0001  SafeNet (wrong ID)
+	var pciids = []byte(`0001  SafeNet (wrong ID)
 0010  Allied Telesis, Inc (Wrong ID)
-# This is a relabelled RTL-8139
 	8139  AT-2500TX V3 Ethernet
 001c  PEAK-System Technik GmbH
 	0001  PCAN-PCI CAN-Bus controller
-		001c 0004  2 Channel CAN Bus SJC1000
-		001c 0005  2 Channel CAN Bus SJC1000 (Optically Isolated)
 003d  Lockheed Martin-Marietta Corp
-# Real TJN ID is e159, but they got it wrong several times --mj
 0059  Tiger Jet Network Inc. (Wrong ID)
 0070  Hauppauge computer works Inc.
 	7801  WinTV HVR-1800 MCE
 0071  Nebula Electronics Ltd.
 0095  Silicon Image, Inc. (Wrong ID)
 	0680  Ultra ATA/133 IDE RAID CONTROLLER CARD
-# Wrong ID used in subsystem ID of the TELES.S0/PCI 2.x ISDN adapter
 00a7  Teles AG (Wrong ID)
-# nee nCipher
 0100  Thales e-Security
 0123  General Dynamics
-# 018a is not LevelOne but there is a board misprogrammed
 018a  LevelOne
 	0106  FPC-0106TX misprogrammed [RTL81xx]
-# 021b is not Compaq but there is a board misprogrammed
 021b  Compaq Computer Corporation
 	8139  HNE-300 (RealTek RTL8139c) [iPaq Networking]
 0270  Hauppauge computer works Inc. (Wrong ID)
 0291  Davicom Semiconductor, Inc. (Wrong ID)
-# SpeedStream is Efficient Networks, Inc, a Siemens Company
 02ac  SpeedStream
 	1012  1012 PCMCIA 10/100 Ethernet Card [RTL81xx]
 02e0  XFX Pine Group Inc. (Wrong ID)
@@ -95,11 +78,6 @@ var pciids = []byte(`#
 	0001  PCI to EISA Bridge
 	0002  PCI to ISA Bridge
 	0046  Smart Array 64xx
-		0e11 4091  Smart Array 6i
-		0e11 409a  Smart Array 641
-		0e11 409b  Smart Array 642
-		0e11 409c  Smart Array 6400
-		0e11 409d  Smart Array 6400 EM
 	0049  NC7132 Gigabit Upgrade Module
 	004a  NC6136 Gigabit Server Adapter
 	005a  Remote Insight II board - Lights-Out
@@ -139,19 +117,11 @@ var pciids = []byte(`#
 	7020  USB Controller
 	a0ec  Fibre Channel Host Controller
 	a0f0  Advanced System Management Controller
-		0e11 b0f3  ProLiant DL360
 	a0f3  Triflex PCI to ISA Bridge
 	a0f7  PCI Hotplug Controller
-		8086 002a  PCI Hotplug Controller A
-		8086 002b  PCI Hotplug Controller B
 	a0f8  ZFMicro Chipset USB
 	a0fc  FibreChannel HBA Tachyon
 	ae10  Smart-2/P RAID Controller
-		0e11 4030  Smart-2/P Array Controller
-		0e11 4031  Smart-2SL Array Controller
-		0e11 4032  Smart Array 3200 Controller
-		0e11 4033  Smart Array 3100ES Controller
-		0e11 4034  Smart Array 221 Controller
 	ae29  MIS-L
 	ae2a  MPC
 	ae2b  MIS-E
@@ -188,9 +158,6 @@ var pciids = []byte(`#
 	b163  NC3134 Fast Ethernet NIC
 	b164  NC3165 Fast Ethernet Upgrade Module
 	b178  Smart Array 5i/532
-		0e11 4080  Smart Array 5i
-		0e11 4082  Smart Array 532
-		0e11 4083  Smart Array 5312
 	b1a4  NC7131 Gigabit Server Adapter
 	b200  Memory Hot-Plug Controller
 	b203  Integrated Lights Out Controller
@@ -202,360 +169,66 @@ var pciids = []byte(`#
 0eac  SHF Communication Technologies AG
 	0008  Ethernet Powerlink Managing Node 01
 0f62  Acrox Technologies Co., Ltd.
-# Formerly NCR
 1000  LSI Logic / Symbios Logic
 	0001  53c810
-		1000 1000  LSI53C810AE PCI to SCSI I/O Processor
 	0002  53c820
 	0003  53c825
-		1000 1000  LSI53C825AE PCI to SCSI I/O Processor (Ultra Wide)
 	0004  53c815
 	0005  53c810AP
 	0006  53c860
-		1000 1000  LSI53C860E PCI to Ultra SCSI I/O Processor
 	000a  53c1510
-		0e11 b143  Integrated Dual Channel Wide Ultra2 SCSI Controller
-		1000 1000  LSI53C1510 PCI to Dual Channel Wide Ultra2 SCSI Controller (Nonintelligent mode)
 	000b  53C896/897
-		0e11 6004  EOB003 Series SCSI host adapter
-		1000 1000  LSI53C896/7 PCI to Dual Channel Ultra2 SCSI Multifunction Controller
-		1000 1010  LSI22910 PCI to Dual Channel Ultra2 SCSI host adapter
-		1000 1020  LSI21002 PCI to Dual Channel Ultra2 SCSI host adapter
-		13e9 1000  6221L-4U (Dual U2W SCSI, dual 10/100TX, graphics)
 	000c  53c895
-		1000 1010  LSI8951U PCI to Ultra2 SCSI host adapter
-		1000 1020  LSI8952U PCI to Ultra2 SCSI host adapter
-		1de1 3906  DC-390U2B SCSI adapter
-		1de1 3907  DC-390U2W
 	000d  53c885
 	000f  53c875
-		0e11 7004  Embedded Ultra Wide SCSI Controller
-		1000 1000  LSI53C876/E PCI to Dual Channel SCSI Controller
-		1000 1010  LSI22801 PCI to Dual Channel Ultra SCSI host adapter
-		1000 1020  LSI22802 PCI to Dual Channel Ultra SCSI host adapter
-		1092 8760  FirePort 40 Dual SCSI Controller
-		1775 10d0  V5D Single Board Computer Wide Ultra SCSI
-		1775 10d1  V5D Single Board Computer Ultra SCSI
-		1de1 3904  DC390F/U Ultra Wide SCSI Adapter
-		4c53 1000  CC7/CR7/CP7/VC7/VP7/VR7 mainboard
-		4c53 1050  CT7 mainboard
 	0010  53C1510
-		0e11 4040  Integrated Smart Array Controller
-		0e11 4048  RAID LC2 Controller
-		1000 1000  53C1510 PCI to Dual Channel Wide Ultra2 SCSI Controller (Intelligent mode)
 	0012  53c895a
-		1000 1000  LSI53C895A PCI to Ultra2 SCSI Controller
 	0013  53c875a
-		1000 1000  LSI53C875A PCI to Ultra SCSI Controller
 	0014  MegaRAID Tri-Mode SAS3516
-		1028 1fd4  PERC H745P MX
-		1d49 0602  ThinkSystem RAID 930-16i 4GB Flash PCIe 12Gb Adapter
-		1d49 0604  ThinkSystem RAID 930-8e 4GB Flash PCIe 12Gb Adapter
-		8086 352d  Integrated RAID Module RMSP3AD160F
-		8086 9460  RAID Controller RSP3TD160F
-		8086 9480  RAID Controller RSP3MD088F
 	0015  MegaRAID Tri-Mode SAS3416
 	0016  MegaRAID Tri-Mode SAS3508
-		1028 1fc9  PERC H840 Adapter
-		1028 1fcb  PERC H740P Adapter
-		1028 1fcd  PERC H740P Mini
-		1028 1fcf  PERC H740P Mini
-		1d49 0601  ThinkSystem RAID 930-8i 2GB Flash PCIe 12Gb Adapter
-		1d49 0603  ThinkSystem RAID 930-24i 4GB Flash PCIe 12Gb Adapter
-		1d49 0604  ThinkSystem RAID 930-8e 4GB Flash PCIe 12Gb Adapter
-		8086 352e  Integrated RAID Module RMSP3CD080F
-		8086 352f  Integrated RAID Module RMSP3HD080E
-		8086 9461  RAID Controller RSP3DD080F
 	0017  MegaRAID Tri-Mode SAS3408
-		1d49 0500  ThinkSystem RAID 530-8i PCIe 12Gb Adapter
-		1d49 0502  ThinkSystem RAID 530-8i Dense Adapter
-		8086 3528  Integrated RAID RMSP3LD060
-		8086 3529  Integrated RAID RMSP3LD060
-		8086 9441  RAID Controller RSP3WD080E
 	001b  MegaRAID Tri-Mode SAS3504
-		1d49 0605  ThinkSystem RAID 930-4i 2GB Flash Flex Adapter
 	001c  MegaRAID Tri-Mode SAS3404
-		1d49 0501  ThinkSystem RAID 530-4i Flex Adapter
 	0020  53c1010 Ultra3 SCSI Adapter
-		1000 1000  LSI53C1010-33 PCI to Dual Channel Ultra160 SCSI Controller
-		107b 1040  Server Onboard 53C1010-33
-		1de1 1020  DC-390U3W
 	0021  53c1010 66MHz  Ultra3 SCSI Adapter
-		1000 1000  LSI53C1000/1000R/1010R/1010-66 PCI to Ultra160 SCSI Controller
-		1000 1010  Asus TR-DLS onboard 53C1010-66
-		103c 1300  Ultra160 SCSI [AB306A]
-		103c 1310  Ultra160 SCSI [A9918A]
-		103c 1330  Ultra160 SCSI [A7059A]
-		103c 1340  Ultra160 SCSI [A7060A]
-		124b 1070  PMC-USCSI3
-		4c53 1080  CT8 mainboard
-		4c53 1300  P017 mezzanine (32-bit PMC)
-		4c53 1310  P017 mezzanine (64-bit PMC)
 	002f  MegaRAID SAS 2208 IOV [Thunderbolt]
-		1028 1f39  SPERC8-e
-		1028 1f3e  SPERC 8
 	0030  53c1030 PCI-X Fusion-MPT Dual Ultra320 SCSI
-		0e11 00da  ProLiant ML 350
-		1028 0123  LSI Logic 1020/1030
-		1028 014a  LSI Logic 1020/1030
-		1028 016c  PowerEdge 1850 MPT Fusion SCSI/RAID (Perc 4)
-		1028 0183  LSI Logic 1020/1030
-		1028 018a  PERC 4/IM
-		1028 1010  LSI U320 SCSI Controller
-		103c 12c5  Ultra320 SCSI [A7173A]
-		103c 1323  Core I/O LAN/SCSI Combo [AB314A]
-		103c 3108  Single Channel Ultra320 SCSI HBA G2
-		103c 322a  SC11Xe Ultra320 Single Channel PCIe x4 SCSI Host Bus Adapter (412911-B21)
-		124b 1170  PMC-USCSI320
-# VMware's emulation of this device. Was missing from the list.
-		15ad 1976  LSI Logic Parallel SCSI Controller
-		1734 1052  PRIMERGY BX/RX/TX S2 series onboard SCSI(IME)
 	0031  53c1030ZC PCI-X Fusion-MPT Dual Ultra320 SCSI
 	0032  53c1035 PCI-X Fusion-MPT Dual Ultra320 SCSI
-		1000 1000  LSI53C1020/1030 PCI-X to Ultra320 SCSI Controller
 	0033  1030ZC_53c1035 PCI-X Fusion-MPT Dual Ultra320 SCSI
 	0040  53c1035 PCI-X Fusion-MPT Dual Ultra320 SCSI
-		1000 0033  MegaRAID SCSI 320-2XR
-		1000 0066  MegaRAID SCSI 320-2XRWS
 	0041  53C1035ZC PCI-X Fusion-MPT Dual Ultra320 SCSI
 	0050  SAS1064 PCI-X Fusion-MPT SAS
-		1028 1f04  SAS 5/E
-		1028 1f09  SAS 5i/R
 	0052  MegaRAID SAS-3 3216/3224 [Cutlass]
 	0053  MegaRAID SAS-3 3216/3224 [Cutlass]
-		1000 9350  MegaRAID SAS 9341-16i
-		1000 9351  MegaRAID SAS 9341-24i
 	0054  SAS1068 PCI-X Fusion-MPT SAS
-		1028 1f04  SAS 5/E Adapter Controller
-		1028 1f05  SAS 5/i Adapter Controller
-		1028 1f06  SAS 5/i Integrated Controller
-		1028 1f07  SAS 5/iR Integrated RAID Controller
-		1028 1f08  SAS 5/iR Integrated RAID Controller
-		1028 1f09  SAS 5/iR Adapter RAID Controller
-		15ad 1976  SAS Controller
 	0055  SAS1068 PCI-X Fusion-MPT SAS
-		1033 8336  SAS1068
 	0056  SAS1064ET PCI-Express Fusion-MPT SAS
-		1014 03bb  ServeRAID BR10il SAS/SATA Controller v2
-		8086 34dc  AXX4SASMOD RAID Controller
 	0057  M1064E MegaRAID SAS
-		8086 346c  Embedded Software RAID Technology II (ESTRII)
 	0058  SAS1068E PCI-Express Fusion-MPT SAS
-		1000 3140  SAS3081E-R 8-Port SAS/SATA Host Bus Adapter
-		1028 021d  SAS 6/iR Integrated Workstations RAID Controller
-		1028 1f0e  SAS 6/iR Adapter RAID Controller
-		1028 1f0f  SAS 6/iR Integrated Blades RAID Controller
-		1028 1f10  SAS 6/iR Integrated RAID Controller
-		103c 3229  SC44Ge Host Bus Adapter
 	0059  MegaRAID SAS 8208ELP/8208ELP
 	005a  SAS1066E PCI-Express Fusion-MPT SAS
 	005b  MegaRAID SAS 2208 [Thunderbolt]
-		1000 9265  MegaRAID SAS 9265-8i
-		1000 9266  MegaRAID SAS 9266-8i
-		1000 9267  MegaRAID SAS 9267-8i
-		1000 9268  MegaRAID SAS 9265CV-8i / 9270CV-8i
-		1000 9269  MegaRAID SAS 9266-4i
-		1000 9270  MegaRAID SAS 9270-8i
-		1000 9271  MegaRAID SAS 9271-8i
-		1000 9272  MegaRAID SAS 9272-8i
-		1000 9273  MegaRAID SAS 9270CV-8i
-		1000 9274  MegaRAID SAS 9270-4i
-		1000 9275  MegaRAID SAS 9271-8iCC
-		1000 9276  MegaRAID SAS 9271-4i
-		1000 9285  MegaRAID SAS 9285-8e
-		1000 9288  MegaRAID SAS 9285CV-8e
-		1000 9290  MegaRAID SAS 9286-8e
-		1000 9291  MegaRAID SAS 9286CV-8e
-		1000 9295  MegaRAID SAS 9286CV-8eCC
-		1014 040b  ServeRAID M5110 SAS/SATA Controller
-		1014 040c  ServeRAID M5120 SAS/SATA Controller
-		1014 0412  ServeRAID M5110e SAS/SATA Controller
-		1028 1f2d  PERC H810 Adapter
-		1028 1f30  PERC H710 Embedded
-		1028 1f31  PERC H710P Adapter
-		1028 1f33  PERC H710P Mini (for blades)
-		1028 1f34  PERC H710P Mini (for monolithics)
-		1028 1f35  PERC H710 Adapter
-		1028 1f37  PERC H710 Mini (for blades)
-		1028 1f38  PERC H710 Mini (for monolithics)
-		15d9 0690  LSI MegaRAID ROMB
-		8086 3510  RMS25PB080 RAID Controller
-		8086 3511  RMS25PB040 RAID Controller
-		8086 3512  RMT3PB080 RAID Controller
-		8086 3513  RMS25CB080 RAID Controller
-		8086 3514  RMS25CB040 RAID Controller
-		8086 351c  RMS25PB080N RAID Controller
-		8086 351d  RMS25CB080N RAID Controller
-		8086 9265  RS25DB080 RAID Controller
-		8086 9268  RS25AB080 RAID Controller
-		8086 9285  RS25NB008 RAID Controller
-		8086 9288  RS25SB008 RAID Controller
 	005c  SAS1064A PCI-X Fusion-MPT SAS
 	005d  MegaRAID SAS-3 3108 [Invader]
-		1000 9361  MegaRAID SAS 9361-8i
-		1000 9364  MegaRAID SAS 9364-8i
-		1000 936a  MegaRAID SAS 9364-8i
-		1028 1f41  PERC H830 Adapter
-		1028 1f42  PERC H730P Adapter
-		1028 1f43  PERC H730 Adapter
-		1028 1f47  PERC H730P Mini
-		1028 1f48  PERC H730P Mini (for blades)
-		1028 1f49  PERC H730 Mini
-		1028 1f4a  PERC H730 Mini (for blades)
-		1028 1f4d  PERC FD33xS
-		1028 1f4f  PERC H730P Slim
-		1028 1f54  PERC FD33xD
-		1028 1fd1  PERC H730P MX
-		17aa 1052  ThinkServer RAID 720i
-		17aa 1053  ThinkServer RAID 720ix
-		1d49 0600  ThinkSystem RAID 730-8i 1GB Cache PCIe 12Gb Adapter
-		8086 351e  RMS3CC080 RAID Controller
-		8086 351f  RMS3CC040 RAID Controller
-		8086 9360  RS3DC080 RAID Controller
-		8086 9362  RS3DC040 RAID Controller
-		8086 9380  RS3SC008 RAID Controller
-		8086 9381  RS3MC044 RAID Controller
 	005e  SAS1066 PCI-X Fusion-MPT SAS
 	005f  MegaRAID SAS-3 3008 [Fury]
-		1028 1f44  PERC H330 Adapter
-		1028 1f4b  PERC H330 Mini
-		1028 1f4c  PERC H330 Mini (for blades)
-		1028 1f4d  PERC H330 Embedded (for monolithic)
-		1054 306a  SAS 3004 iMR ROMB
-		1d49 04db  ServeRAID M1210 SAS/SATA Controller
 	0060  MegaRAID SAS 1078
-		1000 1006  MegaRAID SAS 8888ELP
-		1000 100a  MegaRAID SAS 8708ELP
-		1000 100e  MegaRAID SAS 8884E
-		1000 100f  MegaRAID SAS 8708E
-		1000 1010  MegaRAID SATA 350-8ELP
-		1000 1011  MegaRAID SATA 350-4ELP
-		1000 1012  MegaRAID SAS 8704ELP
-		1000 1016  MegaRAID SAS 8880EM2
-		1014 0363  MegaRAID SAS PCI Express ROMB
-		1014 0364  SystemX MegaRAID SAS 8808E
-		1014 0365  SystemX MegaRAID SAS 8884E
-		1014 0379  SystemX MegaRAID SAS 8880EM2
-		1028 1f0a  PERC 6/E Adapter RAID Controller
-		1028 1f0b  PERC 6/i Adapter RAID Controller
-		1028 1f0c  PERC 6/i Integrated RAID Controller
-		1028 1f0d  PERC 6/i Integrated RAID Controller
-		1028 1f11  CERC 6/i Integrated RAID Controller
-		1033 835a  MegaRAID SAS PCI Express ROMB
-		1043 824d  MegaRAID SAS PCI Express ROMB
-		1170 002f  MegaRAID SAS PCI Express ROMB
-		1170 0036  MegaRAID SAS PCI Express ROMB
-		15d9 c080  MegaRAID SAS PCI Express ROMB
-		17aa 6b7c  MegaRAID SAS PCI Express ROMB
-		18a1 0003  LSI MegaRAID SAS PCI Express ROMB
-		8086 1006  RAID Controller SRCSAS28EP
-		8086 100a  RAID Controller SRCSAS28EV
-		8086 1010  RAID Controller SRCSATA28E
-		8086 34cc  Integrated RAID Controller SROMBSAS28E
-		8086 34cd  Integrated RAID Controller SROMBSAS28E
-		8086 3505  Integrated RAID Controller SROMBSASMP2
 	0062  SAS1078 PCI-Express Fusion-MPT SAS
-		1000 0062  SAS1078 PCI-Express Fusion-MPT SAS
 	0064  SAS2116 PCI-Express Fusion-MPT SAS-2 [Meteor]
-		1000 30c0  SAS 9201-16i
 	0065  SAS2116 PCI-Express Fusion-MPT SAS-2 [Meteor]
 	006e  SAS2308 PCI-Express Fusion-MPT SAS-2
 	0070  SAS2004 PCI-Express Fusion-MPT SAS-2 [Spitfire]
 	0071  MR SAS HBA 2004
 	0072  SAS2008 PCI-Express Fusion-MPT SAS-2 [Falcon]
-		1028 1f1c  6Gbps SAS HBA Adapter
-		1028 1f1d  PERC H200 Adapter
-		1028 1f1e  PERC H200 Integrated
-		1028 1f1f  PERC H200 Modular
-		1028 1f20  PERC H200 Embedded
-		1028 1f22  Internal Tape Adapter
-		8086 350f  RMS2LL040 RAID Controller
-		8086 3700  SSD 910 Series
 	0073  MegaRAID SAS 2008 [Falcon]
-		1000 9240  MegaRAID SAS 9240-8i
-		1000 9241  MegaRAID SAS 9240-4i
-		1000 92a0  MegaRAID SAS 9220-8i
-		1014 03b1  ServeRAID M1015 SAS/SATA Controller
-		1028 1f4e  PERC H310 Adapter
-		1028 1f4f  PERC H310 Integrated
-		1028 1f50  PERC H310 Mini Blades
-		1028 1f51  PERC H310 Mini Monolithics
-		1028 1f52  PERC H310 Embedded1
-		1028 1f53  PERC H310 Embedded2
-		1028 1f54  PERC H310 Reserved
-		1054 3035  LSI MegaRAID SAS 9240-8i
-		1137 0072  2004 iMR ROMB
-		1137 0073  2008 ROMB
-		1137 00b0  UCSC RAID SAS 2008M-8i
-		1137 00b1  UCSC RAID SAS 2008M-8i
-		1137 00c2  UCS E-Series Double Wide
-		1137 00c3  UCS E-Series Single Wide
-		15d9 0400  Supermicro SMC2008-iMR
-		1734 1177  RAID Ctrl SAS 6G 0/1 (D2607)
-		17aa 1051  ThinkServer RAID 510i
-		8086 350d  RMS2AF040 RAID Controller
-		8086 9240  RAID Controller RS2WC080
-		8086 9241  RAID Controller RS2WC040
 	0074  SAS2108 PCI-Express Fusion-MPT SAS-2 [Liberator]
 	0076  SAS2108 PCI-Express Fusion-MPT SAS-2 [Liberator]
 	0077  SAS2108 PCI-Express Fusion-MPT SAS-2 [Liberator]
 	0079  MegaRAID SAS 2108 [Liberator]
-		1000 9251  MegaRAID SAS 9260-4ix
-		1000 9256  MegaRAID SAS 9260-8ix
-		1000 9260  MegaRAID SAS 9260-4i
-		1000 9261  MegaRAID SAS 9260-8i
-		1000 9262  MegaRAID SAS 9262-8i
-		1000 9263  MegaRAID SAS 9261-8i
-		1000 9264  MegaRAID SAS 9264-8i
-		1000 9267  MegaRAID SAS 9260CV-4i
-		1000 9268  MegaRAID SAS 9260CV-8i
-		1000 9275  MegaRAID SAS 9280-8ex
-		1000 9276  MR9260-16i
-		1000 9280  MegaRAID SAS 9280-8e
-		1000 9281  MegaRAID SAS 9281-8E
-		1000 9282  MegaRAID SAS 9280-4i4e
-		1000 9290  MegaRAID SAS 9280DE-24i4e
-		1014 03b2  ServeRAID M5015 SAS/SATA Controller
-		1014 03b3  ServeRAID M5025 SAS/SATA Controller
-		1028 1f15  PERC H800 Adapter
-		1028 1f16  PERC H700 Adapter
-		1028 1f17  PERC H700 Integrated
-		1028 1f18  PERC H700 Modular
-		1028 1f1a  PERC H800 Proto Adapter
-		1028 1f1b  PERC H700 Integrated
-		1043 8480  PIKE-2108 16PD
-		1734 1176  RAID Ctrl SAS 6G 5/6 512MB (D2616)
-		1734 1177  RAID Ctrl SAS 6G 0/1 (D2607)
-		8086 350b  RMS2MH080 RAID Controller
-		8086 9256  MegaRAID SAS 9260DE-8i RS2BL080DE
-		8086 9260  RAID Controller RS2BL040
-		8086 9261  RAID Controller RS2BL080
-		8086 9264  RAID Controller RT3WB080 Warm Beach (Caster Lite)
-		8086 9267  RAID Controller RS2VB040
-		8086 9268  RAID Controller RS2VB080
-		8086 9275  RAID Controller RS2PI008DE
-		8086 9276  RAID Controller RS2WG160
-		8086 9280  RAID Controller RS2PI008
-		8086 9282  RAID Controller RS2MB044
-		8086 9290  RAID Controller RS2SG244
 	007c  MegaRAID SAS 1078DE
-		1014 0395  ServeRAID-AR10is SAS/SATA Controller
 	007e  SSS6200 PCI-Express Flash SSD
-		1000 0504  Nytro NWD-BLP4-800
-		1000 0507  Nytro NWD-BLP4-1600
-		1000 0581  Nytro NWD-BLP4-400
-		1000 100d  Nytro NWD-BFH6-1200
-		1000 100e  Nytro NWD-BFH8-1600
-		1000 107e  Nytro NWD-BFH8-3200
-		1000 1310  Nytro XP6302-8B1536
-		1000 1311  Nytro XP6302-8B2048
-		1000 1314  Nytro XP6302-8B4096
-		1000 150c  Nytro XP6210-4A2048
-		1000 150f  Nytro XP6210-4B2048
-		1000 160b  Nytro XP6209-4A1024
-		1000 1613  Nytro XP6209-4B2048
-		108e 050a  Nytro ELP4x200_4d_n
-		108e 0581  Nytro ELP4x100_4d_n
 	0080  SAS2208 PCI-Express Fusion-MPT SAS-2
 	0081  SAS2208 PCI-Express Fusion-MPT SAS-2
 	0082  SAS2208 PCI-Express Fusion-MPT SAS-2
@@ -564,48 +237,17 @@ var pciids = []byte(`#
 	0085  SAS2208 PCI-Express Fusion-MPT SAS-2
 	0086  SAS2308 PCI-Express Fusion-MPT SAS-2
 	0087  SAS2308 PCI-Express Fusion-MPT SAS-2
-		1000 3020  9207-8i SAS2.1 HBA
-		1000 3040  9207-8e SAS2.1 HBA
-		1000 3050  SAS9217-8i
-		1590 0044  H220i
-		8086 3000  RS25GB008 RAID Controller
-		8086 3060  RS25FB044 RAID Controller
-		8086 3516  RMS25JB080 RAID Controller
-		8086 3517  RMS25JB040 RAID Controller
-		8086 3518  RMS25KB080 RAID Controller
-		8086 3519  RMS25KB040 RAID Controller
-		8086 351a  RMS25LB040 RAID Controller
-		8086 351b  RMS25LB080 RAID Controller
 	008f  53c875J
-		1092 8000  FirePort 40 SCSI Controller
-		1092 8760  FirePort 40 Dual SCSI Host Adapter
 	0090  SAS3108 PCI-Express Fusion-MPT SAS-3
 	0091  SAS3108 PCI-Express Fusion-MPT SAS-3
 	0094  SAS3108 PCI-Express Fusion-MPT SAS-3
 	0095  SAS3108 PCI-Express Fusion-MPT SAS-3
 	0096  SAS3004 PCI-Express Fusion-MPT SAS-3
 	0097  SAS3008 PCI-Express Fusion-MPT SAS-3
-		1000 3090  SAS9311-8i
-		1000 30e0  SAS9300-8i
-		1000 3130  SAS 9300-16i
-		1028 1f45  HBA330 Adapter
-		1028 1f46  12Gbps HBA
-		1028 1f53  HBA330 Mini
-		1028 1fd2  HBA330 MX
-		1028 1fd3  HBA330 MMZ
-		1bd4 0011  Inspur 12Gb 8i-3008 IT SAS HBA
 	00ab  SAS3516 Fusion-MPT Tri-Mode RAID On Chip (ROC)
-		8086 3530  Integrated RAID Module RMSP3JD160J
 	00ac  SAS3416 Fusion-MPT Tri-Mode I/O Controller Chip (IOC)
-		1d49 0201  ThinkSystem 430-16i SAS/SATA 12Gb HBA
-		1d49 0203  ThinkSystem 430-16e SAS/SATA 12Gb HBA
-		8086 3000  RAID Controller RSP3QD160J
-		8086 3020  RAID Controller RSP3GD016J
 	00ae  SAS3508 Fusion-MPT Tri-Mode RAID On Chip (ROC)
 	00af  SAS3408 Fusion-MPT Tri-Mode I/O Controller Chip (IOC)
-		1d49 0200  ThinkSystem 430-8i SAS/SATA 12Gb HBA
-		1d49 0202  ThinkSystem 430-8e SAS/SATA 12Gb HBA
-		1d49 0204  ThinkSystem 430-8i SAS/SATA 12Gb Dense HBA
 	00be  SAS3504 Fusion-MPT Tri-Mode RAID On Chip (ROC)
 	00bf  SAS3404 Fusion-MPT Tri-Mode I/O Controller Chip (IOC)
 	00c0  SAS3324 PCI-Express Fusion-MPT SAS-3
@@ -619,71 +261,22 @@ var pciids = []byte(`#
 	00c8  SAS3316 PCI-Express Fusion-MPT SAS-3
 	00c9  SAS3216 PCI-Express Fusion-MPT SAS-3
 	00ce  MegaRAID SAS-3 3316 [Intruder]
-		1000 9371  MegaRAID SAS 9361-16i
-		1000 9390  MegaRAID SAS 9380-8i8e
 	00cf  MegaRAID SAS-3 3324 [Intruder]
-		1000 9370  MegaRAID SAS 9361-24i
 	00d0  SAS3716 Fusion-MPT Tri-Mode RAID Controller Chip (ROC)
 	00d1  SAS3616 Fusion-MPT Tri-Mode I/O Controller Chip (IOC)
 	00d3  MegaRAID Tri-Mode SAS3716W
 	02b0  Virtual Endpoint on PCIe Switch
-		1d49 0001  ThinkSystem 1610-4P NVMe Switch Adapter
-		1d49 0002  ThinkSystem 810-4P NVMe Switch Adapter
 	0407  MegaRAID
-		1000 0530  MegaRAID 530 SCSI 320-0X RAID Controller
-		1000 0531  MegaRAID 531 SCSI 320-4X RAID Controller
-		1000 0532  MegaRAID 532 SCSI 320-2X RAID Controller
-		1028 0531  PowerEdge Expandable RAID Controller 4/QC
-		1028 0533  PowerEdge Expandable RAID Controller 4/QC
-		8086 0530  MegaRAID Intel RAID Controller SRCZCRX
-		8086 0532  MegaRAID Intel RAID Controller SRCU42X
 	0408  MegaRAID
-		1000 0001  MegaRAID SCSI 320-1E RAID Controller
-		1000 0002  MegaRAID SCSI 320-2E RAID Controller
-		1025 004d  MegaRAID ACER ROMB-2E RAID Controller
-		1028 0001  PowerEdge RAID Controller PERC4e/SC
-		1028 0002  PowerEdge RAID Controller PERC4e/DC
-		1028 0012  PowerEdge RAID Controller RAC4
-		1028 0015  PowerEdge RAID Controller PERC5
-		1028 1f03  PowerEdge RAID Controller PERC5
-		1734 1065  FSC MegaRAID PCI Express ROMB
-		8086 0002  MegaRAID Intel RAID Controller SRCU42E
-		8086 3449  MegaRAID Intel RAID Controller SROMBU
 	0409  MegaRAID
-		1000 3004  MegaRAID SATA 300-4X RAID Controller
-		1000 3008  MegaRAID SATA 300-8X RAID Controller
-		8086 3008  MegaRAID RAID Controller SRCS28X
-		8086 3431  MegaRAID RAID Controller Alief SROMBU42E
-		8086 3499  MegaRAID RAID Controller Harwich SROMBU42E
 	0411  MegaRAID SAS 1068
-		1000 1001  MegaRAID SAS 8408E
-		1000 1002  MegaRAID SAS 8480E
-		1000 1003  MegaRAID SAS 8344ELP
-		1000 1004  MegaRAID SAS 8308ELP
-		1000 1008  MegaRAID SAS 84016E
-		1000 100c  MegaRAID SATA 300-12E
-		1000 100d  MegaRAID SATA 300-16E
-		1000 2004  MegaRAID SATA 300-8ELP
-		1000 2005  MegaRAID SATA 300-4ELP
-		1033 8287  MegaRAID SAS PCI Express ROMB
-		1054 3016  MegaRAID SAS RoMB Server
-		1734 1081  MegaRAID SAS PCI Express ROMB
-		1734 10a3  MegaRAID SAS PCI Express ROMB
-		8086 1001  RAID Controller SRCSAS18E
-		8086 1003  RAID Controller SRCSAS144E
-		8086 3500  SROMBSAS18E RAID Controller
-		8086 3501  SROMBSAS18E RAID Controller
-		8086 3504  SROMBSAS18E RAID Controller
 	0413  MegaRAID SAS 1068 [Verde ZCR]
-		1000 1005  MegaRAID SAS 8300XLP
 	0621  FC909 Fibre Channel Adapter
 	0622  FC929 Fibre Channel Adapter
-		1000 1020  44929 O Dual Fibre Channel card
 	0623  FC929 LAN
 	0624  FC919 Fibre Channel Adapter
 	0625  FC919 LAN
 	0626  FC929X Fibre Channel Adapter
-		1000 1010  7202-XP-LC Dual Fibre Channel card
 	0627  FC929X LAN
 	0628  FC919X Fibre Channel Adapter
 	0629  FC919X LAN
@@ -692,7 +285,6 @@ var pciids = []byte(`#
 	0646  FC949ES Fibre Channel Adapter
 	0701  83C885 NT50 DigitalScape Fast Ethernet
 	0702  Yellowfin G-NIC gigabit ethernet
-		1318 0000  PEI100X
 	0804  SA2010
 	0805  SA2010ZC
 	0806  SA2020
@@ -700,18 +292,6 @@ var pciids = []byte(`#
 	0901  61C102
 	1000  63C815
 	1960  MegaRAID
-		1000 0518  MegaRAID 518 SCSI 320-2 Controller
-		1000 0520  MegaRAID 520 SCSI 320-1 Controller
-		1000 0522  MegaRAID 522 i4 133 RAID Controller
-		1000 0523  MegaRAID SATA 150-6 RAID Controller
-		1000 4523  MegaRAID SATA 150-4 RAID Controller
-		1000 a520  MegaRAID ZCR SCSI 320-0 Controller
-		1028 0518  MegaRAID 518 DELL PERC 4/DC RAID Controller
-		1028 0520  MegaRAID 520 DELL PERC 4/SC RAID Controller
-		1028 0531  PowerEdge Expandable RAID Controller 4/QC
-		1028 0533  PowerEdge Expandable RAID Controller 4/QC
-		8086 0520  MegaRAID RAID Controller SRCU41L
-		8086 0523  MegaRAID RAID Controller SRCS16
 	3050  SAS2008 PCI-Express Fusion-MPT SAS-2
 	6001  DX1 Multiformat Broadcast HD/SD Encoder/Decoder
 1001  Kolter Electronic
@@ -724,7 +304,6 @@ var pciids = []byte(`#
 	0016  PCI-MFB Analogue I/O board
 	0017  PROTO-3 PCI Prototyping board
 	9100  INI-9100/9100W SCSI Host
-# nee ATI Technologies, Inc.
 1002  Advanced Micro Devices, Inc. [AMD/ATI]
 	1304  Kaveri
 	1305  Kaveri
@@ -743,7 +322,6 @@ var pciids = []byte(`#
 	1312  Kaveri
 	1313  Kaveri [Radeon R7 Graphics]
 	1314  Wrestler HDMI Audio
-		174b 1001  PURE Fusion Mini
 	1315  Kaveri [Radeon R5 Graphics]
 	1316  Kaveri [Radeon R5 Graphics]
 	1317  Kaveri
@@ -752,9 +330,7 @@ var pciids = []byte(`#
 	131c  Kaveri [Radeon R7 Graphics]
 	131d  Kaveri [Radeon R6 Graphics]
 	1714  BeaverCreek HDMI Audio [Radeon HD 6500D and 6400G-6600G series]
-		103c 168b  ProBook 4535s
 	3150  RV380/M24 [Mobility Radeon X600]
-		103c 0934  nx8220
 	3151  RV380 GL [FireMV 2400]
 	3152  RV370/M22 [Mobility Radeon X300]
 	3154  RV380/M24 GL [Mobility FireGL V3200]
@@ -770,30 +346,9 @@ var pciids = []byte(`#
 	4147  R300 GL [FireGL Z1]
 	4148  R350 [Radeon 9800/9800 SE]
 	4150  RV350 [Radeon 9550/9600/X1050 Series]
-		1002 0002  R9600 Pro primary (Asus OEM for HP)
-		1002 0003  R9600 Pro secondary (Asus OEM for HP)
-		1002 4722  All-in-Wonder 2006 AGP Edition
-		1458 4024  GV-R96128D
-		148c 2064  R96A-C3N
-		148c 2066  R96A-C3N
-		174b 7c19  Atlantis Radeon 9600 Pro
-		174b 7c29  GC-R9600PRO
-		17ee 2002  Radeon 9600 256Mb Primary
-		18bc 0101  GC-R9600PRO (Primary)
 	4151  RV350 [Radeon 9600 Series]
-		1043 c004  A9600SE
-		174b 7c37  Radeon 9600 SE
 	4152  RV360 [Radeon 9600/X1050 Series]
-		1002 0002  Radeon 9600XT
-		1002 4772  All-in-Wonder 9600 XT
-		1043 c002  Radeon 9600 XT TVD
-		1043 c01a  A9600XT/TD
-		1462 9510  RX9600XT (MS-8951)
-		174b 7c29  Radeon 9600XT
-		1787 4002  Radeon 9600 XT
 	4153  RV350 [Radeon 9550]
-		1043 010c  A9550GE/TD
-		1462 932c  RX9550SE-TD128 (MS-8932)
 	4154  RV350 GL [FireGL T2]
 	4155  RV350 [Radeon 9600]
 	4157  RV350 GL [FireGL T2]
@@ -803,35 +358,13 @@ var pciids = []byte(`#
 	4166  R300 [Radeon 9700 PRO] (Secondary)
 	4168  RV350 [Radeon 9800 SE] (Secondary)
 	4170  RV350 [Radeon 9550/9600/X1050 Series] (Secondary)
-		1002 0003  R9600 Pro secondary (Asus OEM for HP)
-		1002 4723  All-in-Wonder 2006 AGP Edition (Secondary)
-		1458 4025  GV-R96128D (Secondary)
-		148c 2067  R96A-C3N (Secondary)
-		174b 7c28  GC-R9600PRO (Secondary)
-		17ee 2003  Radeon 9600 256Mb (Secondary)
-		18bc 0100  GC-R9600PRO (Secondary)
 	4171  RV350 [Radeon 9600] (Secondary)
-		1043 c005  A9600SE (Secondary)
-		174b 7c36  Radeon 9600 SE (secondary)
 	4172  RV350 [Radeon 9600/X1050 Series] (Secondary)
-		1002 0003  Radeon 9600XT (Secondary)
-		1002 4773  All-in-Wonder 9600 XT (Secondary)
-		1043 c003  A9600XT (Secondary)
-		1043 c01b  A9600XT/TD (Secondary)
-		174b 7c28  Radeon 9600XT (Secondary)
-		1787 4003  Radeon 9600 XT (Secondary)
 	4173  RV350 [Radeon 9550] (Secondary)
-		1043 010d  A9550GE/TD (Secondary)
 	4242  R200 [All-In-Wonder Radeon 8500 DV]
-		1002 02aa  Radeon 8500 AIW DV Edition
 	4243  R200 PCI Bridge [All-in-Wonder Radeon 8500DV]
 	4336  RS100 [Radeon IGP 320M]
-		1002 4336  Pavilion ze4300 ATI Radeon Mobility U1 (IGP 320 M)
-		103c 0024  Pavilion ze4400 builtin Video
-		161f 2029  eMachines M5312 builtin Video
 	4337  RS200M [Radeon IGP 330M/340M/345M/350M]
-		1014 053a  ThinkPad R40e
-		103c 0850  Radeon IGP 345M
 	4341  IXP150 AC'97 Audio Controller
 	4342  IXP200 3COM 3C920B Ethernet Controller
 	4345  EHCI USB Controller
@@ -846,194 +379,44 @@ var pciids = []byte(`#
 	4363  SMBus
 	436e  436E Serial ATA Controller
 	4370  IXP SB400 AC'97 Audio Controller
-		1025 0079  Aspire 5024WLMMi
-		1025 0091  Aspire 5032WXMi
-		103c 2a05  Pavilion t3030.de Desktop PC
-		103c 308b  MX6125
-		105b 0c81  Realtek ALC 653
-		107b 0300  MX6421
-		1462 0131  MS-1013 Notebook
 	4371  IXP SB4x0 PCI-PCI Bridge
-		103c 308b  MX6125
-		1462 7217  Aspire L250
 	4372  IXP SB4x0 SMBus Controller
-		1025 0080  Aspire 5024WLMMi
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 308b  MX6125
-		1462 0131  MS-1013 Notebook
-		1462 7217  Aspire L250
 	4373  IXP SB4x0 USB2 Host Controller
-		1025 0080  Aspire 5024WLMMi
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 308b  MX6125
-		1462 7217  Aspire L250
 	4374  IXP SB4x0 USB Host Controller
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 308b  MX6125
-		1462 7217  Aspire L250
 	4375  IXP SB4x0 USB Host Controller
-		1025 0080  Aspire 5024WLMMi
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 308b  MX6125
-		1462 7217  Aspire L250
 	4376  IXP SB4x0 IDE Controller
-		1025 0080  Aspire 5024WLMMi
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 308b  MX6125
-		1462 0131  MS-1013 Notebook
-		1462 7217  Aspire L250
 	4377  IXP SB4x0 PCI-ISA Bridge
-		1025 0080  Aspire 5024WLMi
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 308b  MX6125
-		1462 7217  Aspire L250
 	4378  IXP SB400 AC'97 Modem Controller
-		1025 0080  Aspire 5024WLMMi
-		103c 308b  MX6125
-		1462 0131  MS-1013 Notebook
 	4379  IXP SB4x0 Serial ATA Controller
-		1462 7141  Aspire L250
 	437a  IXP SB400 Serial ATA Controller
-		1002 4379  4379 Serial ATA Controller
-		1002 437a  437A Serial ATA Controller
-		1462 7141  Aspire L250
-		14f1 8800  Leadtek WinFast TV2000XP Expert
 	437b  IXP SB4x0 High Definition Audio Controller
-		1002 437b  IXP SB4x0 High Definition Audio Controller
-		10cf 1326  Fujitsu Lifebook A3040
-		1734 10b8  Realtek High Definition Audio
 	4380  SB600 Non-Raid-5 SATA
-		103c 2813  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1458 b003  GA-MA790FX-DS5 (rev. 1.0)
-		1458 b005  Gigabyte GA-MA69G-S3H Motherboard
-		1462 7327  K9AG Neo2
-		17f2 5999  KI690-AM2 Motherboard
 	4381  SB600 SATA Controller (RAID 5 mode)
 	4382  SB600 AC97 Audio
 	4383  SBx00 Azalia (Intel HDA)
-		1019 2120  A785GM-M
-		103c 1611  Pavilion DM1Z-3000
-		103c 280a  DC5750 Microtower
-		1043 8230  M3A78-EH Motherboard
-		1043 836c  M4A785TD Motherboard
-		1043 8410  M4A89GTD PRO/USB3 Motherboard
-		1043 841b  M5A88-V EVO
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		1179 ff50  Satellite P305D-S8995E
-		1458 a022  GA-MA770-DS3rev2.0 Motherboard
-		17f2 5000  KI690-AM2 Motherboard
 	4384  SBx00 PCI to PCI Bridge
 	4385  SBx00 SMBus Controller
-		1019 2120  A785GM-M
-		103c 1611  Pavilion DM1Z-3000
-		103c 280a  DC5750 Microtower
-		1043 82ef  M3A78-EH Motherboard
-		1043 8389  M4A785TD Motherboard
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		1179 ff50  Satellite P305D-S8995E
-		1458 4385  GA-MA770-DS3rev2.0 Motherboard
-		1462 7368  K9AG Neo2
-		15d9 a811  H8DGU
-		174b 1001  PURE Fusion Mini
-		17f2 5000  KI690-AM2 Motherboard
 	4386  SB600 USB Controller (EHCI)
-		103c 280a  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1462 7368  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	4387  SB600 USB (OHCI0)
-		103c 280a  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1462 7368  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	4388  SB600 USB (OHCI1)
-		103c 280a  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1462 7368  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	4389  SB600 USB (OHCI2)
-		103c 280a  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1462 7368  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	438a  SB600 USB (OHCI3)
-		103c 280a  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1462 7368  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	438b  SB600 USB (OHCI4)
-		103c 280a  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1462 7368  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	438c  SB600 IDE
-		103c 280a  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1458 5002  Gigabyte GA-MA69G-S3H Motherboard
-		1462 7368  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	438d  SB600 PCI to LPC Bridge
-		103c 280a  DC5750 Microtower
-		1179 ff50  Satellite P305D-S8995E
-		1462 7368  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	438e  SB600 AC97 Modem
 	4390  SB7x0/SB8x0/SB9x0 SATA Controller [IDE mode]
-		1043 82ef  M3A78-EH Motherboard
-		1043 8389  M4A785TD Motherboard
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		1458 b002  GA-MA770-DS3rev2.0 Motherboard
-		1849 4390  Motherboard (one of many)
 	4391  SB7x0/SB8x0/SB9x0 SATA Controller [AHCI mode]
-		103c 1611  Pavilion DM1Z-3000
-		1043 82ef  M3A78-EH Motherboard
-		1043 8443  M5A88-V EVO
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		174b 1001  PURE Fusion Mini
 	4392  SB7x0/SB8x0/SB9x0 SATA Controller [Non-RAID5 mode]
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
 	4393  SB7x0/SB8x0/SB9x0 SATA Controller [RAID5 mode]
 	4394  SB7x0/SB8x0/SB9x0 SATA Controller [AHCI mode]
 	4395  SB8x0/SB9x0 SATA Controller [Storage mode]
 	4396  SB7x0/SB8x0/SB9x0 USB EHCI Controller
-		1019 2120  A785GM-M
-		103c 1611  Pavilion DM1Z-3000
-		1043 82ef  M3A78-EH Motherboard
-		1043 8443  M5A88-V EVO
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		15d9 a811  H8DGU
-		174b 1001  PURE Fusion Mini
 	4397  SB7x0/SB8x0/SB9x0 USB OHCI0 Controller
-		1019 2120  A785GM-M
-		103c 1611  Pavilion DM1Z-3000
-		1043 82ef  M3A78-EH Motherboard
-		1043 8443  M5A88-V EVO
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		15d9 a811  H8DGU
-		174b 1001  PURE Fusion Mini
 	4398  SB7x0 USB OHCI1 Controller
-		1019 2120  A785GM-M
-		1043 82ef  M3A78-EH Motherboard
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		15d9 a811  H8DGU
 	4399  SB7x0/SB8x0/SB9x0 USB OHCI2 Controller
-		1019 2120  A785GM-M
-		1043 82ef  M3A78-EH Motherboard
-		1043 8443  M5A88-V EVO
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		174b 1001  PURE Fusion Mini
 	439c  SB7x0/SB8x0/SB9x0 IDE Controller
-		1019 2120  A785GM-M
-		1043 82ef  M3A78-EH Motherboard
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
 	439d  SB7x0/SB8x0/SB9x0 LPC host controller
-		1019 2120  A785GM-M
-		103c 1611  Pavilion DM1Z-3000
-		1043 82ef  M3A78-EH Motherboard
-		1043 8443  M5A88-V EVO
-		105b 0e13  N15235/A74MX mainboard / AMD SB700
-		174b 1001  PURE Fusion Mini
 	43a0  SB700/SB800/SB900 PCI to PCI bridge (PCIE port 0)
 	43a1  SB700/SB800/SB900 PCI to PCI bridge (PCIE port 1)
 	43a2  SB900 PCI to PCI bridge (PCIE port 2)
@@ -1042,96 +425,24 @@ var pciids = []byte(`#
 	4554  210888ET [Mach64 ET]
 	4654  Mach64 VT
 	4742  3D Rage PRO AGP 2X
-		1002 0040  Rage Pro Turbo AGP 2X
-		1002 0044  Rage Pro Turbo AGP 2X
-		1002 0061  Rage Pro AIW AGP 2X
-		1002 0062  Rage Pro AIW AGP 2X
-		1002 0063  Rage Pro AIW AGP 2X
-		1002 0080  Rage Pro Turbo AGP 2X
-		1002 0084  Rage Pro Turbo AGP 2X
-		1002 4742  Rage Pro Turbo AGP 2X
-		1002 8001  Rage Pro Turbo AGP 2X
-		1028 0082  Rage Pro Turbo AGP 2X
-		1028 4082  Optiplex GX1 Onboard Display Adapter
-		1028 8082  Rage Pro Turbo AGP 2X
-		1028 c082  Rage Pro Turbo AGP 2X
-		8086 4152  Xpert 98D AGP 2X
-		8086 464a  Rage Pro Turbo AGP 2X
 	4744  3D Rage PRO AGP 1X
-		1002 4744  Rage Pro Turbo AGP
-		8086 4d55  Rage 3D Pro AGP 1X [Intel MU440EX]
 	4749  3D Rage PRO PCI
-		1002 0061  Rage Pro AIW
-		1002 0062  Rage Pro AIW
 	474d  Rage XL AGP 2X
-		1002 0004  Xpert 98 RXL AGP 2X
-		1002 0008  Xpert 98 RXL AGP 2X
-		1002 0080  Rage XL AGP 2X
-		1002 0084  Xpert 98 AGP 2X
-		1002 474d  Rage XL AGP
-		1033 806a  Rage XL AGP
 	474e  Rage XC AGP
-		1002 474e  Rage XC AGP
 	474f  Rage XL
-		1002 0008  Rage XL
-		1002 474f  Rage XL
 	4750  3D Rage Pro PCI
-		1002 0040  Rage Pro Turbo
-		1002 0044  Rage Pro Turbo
-		1002 0080  Rage Pro Turbo
-		1002 0084  Rage Pro Turbo
-		1002 4750  Rage Pro Turbo
 	4752  Rage XL PCI
-		0e11 001e  Proliant Rage XL
-		1002 0008  Rage XL
-		1002 4752  Proliant Rage XL
-		1002 8008  Rage XL
-		1014 0240  eServer xSeries server mainboard
-		1028 00ce  PowerEdge 1400
-		1028 00d1  PowerEdge 2550
-		1028 00d9  PowerEdge 2500
-		1028 0134  PowerEdge 600SC
-		1028 014a  PowerEdge 1750
-		1028 0165  PowerEdge 750
-		103c 10e1  NetServer Rage XL
-		103c 3208  ProLiant DL140 G2
-		107b 6400  6400 Server
-		1734 007a  PRIMERGY RX/TX series onboard VGA
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		8086 3411  SDS2 Mainboard
-		8086 3427  S875WP1-E mainboard
-		8086 5744  S845WD1-E mainboard
 	4753  Rage XC
-		1002 4753  Rage XC
 	4754  3D Rage II/II+ PCI [Mach64 GT]
 	4755  Mach64 GTB [3D Rage II+ DVD]
 	4756  3D Rage IIC PCI [Mach64 GT IIC]
-		1002 4756  Rage IIC
 	4757  3D Rage IIC AGP
-		1002 4757  Rage IIC AGP
-		1028 0089  Rage 3D IIC
-		1028 008e  PowerEdge 1300 onboard video
-		1028 4082  Rage 3D IIC
-		1028 8082  Rage 3D IIC
-		1028 c082  Rage 3D IIC
 	4758  210888GX [Mach64 GX PCI]
 	4759  3D Rage IIC PCI
 	475a  3D Rage IIC AGP
-		1002 0084  Rage 3D Pro AGP 2x XPERT 98
-		1002 0087  Rage 3D IIC
-		1002 475a  Rage IIC AGP
 	4966  RV250 [Radeon 9000 Series]
-		10f1 0002  RV250 If [Tachyon G9000 PRO]
-		148c 2039  RV250 If [Radeon 9000 Pro "Evil Commando"]
-		1509 9a00  RV250 If [Radeon 9000 "AT009"]
-		1681 0040  RV250 If [3D prophet 9000]
-		174b 7176  Radeon 9000 Pro
-		174b 7192  RV250 If [Radeon 9000 "Atlantis"]
-		17af 2005  RV250 If [Excalibur Radeon 9000 Pro]
-		17af 2006  RV250 If [Excalibur Radeon 9000]
 	496e  RV250 [Radeon 9000] (Secondary)
 	4a49  R420 [Radeon X800 PRO/GTO AGP]
-		174b 2620  R420 [Radeon X800 GTO AGP]
 	4a4a  R420 [Radeon X800 GT AGP]
 	4a4b  R420 [Radeon X800 AGP Series]
 	4a4d  R420 GL [FireGL X3-256]
@@ -1139,7 +450,6 @@ var pciids = []byte(`#
 	4a4f  R420 [Radeon X850 AGP]
 	4a50  R420 [Radeon X800 XT Platinum Edition AGP]
 	4a54  R420 [Radeon X800 VE AGP]
-		1002 4422  All-In-Wonder X800 VE AGP
 	4a69  R420 [Radeon X800 PRO/GTO] (Secondary)
 	4a6a  R420 [Radeon X800] (Secondary)
 	4a6b  R420 [Radeon X800 XT AGP] (Secondary)
@@ -1152,245 +462,72 @@ var pciids = []byte(`#
 	4b6b  R481 [Radeon X850 PRO AGP] (Secondary)
 	4b6c  R481 [Radeon X850 XT Platinum Edition AGP] (Secondary)
 	4c42  3D Rage LT PRO AGP 2X
-		0e11 b0e7  Rage LT Pro (Compaq Presario 5240)
-		0e11 b0e8  Rage 3D LT Pro
-		0e11 b10e  3D Rage LT Pro (Compaq Armada 1750)
-		1002 0040  Rage LT Pro AGP 2X
-		1002 0044  Rage LT Pro AGP 2X
-		1002 4c42  Rage LT Pro AGP 2X
-		1002 8001  Rage LT Pro AGP 2X
-		1028 0085  Rage 3D LT Pro
 	4c46  Rage Mobility 128 AGP 2X/Mobility M3
-		1002 0155  IBM Thinkpad A22p
-		1014 0155  Thinkpad A22p
-		1028 00b1  Latitude C600
 	4c47  3D Rage IIC PCI / Mobility Radeon 7500/7500C
 	4c49  3D Rage LT PRO PCI
-		1002 0004  Rage LT Pro
-		1002 0040  Rage LT Pro
-		1002 0044  Rage LT Pro
-		1002 4c49  Rage LT Pro
 	4c4d  Rage Mobility AGP 2x Series
-		0e11 b111  Armada M700
-		0e11 b160  Armada E500
-		1002 0084  Xpert 98 AGP 2X (Mobility)
-		1014 0154  ThinkPad A20m/A21m
-		1028 00aa  Latitude CPt
-		1028 00bb  Latitude CPx
-		1179 ff00  Satellite 1715XCDS laptop
-		13bd 1019  PC-AR10
 	4c50  3D Rage LT PRO PCI
-		1002 4c50  Rage LT Pro
 	4c52  Rage Mobility-M1 PCI
-		1033 8112  Versa Note VXi
 	4c54  264LT [Mach64 LT]
 	4c57  RV200/M7 [Mobility Radeon 7500]
-		1014 0517  ThinkPad T30
-		1014 0530  ThinkPad T4x Series
-		1028 00e6  Radeon Mobility M7 LW (Dell Inspiron 8100)
-		1028 012a  Latitude C640
-		1043 1622  Mobility Radeon M7 (L3C/S)
-		144d c006  Radeon Mobility M7 LW in vpr Matrix 170B4
 	4c58  RV200/M7 GL [Mobility FireGL 7800]
 	4c59  RV100/M6 [Rage/Radeon Mobility Series]
-		0e11 b111  Evo N600c
-		1014 0235  ThinkPad A30/A30p (2652/2653)
-		1014 0239  ThinkPad X22/X23/X24
-		103c 0025  XE4500 Notebook
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		104d 8140  PCG-Z1SP laptop
-		1509 1930  Medion MD9703
 	4c66  RV250/M9 GL [Mobility FireGL 9000/Radeon 9000]
-		1014 054d  ThinkPad T41
 	4c6e  RV250/M9 [Mobility Radeon 9000] (Secondary)
 	4d46  Rage Mobility 128 AGP 4X/Mobility M4
 	4d52  Theater 550 PRO PCI [ATI TV Wonder 550]
 	4d53  Theater 550 PRO PCIe
 	4e44  R300 [Radeon 9700/9700 PRO]
-		1002 515e  Radeon ES1000
-		1002 5965  Radeon ES1000
 	4e45  R300 [Radeon 9500 PRO/9700]
-		1002 0002  Radeon R300 NE [Radeon 9500 Pro]
-		1681 0002  Hercules 3D Prophet 9500 PRO [Radeon 9500 Pro]
 	4e46  R300 [Radeon 9600 TX]
 	4e47  R300 GL [FireGL X1]
 	4e48  R350 [Radeon 9800 Series]
 	4e49  R350 [Radeon 9800]
 	4e4a  R360 [Radeon 9800 XXL/XT]
-		1002 4e4a  R360 [Radeon 9800 XT]
 	4e4b  R350 GL [FireGL X2 AGP Pro]
 	4e50  RV350/M10 / RV360/M11 [Mobility Radeon 9600 (PRO) / 9700]
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: ATI RV360/M11 [Mobility Radeon 9700]
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		144d c00c  P35 notebook
-		1462 0311  MSI M510A
-		1734 1055  Amilo M1420W
 	4e51  RV350 [Radeon 9550/9600/X1050 Series]
 	4e52  RV350/M10 [Mobility Radeon 9500/9700 SE]
-		144d c00c  P35 notebook
 	4e54  RV350/M10 GL [Mobility FireGL T2]
 	4e56  RV360/M12 [Mobility Radeon 9550]
 	4e64  R300 [Radeon 9700 PRO] (Secondary)
 	4e65  R300 [Radeon 9500 PRO] (Secondary)
-		1002 0003  Radeon R300 NE [Radeon 9500 Pro]
-		1681 0003  Hercules 3D Prophet 9500 PRO [Radeon 9500 Pro] (Secondary)
 	4e66  RV350 [Radeon 9600] (Secondary)
 	4e67  R300 GL [FireGL X1] (Secondary)
 	4e68  R350 [Radeon 9800 PRO] (Secondary)
 	4e69  R350 [Radeon 9800] (Secondary)
 	4e6a  RV350 [Radeon 9800 XT] (Secondary)
-		1002 4e6a  R360 [Radeon 9800 XT] (Secondary)
-		1002 4e71  M10 NQ [Radeon Mobility 9600]
 	4e71  RV350/M10 [Mobility Radeon 9600] (Secondary)
 	4f72  RV250 [Radeon 9000 Series]
 	4f73  RV250 [Radeon 9000 Series] (Secondary)
 	5044  All-In-Wonder 128 PCI
-		1002 0028  Rage 128 AIW
-		1002 0029  Rage 128 AIW
 	5046  Rage 128 PRO AGP 4x TMDS
-		1002 0004  Rage Fury Pro
-		1002 0008  Rage Fury Pro/Xpert 2000 Pro
-		1002 0014  Rage Fury Pro
-		1002 0018  Rage Fury Pro/Xpert 2000 Pro
-		1002 0028  Rage 128 Pro AIW AGP
-		1002 002a  Rage 128 Pro AIW AGP
-		1002 0048  Rage Fury Pro
-		1002 2000  Rage Fury MAXX AGP 4x (TMDS) (VGA device)
-		1002 2001  Rage Fury MAXX AGP 4x (TMDS) (Extra device?!)
 	5050  Rage128 [Xpert 128 PCI]
-		1002 0008  Xpert 128
 	5052  Rage 128 PRO AGP 4X TMDS
 	5144  R100 [Radeon 7200 / All-In-Wonder Radeon]
-		1002 0008  Radeon 7000/Radeon VE
-		1002 0009  Radeon 7000/Radeon
-		1002 000a  Radeon 7000/Radeon
-		1002 001a  Radeon 7000/Radeon
-		1002 0029  Radeon AIW
-		1002 0038  Radeon 7000/Radeon
-		1002 0039  Radeon 7000/Radeon
-		1002 008a  Radeon 7000/Radeon
-		1002 00ba  Radeon 7000/Radeon
-		1002 0139  Radeon 7000/Radeon
-		1002 028a  Radeon 7000/Radeon
-		1002 02aa  Radeon AIW
-		1002 053a  Radeon 7000/Radeon
 	5148  R200 GL [FireGL 8800]
-		1002 010a  FireGL 8800 64Mb
-		1002 0152  FireGL 8800 128Mb
-		1002 0162  FireGL 8700 32Mb
-		1002 0172  FireGL 8700 64Mb
 	514c  R200 [Radeon 8500/8500 LE]
-		1002 003a  Radeon R200 QL [Radeon 8500 LE]
-		1002 013a  Radeon 8500
-		148c 2026  R200 QL [Radeon 8500 Evil Master II Multi Display Edition]
-		1681 0010  Radeon 8500 [3D Prophet 8500 128Mb]
-		174b 7149  Radeon 8500 LE
-		1787 0f08  Radeon R200 QL [PowerMagic Radeon 8500]
 	514d  R200 [Radeon 9100]
 	5157  RV200 [Radeon 7500/7500 LE]
-		1002 013a  Radeon 7500
-		1002 0f2b  ALL-IN-WONDER VE PCI
-		1002 103a  Dell Optiplex GX260
-		1458 4000  RV200 QW [RADEON 7500 PRO MAYA AR]
-		148c 2024  RV200 QW [Radeon 7500LE Dual Display]
-		148c 2025  RV200 QW [Radeon 7500 Evil Master Multi Display Edition]
-		148c 2036  RV200 QW [Radeon 7500 PCI Dual Display]
-		174b 7146  RV200 QW [Radeon 7500 LE]
-		174b 7147  Radeon 7500 LE
-		174b 7161  Radeon RV200 QW [Radeon 7500 LE]
-		17af 0202  RV200 QW [Excalibur Radeon 7500LE]
 	5159  RV100 [Radeon 7000 / Radeon VE]
-		1002 000a  Radeon 7000/Radeon VE
-		1002 000b  Radeon 7000
-		1002 0038  Radeon 7000/Radeon VE
-		1002 003a  Radeon 7000/Radeon VE
-		1002 00ba  Radeon 7000/Radeon VE
-		1002 013a  Radeon 7000/Radeon VE
-		1002 0908  XVR-100 (supplied by Sun)
-# The IBM card doubles as an ATI PCI video adapter
-		1014 029a  Remote Supervisor Adapter II (RSA2)
-		1014 02c8  eServer xSeries server mainboard
-		1028 016c  PowerEdge 1850 Embedded Radeon 7000/VE
-		1028 016d  PowerEdge 2850 Embedded Radeon 7000-M
-		1028 0170  PowerEdge 6850 Embedded Radeon 7000/VE
-		1028 019a  PowerEdge SC1425
-		103c 1292  Radeon 7000
-		1043 c00a  A7000/T/64M
-		1458 4002  RV100 QY [RADEON 7000 PRO MAYA AV Series]
-		148c 2003  RV100 QY [Radeon 7000 Multi-Display Edition]
-		148c 2023  RV100 QY [Radeon 7000 Evil Master Multi-Display]
-		148c 2081  RV6DE
-		174b 0280  Radeon RV100 QY [Radeon 7000/VE]
-		174b 7112  Radeon VE 7000
-		174b 7c28  Radeon VE 7000 DDR
-		1787 0202  RV100 QY [Excalibur Radeon 7000]
-		17ee 1001  Radeon 7000 64MB DDR + DVI
 	515e  ES1000
-		1028 01bb  PowerEdge 1955 Embedded ATI ES1000
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
-		1028 01f0  PowerEdge R900 Embedded ATI ES1000
-		1028 0205  PowerEdge 2970 Embedded ATI ES1000
-		1028 020b  PowerEdge T605 Embedded ATI ES1000
-		1028 020f  PowerEdge R300 Embedded ATI ES1000
-		1028 0210  PowerEdge T300 Embedded ATI ES1000
-		1028 0221  PowerEdge R805 Embedded ATI ES1000
-		1028 0223  PowerEdge R905 Embedded ATI ES1000
-		1028 0225  PowerEdge T105 Embedded ATI ES1000
-		1028 023c  PowerEdge R200 Embedded ATI ES1000
-		103c 1304  Integrity iLO2 Advanced KVM VGA [AD307A]
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	5245  Rage 128 GL PCI
-		1002 0008  Xpert 128
-		1002 0028  Rage 128 AIW
-		1002 0029  Rage 128 AIW
-		1002 0068  Rage 128 AIW
 	5246  Rage Fury/Xpert 128/Xpert 2000 AGP 2x
-		1002 0004  Magnum/Xpert 128/Xpert 99
-		1002 0008  Magnum/Xpert128/X99/Xpert2000
-		1002 0028  Rage 128 AIW AGP
-		1002 0044  Rage Fury/Xpert 128/Xpert 2000
-		1002 0068  Rage 128 AIW AGP
-		1002 0448  Rage Fury
 	524b  Rage 128 VR PCI
 	524c  Rage 128 VR AGP
-		1002 0008  Xpert 99/Xpert 2000
-		1002 0088  Xpert 99
 	5346  Rage 128 SF/4x AGP 2x
-		1002 0048  RAGE 128 16MB VGA TVOUT AMC PAL
 	534d  Rage 128 4X AGP 4x
-		1002 0008  Xpert 99/Xpert 2000
-		1002 0018  Xpert 2000
 	5354  Mach 64 VT
-		1002 5654  Mach 64 reference
 	5446  Rage 128 PRO Ultra AGP 4x
-		1002 0004  Rage Fury Pro
-		1002 0008  Rage Fury Pro/Xpert 2000 Pro
-		1002 0018  Rage Fury Pro/Xpert 2000 Pro
-		1002 0028  Rage 128 AIW Pro AGP
-		1002 0029  Rage 128 AIW
-		1002 002a  Rage 128 AIW Pro AGP
-		1002 002b  Rage 128 AIW
-		1002 0048  Xpert 2000 Pro
 	5452  Rage 128 PRO Ultra4XL VR-R AGP
-		1002 001c  Rage 128 Pro 4XL
-		103c 1279  Rage 128 Pro 4XL
 	5460  RV370/M22 [Mobility Radeon X300]
-		1775 1100  CR11/VR11 Single Board Computer
 	5461  RV370/M22 [Mobility Radeon X300]
 	5462  RV380/M24C [Mobility Radeon X600 SE]
 	5464  RV370/M22 GL [Mobility FireGL V3100]
 	5549  R423 [Radeon X800 GTO]
 	554a  R423 [Radeon X800 XT Platinum Edition]
 	554b  R423 [Radeon X800 GT/SE]
-		1002 0302  Radeon X800 SE
 	554d  R430 [Radeon X800 XL]
-		1002 0322  All-In-Wonder X800 XL
-		1458 2124  GV-R80L256V-B (AGP)
 	554e  R430 [All-In-Wonder X800 GT]
 	554f  R430 [Radeon X800]
 	5550  R423 GL [FireGL V7100]
@@ -1398,17 +535,13 @@ var pciids = []byte(`#
 	5569  R423 [Radeon X800 PRO] (Secondary)
 	556b  R423 [Radeon X800 GT] (Secondary)
 	556d  R430 [Radeon X800 XL] (Secondary)
-		1458 2125  GV-R80L256V-B (AGP)
 	556f  R430 [Radeon X800] (Secondary)
 	5571  R423 GL [FireGL V5100] (Secondary)
 	564b  RV410/M26 GL [Mobility FireGL V5000]
 	564f  RV410/M26 [Mobility Radeon X700 XL]
 	5652  RV410/M26 [Mobility Radeon X700]
 	5653  RV410/M26 [Mobility Radeon X700]
-		1025 0080  Aspire 5024WLMi
-		103c 0940  Compaq NW8240 Mobile Workstation
 	5654  264VT [Mach64 VT]
-		1002 5654  Mach64VT Reference
 	5655  264VT3 [Mach64 VT3]
 	5656  264VT4 [Mach64 VT4]
 	5657  RV410 [Radeon X550 XTX / X700]
@@ -1422,87 +555,43 @@ var pciids = []byte(`#
 	5854  RS480 [Radeon Xpress 200 Series] (Secondary)
 	5874  RS480 [Radeon Xpress 1150] (Secondary)
 	5940  RV280 [Radeon 9200 PRO] (Secondary)
-		17af 2021  Excalibur Radeon 9250 (Secondary)
 	5941  RV280 [Radeon 9200] (Secondary)
-		1458 4019  Radeon 9200
-		174b 7c12  Radeon 9200
-		17af 200d  Excalibur Radeon 9200
-		18bc 0050  GC-R9200-C3 (Secondary)
 	5944  RV280 [Radeon 9200 SE PCI]
 	5950  RS480/RS482/RS485 Host Bridge
-		1025 0080  Aspire 5024WLMMi
-		103c 280a  DC5750 Microtower
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 308b  MX6125
-		1462 0131  MS-1013 Notebook
-		1462 7217  Aspire L250
 	5951  RX480/RX482 Host Bridge
 	5952  RD580 Host Bridge
 	5954  RS480 [Radeon Xpress 200 Series]
-		1002 5954  RV370 [Radeon Xpress 200G Series]
 	5955  RS480M [Mobility Radeon Xpress 200]
-		1002 5955  RS480 0x5955 [Radeon XPRESS 200M 5955 (PCIE)]
-		103c 308b  MX6125
-		1462 0131  MS-1013 Notebook
 	5956  RD790 Host Bridge
 	5957  RX780/RX790 Host Bridge
-		1849 5957  A770CrossFire Motherboard
 	5958  RD780 Host Bridge
 	5960  RV280 [Radeon 9200 PRO]
-		17af 2020  Excalibur Radeon 9250
 	5961  RV280 [Radeon 9200]
-		1002 2f72  All-in-Wonder 9200 Series
-		1019 4c30  Radeon 9200 VIVO
-		12ab 5961  YUAN SMARTVGA Radeon 9200
-		1458 4018  Radeon 9200
-		174b 7c13  Radeon 9200
-		17af 200c  Excalibur Radeon 9200
-		18bc 0050  Radeon 9200 Game Buster
-		18bc 0051  GC-R9200-C3
-		18bc 0053  Radeon 9200 Game Buster VIVO
 	5962  RV280 [Radeon 9200]
 	5964  RV280 [Radeon 9200 SE]
-		1002 5964  Radeon 9200 SE, 64-bit 128MB DDR, 200/166MHz
-		1043 c006  Radeon 9200 SE / TD / 128M
-		1458 4018  Radeon 9200 SE
-		1458 4032  Radeon 9200 SE 128MB
-		147b 6191  R9200SE-DT
-		148c 2073  CN-AG92E
-		174b 7c13  Radeon 9200 SE
-		1787 5964  Excalibur 9200SE VIVO 128M
-		17af 2012  Radeon 9200 SE Excalibur
-		18bc 0170  Sapphire Radeon 9200 SE 128MB Game Buster
-		18bc 0173  GC-R9200L(SE)-C3H [Radeon 9200 Game Buster]
 	5965  RV280 GL [FireMV 2200 PCI]
 	5974  RS482/RS485 [Radeon Xpress 1100/1150]
-		103c 280a  DC5750 Microtower
-		1462 7141  Aspire L250
 	5975  RS482M [Mobility Radeon Xpress 200]
 	5978  RX780/RD790 PCI to PCI bridge (external gfx0 port A)
-		1849 5957  A770CrossFire Motherboard
 	5979  RD790 PCI to PCI bridge (external gfx0 port B)
 	597a  RD790 PCI to PCI bridge (PCI express gpp port A)
 	597b  RX780/RD790 PCI to PCI bridge (PCI express gpp port B)
 	597c  RD790 PCI to PCI bridge (PCI express gpp port C)
 	597d  RX780/RD790 PCI to PCI bridge (PCI express gpp port D)
 	597e  RD790 PCI to PCI bridge (PCI express gpp port E)
-		1849 5957  A770CrossFire Motherboard
 	597f  RD790 PCI to PCI bridge (PCI express gpp port F)
-		1849 5957  A770CrossFire Motherboard
 	5980  RD790 PCI to PCI bridge (external gfx1 port A)
 	5981  RD790 PCI to PCI bridge (external gfx1 port B)
 	5982  RD790 PCI to PCI bridge (NB-SB link)
 	5a10  RD890 Northbridge only dual slot (2x16) PCI-e GFX Hydra part
 	5a11  RD890 Northbridge only single slot PCI-e GFX Hydra part
 	5a12  RD890 Northbridge only dual slot (2x8) PCI-e GFX Hydra part
-		15d9 a811  H8DGU
 	5a13  RD890S/SR5650 Host Bridge
 	5a14  RD9x0/RX980 Host Bridge
 	5a15  RD890 PCI to PCI bridge (PCI express gpp port A)
 	5a16  RD890/RD9x0/RX980 PCI to PCI bridge (PCI Express GFX port 0)
 	5a17  RD890/RD9x0 PCI to PCI bridge (PCI Express GFX port 1)
 	5a18  RD890/RD9x0/RX980 PCI to PCI bridge (PCI Express GPP Port 0)
-		15d9 a811  H8DGU
 	5a19  RD890/RD9x0/RX980 PCI to PCI bridge (PCI Express GPP Port 1)
 	5a1a  RD890/RD9x0/RX980 PCI to PCI bridge (PCI Express GPP Port 2)
 	5a1b  RD890/RD9x0/RX980 PCI to PCI bridge (PCI Express GPP Port 3)
@@ -1510,7 +599,6 @@ var pciids = []byte(`#
 	5a1d  RD890/RD9x0/RX980 PCI to PCI bridge (PCI Express GPP Port 5)
 	5a1e  RD890/RD9x0/RX980 PCI to PCI bridge (PCI Express GPP2 Port 0)
 	5a1f  RD890/RD990 PCI to PCI bridge (PCI Express GFX2 port 0)
-		15d9 a811  H8DGU
 	5a20  RD890/RD990 PCI to PCI bridge (PCI Express GFX2 port 1)
 	5a23  RD890S/RD990 I/O Memory Management Unit (IOMMU)
 	5a31  RC410 Host Bridge
@@ -1521,46 +609,24 @@ var pciids = []byte(`#
 	5a38  RC4xx/RS4xx PCI Express Port 3
 	5a39  RC4xx/RS4xx PCI Express Port 4
 	5a3f  RC4xx/RS4xx PCI Bridge [int gfx]
-		1462 7217  Aspire L250
 	5a41  RS400 [Radeon Xpress 200]
 	5a42  RS400M [Radeon Xpress 200M]
 	5a61  RC410 [Radeon Xpress 200/1100]
 	5a62  RC410M [Mobility Radeon Xpress 200M]
 	5b60  RV370 [Radeon X300]
-		1043 002a  Extreme AX300SE-X
-		1043 032e  Extreme AX300/TD
-		1458 2102  GV-RX30S128D (X300SE)
-		1462 0400  RX300SE-TD128E (MS-8940 REV:200)
-		1462 0402  RX300SE-TD128E (MS-8940)
-		174b 0500  Radeon X300 (PCIE)
-		196d 1086  X300SE HM
 	5b62  RV370 [Radeon X600/X600 SE]
 	5b63  RV370 [Radeon X300/X550/X1050 Series]
 	5b64  RV370 GL [FireGL V3100]
 	5b65  RV370 GL [FireMV 2200]
 	5b66  RV370X
 	5b70  RV370 [Radeon X300 SE]
-# RX300SE-TD128E
-		1462 0403  Radeon X300 SE 128MB DDR
-		174b 0501  Radeon X300 SE
-		196d 1087  Radeon X300 SE HyperMemory
 	5b72  RV380 [Radeon X300/X550/X1050 Series] (Secondary)
 	5b73  RV370 [Radeon X300/X550/X1050 Series] (Secondary)
 	5b74  RV370 GL [FireGL V3100] (Secondary)
 	5b75  RV370 GL [FireMV 2200] (Secondary)
 	5c61  RV280/M9+ [Mobility Radeon 9200 AGP]
 	5c63  RV280/M9+ [Mobility Radeon 9200 AGP]
-		1002 5c63  Apple iBook G4 2004
-		144d c00c  P30 notebook
 	5d44  RV280 [Radeon 9200 SE] (Secondary)
-		1458 4019  Radeon 9200 SE (Secondary)
-		1458 4032  Radeon 9200 SE 128MB
-		147b 6190  R9200SE-DT (Secondary)
-		174b 7c12  Radeon 9200 SE (Secondary)
-		1787 5965  Excalibur 9200SE VIVO 128M (Secondary)
-		17af 2013  Radeon 9200 SE Excalibur (Secondary)
-		18bc 0171  Radeon 9200 SE 128MB Game Buster (Secondary)
-		18bc 0172  GC-R9200L(SE)-C3H [Radeon 9200 Game Buster]
 	5d45  RV280 GL [FireMV 2200 PCI] (Secondary)
 	5d48  R423/M28 [Mobility Radeon X800 XT]
 	5d49  R423/M28 GL [Mobility FireGL V5100]
@@ -1570,12 +636,10 @@ var pciids = []byte(`#
 	5d4f  R480 [Radeon X800 GTO]
 	5d50  R480 GL [FireGL V7200]
 	5d52  R480 [Radeon X850 XT]
-		1002 0b12  PowerColor X850XT PCIe (Primary)
 	5d57  R423 [Radeon X800 XT]
 	5d6d  R480 [Radeon X850 XT Platinum Edition] (Secondary)
 	5d6f  R480 [Radeon X800 GTO] (Secondary)
 	5d72  R480 [Radeon X850 XT] (Secondary)
-		1002 0b13  PowerColor X850XT PCIe (Secondary)
 	5d77  R423 [Radeon X800 XT] (Secondary)
 	5e48  RV410 GL [FireGL V5000]
 	5e49  RV410 [Radeon X700 Series]
@@ -1583,46 +647,22 @@ var pciids = []byte(`#
 	5e4b  RV410 [Radeon X700 PRO]
 	5e4c  RV410 [Radeon X700 SE]
 	5e4d  RV410 [Radeon X700]
-		148c 2116  Bravo X700
 	5e4f  RV410 [Radeon X700]
-		1569 1e4f  Radeon X550 XT
 	5e6b  RV410 [Radeon X700 PRO] (Secondary)
 	5e6d  RV410 [Radeon X700] (Secondary)
-		148c 2117  Bravo X700 (Secondary)
 	5f57  R423 [Radeon X800 XT]
 	6600  Mars [Radeon HD 8670A/8670M/8750M]
-		103c 1952  ProBook 455 G1
 	6601  Mars [Radeon HD 8730M]
-		103c 2100  FirePro M4100
 	6602  Mars
 	6603  Mars
 	6604  Opal XT [Radeon R7 M265]
-		103c 8006  FirePro M4170
-		17aa 3643  Radeon R7 A360
 	6605  Opal PRO [Radeon R7 M260]
 	6606  Mars XTX [Radeon HD 8790M]
-		1028 0684  FirePro W4170M
 	6607  Mars LE [Radeon HD 8530M / R5 M240]
 	6608  Oland GL [FirePro W2100]
 	6610  Oland XT [Radeon HD 8670 / R7 250/350]
-		1019 0030  Radeon HD 8670
-		1028 2120  Radeon R7 250
-		1028 2322  Radeon R7 250
-		1462 2910  Radeon HD 8670
-		1462 2911  Radeon HD 8670
-		148c 7350  Radeon R7 350
-		1642 3c81  Radeon HD 8670
-		1642 3c91  Radeon HD 8670
-		1642 3f09  Radeon R7 350
 	6611  Oland [Radeon HD 8570 / R7 240/340 OEM]
-		1028 210b  Radeon R5 240 OEM
-		174b 4248  Radeon R7 240 OEM
-		174b a240  Radeon R7 240 OEM
-		174b d340  Radeon R7 340 OEM
-		1b0a 90d3  Radeon R7 240 OEM
 	6613  Oland PRO [Radeon R7 240/340]
-		148c 7340  Radeon R7 340
-		1682 7240  R7 240 2048 MB
 	6620  Mars
 	6621  Mars PRO
 	6623  Mars
@@ -1632,54 +672,16 @@ var pciids = []byte(`#
 	6646  Bonaire XT [Radeon R9 M280X]
 	6647  Bonaire PRO [Radeon R9 M270X]
 	6649  Bonaire [FirePro W5100]
-		1002 0b0c  FirePro W4300
-		103c 0b0c  Bonaire [FirePro W4300]
-		103c 230c  FirePro W5100
 	6650  Bonaire
 	6651  Bonaire
 	6658  Bonaire XTX [Radeon R7 260X/360]
-		148c 0907  Radeon R7 360
-		1682 0907  Radeon R7 360
-		1682 7360  Radeon R7 360
 	665c  Bonaire XT [Radeon HD 7790/8770 / R7 360 / R9 260/360 OEM]
-		1043 0452  Radeon HD 7790 DirectCU II OC
-# R7790-1GD5/OC
-		1462 2930  Radeon HD 7790 OC
-		1462 2932  Radeon HD 8770
-		1462 2934  Radeon R9 260 OEM
-		1462 2938  Radeon R9 360 OEM
-		148c 0907  Radeon R7 360
-		148c 9260  Radeon R9 260 OEM
-		148c 9360  Radeon R9 360 OEM
-		1682 0907  Radeon R7 360
-# FX-779A-CDB4 / FX-779A-CDBC
-		1682 3310  Radeon HD 7790 Black Edition 2 GB
-# 100356OCL / 11210-01-20G
-		174b e253  Radeon HD 7790 Dual-X OC
-		1787 2329  Radeon HD 7790 TurboDuo
 	665d  Bonaire [Radeon R7 200 Series]
 	665f  Tobago PRO [Radeon R7 360 / R9 360 OEM]
-		1028 0b04  Radeon R9 360 OEM
-		1462 2938  Radeon R9 360 OEM
-		1462 3271  Radeon R9 360 OEM
-		1682 7360  Radeon R7 360
 	6660  Sun XT [Radeon HD 8670A/8670M/8690M / R5 M330 / M430 / R7 M520]
-		1028 05ea  Radeon HD 8670M
-		1028 06bf  Radeon R5 M335
-		103c 1970  Radeon HD 8670M
-		103c 80be  Radeon R5 M330
-		103c 8136  Radeon R5 M330
-		103c 8329  Radeon R7 M520
-		17aa 3804  Radeon R5 M330
-		17aa 3809  Radeon R5 M330
-		17aa 381a  Radeon R5 M430
-		17aa 390c  Radeon R5 M330
 	6663  Sun PRO [Radeon HD 8570A/8570M]
-		1025 0846  Radeon HD 8570A
-		17aa 3805  Radeon HD 8570M
 	6664  Jet XT [Radeon R5 M240]
 	6665  Jet PRO [Radeon R5 M230]
-		17aa 368f  Radeon R5 A230
 	6667  Jet ULT [Radeon R5 M230]
 	666f  Sun LE [Radeon HD 8550M / R5 M230]
 	6704  Cayman PRO GL [FirePro V7900]
@@ -1690,411 +692,23 @@ var pciids = []byte(`#
 	671d  Antilles [Radeon HD 6990]
 	671f  Cayman CE [Radeon HD 6930]
 	6720  Blackcomb [Radeon HD 6970M/6990M]
-		1028 048f  Radeon HD 6990M
-		1028 0490  Alienware M17x R3 Radeon HD 6970M
-		1028 04a4  FirePro M8900
-		1028 04ba  Radeon HD 6990M
-		1028 053f  FirePro M8900
-		106b 0b00  Radeon HD 6970M
-		1558 5102  Radeon HD 6970M
-		1558 5104  Radeon HD 6990M
-		1558 7201  Radeon HD 6990M
-		174b e188  Radeon HD 6970M
 	6738  Barts XT [Radeon HD 6870]
-# HD-687A-ZDFC
-		1682 3103  Radeon HD 8670
-		1787 201a  Barts XT [Radeon HD 6870 X2]
-		1787 201b  Barts XT [Radeon HD 6870 X2]
 	6739  Barts PRO [Radeon HD 6850]
-		1043 03b4  EAH6850 [Radeon HD 6850]
 	673e  Barts LE [Radeon HD 6790]
-		148c 7720  Radeon HD 7720 OEM
 	6740  Whistler [Radeon HD 6730M/6770M/7690M XT]
-		1019 238c  Radeon HD 6730M
-		1019 238e  Radeon HD 6730M
-		1019 2391  Radeon HD 6730M
-		1019 2392  Radeon HD 6770M
-		1028 04a3  Precision M4600
-		1028 053e  FirePro M5950
-		103c 1630  FirePro M5950
-		103c 1631  FirePro M5950
-		103c 164b  Radeon HD 6730M
-		103c 164e  Radeon HD 6730M
-		103c 1657  Radeon HD 6770M
-		103c 1658  Radeon HD 6770M
-		103c 165a  Radeon HD 6770M
-		103c 165b  Radeon HD 6770M
-		103c 1688  Radeon HD 6770M
-		103c 1689  Radeon HD 6770M
-		103c 168a  Radeon HD 6770M
-		103c 185e  Radeon HD 7690M XT
-		103c 3388  Radeon HD 6770M
-		103c 3389  Radeon HD 6770M
-		103c 3582  Radeon HD 6770M
-		103c 366c  Radeon HD 6730M
-		1043 1d02  Radeon HD 6730M
-		1043 1d12  Radeon HD 6730M
-		104d 9084  Radeon HD 6730M
-		104d 9085  Radeon HD 6730M
-		144d b074  Radeon HD 6730M
-		144d b077  Radeon HD 6730M
-		144d b084  Radeon HD 6730M
-		144d b088  Radeon HD 6730M
-		17aa 3982  Radeon HD 6730M
 	6741  Whistler [Radeon HD 6630M/6650M/6750M/7670M/7690M]
-		1019 238e  Radeon HD 6650M
-		1019 238f  Radeon HD 6650M
-		1025 0379  Radeon HD 6650M
-		1025 037b  Radeon HD 6650M
-		1025 037e  Radeon HD 6650M
-		1025 0382  Radeon HD 6650M
-		1025 0384  Radeon HD 6650M
-		1025 0385  Radeon HD 6650M
-		1025 0386  Radeon HD 6650M
-		1025 0387  Radeon HD 6650M
-		1025 0388  Radeon HD 6650M
-		1025 0442  Radeon HD 6650M
-		1025 0451  Radeon HD 6650M
-		1025 0489  Radeon HD 6650M
-		1025 048b  Radeon HD 6650M
-		1025 048c  Radeon HD 6650M
-		1025 050a  Radeon HD 6650M
-		1025 050b  Radeon HD 6650M
-		1025 050c  Radeon HD 6650M
-		1025 050e  Radeon HD 6650M
-		1025 050f  Radeon HD 6650M
-		1025 0513  Radeon HD 6650M
-		1025 0514  Radeon HD 6650M
-		1025 0515  Radeon HD 6650M
-		1025 0516  Radeon HD 6650M
-		1025 051e  Radeon HD 6650M
-		1025 051f  Radeon HD 6650M
-		1025 0520  Radeon HD 6650M
-		1025 0521  Radeon HD 6650M
-		1025 052a  Radeon HD 6650M
-		1025 0555  Radeon HD 6650M
-		1025 0556  Radeon HD 6650M
-		1025 055d  Radeon HD 6650M
-		1025 055e  Radeon HD 6650M
-		1025 056d  Radeon HD 6650M
-		1025 059a  Radeon HD 6650M
-		1025 059b  Radeon HD 6650M
-		1025 059e  Radeon HD 6650M
-		1025 059f  Radeon HD 6650M
-		1025 0600  Radeon HD 6650M
-		1025 0605  Radeon HD 6650M
-		1025 0606  Radeon HD 6650M
-		1025 0619  Radeon HD 6650M
-		1028 04c1  Radeon HD 6630M
-		1028 04c5  Radeon HD 6630M
-		1028 04cd  Radeon HD 6630M
-		1028 04d7  Radeon HD 6630M
-		1028 04d9  Radeon HD 6630M
-		1028 052d  Radeon HD 6630M
-		103c 1617  Radeon HD 6650M
-		103c 1646  Radeon HD 6750M
-		103c 1647  Radeon HD 6650M
-		103c 164b  Radeon HD 6650M
-		103c 164e  Radeon HD 6650M
-		103c 1688  Radeon HD 6750M
-		103c 1689  Radeon HD 6750M
-		103c 168a  Radeon HD 6750M
-		103c 1860  Radeon HD 7690M
-		103c 3385  Radeon HD 6630M
-		103c 3560  Radeon HD 6750M
-		103c 358d  Radeon HD 6750M
-		103c 3590  Radeon HD 6750M
-		103c 3593  Radeon HD 6750M
-		103c 366c  Radeon HD 6650M
-		1043 1cd2  Radeon HD 6650M
-		1043 2121  Radeon HD 6650M
-		1043 2122  Radeon HD 6650M
-		1043 2123  Radeon HD 6650M
-		1043 2125  Radeon HD 7670M
-		1043 2127  Radeon HD 7670M
-		104d 907b  Radeon HD 6630M
-		104d 9080  Radeon HD 6630M
-		104d 9081  Radeon HD 6630M
-		106b 00e2  MacBookPro8,2 [Core i7, 15", Late 2011]
-		1179 fd63  Radeon HD 6630M
-		1179 fd65  Radeon HD 6630M
-		144d c093  Radeon HD 6650M
-		144d c0ac  Radeon HD 6650M
-		144d c0b3  Radeon HD 6750M
-		144d c539  Radeon HD 6630M
-		144d c609  Radeon HD 6630M
-		152d 0914  Radeon HD 6650M
-		17aa 21e1  Radeon HD 6630M
-		17aa 3970  Radeon HD 6650M
-		17aa 3976  Radeon HD 6650M
-		1854 0907  Radeon HD 6650M
 	6742  Whistler LE [Radeon HD 6610M/7610M]
-		1002 6570  Turks [Radeon HD 6570]
-		1019 2393  Radeon HD 6610M
-		1043 1d82  K53SK Laptop Radeon HD 7610M
-		1179 fb22  Radeon HD 7610M
-		1179 fb23  Radeon HD 7610M
-		1179 fb27  Radeon HD 7610M
-		1179 fb2a  Radeon HD 7610M
-		1179 fb2c  Radeon HD 7610M
-		1179 fb30  Radeon HD 7610M
-		1179 fb31  Radeon HD 7610M
-		1179 fb32  Radeon HD 7610M
-		1179 fb38  Radeon HD 7610M
-		1179 fb39  Radeon HD 7610M
-		1179 fb3a  Radeon HD 7610M
-		1179 fb3b  Radeon HD 7610M
-		1179 fb40  Radeon HD 7610M
-		1179 fb41  Radeon HD 7610M
-		1179 fb47  Radeon HD 7610M
-		1179 fb48  Radeon HD 7610M
-		1179 fb49  Radeon HD 7610M
-		1179 fb51  Radeon HD 7610M
-		1179 fb52  Radeon HD 7610M
-		1179 fb53  Radeon HD 7610M
-		1179 fb56  Radeon HD 7610M
-		1179 fb81  Radeon HD 7610M
-		1179 fb82  Radeon HD 7610M
-		1179 fb83  Radeon HD 7610M
-		1179 fc56  Radeon HD 7610M
-		1179 fcd4  Radeon HD 7610M
-		1179 fcee  Radeon HD 7610M
-		1458 6570  Turks [Radeon HD 6570]
-		1462 6570  Turks [Radeon HD 6570]
-		148c 6570  Turks [Radeon HD 6570]
-		1682 6570  Turks [Radeon HD 6570]
-		174b 5570  Turks [Radeon HD 5570]
-		174b 6570  Turks [Radeon HD 6570]
-		174b 7570  Turks [Radeon HD 7570]
-		174b 8510  Turks [Radeon HD 8510]
-		174b 8570  Turks [Radeon HD 8570]
-		1787 6570  Turks [Radeon HD 6570]
-		17af 6570  Turks [Radeon HD 6570]
-		8086 2111  Radeon HD 6625M
 	6743  Whistler [Radeon E6760]
 	6749  Turks GL [FirePro V4900]
 	674a  Turks GL [FirePro V3900]
 	6750  Onega [Radeon HD 6650A/7650A]
-		1462 2670  Radeon HD 6670A
-		17aa 3079  Radeon HD 7650A
-		17aa 307a  Radeon HD 6650A
-		17aa 3087  Radeon HD 7650A
-		17aa 3618  Radeon HD 6650A
-		17aa 3623  Radeon HD 6650A
-		17aa 3627  Radeon HD 6650A
 	6751  Turks [Radeon HD 7650A/7670A]
-		1028 0548  Radeon HD 7650A
-		1462 2671  Radeon HD 7670A
-		1462 2672  Radeon HD 7670A
-		1462 2680  Radeon HD 7650A
-		1462 2681  Radeon HD 7650A
-		17aa 3087  Radeon HD 7650A
 	6758  Turks XT [Radeon HD 6670/7670]
-		1028 0b0e  Radeon HD 6670
-		103c 6882  Radeon HD 6670
-		1462 250a  Radeon HD 7670
-		148c 7670  Radeon HD 7670
-		1545 7670  Radeon HD 7670
-		1682 3300  Radeon HD 7670
-		174b 7670  Radeon HD 7670
-		174b e181  Radeon HD 6670
-		1787 2309  Radeon HD 6670
 	6759  Turks PRO [Radeon HD 6570/7570/8550]
-		103c 3130  Radeon HD 6570
-		1043 0403  Radeon HD 6570
-		1462 2500  Radeon HD 6570
-		1462 2509  Radeon HD 7570
-		148c 7570  Radeon HD 7570
-		1642 3a67  Radeon HD 6570
-		1682 3280  Radeon HD 7570
-		1682 3530  Radeon HD 8550
-		174b 7570  Radeon HD 7570
-		174b e142  Radeon HD 6570
-		174b e181  Radeon HD 6570
-		1b0a 908f  Radeon HD 6570
-		1b0a 9090  Radeon HD 6570
-		1b0a 9091  Radeon HD 6570
-		1b0a 9092  Radeon HD 6570
-		1b0a 909e  Radeon HD 6570
-		1b0a 90b5  Radeon HD 7570
-		1b0a 90b6  Radeon HD 7570
 	675b  Turks [Radeon HD 7600 Series]
 	675d  Turks PRO [Radeon HD 7570]
 	675f  Turks LE [Radeon HD 5570/6510/7510/8510]
-		148c 6510  Radeon HD 6510
-		148c 6530  Radeon HD 6530
-		148c 7510  Radeon HD 7510
-		1545 7570  Radeon HD 7570
-		174b 6510  Radeon HD 6510
-		174b 7510  Radeon HD 7510
-		174b 8510  Radeon HD 8510
-		1787 2012  Radeon HD 5570 2GB GDDR3
-		1787 2314  Radeon HD 5570 1GB DDR2/GDDR3
 	6760  Seymour [Radeon HD 6400M/7400M Series]
-		1002 0124  Radeon HD 6470M
-		1002 0134  Radeon HD 6470M
-		1019 238b  Radeon HD 6470M
-		1019 238e  Radeon HD 6470M
-		1019 2390  Radeon HD 6470M
-		1019 9985  Radeon HD 6470M
-		1028 04c1  Radeon HD 6470M
-		1028 04c3  Radeon HD 6470M
-		1028 04ca  Radeon HD 6470M
-		1028 04cb  Radeon HD 6470M
-		1028 04cc  Vostro 3350
-		1028 04d1  Radeon HD 6470M
-		1028 04d3  Radeon HD 6470M
-		1028 04d7  Radeon HD 6470M
-		1028 0502  Radeon HD 6470M
-		1028 0503  Radeon HD 6470M
-		1028 0506  Radeon HD 6470M
-		1028 0507  Radeon HD 6470M
-		1028 0514  Radeon HD 6470M
-		1028 051c  Radeon HD 6450M
-		1028 051d  Radeon HD 6450M
-		103c 161a  Radeon HD 6470M
-		103c 161b  Radeon HD 6470M
-		103c 161e  Radeon HD 6470M
-		103c 161f  Radeon HD 6470M
-		103c 1622  Radeon HD 6450M
-		103c 1623  Radeon HD 6450M
-		103c 164a  Radeon HD 6470M
-		103c 164d  Radeon HD 6470M
-		103c 1651  Radeon HD 6470M
-		103c 1656  Radeon HD 6490M
-		103c 1658  Radeon HD 6490M
-		103c 1659  Radeon HD 6490M
-		103c 165b  Radeon HD 6490M
-		103c 165d  Radeon HD 6470M
-		103c 165f  Radeon HD 6470M
-		103c 1661  Radeon HD 6470M
-		103c 1663  Radeon HD 6470M
-		103c 1665  Radeon HD 6470M
-		103c 1667  Radeon HD 6470M
-		103c 1669  Radeon HD 6470M
-		103c 166b  Radeon HD 6470M
-		103c 166c  Radeon HD 6470M
-		103c 166e  Radeon HD 6470M
-		103c 1670  Radeon HD 6470M
-		103c 1672  Radeon HD 6470M
-		103c 167a  Radeon HD 6470M
-		103c 167b  Radeon HD 6470M
-		103c 167d  Radeon HD 6490M
-		103c 167f  Radeon HD 6490M
-		103c 168c  Radeon HD 6470M
-		103c 168f  Radeon HD 6470M
-		103c 1694  Radeon HD 6470M
-		103c 1696  Radeon HD 6470M
-		103c 1698  Radeon HD 6470M
-		103c 169a  Radeon HD 6470M
-		103c 169c  Radeon HD 6490M
-		103c 1855  Radeon HD 7450M
-		103c 1859  Radeon HD 7450M
-		103c 185c  Radeon HD 7450M
-		103c 185d  Radeon HD 7470M
-		103c 185f  Radeon HD 7470M
-		103c 1863  Radeon HD 7450M
-		103c 355c  Radeon HD 6490M
-		103c 355f  Radeon HD 6490M
-		103c 3563  Radeon HD 6470M
-		103c 3565  Radeon HD 6470M
-		103c 3567  Radeon HD 6470M
-		103c 3569  Radeon HD 6470M
-		103c 3581  Radeon HD 6490M
-		103c 3584  Radeon HD 6470M
-		103c 358c  Radeon HD 6490M
-		103c 358f  Radeon HD 6490M
-		103c 3592  Radeon HD 6490M
-		103c 3596  Radeon HD 6490M
-		103c 366b  Radeon HD 6470M
-		103c 3671  FirePro M3900
-		103c 3673  Radeon HD 6470M
-		1043 100a  Radeon HD 7470M
-		1043 100c  Radeon HD 6470M
-		1043 101b  Radeon HD 6470M
-		1043 101c  Radeon HD 6470M
-		1043 102a  Radeon HD 7450M
-		1043 102c  Radeon HD 6470M
-		1043 104b  Radeon HD 7470M
-		1043 105d  Radeon HD 7470M
-		1043 106b  Radeon HD 7470M
-		1043 106d  Radeon HD 7470M
-		1043 107d  Radeon HD 7470M
-		1043 1cb2  Radeon HD 6470M
-		1043 1d22  Radeon HD 6470M
-		1043 1d32  Radeon HD 6470M
-		1043 2001  Radeon HD 6470M
-		1043 2002  Radeon HD 7470M
-		1043 2107  Radeon HD 7470M
-		1043 2108  Radeon HD 7470M
-		1043 2109  Radeon HD 7470M
-		1043 84a0  Radeon HD 6470M
-		1043 84e9  Radeon HD 6470M
-		1043 8515  Radeon HD 7470M
-		1043 8517  Radeon HD 7470M
-		1043 855a  Radeon HD 7470M
-		104d 907b  Radeon HD 6470M
-		104d 9081  Radeon HD 6470M
-		104d 9084  Radeon HD 6470M
-		104d 9085  Radeon HD 6470M
-		1179 0001  Radeon HD 6450M
-		1179 0003  Radeon HD 6450M
-		1179 0004  Radeon HD 6450M
-		1179 fb22  Radeon HD 7470M
-		1179 fb23  Radeon HD 7470M
-		1179 fb2c  Radeon HD 7470M
-		1179 fb31  Radeon HD 7470M
-		1179 fb32  Radeon HD 7470M
-		1179 fb33  Radeon HD 7470M
-		1179 fb38  Radeon HD 7470M
-		1179 fb39  Radeon HD 7470M
-		1179 fb3a  Radeon HD 7470M
-		1179 fb40  Radeon HD 7470M
-		1179 fb41  Radeon HD 7470M
-		1179 fb42  Radeon HD 7470M
-		1179 fb47  Radeon HD 7470M
-		1179 fb48  Radeon HD 7470M
-		1179 fb51  Radeon HD 7470M
-		1179 fb52  Radeon HD 7470M
-		1179 fb53  Radeon HD 7470M
-		1179 fb81  Radeon HD 7470M
-		1179 fb82  Radeon HD 7470M
-		1179 fb83  Radeon HD 7470M
-		1179 fc51  Radeon HD 6470M
-		1179 fc52  Radeon HD 7470M
-		1179 fc56  Radeon HD 7470M
-		1179 fcd3  Radeon HD 7470M
-		1179 fcd4  Radeon HD 7470M
-		1179 fcee  Radeon HD 7470M
-		1179 fdee  Radeon HD 7470M
-		144d b074  Radeon HD 6470M
-		144d b084  Radeon HD 6470M
-		144d c095  Radeon HD 6470M
-		144d c0b3  Radeon HD 6490M
-		144d c538  Radeon HD 6470M
-		144d c581  Radeon HD 6470M
-		144d c589  Radeon HD 6470M
-		144d c609  Radeon HD 7470M
-		144d c625  Radeon HD 7470M
-		144d c636  Radeon HD 7450M
-		1462 10ac  Radeon HD 6470M
-		152d 0916  Radeon HD 6470M
-		17aa 21e5  Radeon HD 6470M
-		17aa 3900  Radeon HD 7450M
-		17aa 3902  Radeon HD 7450M
-		17aa 3969  Radeon HD 6470M
-		17aa 3970  Radeon HD 7450M
-		17aa 3976  Radeon HD 6470M
-		17aa 397b  Radeon HD 6470M
-		17aa 397d  Radeon HD 6470M
-		17aa 5101  Radeon HD 7470M
-		17aa 5102  Radeon HD 7450M
-		17aa 5103  Radeon HD 7450M
-		17aa 5106  Radeon HD 7450M
-		1854 0897  Radeon HD 6470M
-		1854 0900  Radeon HD 6470M
-		1854 0908  Radeon HD 6470M
-		1854 2015  Radeon HD 6470M
 	6761  Seymour LP [Radeon HD 6430M]
 	6763  Seymour [Radeon E6460]
 	6764  Seymour [Radeon HD 6400M Series]
@@ -2103,196 +717,37 @@ var pciids = []byte(`#
 	6767  Caicos
 	6768  Caicos
 	6770  Caicos [Radeon HD 6450A/7450A]
-		17aa 308d  Radeon HD 7450A
-		17aa 3623  Radeon HD 6450A
-		17aa 3627  Radeon HD 6450A
-		17aa 3629  Radeon HD 6450A
-		17aa 363c  Radeon HD 6450A
-		17aa 3658  Radeon HD 7470A
 	6771  Caicos XTX [Radeon HD 8490 / R5 235X OEM]
 	6772  Caicos [Radeon HD 7450A]
 	6778  Caicos XT [Radeon HD 7470/8470 / R5 235/310 OEM]
-		1019 0024  Radeon HD 7470
-		1019 0027  Radeon HD 8470
-		1028 2120  Radeon HD 7470
-		1462 b491  Radeon HD 8470
-		1462 b492  Radeon HD 8470
-		1462 b493  Radeon HD 8470 OEM
-		1462 b499  Radeon R5 235 OEM
-		1642 3c65  Radeon HD 8470
-		1642 3c75  Radeon HD 8470
-		174b 8145  Radeon HD 8470
-		174b d145  Radeon R5 235 OEM
-		174b d335  Radeon R5 310 OEM
-		174b e145  Radeon HD 7470
-		17aa 3694  Radeon R5 A220
 	6779  Caicos [Radeon HD 6450/7450/8450 / R5 230 OEM]
-		1019 0016  Radeon HD 6450
-		1019 0017  Radeon HD 6450
-		1019 0018  Radeon HD 6450
-		1028 2120  Radeon HD 6450
-		103c 2128  Radeon HD 6450
-		103c 2aee  Radeon HD 7450A
-		1462 2125  Radeon HD 6450
-		1462 2346  Radeon HD 7450
-		1462 2490  Radeon HD 6450
-		1462 2494  Radeon HD 6450
-		1462 2496  Radeon HD 7450
-		148c 7450  Radeon HD 7450
-		148c 8450  Radeon HD 8450 OEM
-		1545 7470  Radeon HD 7470
-		1642 3a65  Radeon HD 6450
-		1642 3a66  Radeon HD 7450
-		1642 3a75  Radeon HD 6450
-		1642 3a76  Radeon HD 7450
-		1682 3200  Radeon HD 7450
-		174b 7450  Radeon HD 7450
-		174b e127  Radeon HD 6450
-		174b e153  Radeon HD 6450
-		174b e164  Radeon HD 6450 1 GB DDR3
-		174b e180  Radeon HD 6450
-		174b e201  Radeon HD 6450
-		17af 8450  Radeon HD 8450 OEM
-		1b0a 9096  Radeon HD 6450
-		1b0a 9097  Radeon HD 6450
-		1b0a 90a8  Radeon HD 6450A
-		1b0a 90b1  Radeon HD 6450
-		1b0a 90b3  Radeon HD 7450A
-		1b0a 90bb  Radeon HD 7450A
 	677b  Caicos PRO [Radeon HD 7450]
 	6780  Tahiti XT GL [FirePro W9000]
 	6784  Tahiti [FirePro Series Graphics Adapter]
 	6788  Tahiti [FirePro Series Graphics Adapter]
 	678a  Tahiti PRO GL [FirePro Series]
-		1002 030c  FirePro W8000
-		1002 0310  FirePro S9000
-		1002 0420  Radeon Sky 700
-		1002 0422  Radeon Sky 900
-		1002 0710  FirePro S9050
-		1002 0b0e  FirePro S10000 Passive
-		1002 0b2a  FirePro S10000
-		1028 030c  FirePro W8000
-		1028 0710  FirePro S9000
 	6798  Tahiti XT [Radeon HD 7970/8970 OEM / R9 280X]
-		1002 3000  Tahiti XT2 [Radeon HD 7970 GHz Edition]
-		1002 3001  Tahiti XTL [Radeon R9 280X]
-		1002 4000  Radeon HD 8970 OEM
-		1043 041c  HD 7970 DirectCU II
-		1043 0420  HD 7970 DirectCU II TOP
-		1043 0444  HD 7970 DirectCU II TOP
-		1043 0448  HD 7970 DirectCU II TOP
-		1043 044a  Tahiti XT2 [Matrix HD 7970]
-		1043 044c  Tahiti XT2 [Matrix HD 7970 Platinum]
-		1043 3001  Tahiti XTL [ROG Matrix R9 280X]
-		1043 3006  Tahiti XTL [Radeon R9 280X DirectCU II TOP]
-		1043 9999  ARES II
-		1092 3000  Tahiti XT2 [Radeon HD 7970 GHz Edition]
-		1458 2261  Tahiti XT2 [Radeon HD 7970 GHz Edition OC]
-# GV-R928XOC-3GD
-		1458 3001  Tahiti XTL [Radeon R9 280X OC]
-		1462 2774  MSI R7970 TF 3GD5/OC BE
-		1682 3001  Tahiti XTL [Radeon R9 280X]
-		1682 3211  Double D HD 7970 Black Edition
-# FX-797A-TNBC
-		1682 3213  HD 7970 Black Edition
-		1682 3214  Double D HD 7970
-		1787 201c  HD 7970 IceQ X²
-# Radeon HD 7970 X2
-		1787 2317  Radeon HD 7990
-		1787 3000  Tahiti XT2 [Radeon HD 7970 GHz Edition]
 	679a  Tahiti PRO [Radeon HD 7950/8950 OEM / R9 280]
-		1002 0b01  Radeon HD 8950 OEM
-		1002 3000  Tahiti PRO2 [Radeon HD 7950 Boost]
-		1462 3000  Radeon HD 8950 OEM
-		174b a003  Radeon R9 280
 	679b  Malta [Radeon HD 7990/8990 OEM]
-		1002 0b28  Radeon HD 8990 OEM
-		1002 0b2a  Radeon HD 7990
-		1462 8036  Radeon HD 8990 OEM
-		148c 8990  Radeon HD 8990 OEM
 	679e  Tahiti LE [Radeon HD 7870 XT]
-		1787 2328  Radeon HD 7870 Black Edition 2 GB GDDR5 [2GBD5-2DHV3E]
 	679f  Tahiti
 	67a0  Hawaii XT GL [FirePro W9100]
-		1002 0335  FirePro S9150
-		1002 0735  FirePro S9170
-		1028 031f  FirePro W9100
-		1028 0335  FirePro S9150
 	67a1  Hawaii PRO GL [FirePro W8100]
-		1002 0335  FirePro S9100
-		1028 0335  FirePro S9100
 	67a2  Hawaii GL
 	67a8  Hawaii
 	67a9  Hawaii
 	67aa  Hawaii
 	67b0  Hawaii XT / Grenada XT [Radeon R9 290X/390X]
-		1028 0b00  Grenada XT [Radeon R9 390X]
-		103c 6566  Radeon R9 390X
-		1043 046a  R9 290X DirectCU II
-		1043 046c  R9 290X DirectCU II OC
-		1043 0474  Matrix R9 290X Platinum
-		1043 0476  ARES III
-		1043 04d7  Radeon R9 390X
-		1043 04db  Radeon R9 390X
-		1043 04df  Radeon R9 390X
-		1043 04e9  Radeon R9 390X
-		1458 227c  R9 290X WindForce 3X OC
-		1458 2281  R9 290X WindForce 3X OC
-		1458 228c  R9 290X WindForce 3X
-		1458 228d  R9 290X WindForce 3X OC
-		1458 2290  R9 290X WindForce 3X
-		1458 22bc  Radeon R9 390X
-		1458 22c1  Grenada PRO [Radeon R9 390]
-		1462 2015  Radeon R9 390X
-		1462 3070  R9 290X Lightning
-		1462 3071  R9 290X Lightning
-		1462 3072  R9 290X Lightning LE
-		1462 3080  R9 290X Gaming
-		1462 3082  R9 290X Gaming OC
-		148c 2347  Devil 13 Dual Core R9 290X
-		148c 2357  Grenada XT [Radeon R9 390X]
-		1682 9290  Double Dissipation R9 290X
-		1682 9395  Grenada XT [Radeon R9 390X]
-		174b 0e34  Radeon R9 390X
-		174b e282  Vapor-X R9 290X Tri-X OC
-		174b e285  R9 290X Tri-X OC
-		174b e324  Grenada XT2 [Radeon R9 390X]
-		1787 2020  R9 290X IceQ X² Turbo
-		1787 2357  Grenada XT [Radeon R9 390X]
 	67b1  Hawaii PRO [Radeon R9 290/390]
-		1043 04dd  STRIX R9 390
-		148c 2358  Radeon R9 390
-		174b e324  Sapphire Nitro R9 390
 	67b9  Vesuvius [Radeon R9 295X2]
 	67be  Hawaii LE
 	67c0  Ellesmere [Radeon Pro WX 7100]
 	67c4  Ellesmere [Radeon Pro WX 7100]
-		1002 0336  Radeon Pro Duo
-		1002 1336  Radeon Pro Duo
 	67c7  Ellesmere [Radeon Pro WX 5100]
 	67ca  Ellesmere [Polaris10]
 	67cc  Ellesmere [Polaris10]
 	67cf  Ellesmere [Polaris10]
 	67df  Ellesmere [Radeon RX 470/480/570/580]
-		1002 0b37  Radeon RX 480
-		1043 04a8  Radeon RX 480
-		1043 04b0  Radeon RX 470
-		1043 04fb  Radeon RX 480
-		1043 04fd  Radeon RX 480 8GB
-		1458 22f0  Radeon RX 570
-		1462 3411  Radeon RX 470
-		1462 3413  Radeon RX 480
-		148c 2372  Radeon RX 480
-		148c 2373  Radeon RX 470
-		1682 9470  Radeon RX 470
-		1682 9480  Radeon RX 480
-		1682 9588  Radeon RX 580 XTR
-		174b e347  Radeon RX 470/480
-		174b e349  Radeon RX 470
-		1787 a470  Radeon RX 470
-		1787 a480  Radeon RX 480
-		1da2 e353  Sapphire Radeon RX 580 Pulse 8GB
-		1da2 e366  Radeon RX 570
 	67e0  Baffin [Polaris11]
 	67e1  Baffin [Polaris11]
 	67e3  Baffin [Radeon Pro WX 4100]
@@ -2300,70 +755,24 @@ var pciids = []byte(`#
 	67e9  Baffin [Polaris11]
 	67eb  Baffin [Polaris11]
 	67ef  Baffin [Radeon RX 460/560D / Pro 450/455/460/560]
-		106b 0160  Radeon Pro 460
-		106b 0166  Radeon Pro 455
-		106b 0167  Radeon Pro 450
-		106b 0179  Radeon Pro 560
-		1642 1727  Polaris 21 XL [Radeon RX 560D]
-		1682 956d  Polaris 21 XL [Radeon RX 560D]
 	67ff  Baffin [Radeon RX 560]
 	6800  Wimbledon XT [Radeon HD 7970M]
-		1002 0124  Radeon HD 7970M
-		8086 2110  Radeon HD 7970M
-		8086 2111  Radeon HD 7970M
 	6801  Neptune XT [Radeon HD 8970M]
-		1002 0124  Radeon HD 8970M
-		1462 1117  Radeon R9 M290X
-		8086 2110  Radeon HD 8970M
-		8086 2111  Radeon HD 8970M
 	6802  Wimbledon
 	6806  Neptune
 	6808  Pitcairn XT GL [FirePro W7000]
-		1002 0310  FirePro S7000
-		1002 0420  Radeon Sky 500
 	6809  Pitcairn LE GL [FirePro W5000]
 	6810  Curacao XT / Trinidad XT [Radeon R7 370 / R9 270X/370X]
-		148c 0908  Radeon R9 370 OEM
-		1682 7370  Radeon R7 370
 	6811  Curacao PRO [Radeon R7 370 / R9 270/370 OEM]
-		1028 0b00  Trinidad PRO [Radeon R9 370 OEM]
-		1043 2016  Trinidad PRO [Radeon R9 370 OEM]
-		1458 2016  Trinidad PRO [Radeon R9 370 OEM]
-		1462 2016  Trinidad PRO [Radeon R9 370 OEM]
-		1462 3050  R9 270 Gaming OC
-		148c 2016  Trinidad PRO [Radeon R9 370 OEM]
-		1682 2015  Trinidad PRO [Radeon R7 370]
-		174b 2015  NITRO Radeon R7 370
-		174b 2016  Trinidad PRO [Radeon R9 370 OEM]
-		1787 2016  Trinidad PRO [Radeon R9 370 OEM]
 	6816  Pitcairn
 	6817  Pitcairn
 	6818  Pitcairn XT [Radeon HD 7870 GHz Edition]
-		1002 0b05  Radeon HD 8870 OEM
-		174b 8b04  Radeon HD 8860
 	6819  Pitcairn PRO [Radeon HD 7850 / R7 265 / R9 270 1024SP]
-		1682 7269  Radeon R9 270 1024SP
-		1682 9278  Radeon R9 270 1024SP
-		174b a008  Radeon R9 270 1024SP
-		174b e221  Radeon HD 7850 2GB GDDR5 DVI-I/DVI-D/HDMI/DP
 	6820  Venus XTX [Radeon HD 8890M / R9 M275X/M375X]
-		103c 1851  Radeon HD 7750M
-		17aa 3643  Radeon R9 A375
-		17aa 3801  Radeon R9 M275
-		17aa 3824  Radeon R9 M375
 	6821  Venus XT [Radeon HD 8870M / R9 M270X/M370X]
-		1002 031e  FirePro SX4000
-		1028 05cc  FirePro M5100
-		1028 15cc  FirePro M5100
-		106b 0149  Radeon R9 M370X Mac Edition
 	6822  Venus PRO [Radeon E8860]
 	6823  Venus PRO [Radeon HD 8850M / R9 M265X]
 	6825  Heathrow XT [Radeon HD 7870M]
-		1028 053f  FirePro M6000
-		1028 05cd  FirePro M6000
-		1028 15cd  FirePro M6000
-		103c 176c  FirePro M6000
-		8086 2111  Chelsea PRO
 	6826  Chelsea LP [Radeon HD 7700M Series]
 	6827  Heathrow PRO [Radeon HD 7850M/8850M]
 	6828  Cape Verde PRO [FirePro W600]
@@ -2373,645 +782,68 @@ var pciids = []byte(`#
 	682c  Cape Verde GL [FirePro W4100]
 	682d  Chelsea XT GL [FirePro M4000]
 	682f  Chelsea LP [Radeon HD 7730M]
-		103c 1851  Radeon HD 7750M
 	6830  Cape Verde [Radeon HD 7800M Series]
 	6831  Cape Verde [AMD Radeon HD 7700M Series]
 	6835  Cape Verde PRX [Radeon R9 255 OEM]
 	6837  Cape Verde LE [Radeon HD 7730/8730]
-		1462 2796  Radeon HD 8730
-		1462 8092  Radeon HD 8730
-		148c 8730  Radeon HD 8730
-		1787 3000  Radeon HD 6570
 	683d  Cape Verde XT [Radeon HD 7770/8760 / R7 250X]
-		1002 0030  Radeon HD 8760 OEM
-		1019 0030  Radeon HD 8760 OEM
-		103c 6890  Radeon HD 8760 OEM
-		1043 8760  Radeon HD 8760 OEM
-		1462 2710  R7770-PMD1GD5
-		174b 8304  Radeon HD 8760 OEM
 	683f  Cape Verde PRO [Radeon HD 7750/8740 / R7 250E]
-		1462 2790  Radeon HD 8740
-		1462 2791  Radeon HD 8740
-		1642 3b97  Radeon HD 8740
 	6840  Thames [Radeon HD 7500M/7600M Series]
-		1025 050e  Radeon HD 7670M
-		1025 050f  Radeon HD 7670M
-		1025 0513  Radeon HD 7670M
-		1025 0514  Radeon HD 7670M
-		1025 056d  Radeon HD 7670M
-		1025 059a  Radeon HD 7670M
-		1025 059b  Radeon HD 7670M
-		1025 059e  Radeon HD 7670M
-		1025 0600  Radeon HD 7670M
-		1025 0606  Radeon HD 7670M
-		1025 0696  Radeon HD 7650M
-		1025 0697  Radeon HD 7650M
-		1025 0698  Radeon HD 7650M
-		1025 0699  Radeon HD 7650M
-		1025 0757  Radeon HD 7670M
-		1028 056a  Radeon HD 7670M
-		1028 056e  Radeon HD 7670M
-		1028 0598  Radeon HD 7670M
-		1028 059d  Radeon HD 7670M
-		1028 05a3  Radeon HD 7670M
-		1028 05b9  Radeon HD 7670M
-		1028 05bb  Radeon HD 7670M
-		103c 1789  FirePro M2000
-		103c 17f1  Radeon HD 7570M
-		103c 17f4  Radeon HD 7650M
-		103c 1813  Radeon HD 7590M
-		103c 182f  Radeon HD 7670M
-		103c 1830  Radeon HD 7670M
-		103c 1835  Radeon HD 7670M
-		103c 183a  Radeon HD 7670M
-		103c 183c  Radeon HD 7670M
-		103c 183e  Radeon HD 7670M
-		103c 1840  Radeon HD 7670M
-		103c 1842  Radeon HD 7670M
-		103c 1844  Radeon HD 7670M
-		103c 1848  Radeon HD 7670M
-		103c 184a  Radeon HD 7670M
-		103c 184c  Radeon HD 7670M
-		103c 1895  Radeon HD 7670M
-		103c 1897  Radeon HD 7670M
-		103c 18a5  Radeon HD 7670M
-		103c 18a7  Radeon HD 7670M
-		103c 18f4  Radeon HD 7670M
-		1043 100a  Radeon HD 7670M
-		1043 104b  Radeon HD 7670M
-		1043 10dc  Radeon HD 7670M
-		1043 2121  Radeon HD 7670M
-		1043 2122  Radeon HD 7670M
-		1043 2123  Radeon HD 7670M
-		1043 2125  Radeon HD 7670M
-		1043 2127  Radeon HD 7670M
-		1179 fb11  Radeon HD 7670M
-		1179 fb22  Radeon HD 7670M
-		1179 fb23  Radeon HD 7670M
-		1179 fb2c  Radeon HD 7670M
-		1179 fb31  Radeon HD 7670M
-		1179 fb32  Radeon HD 7670M
-		1179 fb38  Radeon HD 7670M
-		1179 fb39  Radeon HD 7670M
-		1179 fb3a  Radeon HD 7670M
-		1179 fb40  Radeon HD 7670M
-		1179 fb41  Radeon HD 7670M
-		1179 fb47  Radeon HD 7670M
-		1179 fb48  Radeon HD 7670M
-		1179 fb51  Radeon HD 7670M
-		1179 fb52  Radeon HD 7670M
-		1179 fb53  Radeon HD 7670M
-		1179 fb81  Radeon HD 7670M
-		1179 fb82  Radeon HD 7670M
-		1179 fb83  Radeon HD 7670M
-		1179 fc56  Radeon HD 7670M
-		1179 fcd4  Radeon HD 7670M
-		1179 fcee  Radeon HD 7670M
-		144d c0c5  Radeon HD 7690M
-		144d c0ce  Radeon HD 7670M
-		144d c0da  Radeon HD 7670M
-		17aa 3970  Radeon HD 7670M
-		17aa 397b  Radeon HD 7670M
-		17aa 5101  Radeon HD 7670M
-		17aa 5102  Radeon HD 7670M
-		17aa 5103  Radeon HD 7670M
 	6841  Thames [Radeon HD 7550M/7570M/7650M]
-		1028 0561  Radeon HD 7650M
-		1028 056c  Radeon HD 7650M
-		1028 057f  Radeon HD 7570M
-		103c 17f1  Radeon HD 7570M
-		103c 17f4  Radeon HD 7650M
-		103c 1813  Radeon HD 7570M
-		103c 183a  Radeon HD 7650M
-		103c 183c  Radeon HD 7650M
-		103c 183e  Radeon HD 7650M
-		103c 1840  Radeon HD 7650M
-		103c 1842  Radeon HD 7650M
-		103c 1844  Radeon HD 7650M
-		1043 100a  Radeon HD 7650M
-		1043 104b  Radeon HD 7650M
-		1043 10dc  Radeon HD 7650M
-		1043 2134  Radeon HD 7650M
-		1179 0001  Radeon HD 7570M
-		1179 0002  Radeon HD 7570M
-		1179 fb43  Radeon HD 7550M
-		1179 fb91  Radeon HD 7550M
-		1179 fb92  Radeon HD 7550M
-		1179 fb93  Radeon HD 7550M
-		1179 fba2  Radeon HD 7550M
-		1179 fba3  Radeon HD 7550M
-		144d c0c7  Radeon HD 7550M
 	6842  Thames LE [Radeon HD 7000M Series]
 	6843  Thames [Radeon HD 7670M]
 	6863  Vega 10 XTX [Radeon Vega Frontier Edition]
 	687f  Vega 10 XT [Radeon RX Vega 64]
 	6888  Cypress XT [FirePro V8800]
 	6889  Cypress PRO [FirePro V7800]
-		1002 0301  FirePro V7800P
 	688a  Cypress XT [FirePro V9800]
-		1002 030c  FirePro V9800P
 	688c  Cypress XT GL [FireStream 9370]
 	688d  Cypress PRO GL [FireStream 9350]
 	6898  Cypress XT [Radeon HD 5870]
-		1002 0b00  Radeon HD 5870 Eyefinity⁶ Edition
-		106b 00d0  Radeon HD 5870 Mac Edition
-# R5870-PM2D1G
-		1462 8032  Radeon HD 5870 1 GB GDDR5
-		174b 6870  Radeon HD 6870 1600SP Edition
 	6899  Cypress PRO [Radeon HD 5850]
-# EAH5850
-		1043 0330  Radeon HD 5850
-		174b 237b  Radeon HD 5850 X2
-		174b 6850  Radeon HD 6850 1440SP Edition
 	689b  Cypress PRO [Radeon HD 6800 Series]
 	689c  Hemlock [Radeon HD 5970]
-		1043 0352  ARES
 	689d  Hemlock [Radeon HD 5970]
 	689e  Cypress LE [Radeon HD 5830]
 	68a0  Broadway XT [Mobility Radeon HD 5870]
-		1028 12ef  FirePro M7820
-		103c 1520  FirePro M7820
 	68a1  Broadway PRO [Mobility Radeon HD 5850]
-		106b 00cc  iMac MC511 Mobility Radeon HD 5850 MXM Module
 	68a8  Granville [Radeon HD 6850M/6870M]
-		1025 0442  Radeon HD 6850M
-		1025 0451  Radeon HD 6850M
-		1025 050a  Radeon HD 6850M
-		1025 050b  Radeon HD 6850M
-		1025 050c  Radeon HD 6850M
-		1025 050e  Radeon HD 6850M
-		1025 050f  Radeon HD 6850M
-		1025 0513  Radeon HD 6850M
-		1025 0514  Radeon HD 6850M
-		1025 0515  Radeon HD 6850M
-		1025 0516  Radeon HD 6850M
-		1025 0525  Radeon HD 6850M
-		1025 0526  Radeon HD 6850M
-		1025 056d  Radeon HD 6850M
-		1028 048f  Radeon HD 6870M
-		1028 0490  Radeon HD 6870M
-		1028 04b9  Radeon HD 6870M
-		1028 04ba  Radeon HD 6870M
-		103c 159b  Radeon HD 6850M
-		144d c0ad  Radeon HD 6850M
 	68a9  Juniper XT [FirePro V5800]
 	68b8  Juniper XT [Radeon HD 5770]
-		106b 00cf  MacPro5,1 [Mac Pro 2.8GHz DDR3]
 	68b9  Juniper LE [Radeon HD 5670 640SP Edition]
 	68ba  Juniper XT [Radeon HD 6770]
 	68be  Juniper PRO [Radeon HD 5750]
-		148c 3000  Radeon HD 6750
 	68bf  Juniper PRO [Radeon HD 6750]
-		174b 6750  Radeon HD 6750
 	68c0  Madison [Mobility Radeon HD 5730 / 6570M]
-		1019 2383  Mobility Radeon HD 5730
-		1028 02a2  Mobility Radeon HD 5730
-		1028 02fe  Mobility Radeon HD 5730
-		1028 0419  Mobility Radeon HD 5730
-		103c 147d  Mobility Radeon HD 5730
-		103c 1521  Madison XT [FirePro M5800]
-		103c 1593  Mobility Radeon HD 6570
-		103c 1596  Mobility Radeon HD 6570
-		103c 1599  Mobility Radeon HD 6570
-		1043 1c22  Mobility Radeon HD 5730
-		17aa 3927  Mobility Radeon HD 5730
-		17aa 3952  Mobility Radeon HD 5730
-		17aa 3978  Radeon HD 6570M
 	68c1  Madison [Mobility Radeon HD 5650/5750 / 6530M/6550M]
-		1025 0205  Mobility Radeon HD 5650
-		1025 0293  Mobility Radeon HD 5650
-		1025 0294  Mobility Radeon HD 5650
-		1025 0296  Mobility Radeon HD 5650
-		1025 0308  Mobility Radeon HD 5650
-		1025 030a  Mobility Radeon HD 5650
-		1025 0311  Mobility Radeon HD 5650
-		1025 0312  Mobility Radeon HD 5650
-		1025 031c  Mobility Radeon HD 5650
-		1025 031d  Mobility Radeon HD 5650
-		1025 033d  Mobility Radeon HD 5650
-		1025 033e  Mobility Radeon HD 5650
-		1025 033f  Mobility Radeon HD 5650
-		1025 0346  Mobility Radeon HD 5650
-		1025 0347  Aspire 7740G
-		1025 0348  Mobility Radeon HD 5650
-		1025 0356  Mobility Radeon HD 5650
-		1025 0357  Mobility Radeon HD 5650
-		1025 0358  Mobility Radeon HD 5650
-		1025 0359  Mobility Radeon HD 5650
-		1025 035a  Mobility Radeon HD 5650
-		1025 035b  Mobility Radeon HD 5650
-		1025 035c  Mobility Radeon HD 5650
-		1025 035d  Mobility Radeon HD 5650
-		1025 035e  Mobility Radeon HD 5650
-		1025 0360  Mobility Radeon HD 5650
-		1025 0362  Mobility Radeon HD 5650
-		1025 0364  Mobility Radeon HD 5650
-		1025 0365  Mobility Radeon HD 5650
-		1025 0366  Mobility Radeon HD 5650
-		1025 0367  Mobility Radeon HD 5650
-		1025 0368  Mobility Radeon HD 5650
-		1025 036c  Mobility Radeon HD 5650
-		1025 036d  Mobility Radeon HD 5650
-		1025 036e  Mobility Radeon HD 5650
-		1025 036f  Mobility Radeon HD 5650
-		1025 0372  Mobility Radeon HD 5650
-		1025 0373  Mobility Radeon HD 5650
-		1025 0377  Mobility Radeon HD 5650
-		1025 0378  Mobility Radeon HD 5650
-		1025 0379  Mobility Radeon HD 5650
-		1025 037a  Mobility Radeon HD 5650
-		1025 037b  Mobility Radeon HD 5650
-		1025 037e  Mobility Radeon HD 5650
-		1025 037f  Mobility Radeon HD 5650
-		1025 0382  Mobility Radeon HD 5650
-		1025 0383  Mobility Radeon HD 5650
-		1025 0384  Mobility Radeon HD 5650
-		1025 0385  Mobility Radeon HD 5650
-		1025 0386  Mobility Radeon HD 5650
-		1025 0387  Mobility Radeon HD 5650
-		1025 0388  Mobility Radeon HD 5650
-		1025 038b  Mobility Radeon HD 5650
-		1025 038c  Mobility Radeon HD 5650
-		1025 039a  Mobility Radeon HD 5650
-		1025 0411  Mobility Radeon HD 5650
-		1025 0412  Mobility Radeon HD 5650
-		1025 0418  Mobility Radeon HD 5650
-		1025 0419  Mobility Radeon HD 5650
-		1025 0420  Mobility Radeon HD 5650
-		1025 0421  Mobility Radeon HD 5650
-		1025 0425  Mobility Radeon HD 5650
-		1025 042a  Mobility Radeon HD 5650
-		1025 042e  Mobility Radeon HD 5650
-		1025 042f  Mobility Radeon HD 5650
-		1025 0432  Mobility Radeon HD 5650
-		1025 0433  Mobility Radeon HD 5650
-		1025 0442  Mobility Radeon HD 5650
-		1025 044c  Mobility Radeon HD 5650
-		1025 044e  Mobility Radeon HD 5650
-		1025 0451  Mobility Radeon HD 5650
-		1025 0454  Mobility Radeon HD 5650
-		1025 0455  Mobility Radeon HD 5650
-		1025 0475  Mobility Radeon HD 5650
-		1025 0476  Mobility Radeon HD 5650
-		1025 0487  Mobility Radeon HD 5650
-		1025 0489  Mobility Radeon HD 5650
-		1025 0498  Mobility Radeon HD 5650
-		1025 0517  Radeon HD 6550M
-		1025 051a  Radeon HD 6550M
-		1025 051b  Radeon HD 6550M
-		1025 051c  Radeon HD 6550M
-		1025 051d  Radeon HD 6550M
-		1025 0525  Radeon HD 6550M
-		1025 0526  Radeon HD 6550M
-		1025 052b  Radeon HD 6550M
-		1025 052c  Radeon HD 6550M
-		1025 053c  Radeon HD 6550M
-		1025 053d  Radeon HD 6550M
-		1025 053e  Radeon HD 6550M
-		1025 053f  Radeon HD 6550M
-		1025 0607  Radeon HD 6550M
-		1028 041b  Mobility Radeon HD 5650
-		1028 0447  Mobility Radeon HD 5650
-		1028 0448  Mobility Radeon HD 5650
-		1028 0456  Mobility Radeon HD 5650
-		1028 0457  Mobility Radeon HD 5650
-		103c 1436  Mobility Radeon HD 5650
-		103c 1437  Mobility Radeon HD 5650
-		103c 1440  Mobility Radeon HD 5650
-		103c 1448  Mobility Radeon HD 5650
-		103c 1449  Mobility Radeon HD 5650
-		103c 144a  Mobility Radeon HD 5650
-		103c 144b  Mobility Radeon HD 5650
-		103c 147b  Mobility Radeon HD 5650
-		103c 149c  Mobility Radeon HD 5650
-		103c 149e  Mobility Radeon HD 5650
-		103c 1521  Madison Pro [FirePro M5800]
-		1043 1bc2  Mobility Radeon HD 5650
-		104d 9071  Mobility Radeon HD 5650
-		104d 9077  Mobility Radeon HD 5650
-		104d 9081  Mobility Radeon HD 5650
-		1179 fd00  Mobility Radeon HD 5650
-		1179 fd12  Mobility Radeon HD 5650
-		1179 fd1a  Mobility Radeon HD 5650
-		1179 fd30  Mobility Radeon HD 5650
-		1179 fd31  Mobility Radeon HD 5650
-		1179 fd50  Mobility Radeon HD 5650
-		1179 fd52  Radeon HD 6530M
-		1179 fd63  Radeon HD 6530M
-		1179 fd65  Radeon HD 6530M
-		1179 fdd0  Mobility Radeon HD 5650
-		1179 fdd2  Radeon HD 6530M
-		144d c07e  Mobility Radeon HD 5650
-		144d c085  Mobility Radeon HD 5650
-		14c0 0043  Mobility Radeon HD 5650
-		14c0 004d  Mobility Radeon HD 5650
-		17aa 3928  Mobility Radeon HD 5650
-		17aa 3951  Mobility Radeon HD 5650
-		17aa 3977  Radeon HD 6550M
 	68c7  Madison [Mobility Radeon HD 5570/6550A]
-		1462 2241  Mobility Radeon HD 5570
-		1462 2243  Mobility Radeon HD 5570
-		1462 2244  Mobility Radeon HD 5570
-		1462 2245  Radeon HD 6550A
-		1462 2246  Radeon HD 6550A
 	68c8  Redwood XT GL [FirePro V4800]
 	68c9  Redwood PRO GL [FirePro V3800]
 	68d8  Redwood XT [Radeon HD 5670/5690/5730]
-		1028 68e0  Radeon HD 5670
-		174b 5690  Radeon HD 5690
-		174b 5730  Radeon HD 5730
-		174b e151  Radeon HD 5670
-		1787 3000  Radeon HD 5730
-		17af 3010  Radeon HD 5730
-		17af 3011  Radeon HD 5690
 	68d9  Redwood PRO [Radeon HD 5550/5570/5630/6510/6610/7570]
-		103c 6870  Radeon HD 5570
-		103c 6872  Radeon HD 5570
-		1043 03ce  Radeon HD 5550
-		1462 2151  Radeon HD 5570
-		1462 2240  Radeon HD 5570
-		148c 3000  Radeon HD 6510
-		148c 3001  Radeon HD 6610
-		1545 5550  Radeon HD 5550
-		1545 7570  Radeon HD 7570
-		1642 3985  Radeon HD 5570
-		1642 3996  Radeon HD 5570
-		174b 3000  Radeon HD 6510
-		174b 6510  Radeon HD 6510
-		174b 6610  Radeon HD 6610
-		174b e142  Radeon HD 5570
-		1787 3000  Radeon HD 6510
-		17af 3000  Radeon HD 6510
-		17af 3010  Radeon HD 5630
 	68da  Redwood LE [Radeon HD 5550/5570/5630/6390/6490/7570]
-		148c 3000  Radeon HD 6390
-		148c 3001  Radeon HD 6490
-		1545 7570  Radeon HD 7570
-		174b 3000  Radeon HD 6390
-		174b 5570  Radeon HD 5570
-		174b 5630  Radeon HD 5630
-		174b 6490  Radeon HD 6490
-		1787 3000  Radeon HD 5630
-		17af 3000  Radeon HD 6390
-		17af 3010  Radeon HD 5630
 	68de  Redwood
 	68e0  Park [Mobility Radeon HD 5430/5450/5470]
-		1028 0404  Mobility Radeon HD 5450
-		1028 0414  Mobility Radeon HD 5450
-		1028 0434  Mobility Radeon HD 5450
-		103c 1433  Mobility Radeon HD 5450
-		103c 1434  Mobility Radeon HD 5450
-		103c 1469  Mobility Radeon HD 5450
-		103c 146b  Mobility Radeon HD 5450
-		103c 1486  TouchSmart tm2-2050er discrete GPU (Mobility Radeon HD 5450)
-		103c 1622  Mobility Radeon HD 5450
-		103c 1623  Mobility Radeon HD 5450
-		103c eeee  Mobility Radeon HD 5450
-		104d 9076  Mobility Radeon HD 5450
-		1682 304e  Caicos [Radeon HD 5450]
-		1682 6000  Caicos [Radeon HD 5450]
-		17aa 9e52  FirePro M3800
-		17aa 9e53  FirePro M3800
 	68e1  Park [Mobility Radeon HD 5430]
-		1043 041f  Caicos [Radeon HD 7350]
-		1043 3000  Caicos [Radeon HD 5450]
-		148c 3000  Caicos [Radeon HD 5450]
-		148c 3001  Caicos [Radeon HD 6230]
-		148c 3002  Caicos [Radeon HD 6250]
-		148c 3003  Caicos [Radeon HD 6350]
-		148c 7350  Caicos [Radeon HD 7350]
-		148c 8350  Caicos [Radeon HD 8350]
-		1545 5450  Caicos [Radeon HD 5450]
-		1545 7350  Caicos [Radeon HD 7350]
-		1682 3000  Caicos [Radeon HD 5450]
-		1682 6000  Caicos [Radeon HD 5450]
-		1682 7350  Caicos [Radeon HD 7350]
-		174b 3000  Caicos [Radeon HD 5450]
-		174b 5470  Caicos [Radeon HD 5470]
-		174b 6000  Caicos [Radeon HD 5450]
-		174b 6230  Caicos [Radeon HD 6230]
-		174b 6350  Caicos [Radeon HD 6350]
-		174b 7350  Caicos [Radeon HD 7350]
-		1787 3000  Caicos [Radeon HD 5450]
-		17af 3000  Caicos [Radeon HD 5450]
-		17af 3001  Caicos [Radeon HD 6230]
-		17af 3014  Caicos [Radeon HD 6350]
-		17af 3015  Caicos [Radeon HD 7350]
-		17af 8350  Caicos [Radeon HD 8350 OEM]
 	68e4  Robson CE [Radeon HD 6370M/7370M]
-		1019 2386  Radeon HD 6350M
-		1019 2387  Radeon HD 6350M
-		1019 238d  Radeon HD 6370M
-		1019 238e  Radeon HD 6370M
-		1025 0382  Radeon HD 6370M
-		1025 0489  Radeon HD 6370M
-		1025 048a  Radeon HD 6370M
-		1025 048b  Radeon HD 6370M
-		1025 048c  Radeon HD 6370M
-		1028 04c1  Radeon HD 6370M
-		1028 04ca  Radeon HD 6370M
-		1028 04cc  Radeon HD 6370M
-		1028 04cd  Radeon HD 6370M
-		1028 04d7  Radeon HD 6370M
-		103c 1411  Radeon HD 6370M
-		103c 1421  Radeon HD 6370M
-		103c 1426  Radeon HD 6370M
-		103c 1428  Radeon HD 6370M
-		103c 142a  Radeon HD 6370M
-		103c 142b  Radeon HD 6370M
-		103c 143a  Radeon HD 6370M
-		103c 143c  Radeon HD 6370M
-		103c 1445  Radeon HD 6370M
-		103c 162c  Radeon HD 6370M
-		103c 162d  Radeon HD 6370M
-		103c 162e  Radeon HD 6370M
-		103c 162f  Radeon HD 6370M
-		103c 1639  Radeon HD 6370M
-		103c 163a  Radeon HD 6370M
-		103c 163b  Radeon HD 6370M
-		103c 163c  Radeon HD 6370M
-		103c 163d  Radeon HD 6370M
-		103c 163e  Radeon HD 6370M
-		103c 163f  Radeon HD 6370M
-		103c 1641  Radeon HD 6370M
-		103c 1643  Radeon HD 6370M
-		103c 3578  Radeon HD 6370M
-		103c 357a  Radeon HD 6370M
-		103c 3673  Radeon HD 6370M
-		103c 3675  Radeon HD 6370M
-		1043 1c92  Radeon HD 6370M
-		1043 84a1  Radeon HD 6370M
-		1043 84ad  Radeon HD 6370M
-		104d 9081  Radeon HD 6370M
-		1545 7350  Cedar [Radeon HD 7350]
-		1558 4510  Radeon HD 6370M
-		1558 5505  Radeon HD 6370M
-		174b 5450  Cedar [Radeon HD 5450]
-		17aa 21dd  Radeon HD 6370M
-		17aa 21e9  Radeon HD 6370M
-		17aa 3971  Radeon HD 6370M
-		17aa 3972  Radeon HD 7370M
-		17aa 397a  Radeon HD 6370M/7370M
-		17aa 397b  Radeon HD 6370M/7370M
-		17aa 397f  Radeon HD 7370M
 	68e5  Robson LE [Radeon HD 6330M]
-		1179 fd3c  Radeon HD 6330M
-		1179 fd50  Radeon HD 6330M
-		1179 fd52  Radeon HD 6330M
-		1179 fd63  Radeon HD 6330M
-		1179 fd65  Radeon HD 6330M
-		1179 fd73  Radeon HD 6330M
-		1179 fd75  Radeon HD 6330M
-		1179 fdd0  Radeon HD 6330M
-		1179 fdd2  Radeon HD 6330M
-		1179 fdea  Radeon HD 6330M
-		1179 fdf8  Radeon HD 6330M
-		148c 5450  Cedar [Radeon HD 5450]
-		148c 6350  Cedar [Radeon HD 6350]
-		148c 7350  Cedar [Radeon HD 7350]
-		148c 8350  Cedar [Radeon HD 8350]
-		1545 7350  Cedar [Radeon HD 7350]
 	68e8  Cedar
 	68e9  Cedar [ATI FirePro (FireGL) Graphics Adapter]
 	68f1  Cedar GL [FirePro 2460]
 	68f2  Cedar GL [FirePro 2270]
 	68f8  Cedar [Radeon HD 7300 Series]
 	68f9  Cedar [Radeon HD 5000/6000/7350/8350 Series]
-		1019 0001  Radeon HD 5450
-		1019 0002  Radeon HD 5450
-		1019 0019  Radeon HD 6350
-		1025 0518  Radeon HD 5450
-		1025 0519  Radeon HD 5450
-		1028 010e  XPS 8300
-		1028 2126  Radeon HD 6350
-		103c 2126  Radeon HD 6350
-		103c 2aac  Radeon HD 5450
-		103c 2aae  Radeon HD 5450
-		103c 3580  Radeon HD 5450
-		1043 0386  Radeon HD 5450
-		1043 03c2  EAH5450 SILENT/DI/512MD2 (LP)
-		1462 2130  Radeon HD 5450
-		1462 2131  Radeon HD 5450
-		1462 2133  Radeon HD 6350
-		1462 2180  Radeon HD 5450
-		1462 2181  Radeon HD 5450
-		1462 2182  Radeon HD 6350
-		1462 2183  Radeon HD 6350
-		1462 2230  Radeon HD 5450
-		1462 2231  Radeon HD 5450
-		1462 2495  Radeon HD 6350
-		148c 3001  Radeon HD 5530/6250
-		148c 3002  Radeon HD 6290
-		148c 3003  Radeon HD 6230
-		148c 3004  Radeon HD 6350
-		148c 7350  Radeon HD 7350
-		148c 8350  Radeon HD 8350
-		1545 7350  Radeon HD 7350
-		1642 3983  Radeon HD 5450
-		1642 3984  Radeon HD 6350
-		1642 3987  Radeon HD 6350
-		1642 3997  Radeon HD 5450
-		1642 3a05  Radeon HD 5450
-		1642 3b31  Radeon HD 6350A
-		1682 3270  Radeon HD 7350
-		174b 3000  Radeon HD 6230
-		174b 3987  Radeon HD 6350
-		174b 5470  Radeon HD 5470
-		174b 5490  Radeon HD 5490
-		174b 5530  Radeon HD 5530
-		174b 6230  Radeon HD 6230
-		174b 6250  Radeon HD 6250
-		174b 6290  Radeon HD 6290
-		174b 6350  Radeon HD 6350
-		174b 7350  Radeon HD 7350
-		174b 8350  Radeon HD 8350
-		174b e127  Radeon HD 5450
-		174b e145  Radeon HD 5450
-		174b e153  Radeon HD 5450
-		1787 3000  Radeon HD 5470
-		1787 3001  Radeon HD 5530
-		1787 3002  Radeon HD 5490
-		17aa 3602  Radeon HD 5450
-		17aa 3603  Radeon HD 5450
-		17aa 360f  Radeon HD 5450
-		17aa 3619  Radeon HD 5450
-		17af 3000  Radeon HD 6250
-		17af 3001  Radeon HD 6230
-		17af 3002  Radeon HD 6290
-		17af 3011  Radeon HD 5470
-		17af 3012  Radeon HD 5490
-		17af 3013  Radeon HD 5470
-		17af 3014  Radeon HD 6350
 	68fa  Cedar [Radeon HD 7350/8350 / R5 220]
-		1019 0019  Radeon HD 7350
-		1019 0021  Radeon HD 7350
-		1019 0022  Radeon HD 7350
-		1019 0026  Radeon HD 8350
-		103c 2adf  Radeon HD 7350A
-		103c 2ae8  Radeon HD 7350A
-		1043 8350  Radeon HD 8350
-		1462 2128  Radeon HD 7350
-		1462 2184  Radeon HD 7350
-		1462 2186  Radeon HD 7350
-		1462 2495  Radeon HD 7350
-		1462 b490  Radeon HD 7350
-		1642 3985  Radeon HD 7350
-		174b 3510  Radeon HD 8350
-		174b 3521  Radeon R5 220
-		174b 3522  Radeon R5 220
-		174b 7350  Radeon HD 7350
-		174b 8153  Radeon HD 8350
-		174b e127  Radeon HD 7350
-		174b e153  Radeon HD 7350
-		174b e180  Radeon HD 7350
-		17af 3015  Radeon HD 7350
 	68fe  Cedar LE
 	6900  Topaz XT [Radeon R7 M260/M265 / M340/M360 / M440/M445]
-		1025 1056  Radeon R7 M360 / R8 M365DX
-		1028 0640  Radeon R7 M260/M265
-		1028 0643  Radeon R7 M260/M265
-		1028 067f  Radeon R7 M260
-		1028 0767  Radeon R7 M445
-		1028 130a  Radeon R7 M260
-		103c 2263  Radeon R7 M260
-		103c 2269  Radeon R7 M260
-		103c 22c6  Radeon R7 M260
-		103c 22c8  Radeon R7 M260
-		103c 808c  Radeon R7 M260
-		103c 8099  Radeon R7 M360
-		103c 80b5  Radeon R7 M360
-		103c 80b9  Radeon R7 M360
-		103c 811c  Radeon R7 M340
-		103c 8226  Radeon R7 M440
-		10cf 1906  Radeon R7 M260
-		1170 9979  Radeon R7 M360
-		1179 f903  Radeon R7 M260
-		1179 f922  Radeon R7 M260
-		1179 f923  Radeon R7 M260
-		1179 f934  Radeon R7 M260
-		17aa 3822  Radeon R7 M360
-		17aa 3824  Radeon R7 M360
-		17aa 5021  Radeon R7 M260
 	6901  Topaz PRO [Radeon R5 M255]
-		103c 1318  Radeon R6 M255DX
 	6907  Meso XT [Radeon R5 M315]
 	6921  Amethyst XT [Radeon R9 M295X]
 	6929  Tonga XT GL [FirePro S7150]
 	692b  Tonga PRO GL [FirePro W7100]
 	692f  Tonga XTV GL [FirePro S7150V]
 	6938  Tonga XT / Amethyst XT [Radeon R9 380X / R9 M295X]
-		1043 04f5  Radeon R9 380X
-		1043 04f7  Radeon R9 380X
-		106b 013a  Radeon R9 M295X Mac Edition
-		1458 22c8  Radeon R9 380X
-		148c 2350  Radeon R9 380X
-		1682 9385  Radeon R9 380X
-		174b e308  Radeon R9 380X Nitro 4G D5
-		17af 2006  Radeon R9 380X
 	6939  Tonga PRO [Radeon R9 285/380]
-		148c 9380  Radeon R9 380
-# Make naming scheme consistent
-		174b e308  Radeon R9 380 Nitro 4G D5
 	6980  Polaris12
 	6981  Polaris12
 	6985  Lexa XT [Radeon PRO WX 3100]
@@ -3019,8 +851,6 @@ var pciids = []byte(`#
 	6987  Polaris12
 	6995  Lexa XT [Radeon PRO WX 2100]
 	699f  Lexa PRO [Radeon RX 550]
-		148c 2380  Lexa XL [Radeon RX 550]
-		1da2 e367  Lexa PRO [Radeon RX 550]
 	700f  RS100 AGP Bridge
 	7010  RS200/RS250 AGP Bridge
 	7100  R520 [Radeon X1800 XT]
@@ -3028,26 +858,16 @@ var pciids = []byte(`#
 	7102  R520/M58 [Mobility Radeon X1800]
 	7104  R520 GL [FireGL V7200]
 	7109  R520 [Radeon X1800 XL]
-		1002 0322  All-in-Wonder X1800XL
-		1002 0d02  Radeon X1800 CrossFire Edition
 	710a  R520 [Radeon X1800 GTO]
-		1002 0b12  Radeon X1800 GTO²
 	710b  R520 [Radeon X1800 GTO]
 	7120  R520 [Radeon X1800] (Secondary)
 	7124  R520 GL [FireGL V7200] (Secondary)
 	7129  R520 [Radeon X1800] (Secondary)
-		1002 0323  All-In-Wonder X1800 XL (Secondary)
-		1002 0d03  Radeon X1800 CrossFire Edition (Secondary)
 	7140  RV515 [Radeon X1300/X1550/X1600 Series]
 	7142  RV515 PRO [Radeon X1300/X1550 Series]
-		1002 0322  All-in-Wonder 2006 PCI-E Edition
-		1043 0142  EAX1300PRO/TD/256M
 	7143  RV505 [Radeon X1300/X1550 Series]
 	7145  RV515/M54 [Mobility Radeon X1400]
-		17aa 2006  Thinkpad T60 model 2007
 	7146  RV515 [Radeon X1300/X1550]
-		1002 0322  All-in-Wonder 2006 PCI-E Edition
-		1545 1996  Radeon X1300 512MB PCI-e
 	7147  RV505 [Radeon X1550 64-bit]
 	7149  RV515/M52 [Mobility Radeon X1300]
 	714a  RV515/M52 [Mobility Radeon X1300]
@@ -3055,11 +875,8 @@ var pciids = []byte(`#
 	7153  RV515 GL [FireGL V3350]
 	715f  RV505 CE [Radeon X1550 64-bit]
 	7162  RV515 PRO [Radeon X1300/X1550 Series] (Secondary)
-		1002 0323  All-in-Wonder 2006 PCI-E Edition (Secondary)
 	7163  RV505 [Radeon X1550 Series] (Secondary)
 	7166  RV515 [Radeon X1300/X1550 Series] (Secondary)
-		1002 0323  All-in-Wonder 2006 PCI-E Edition (Secondary)
-		1545 1997  Radeon X1300 512MB PCI-e (Secondary)
 	7167  RV515 [Radeon X1550 64-bit] (Secondary)
 	7172  RV515 GL [FireGL V3300] (Secondary)
 	7173  RV515 GL [FireGL V3350] (Secondary)
@@ -3068,10 +885,8 @@ var pciids = []byte(`#
 	7186  RV516/M64 [Mobility Radeon X1450]
 	7187  RV516 [Radeon X1300/X1550 Series]
 	7188  RV516/M64-S [Mobility Radeon X2300]
-		103c 30c1  6910p
 	718a  RV516/M64 [Mobility Radeon X2300]
 	718b  RV516/M62 [Mobility Radeon X1350]
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
 	718c  RV516/M62-CSP64 [Mobility Radeon X1350]
 	718d  RV516/M64-CSP128 [Mobility Radeon X1450]
 	7193  RV516 [Radeon X1550 Series]
@@ -3084,21 +899,12 @@ var pciids = []byte(`#
 	71a7  RV516 [Radeon X1300/X1550 Series] (Secondary)
 	71bb  RV516 GL [FireMV 2250] (Secondary)
 	71c0  RV530 [Radeon X1600 XT/X1650 GTO]
-		1002 e160  Radeon X1650 GTO
-		174b e160  Radeon X1650 GTO
 	71c1  RV535 [Radeon X1650 PRO]
-		174b 0880  Radeon X1700 FSC
 	71c2  RV530 [Radeon X1600 PRO]
 	71c4  RV530/M56 GL [Mobility FireGL V5200]
-		17aa 2007  ThinkPad T60p
 	71c5  RV530/M56-P [Mobility Radeon X1600]
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a3  Compaq NW8440
-		1043 10b2  A6J-Q008
-		106b 0080  MacBook Pro
 	71c6  RV530LE [Radeon X1600/X1650 PRO]
 	71c7  RV535 [Radeon X1650 PRO]
-		1787 3000  PowerColor X1650 PRO AGP
 	71ce  RV530 [Radeon X1300 XT/X1600 PRO]
 	71d2  RV530 GL [FireGL V3400]
 	71d4  RV530/M66 GL [Mobility FireGL V5250]
@@ -3106,28 +912,18 @@ var pciids = []byte(`#
 	71d6  RV530/M66-XT [Mobility Radeon X1700]
 	71de  RV530/M66 [Mobility Radeon X1700/X2500]
 	71e0  RV530 [Radeon X1600] (Secondary)
-		174b e161  Radeon X1600 GTO (Secondary)
 	71e1  RV535 [Radeon X1650 PRO] (Secondary)
-		174b 0881  Radeon X1700 FSC (Secondary)
 	71e2  RV530 [Radeon X1600] (Secondary)
 	71e6  RV530 [Radeon X1650] (Secondary)
 	71e7  RV535 [Radeon X1650 PRO] (Secondary)
-		1787 3001  Radeon X1650 PRO AGP
 	71f2  RV530 GL [FireGL V3400] (Secondary)
 	7210  RV550/M71 [Mobility Radeon HD 2300]
 	7211  RV550/M71 [Mobility Radeon X2300 HD]
 	7240  R580+ [Radeon X1950 XTX]
-		1002 0d02  Radeon X1950 CrossFire Edition
 	7244  R580+ [Radeon X1950 XT]
 	7248  R580 [Radeon X1950]
 	7249  R580 [Radeon X1900 XT]
-		1002 0412  All-In-Wonder X1900
-		1002 0b12  Radeon X1900 XT/XTX
-		1002 0d02  Radeon X1900 CrossFire Edition
-		1043 0160  Radeon X1900 XTX 512 MB GDDR3
 	724b  R580 [Radeon X1900 GT]
-		1002 0b12  Radeon X1900 (Primary)
-		1002 0b13  Radeon X1900 (Secondary)
 	724e  R580 GL [FireGL V7350]
 	7269  R580 [Radeon X1900 XT] (Secondary)
 	726b  R580 [Radeon X1900 GT] (Secondary)
@@ -3135,40 +931,26 @@ var pciids = []byte(`#
 	7280  RV570 [Radeon X1950 PRO]
 	7288  RV570 [Radeon X1950 GT]
 	7291  RV560 [Radeon X1650 XT]
-		1462 0810  Radeon X1700 SE
 	7293  RV560 [Radeon X1650 GT]
 	72a0  RV570 [Radeon X1950 PRO] (Secondary)
 	72a8  RV570 [Radeon X1950 GT] (Secondary)
 	72b1  RV560 [Radeon X1650 XT] (Secondary)
 	72b3  RV560 [Radeon X1650 GT] (Secondary)
 	7300  Fiji [Radeon R9 FURY / NANO Series]
-		1002 0b36  Radeon R9 FURY X / NANO
-		1002 1b36  Radeon Pro Duo
-		1043 049e  Radeon R9 FURY
-		1043 04a0  Radeon R9 FURY X
-		174b e329  Radeon R9 FURY
 	7833  RS350 Host Bridge
 	7834  RS350 [Radeon 9100 PRO/XT IGP]
 	7835  RS350M [Mobility Radeon 9000 IGP]
 	7838  RS350 AGP Bridge
 	7910  RS690 Host Bridge
-		1179 ff50  Satellite P305D-S8995E
-		17f2 5000  KI690-AM2 Motherboard
 	7911  RS690/RS740 Host Bridge
 	7912  RS690/RS740 PCI to PCI Bridge (Internal gfx)
 	7913  RS690 PCI to PCI Bridge (PCI Express Graphics Port 0)
 	7915  RS690 PCI to PCI Bridge (PCI Express Port 1)
 	7916  RS690 PCI to PCI Bridge (PCI Express Port 2)
 	7917  RS690 PCI to PCI Bridge (PCI Express Port 3)
-		1002 7910  RS690 PCI to PCI Bridge
 	7919  RS690 HDMI Audio [Radeon Xpress 1200 Series]
-		1179 7919  Satellite P305D-S8995E
-		17f2 5000  KI690-AM2 Motherboard
 	791e  RS690 [Radeon X1200]
-		1462 7327  K9AG Neo2
-		17f2 5000  KI690-AM2 Motherboard
 	791f  RS690M [Radeon Xpress 1200/1250/1270]
-		1179 ff50  Satellite P305D-S8995E
 	7930  RS600 Host Bridge
 	7932  RS600 PCI to PCI Bridge (Internal gfx)
 	7933  RS600 PCI to PCI Bridge (PCI Express Graphics Port 0)
@@ -3180,11 +962,7 @@ var pciids = []byte(`#
 	7941  RS600 [Radeon Xpress 1250]
 	7942  RS600M [Radeon Xpress 1250]
 	796e  RS740 [Radeon 2100]
-		105b 0e13  N15235/A74MX mainboard
 	9400  R600 [Radeon HD 2900 PRO/XT]
-		1002 2552  Radeon HD 2900 XT
-		1002 3000  Radeon HD 2900 PRO
-		1002 3142  HIS Radeon HD 2900XT 512MB GDDR3 VIVO PCIe
 	9401  R600 [Radeon HD 2900 XT]
 	9403  R600 [Radeon HD 2900 PRO]
 	9405  R600 [Radeon HD 2900 GT]
@@ -3194,8 +972,6 @@ var pciids = []byte(`#
 	9440  RV770 [Radeon HD 4870]
 	9441  R700 [Radeon HD 4870 X2]
 	9442  RV770 [Radeon HD 4850]
-		1002 0502  MSI Radeon HD 4850 512MB GDDR3
-		174b e810  Radeon HD 4850 512MB GDDR3
 	9443  R700 [Radeon HD 4850 X2]
 	9444  RV770 GL [FirePro V8750]
 	9446  RV770 GL [FirePro V7760]
@@ -3203,7 +979,6 @@ var pciids = []byte(`#
 	944b  RV770/M98 [Mobility Radeon HD 4850 X2]
 	944c  RV770 LE [Radeon HD 4830]
 	944e  RV770 CE [Radeon HD 4710]
-		174b 3261  Radeon HD 4810
 	9450  RV770 GL [FireStream 9270]
 	9452  RV770 GL [FireStream 9250]
 	9456  RV770 GL [FirePro V8700]
@@ -3212,18 +987,11 @@ var pciids = []byte(`#
 	9462  RV790 [Radeon HD 4860]
 	946a  RV770 GL [FirePro M7750]
 	9480  RV730/M96 [Mobility Radeon HD 4650/5165]
-		103c 3628  Mobility Radeon HD 4650 [dv6-1190en]
 	9488  RV730/M96-XT [Mobility Radeon HD 4670]
 	9489  RV730/M96 GL [Mobility FireGL V5725]
 	9490  RV730 XT [Radeon HD 4670]
-		174b e880  Radeon HD 4670 512MB GDDR3 Dual DVI-I/TVO
 	9491  RV730/M96-CSP [Radeon E4690]
 	9495  RV730 [Radeon HD 4600 AGP Series]
-		1002 0028  Radeon HD 4650/4670 AGP
-		1092 0028  Radeon HD 4670 AGP 512MB DDR2
-		1458 0028  Radeon HD 4650 AGP
-		1682 0028  Radeon HD 4650 AGP
-		174b 0028  Radeon HD 4650 AGP DDR2
 	9498  RV730 PRO [Radeon HD 4650]
 	949c  RV730 GL [FirePro V7750]
 	949e  RV730 GL [FirePro V5700]
@@ -3234,28 +1002,18 @@ var pciids = []byte(`#
 	94b3  RV740 PRO [Radeon HD 4770]
 	94b4  RV740 PRO [Radeon HD 4750]
 	94c1  RV610 [Radeon HD 2400 PRO/XT]
-		1028 0211  Optiplex 755
-		1028 0d02  Optiplex 755
 	94c3  RV610 [Radeon HD 2400 PRO]
-		1028 0302  Radeon HD 2400 Pro
-		174b e400  Radeon HD 2400 PRO
-		18bc 3550  Radeon HD 2400 PRO
 	94c4  RV610 LE [Radeon HD 2400 PRO AGP]
 	94c5  RV610 [Radeon HD 2400 LE]
 	94c7  RV610 [Radeon HD 2350]
 	94c8  RV610/M74 [Mobility Radeon HD 2400 XT]
 	94c9  RV610/M72-S [Mobility Radeon HD 2400]
-		1002 94c9  Radeon HD2400
 	94cb  RV610 [Radeon E2400]
 	94cc  RV610 LE [Radeon HD 2400 PRO PCI]
 	9500  RV670 [Radeon HD 3850 X2]
 	9501  RV670 [Radeon HD 3870]
-		174b e620  Radeon HD 3870
 	9504  RV670/M88 [Mobility Radeon HD 3850]
 	9505  RV670 [Radeon HD 3690/3850]
-		148c 3000  Radeon HD 3850
-		174b 3000  Radeon HD 3690/3850
-		1787 3000  Radeon HD 3690
 	9506  RV670/M88 [Mobility Radeon HD 3850 X2]
 	9507  RV670 [Radeon HD 3830]
 	9508  RV670/M88-XT [Mobility Radeon HD 3870]
@@ -3267,73 +1025,33 @@ var pciids = []byte(`#
 	9519  RV670 GL [FireStream 9170]
 	9540  RV710 [Radeon HD 4550]
 	954f  RV710 [Radeon HD 4350/4550]
-		1462 1618  R4350 MD512H (MS-V161)
 	9552  RV710/M92 [Mobility Radeon HD 4330/4350/4550]
-		1028 1103  M92 [Mobility Radeon HD 4330]
-# GV-R435OC-512I/FF1
-		1458 21ac  Radeon HD 4350
-# GV-R455HM-512I/F41
-		1458 21ed  Radeon HD 4550
-# 113-100928-J01
-		148c 3000  Radeon HD 4350 Go! Green 512MB GDDR3
-# 113-2E172001-003
-		174b 3000  Radeon HD 4350/4550 HyperMemory DDR2
 	9553  RV710/M92 [Mobility Radeon HD 4530/4570/545v]
-		1025 015e  Mobility Radeon HD 4570
-		1025 017d  Mobility Radeon HD 4570
-		1025 0205  Mobility Radeon HD 4570
-		1025 0206  Mobility Radeon HD 4570
-		1025 0237  Mobility Radeon HD 4570
-		1028 02be  Mobility Radeon HD 4570
-		1028 02e8  Mobility Radeon HD 4530
-		103c 3624  Mobility Radeon HD 4530
-		103c 3628  Mobility Radeon HD 4530
-		103c 3636  Mobility Radeon HD 4530
-		1043 1b32  Mobility Radeon HD 4570
-		1043 1b42  Mobility Radeon HD 4570
-		104d 9056  Mobility Radeon HD 4570
-		1179 ff82  Satellite L505-13T GPU (Mobility Radeon HD 5145)
 	9555  RV710/M92 [Mobility Radeon HD 4350/4550]
-		103c 1411  ProBook 4720s GPU (Mobility Radeon HD 4350)
 	9557  RV711 GL [FirePro RG220]
 	955f  RV710/M92 [Mobility Radeon HD 4330]
 	9580  RV630 [Radeon HD 2600 PRO]
 	9581  RV630/M76 [Mobility Radeon HD 2600]
 	9583  RV630/M76 [Mobility Radeon HD 2600 XT/2700]
-		106b 0083  iMac 7,1
-		1734 1107  Mobility Radeon HD 2700
 	9586  RV630 XT [Radeon HD 2600 XT AGP]
 	9587  RV630 PRO [Radeon HD 2600 PRO AGP]
 	9588  RV630 XT [Radeon HD 2600 XT]
-		1458 216c  Radeon HD 2600 XT, 256MB GDDR3, 2x DVI, TV-out, PCIe (GV-RX26T256H)
 	9589  RV630 PRO [Radeon HD 2600 PRO]
-# Rebranded HD 2600 PRO
-		1787 3000  Radeon HD 3610
 	958a  RV630 [Radeon HD 2600 X2]
 	958b  RV630/M76 [Mobility Radeon HD 2600 XT]
 	958c  RV630 GL [FireGL V5600]
 	958d  RV630 GL [FireGL V3600]
 	9591  RV635/M86 [Mobility Radeon HD 3650]
-		1002 9591  Mobility Radeon HD 3650
 	9593  RV635/M86 [Mobility Radeon HD 3670]
 	9595  RV635/M86 GL [Mobility FireGL V5700]
 	9596  RV635 PRO [Radeon HD 3650 AGP]
-		1043 0028  EAH3650 SILENT/HTDI/512M/A
 	9597  RV635 PRO [Radeon HD 3650 AGP]
 	9598  RV635 [Radeon HD 3650/3750/4570/4580]
-		1002 9598  Mobility Radeon HD 3600
-		1043 01d6  EAH3650 Silent
-		1043 3001  Radeon HD 4570
-		174b 3001  Radeon HD 3750
-		174b 4580  RV635 PRO [Radeon HD 4580]
 	9599  RV635 PRO [Radeon HD 3650 AGP]
 	95c0  RV620 PRO [Radeon HD 3470]
-		1002 95c0  Mobility Radeon HD 3470
 	95c2  RV620/M82 [Mobility Radeon HD 3410/3430]
 	95c4  RV620/M82 [Mobility Radeon HD 3450/3470]
-		1002 95c4  Mobility Radeon HD 3400
 	95c5  RV620 LE [Radeon HD 3450]
-		1028 0342  OptiPlex 980
 	95c6  RV620 LE [Radeon HD 3450 AGP]
 	95c9  RV620 LE [Radeon HD 3450 PCI]
 	95cc  RV620 GL [FirePro V3700]
@@ -3341,7 +1059,6 @@ var pciids = []byte(`#
 	95cf  RV620 GL [FirePro 2260]
 	960f  RS780 HDMI Audio [Radeon 3000/3100 / HD 3200/3300]
 	9610  RS780 [Radeon HD 3200]
-		1458 d000  GA-MA78GM-S2H Motherboard
 	9611  RS780C [Radeon 3100]
 	9612  RS780M [Mobility Radeon HD 3200]
 	9613  RS780MC [Mobility Radeon HD 3100]
@@ -3362,20 +1079,12 @@ var pciids = []byte(`#
 	964e  Sumo
 	964f  Sumo
 	970f  RS880 HDMI Audio [Radeon HD 4200 Series]
-		1019 2120  A785GM-M
-		1043 83a2  M4A785TD Motherboard
-		1043 843e  M5A88-V EVO
 	9710  RS880 [Radeon HD 4200]
-		1019 2120  A785GM-M
-		1043 83a2  M4A785TD Motherboard
 	9712  RS880M [Mobility Radeon HD 4225/4250]
 	9713  RS880M [Mobility Radeon HD 4100]
 	9714  RS880 [Radeon HD 4290]
 	9715  RS880 [Radeon HD 4250]
-		1043 843e  M5A88-V EVO
-# Radeon HD 6250 too?
 	9802  Wrestler [Radeon HD 6310]
-		174b 1001  PURE Fusion Mini
 	9803  Wrestler [Radeon HD 6310]
 	9804  Wrestler [Radeon HD 6250]
 	9805  Wrestler [Radeon HD 6250]
@@ -3398,7 +1107,6 @@ var pciids = []byte(`#
 	9840  Kabini HDMI/DP Audio
 	9850  Mullins [Radeon R3 Graphics]
 	9851  Mullins [Radeon R4/R5 Graphics]
-		1179 f928  Beema [Radeon R5 Graphics]
 	9852  Mullins [Radeon R2 Graphics]
 	9853  Mullins [Radeon R2 Graphics]
 	9854  Mullins [Radeon R3E Graphics]
@@ -3415,15 +1123,9 @@ var pciids = []byte(`#
 	985f  Mullins
 	9874  Carrizo
 	9900  Trinity [Radeon HD 7660G]
-		103c 1985  Pavilion 17-e163sg Notebook PC
-# AMD A10-5800K CPU
 	9901  Trinity [Radeon HD 7660D]
 	9902  Trinity HDMI Audio Controller
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1985  Pavilion 17-e163sg Notebook PC
 	9903  Trinity [Radeon HD 7640G]
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1952  ProBook 455 G1 Notebook
 	9904  Trinity [Radeon HD 7560D]
 	9905  Trinity [FirePro A300 Series Graphics]
 	9906  Trinity [FirePro A300 Series Graphics]
@@ -3456,7 +1158,6 @@ var pciids = []byte(`#
 	999a  Richland [Radeon HD 8410G]
 	999b  Richland [Radeon HD 8310G]
 	999c  Richland
-# AMD Quad-Core A8-Series APU A8-6500T with Radeon HD 8550D
 	999d  Richland [Radeon HD 8550D]
 	99a0  Trinity [Radeon HD 7520G]
 	99a2  Trinity [Radeon HD 7420G]
@@ -3465,36 +1166,24 @@ var pciids = []byte(`#
 	aa01  RV635 HDMI Audio [Radeon HD 3650/3730/3750]
 	aa08  RV630 HDMI Audio [Radeon HD 2600 PRO/XT / HD 3610]
 	aa10  RV610 HDMI Audio [Radeon HD 2350 PRO / 2400 PRO/XT / HD 3410]
-		174b aa10  Radeon HD 2400 PRO
-		18bc aa10  Radeon HD 2400 PRO
 	aa18  RV670/680 HDMI Audio [Radeon HD 3690/3800 Series]
 	aa20  RV635 HDMI Audio [Radeon HD 3650/3730/3750]
 	aa28  RV620 HDMI Audio [Radeon HD 3450/3470/3550/3570]
 	aa30  RV770 HDMI Audio [Radeon HD 4850/4870]
-		174b aa30  Radeon HD 4850 512MB GDDR3 PCI-E Dual Slot Fansink
 	aa38  RV710/730 HDMI Audio [Radeon HD 4000 series]
-		103c 3628  dv6-1190en
 	aa50  Cypress HDMI Audio [Radeon HD 5830/5850/5870 / 6850/6870 Rebrand]
 	aa58  Juniper HDMI Audio [Radeon HD 5700 Series]
-# 5500, 5600 and mobile 5700 series
 	aa60  Redwood HDMI Audio [Radeon HD 5000 Series]
-		1025 033d  Mobility Radeon HD 5650
-		1025 0347  Aspire 7740G
 	aa68  Cedar HDMI Audio [Radeon HD 5400/6300/7300 Series]
-		1028 aa68  XPS 8300
 	aa80  Cayman/Antilles HDMI Audio [Radeon HD 6930/6950/6970/6990]
 	aa88  Barts HDMI Audio [Radeon HD 6790/6850/6870 / 7720 OEM]
 	aa90  Turks HDMI Audio [Radeon HD 6500/6600 / 6700M Series]
-		1028 04a3  Precision M4600
 	aa98  Caicos HDMI Audio [Radeon HD 6450 / 7450/8450/8490 OEM / R5 230/235/235X OEM]
-		174b aa98  Radeon HD 6450 1GB DDR3
 	aaa0  Tahiti HDMI Audio [Radeon HD 7870 XT / 7950/7970]
 	aab0  Cape Verde/Pitcairn HDMI Audio [Radeon HD 7700/7800 Series]
 	aac0  Tobago HDMI Audio [Radeon R7 360 / R9 360 OEM]
 	aac8  Hawaii HDMI Audio [Radeon R9 290/290X / 390/390X]
-# I have a Tonga card and this is the HDMI Audio part
 	aad8  Tonga HDMI Audio [Radeon R9 285/380]
-		174b aad8  Radeon R9 285/380 HDMI Audio
 	aae8  Fiji HDMI/DP Audio [Radeon R9 Nano / FURY/FURY X]
 	aaf0  Ellesmere [Radeon RX 580]
 	ac00  Theater 600 Pro
@@ -3522,21 +1211,9 @@ var pciids = []byte(`#
 	0200  82C975
 	0280  82C925
 	0304  QSound ThunderBird PCI Audio
-		1004 0304  QSound ThunderBird PCI Audio
-		122d 1206  DSP368 Audio
-		1483 5020  XWave Thunder 3D Audio
 	0305  QSound ThunderBird PCI Audio Gameport
-		1004 0305  QSound ThunderBird PCI Audio Gameport
-		122d 1207  DSP368 Audio Gameport
-		1483 5021  XWave Thunder 3D Audio Gameport
 	0306  QSound ThunderBird PCI Audio Support Registers
-		1004 0306  QSound ThunderBird PCI Audio Support Registers
-		122d 1208  DSP368 Audio Support Registers
-		1483 5022  XWave Thunder 3D Audio Support Registers
 	0307  SAA7785 ThunderBird PCI Audio
-		1004 0703  Philips Rhythmic Edge PSC703
-		1004 0705  Philips Seismic Edge PSC705
-		1004 0706  Philips Acoustic Edge PSC706
 	0308  SAA7785 ThunderBird PCI Audio Gameport
 	0702  VAS96011 [Golden Gate II]
 	0703  Tollgate
@@ -3560,15 +1237,8 @@ var pciids = []byte(`#
 	0011  NS87560 National PCI System I/O
 	0012  USB Controller
 	0020  DP83815 (MacPhyter) Ethernet Controller
-		103c 0024  Pavilion ze4400 builtin Network
-		12d9 000c  Aculab E1/T1 PMXc cPCI carrier card
-		1385 f311  FA311 / FA312 (FA311 with WoL HW)
-		1385 f312  FA312 (rev. A1) Fast Ethernet PCI Adapter
 	0021  PC87200 PCI to ISA Bridge
 	0022  DP83820 10/100/1000 Ethernet Controller
-		1186 4900  DGE-500T
-		1385 621a  GA621
-		1385 622a  GA622T
 	0028  Geode GX2 Host Bridge
 	002a  CS5535 South Bridge
 	002b  CS5535 ISA bridge
@@ -3580,17 +1250,12 @@ var pciids = []byte(`#
 	0500  SCx200 Bridge
 	0501  SCx200 SMI
 	0502  SCx200, SC1100 IDE controller
-		100b 0502  IDE Controller
 	0503  SCx200, SC1100 Audio Controller
-		100b 0503  XpressAudio controller
 	0504  SCx200 Video
 	0505  SCx200 XBus
 	0510  SC1100 Bridge
-		100b 0500  GPIO and LPC support bridge
 	0511  SC1100 SMI & ACPI
-		100b 0501  SC1100 SMI & ACPI bridge
 	0515  SC1100 XBus
-		100b 0505  SC1100 PCI to XBus bridge
 	d001  87410 IDE
 100c  Tseng Labs Inc
 	3202  ET4000/W32p rev A
@@ -3613,77 +1278,14 @@ var pciids = []byte(`#
 	0007  NVRAM [Zephyr NVRAM]
 	0008  KZPSA [KZPSA]
 	0009  DECchip 21140 [FasterNet]
-		1025 0310  21140 Fast Ethernet
-		10b8 2001  SMC9332BDT EtherPower 10/100
-		10b8 2002  SMC9332BVT EtherPower T4 10/100
-		10b8 2003  SMC9334BDT EtherPower 10/100 (1-port)
-		1109 2400  ANA-6944A/TX Fast Ethernet
-		1112 2300  RNS2300 Fast Ethernet
-		1112 2320  RNS2320 Fast Ethernet
-		1112 2340  RNS2340 Fast Ethernet
-		1113 1207  EN-1207-TX Fast Ethernet
-		1186 1100  DFE-500TX Fast Ethernet
-		1186 1112  DFE-570TX Fast Ethernet
-		1186 1140  DFE-660 Cardbus Ethernet 10/100
-		1186 1142  DFE-660 Cardbus Ethernet 10/100
-		11f6 0503  Freedomline Fast Ethernet
-		1282 9100  AEF-380TXD Fast Ethernet
-		1385 1100  FA310TX Fast Ethernet
-		2646 0001  KNE100TX Fast Ethernet
 	000a  21230 Video Codec
 	000d  PBXGB [TGA2]
 	000f  DEFPA FDDI PCI-to-PDQ Interface Chip [PFI]
-		1011 def1  FDDI controller (DEFPA)
-		103c def1  FDDI controller (3X-DEFPA)
 	0014  DECchip 21041 [Tulip Pass 3]
-		1186 0100  DE-530+
 	0016  DGLPB [OPPO]
 	0017  PV-PCI Graphics Controller (ZLXp-L)
 	0018  Memory Channel interface
 	0019  DECchip 21142/43
-		1011 500a  DE500A Fast Ethernet
-		1011 500b  DE500B Fast Ethernet
-		1014 0001  10/100 EtherJet Cardbus
-		1025 0315  ALN315 Fast Ethernet
-		1033 800c  PC-9821-CS01 100BASE-TX Interface Card
-		1033 800d  PC-9821NR-B06 100BASE-TX Interface Card
-		103c 125a  10/100Base-TX (PCI) [A5506B]
-		108d 0016  Rapidfire 2327 10/100 Ethernet
-		108d 0017  GoCard 2250 Ethernet 10/100 Cardbus
-		10b8 2005  SMC8032DT Extreme Ethernet 10/100
-		10b8 8034  SMC8034 Extreme Ethernet 10/100
-		10ef 8169  Cardbus Fast Ethernet
-		1109 2a00  ANA-6911A/TX Fast Ethernet
-		1109 2b00  ANA-6911A/TXC Fast Ethernet
-		1109 3000  ANA-6922/TX Fast Ethernet
-		1113 1207  Cheetah Fast Ethernet
-		1113 2220  Cardbus Fast Ethernet
-		115d 0002  Cardbus Ethernet 10/100
-		1179 0203  Fast Ethernet
-		1179 0204  Cardbus Fast Ethernet
-		1186 1100  DFE-500TX Fast Ethernet
-		1186 1101  DFE-500TX Fast Ethernet
-		1186 1102  DFE-500TX Fast Ethernet
-		1186 1112  DFE-570TX Quad Fast Ethernet
-		11f0 4235  21143 [FASTLine-II UTP 10/100]
-		1259 2800  AT-2800Tx Fast Ethernet
-		1266 0004  Eagle Fast EtherMAX
-		12af 0019  NetFlyer Cardbus Fast Ethernet
-		1374 0001  Cardbus Ethernet Card 10/100
-		1374 0002  Cardbus Ethernet Card 10/100
-		1374 0007  Cardbus Ethernet Card 10/100
-		1374 0008  Cardbus Ethernet Card 10/100
-		1385 2100  FA510
-		1395 0001  10/100 Ethernet CardBus PC Card
-		13d1 ab01  EtherFast 10/100 Cardbus (PCMPC200)
-		1498 000a  TPMC880-10 10/100Base-T and 10Base2 PMC Ethernet Adapter
-		1498 000b  TPMC880-11 Single 10/100Base-T PMC Ethernet Adapter
-		1498 000c  TPMC880-12 Single 10Base2 PMC Ethernet Adapter
-		14cb 0100  LNDL-100N 100Base-TX Ethernet PC Card
-		1668 2000  FastNet Pro (PE2000)
-		2646 0001  KNE100TX
-		2646 0002  KNE-CB4TX
-		8086 0001  EtherExpress PRO/100 Mobile CardBus 32
 	001a  Farallon PN9000SX Gigabit Ethernet
 	0021  DECchip 21052
 	0022  DECchip 21150
@@ -3692,23 +1294,9 @@ var pciids = []byte(`#
 	0025  DECchip 21153
 	0026  DECchip 21154
 	0034  56k Modem Cardbus
-		1374 0003  56k Modem Cardbus
 	0045  DECchip 21553
 	0046  DECchip 21554
-		0e11 4050  Smart Array 4200 Controller
-		0e11 4051  Smart Array 4250ES Controller
-		0e11 4058  Smart Array 431 Controller
-		103c 10c2  NetRAID-4M
-		12d9 000a  IP Telephony card
-		4c53 1050  CT7 mainboard
-		4c53 1051  CE7 mainboard
-		9005 0364  5400S (Mustang)
-		9005 0365  5400S (Mustang)
-		9005 1364  Dell PowerEdge RAID Controller 2
-		9005 1365  Dell PowerEdge RAID Controller 2
-		e4bf 1000  CC8-1-BLUES
 	1065  StrongARM DC21285
-		1069 0020  DAC960P / DAC1164P
 1012  Micronics Computers Inc
 1013  Cirrus Logic
 	0038  GD 7548
@@ -3721,16 +1309,12 @@ var pciids = []byte(`#
 	00ac  GD 5436 [Alpine]
 	00b0  GD 5440
 	00b8  GD 5446
-		1af4 1100  QEMU Virtual Machine
 	00bc  GD 5480
-		1013 00bc  CL-GD5480
 	00d0  GD 5462
 	00d2  GD 5462 [Laguna I]
 	00d4  GD 5464 [Laguna]
 	00d5  GD 5464 BD [Laguna]
 	00d6  GD 5465 [Laguna]
-		13ce 8031  Barco Metheus 2 Megapixel, Dual Head
-		13cf 8031  Barco Metheus 2 Megapixel, Dual Head
 	00e8  GD 5436U
 	1100  CL 6729
 	1110  PD 6832 PCMCIA/CardBus Ctrlr
@@ -3742,28 +1326,9 @@ var pciids = []byte(`#
 	4000  MD 5620 [CLM Data Fax Voice]
 	4400  CD 4400
 	6001  CS 4610/11 [CrystalClear SoundFusion Audio Accelerator]
-		1014 1010  CS4610 SoundFusion Audio Accelerator
 	6003  CS 4614/22/24/30 [CrystalClear SoundFusion Audio Accelerator]
-		1013 4280  Crystal SoundFusion PCI Audio Accelerator
-		1014 0153  ThinkPad 600X/A20m
-		153b 112e  DMX XFire 1024
-		153b 1136  SiXPack 5.1+
-		1681 0050  Game Theater XP
-		1681 a010  Gamesurround Fortissimo II
-		1681 a011  Gamesurround Fortissimo III 7.1
-		5053 3357  Santa Cruz
 	6004  CS 4614/22/24 [CrystalClear SoundFusion Audio Accelerator]
 	6005  Crystal CS4281 PCI Audio
-		1013 4281  Crystal CS4281 PCI Audio
-		10cf 10a8  Crystal CS4281 PCI Audio
-		10cf 10a9  Crystal CS4281 PCI Audio
-		10cf 10aa  Crystal CS4281 PCI Audio
-		10cf 10ab  Crystal CS4281 PCI Audio
-		10cf 10ac  Crystal CS4281 PCI Audio
-		10cf 10ad  Crystal CS4281 PCI Audio
-		10cf 10b4  Crystal CS4281 PCI Audio
-		1179 0001  Crystal CS4281 PCI Audio
-		14c0 000c  Crystal CS4281 PCI Audio
 1014  IBM
 	0002  PCI to MCA Bridge
 	0005  Processor to I/O Controller [Alta Lite]
@@ -3778,23 +1343,12 @@ var pciids = []byte(`#
 	0022  PCI to PCI Bridge (IBM27-82351)
 	002d  Processor to I/O Controller [Python]
 	002e  SCSI RAID Adapter [ServeRAID]
-		1014 002e  ServeRAID-3x
-		1014 022e  ServeRAID-4H
 	0031  2 Port Serial Adapter
-# AS400 iSeries PCI sync serial card
-		1014 0031  2721 WAN IOA - 2 Port Sync Serial Adapter
 	0036  PCI to 32-bit LocalBus Bridge [Miami]
 	0037  PowerPC to PCI Bridge (IBM27-82660)
 	003a  CPU to PCI Bridge
 	003c  GXT250P/GXT255P Graphics Adapter
 	003e  16/4 Token ring UTP/STP controller
-		1014 003e  Token-Ring Adapter
-		1014 00cd  Token-Ring Adapter + Wake-On-LAN
-		1014 00ce  16/4 Token-Ring Adapter 2
-		1014 00cf  16/4 Token-Ring Adapter Special
-		1014 00e4  High-Speed 100/16/4 Token-Ring Adapter
-		1014 00e5  16/4 Token-Ring Adapter 2 + Wake-On-LAN
-		1014 016d  iSeries 2744 Card
 	0045  SSA Adapter
 	0046  MPIC interrupt controller
 	0047  PCI to PCI Bridge
@@ -3813,18 +1367,13 @@ var pciids = []byte(`#
 	008b  EADS PCI to PCI Bridge
 	008e  GXT3000P Graphics Adapter
 	0090  GXT 3000P
-		1014 008e  GXT-3000P
 	0091  SSA Adapter
 	0095  20H2999 PCI Docking Bridge
 	0096  Chukar chipset SCSI controller
-		1014 0097  iSeries 2778 DASD IOA
-		1014 0098  iSeries 2763 DASD IOA
-		1014 0099  iSeries 2748 DASD IOA
 	009f  PCI 4758 Cryptographic Accelerator
 	00a5  ATM Controller (1410a500)
 	00a6  ATM 155MBPS MM Controller (1410a600)
 	00b7  GXT2000P Graphics Adapter
-		1092 00b8  FireGL1 AGP 32Mb
 	00b8  GXT2000P Graphics Adapter
 	00be  ATM 622MBPS Controller (1410be00)
 	00dc  Advanced Systems Management Adapter (ASMA)
@@ -3832,95 +1381,40 @@ var pciids = []byte(`#
 	0105  CPC710 Dual Bridge and Memory Controller (PCI-32)
 	010f  Remote Supervisor Adapter (RSA)
 	0142  Yotta Video Compositor Input
-		1014 0143  Yotta Input Controller (ytin)
 	0144  Yotta Video Compositor Output
-		1014 0145  Yotta Output Controller (ytout)
 	0156  405GP PLB to PCI Bridge
 	015e  622Mbps ATM PCI Adapter
 	0160  64bit/66MHz PCI ATM 155 MMF
 	016e  GXT4000P Graphics Adapter
 	0170  GXT6000P Graphics Adapter
-		1092 0172  Fire GL2
-		1092 0173  Fire GL3
-		1092 0174  Fire GL4
-		1092 0184  Fire GL4s
 	017d  GXT300P Graphics Adapter
 	0180  Snipe chipset SCSI controller
-		1014 0241  iSeries 2757 DASD IOA
-		1014 0264  Quad Channel PCI-X U320 SCSI RAID Adapter (2780)
 	0188  EADS-X PCI-X to PCI-X Bridge
 	01a7  PCI-X to PCI-X Bridge
 	01bd  ServeRAID Controller
-		1014 01bd  ServeRAID 4Lx
-		1014 01be  ServeRAID-4M
-		1014 01bf  ServeRAID-4L
-		1014 0208  ServeRAID-4Mx
-		1014 020e  ServeRAID-4Lx
-		1014 022e  ServeRAID-4H
-		1014 0258  ServeRAID-5i
-		1014 0259  ServeRAID-5i
 	01c1  64bit/66MHz PCI ATM 155 UTP
 	01e6  Cryptographic Accelerator
 	01ef  PowerPC 440GP PCI Bridge
-		1734 102b  PCEAS PCI-X Dual Port ESCON Adapter
-		1734 10f8  PCEAT PCI-Express Dual Port ESCON Adapter
 	01ff  10/100 Mbps Ethernet
 	0219  Multiport Serial Adapter
-		1014 021a  Dual RVX
-		1014 0251  Internal Modem/RVX
-		1014 0252  Quad Internal Modem
 	021b  GXT6500P Graphics Adapter
 	021c  GXT4500P Graphics Adapter
 	0233  GXT135P Graphics Adapter
 	028c  Citrine chipset SCSI controller
-		1014 028d  Dual Channel PCI-X DDR SAS RAID Adapter (572E)
-		1014 02be  Dual Channel PCI-X DDR U320 SCSI RAID Adapter (571B)
-		1014 02c0  Dual Channel PCI-X DDR U320 SCSI Adapter (571A)
-		1014 030d  PCI-X DDR Auxiliary Cache Adapter (575B)
 	02a1  Calgary PCI-X Host Bridge
 	02bd  Obsidian chipset SCSI controller
-		1014 02c1  PCI-X DDR 3Gb SAS Adapter (572A/572C)
-		1014 02c2  PCI-X DDR 3Gb SAS RAID Adapter (572B/571D)
-		1014 0338  PCI-X DDR Auxiliary Cache Adapter (575C)
 	0302  Winnipeg PCI-X Host Bridge
 	0308  CalIOC2 PCI-E Root Port
 	0311  FC 5740/1954 4-Port 10/100/1000 Base-TX PCI-X Adapter for POWER
 	0314  ZISC 036 Neural accelerator card
 	032d  Axon - Cell Companion Chip
-		1014 03a1  PCIe PowerXCell 8i Cell Accelerator Board
 	0339  Obsidian-E PCI-E SCSI controller
-		1014 030a  PCIe 3Gb SAS RAID Adapter (574E)
-		1014 033a  PCIe 3Gb SAS Adapter (57B3)
-		1014 035c  PCIe x8 Internal 3Gb SAS adapter (57CC)
-		1014 0360  PCI-E Auxiliary Cache Adapter (57B7)
 	033d  PCI-E IPR SAS Adapter (FPGA)
-		1014 033c  PCIe2 1.8GB Cache 6Gb SAS RAID Adapter Tri-port (57B5)
-		1014 0353  PCIe2 3.1GB Cache 6Gb SAS RAID Enclosure (57C3)
-		1014 0354  PCIe2 6Gb SAS Adapter Dual-port (57C4)
-		1014 0356  PCIe2 1.8GB Cache 6Gb SAS RAID & SSD Adapter (574D)
-		1014 035f  PCIe2 6Gb SAS Adapter Quad-port (57B2)
 	034a  PCI-E IPR SAS Adapter (ASIC)
-		1014 033b  PCIe2 6Gb SAS RAID Adapter Quad-port (57B4)
-		1014 0355  PCIe2 3.6GB Cache 6Gb SAS RAID Adapter Quad-port (57B1)
-		1014 0357  PCIe2 6Gb SAS Adapter Quad-port (57C6)
-		1014 035d  PCIe3 1.8GB Cache RAID SAS Adapter Quad-port 6GB (57C8)
-		1014 035e  PCIe2 3.6GB Cache 6Gb SAS RAID Adapter Quad-port (57CE)
-		1014 03fb  PCIe3 28GB Cache RAID SAS Enclosure 6Gb x 16 (57D5)
-		1014 03fe  PCIe3 x8 Cache SAS RAID Internal Adapter 6Gb (57D8)
-		1014 03ff  PCIe3 x8 SAS RAID Internal Adapter 6Gb (57D7)
-		1014 0474  PCIe3 x16 Cache SAS RAID Internal Adapter 6Gb (57EB)
-		1014 0475  PCIe3 x16 SAS RAID Internal Adapter 6Gb (57EC)
-		1014 0499  PCIe3 x16 Cache SAS RAID Internal Adapter 6Gb (57ED)
-		1014 049a  PCIe3 x16 SAS RAID Internal Adapter 6Gb (57EE)
-		1014 04c7  PCIe3 x 8 Cache SAS RAID Internal Adapter 6GB(2CCA)
-		1014 04c8  PCIe3 x 8 Cache SAS RAID Internal Adapter 6GB(2CD2)
-		1014 04c9  PCIe3 x 8 Cache SAS RAID Internal Adapter 6GB(2CCD)
 	03dc  POWER8 Host Bridge (PHB3)
 	044b  GenWQE Accelerator Adapter
 	04aa  Flash Adapter 90 (PCIe2 0.9TB)
 	04da  PCI-E IPR SAS+ Adapter (ASIC)
-		1014 04fb  PCIe3 x16 20GB Cache 12Gb Quad SAS RAID+ Adapter(580B)
-		1014 04fc  PCIe3 x8 12Gb Quad SAS RAID+ Adapter(580A)
 	04ed  Internal Shared Memory (ISM) virtual PCI device
 	3022  QLA3022 Network Adapter
 	4022  QLA3022 Network Adapter
@@ -3934,22 +1428,14 @@ var pciids = []byte(`#
 101a  AT&T GIS (NCR)
 	0005  100VG ethernet
 	0007  BYNET BIC4G/2C/2G
-		101a 0019  BYNET BIC2C
-		101a 001c  BYNET BIC2G
-		101a 001f  BYNET BIC4G
 	0009  PQS Memory Controller
 	000a  BYNET BPCI Adapter
 	000b  BYNET 4 Port BYA Switch (BYA4P)
 	000c  BYNET 4 Port BYA Switch (BYA4G)
 	0010  NCR AMC Memory Controller
 	1dc1  BYNET BIC2M/BIC4M/BYA4M
-		101a 0019  BIC2M
-		101a 001f  BIC4M
-		101a 0ece  BYA4M
 	1fa8  BYNET Multi-port BIC Adapter (XBIC Based)
-		101a 00c3  BYNET BIC2SE
 101b  Vitesse Semiconductor
-# Maxim VSC452 Super BMC Controller with Video
 	0452  VSC452 [SuperBMC]
 101c  Western Digital
 	0193  33C193A
@@ -3963,25 +1449,10 @@ var pciids = []byte(`#
 	9710  Pipeline 9710
 	9712  Pipeline 9712
 	c24a  90C
-# ID for Newly Acquired Storage Products from Vitesse
 101d  Maxim Integrated Products
 101e  American Megatrends Inc.
 	0009  MegaRAID 428 Ultra RAID Controller (rev 03)
 	1960  MegaRAID
-		101e 0471  MegaRAID 471 Enterprise 1600 RAID Controller
-		101e 0475  MegaRAID 475 Express 500/500LC RAID Controller
-		101e 0477  MegaRAID 477 Elite 3100 RAID Controller
-		101e 0493  MegaRAID 493 Elite 1600 RAID Controller
-		101e 0494  MegaRAID 494 Elite 1650 RAID Controller
-		101e 0503  MegaRAID 503 Enterprise 1650 RAID Controller
-		101e 0511  MegaRAID 511 i4 IDE RAID Controller
-		101e 0522  MegaRAID 522 i4133 RAID Controller
-		1028 0471  PowerEdge RAID Controller 3/QC
-		1028 0475  PowerEdge RAID Controller 3/SC
-		1028 0493  PowerEdge RAID Controller 3/DC
-		1028 0511  PowerEdge Cost Effective RAID Controller ATA100/4Ch
-		103c 60e7  NetRAID-1M
-		103c 60e8  NetRaid 2M [AMI MegaRaid 493]
 	9010  MegaRAID 428 Ultra RAID Controller
 	9030  EIDE Controller
 	9031  EIDE Controller
@@ -3990,7 +1461,6 @@ var pciids = []byte(`#
 	9040  Multimedia card
 	9060  MegaRAID 434 Ultra GT RAID Controller
 	9063  MegaRAC
-		101e 0767  Dell Remote Assistant Card 2
 101f  PictureTel
 1020  Hitachi Computer Products
 1021  OKI Electric Industry Co. Ltd.
@@ -4016,12 +1486,9 @@ var pciids = []byte(`#
 	1404  Family 15h (Models 10h-1fh) Processor Function 4
 	1405  Family 15h (Models 10h-1fh) Processor Function 5
 	1410  Family 15h (Models 10h-1fh) Processor Root Complex
-		103c 1985  Pavilion 17-e163sg Notebook PC
 	1412  Family 15h (Models 10h-1fh) Processor Root Port
-		1022 1234  Trinity A-series APU
 	1413  Family 15h (Models 10h-1fh) Processor Root Port
 	1414  Family 15h (Models 10h-1fh) Processor Root Port
-		1022 1234  Trinity A-series APU
 	1415  Family 15h (Models 10h-1fh) Processor Root Port
 	1416  Family 15h (Models 10h-1fh) Processor Root Port
 	1417  Family 15h (Models 10h-1fh) Processor Root Port
@@ -4041,10 +1508,13 @@ var pciids = []byte(`#
 	1438  Liverpool Processor Root Port
 	1439  Family 16h Processor Functions 5:1
 	1450  Family 17h (Models 00h-0fh) Root Complex
+	1451  Family 17h (Models 00h-0fh) I/O Memory Management Unit
 	1452  Family 17h (Models 00h-0fh) PCIe Dummy Host Bridge
 	1454  Family 17h (Models 00h-0fh) Internal PCIe GPP Bridge 0 to Bus B
+	1456  Family 17h (Models 00h-0fh) Platform Security Processor
+	1457  Family 17h (Models 00h-0fh) HD Audio Controller
 	145b  Zeppelin Non-Transparent Bridge
-	145c  USB3 Host Controller
+	145c  Family 17h (Models 00h-0fh) USB 3.0 Host Controller
 	145f  USB 3.0 Host controller
 	1460  Family 17h (Models 00h-0fh) Data Fabric: Device 18h; Function 0
 	1461  Family 17h (Models 00h-0fh) Data Fabric: Device 18h; Function 1
@@ -4055,7 +1525,6 @@ var pciids = []byte(`#
 	1466  Family 17h (Models 00h-0fh) Data Fabric Device 18h Function 6
 	1467  Family 17h (Models 00h-0fh) Data Fabric: Device 18h; Function 7
 	1510  Family 14h Processor Root Complex
-		174b 1001  PURE Fusion Mini
 	1512  Family 14h Processor Root Port
 	1513  Family 14h Processor Root Port
 	1514  Family 14h Processor Root Port
@@ -4092,34 +1561,9 @@ var pciids = []byte(`#
 	1718  Family 12h/14h Processor Function 6
 	1719  Family 12h/14h Processor Function 7
 	2000  79c970 [PCnet32 LANCE]
-		1014 2000  NetFinity 10/100 Fast Ethernet
-		1022 2000  PCnet - Fast 79C971
-		103c 104c  Ethernet with LAN remote power Adapter
-		103c 1064  Ethernet with LAN remote power Adapter
-		103c 1065  Ethernet with LAN remote power Adapter
-		103c 106c  Ethernet with LAN remote power Adapter
-		103c 106e  Ethernet with LAN remote power Adapter
-		103c 10ea  Ethernet with LAN remote power Adapter
-		1113 1220  EN1220 10/100 Fast Ethernet
-		1259 2450  AT-2450 10/100 Fast Ethernet
-		1259 2454  AT-2450v4 10Mb Ethernet Adapter
-		1259 2700  AT-2700TX 10/100 Fast Ethernet
-		1259 2701  AT-2700FX 100Mb Ethernet
-		1259 2702  AT-2700FTX 10/100 Mb Fiber/Copper Fast Ethernet
-		1259 2703  AT-2701FX
-		1259 2704  AT-2701FTX 10/100 Mb Fiber/Copper Fast Ethernet
-		4c53 1000  CC7/CR7/CP7/VC7/VP7/VR7 mainboard
-		4c53 1010  CP5/CR6 mainboard
-		4c53 1020  VR6 mainboard
-		4c53 1030  PC5 mainboard
-		4c53 1040  CL7 mainboard
-		4c53 1060  PC7 mainboard
 	2001  79c978 [HomePNA]
-		1092 0a78  Multimedia Home Network Adapter
-		1668 0299  ActionLink Home Network Adapter
 	2003  Am 1771 MBW [Alchemy]
 	2020  53c974 [PCscsi]
-		1af4 1100  QEMU Virtual Machine
 	2040  79c974
 	2080  CS5536 [Geode companion] Host Bridge
 	2081  Geode LX Video
@@ -4138,7 +1582,9 @@ var pciids = []byte(`#
 	43a1  Hudson PCI to PCI bridge (PCIE port 1)
 	43a2  Hudson PCI to PCI bridge (PCIE port 2)
 	43a3  Hudson PCI to PCI bridge (PCIE port 3)
-	43bb  USB 3.1 XHCI Controller
+	43b4  300 Series Chipset PCIe Port
+	43b7  300 Series Chipset SATA Controller
+	43bb  300 Series Chipset USB 3.1 xHCI Controller
 	7006  AMD-751 [Irongate] System Controller
 	7007  AMD-751 [Irongate] AGP Bridge
 	700a  AMD-IGR4 AGP Host to PCI Bridge
@@ -4160,10 +1606,8 @@ var pciids = []byte(`#
 	7413  AMD-766 [ViperPlus] ACPI
 	7414  AMD-766 [ViperPlus] USB
 	7440  AMD-768 [Opus] ISA
-		1043 8044  A7M-D Mainboard
 	7441  AMD-768 [Opus] IDE
 	7443  AMD-768 [Opus] ACPI
-		1043 8044  A7M-D Mainboard
 	7445  AMD-768 [Opus] Audio
 	7446  AMD-768 [Opus] MC97 Modem
 	7448  AMD-768 [Opus] PCI
@@ -4175,59 +1619,35 @@ var pciids = []byte(`#
 	7458  AMD-8132 PCI-X Bridge
 	7459  AMD-8132 PCI-X IOAPIC
 	7460  AMD-8111 PCI
-		161f 3017  HDAMB
 	7461  AMD-8111 USB
 	7462  AMD-8111 Ethernet
 	7463  AMD-8111 USB EHCI
 	7464  AMD-8111 USB OHCI
-		161f 3017  HDAMB
 	7468  AMD-8111 LPC
-		161f 3017  HDAMB
 	7469  AMD-8111 IDE
-		1022 2b80  AMD-8111 IDE [Quartet]
-		161f 3017  HDAMB
 	746a  AMD-8111 SMBus 2.0
 	746b  AMD-8111 ACPI
-		161f 3017  HDAMB
 	746d  AMD-8111 AC97 Audio
-		161f 3017  HDAMB
 	746e  AMD-8111 MC97 Modem
 	756b  AMD-8111 ACPI
 	7800  FCH SATA Controller [IDE mode]
 	7801  FCH SATA Controller [AHCI mode]
-		103c 168b  ProBook 4535s Notebook
-		103c 194e  ProBook 455 G1 Notebook
 	7802  FCH SATA Controller [RAID mode]
 	7803  FCH SATA Controller [RAID mode]
 	7804  FCH SATA Controller [AHCI mode]
-		103c 1985  Pavilion 17-e163sg Notebook PC
 	7805  FCH SATA Controller [RAID mode]
 	7806  FCH SD Flash Controller
 	7807  FCH USB OHCI Controller
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1985  Pavilion 17-e163sg Notebook PC
 	7808  FCH USB EHCI Controller
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1985  Pavilion 17-e163sg Notebook PC
 	7809  FCH USB OHCI Controller
-		103c 194e  ProBook 455 G1 Notebook
 	780b  FCH SMBus Controller
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1985  Pavilion 17-e163sg Notebook PC
 	780c  FCH IDE Controller
 	780d  FCH Azalia Controller
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1985  Pavilion 17-e163sg Notebook PC
-		1043 8444  F2A85-M Series
 	780e  FCH LPC Bridge
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1985  Pavilion 17-e163sg Notebook PC
 	780f  FCH PCI Bridge
 	7812  FCH USB XHCI Controller
 	7813  FCH SD Flash Controller
 	7814  FCH USB XHCI Controller
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1985  Pavilion 17-e163sg Notebook PC
 	7900  FCH SATA Controller [IDE mode]
 	7901  FCH SATA Controller [AHCI mode]
 	7902  FCH SATA Controller [RAID mode]
@@ -4240,11 +1660,7 @@ var pciids = []byte(`#
 	790f  FCH PCI Bridge
 	7914  FCH USB XHCI Controller
 	9600  RS780 Host Bridge
-		1043 82ee  M378A-CM Motherboard
-		1043 82f1  M3A78-EH Motherboard
 	9601  RS880 Host Bridge
-		1019 2120  A785GM-M
-		1043 843e  M5A88-V EVO
 	9602  RS780/RS880 PCI to PCI bridge (int gfx)
 	9603  RS780 PCI to PCI bridge (ext gfx port 0)
 	9604  RS780/RS880 PCI to PCI bridge (PCIE port 0)
@@ -4259,20 +1675,13 @@ var pciids = []byte(`#
 	0194  82C194
 	2000  4DWave DX
 	2001  4DWave NX
-		122d 1400  Trident PCI288-Q3DII (NX)
 	2100  CyberBlade XP4m32
 	2200  XGI Volari XP5
 	8400  CyberBlade/i7
-		1023 8400  CyberBlade i7 AGP
 	8420  CyberBlade/i7d
-		0e11 b15a  CyberBlade i7 AGP
 	8500  CyberBlade/i1
 	8520  CyberBlade i1
-		0e11 b16e  CyberBlade i1 AGP
-		1023 8520  CyberBlade i1 AGP
 	8620  CyberBlade/i1
-		1014 0502  ThinkPad R30/T30
-		1014 1025  Travelmate 352TE
 	8820  CyberBlade XPAi1
 	9320  TGUI 9320
 	9350  GUI Accelerator
@@ -4298,8 +1707,6 @@ var pciids = []byte(`#
 	9683  TGUI 9683
 	9685  ProVIDIA 9685
 	9750  3DImage 9750
-		1014 9750  3DImage 9750
-		1023 9750  3DImage 9750
 	9753  TGUI 9753
 	9754  TGUI 9754
 	9759  TGUI 975
@@ -4307,7 +1714,6 @@ var pciids = []byte(`#
 	9785  TGUI 9785
 	9850  3DImage 9850
 	9880  Blade 3D PCI/AGP
-		1023 9880  Blade 3D
 	9910  CyberBlade/XP
 	9930  CyberBlade/XPm
 	9960  CyberBlade XP2
@@ -4323,15 +1729,11 @@ var pciids = []byte(`#
 	1512  ALI M1512 Aladdin
 	1513  M1513
 	1521  ALI M1521 Aladdin III CPU Bridge
-		10b9 1521  ALI M1521 Aladdin III CPU Bridge
 	1523  ALI M1523 ISA Bridge
-		10b9 1523  ALI M1523 ISA Bridge
 	1531  M1531 Northbridge [Aladdin IV/IV+]
 	1533  M1533 PCI-to-ISA Bridge
-		10b9 1533  ALI M1533 Aladdin IV/V ISA South Bridge
 	1535  M1535 PCI Bridge + Super I/O + FIR
 	1541  M1541 Northbridge [Aladdin V]
-		10b9 1541  ALI M1541 Aladdin V/V+ AGP+PCI North Bridge
 	1542  M1542 Northbridge [Aladdin V]
 	1543  M1543 PCI-to-ISA Bridge + Super I/O + FIR
 	1561  M1561 Northbridge [Aladdin 7]
@@ -4369,319 +1771,67 @@ var pciids = []byte(`#
 	5451  M5451 PCI AC-Link Controller Audio Device
 	5453  M5453 PCI AC-Link Controller Modem Device
 	7101  M7101 PCI PMU Power Management Controller
-		10b9 7101  M7101 PCI PMU Power Management Controller
-# should be 1022:9602
 	9602  AMD RS780/RS880 PCI to PCI bridge (int gfx)
 1028  Dell
 	0001  PowerEdge Expandable RAID Controller 2/Si
-		1028 0001  PowerEdge 2400
 	0002  PowerEdge Expandable RAID Controller 3/Di
-		1028 0002  PowerEdge 4400
-		1028 00d1  PERC 3/DiV [Viper]
-		1028 00d9  PERC 3/DiL [Lexus]
 	0003  PowerEdge Expandable RAID Controller 3/Si
-		1028 0003  PowerEdge 2450
-# PowerEdge Codename Iguana
 	0004  PowerEdge Expandable RAID Controller 3/Di [Iguana]
-		1028 0004  PERC 3/DiF [Iguana]
 	0006  PowerEdge Expandable RAID Controller 3/Di
 	0007  Remote Access Card III
 	0008  Remote Access Card III
 	0009  Remote Access Card III: BMC/SMIC device not present
 	000a  PowerEdge Expandable RAID Controller 3/Di
-		1028 0106  PERC 3/DiJ [Jaguar]
-		1028 011b  PERC 3/DiD [Dagger]
-		1028 0121  PERC 3/DiB [Boxster]
 	000c  Embedded Remote Access or ERA/O
 	000d  Embedded Remote Access: BMC/SMIC device
 	000e  PowerEdge Expandable RAID controller 4/Di
 	000f  PowerEdge Expandable RAID controller 4/Di
-		1028 014a  PowerEdge 1750
 	0010  Remote Access Card 4
 	0011  Remote Access Card 4 Daughter Card
 	0012  Remote Access Card 4 Daughter Card Virtual UART
 	0013  PowerEdge Expandable RAID controller 4
-		1028 016c  PowerEdge Expandable RAID Controller 4e/Si
-		1028 016d  PowerEdge Expandable RAID Controller 4e/Di
-		1028 016e  PowerEdge Expandable RAID Controller 4e/Di
-		1028 016f  PowerEdge Expandable RAID Controller 4e/Di
-		1028 0170  PowerEdge Expandable RAID Controller 4e/Di
 	0014  Remote Access Card 4 Daughter Card SMIC interface
 	0015  PowerEdge Expandable RAID controller 5
-		1028 1f01  PERC 5/E Adapter RAID Controller
-		1028 1f02  PERC 5/i Adapter RAID Controller
-		1028 1f03  PERC 5/i Integrated RAID Controller
 	0016  PowerEdge Expandable RAID controller S300
-		1028 1f24  PERC S300 Controller
-# NV-RAM Adapter used in Dell DR appliances
 	0073  NV-RAM Adapter
 1029  Siemens Nixdorf IS
 102a  LSI Logic
 	0000  HYDRA
 	0010  ASPEN
 	001f  AHA-2940U2/U2W /7890/7891 SCSI Controllers
-		9005 000f  2940U2W SCSI Controller
-		9005 0106  2940U2W SCSI Controller
-		9005 a180  2940U2W SCSI Controller
 	00c5  AIC-7899 U160/m SCSI Controller
-		1028 00c5  PowerEdge 2550/2650/4600
 	00cf  AIC-7899P U160/m
-		1028 0106  PowerEdge 4600
-		1028 0121  PowerEdge 2650
 102b  Matrox Electronics Systems Ltd.
-# DJ: I've a suspicion that 0010 is a duplicate of 0d10.
 	0010  MGA-I [Impression?]
 	0100  MGA 1064SG [Mystique]
 	0518  MGA-II [Athena]
 	0519  MGA 2064W [Millennium]
 	051a  MGA 1064SG [Mystique]
-		102b 0100  MGA-1064SG Mystique
-		102b 1100  MGA-1084SG Mystique
-		102b 1200  MGA-1084SG Mystique
-		1100 102b  MGA-1084SG Mystique
-		110a 0018  Scenic Pro C5 (D1025)
 	051b  MGA 2164W [Millennium II]
-		102b 051b  MGA-2164W Millennium II
-		102b 1100  MGA-2164W Millennium II
-		102b 1200  MGA-2164W Millennium II
-		102b 2100  MGA-2164W Millennium II
 	051e  MGA 1064SG [Mystique] AGP
 	051f  MGA 2164W [Millennium II] AGP
-		102b 2100  MGA-2164WA [Millennium II A]
 	0520  MGA G200
-		102b dbc2  G200 Multi-Monitor
-		102b dbc8  G200 Multi-Monitor
-		102b dbe2  G200 Multi-Monitor
-		102b dbe8  G200 Multi-Monitor
-		102b ff03  Millennium G200 SD
-		102b ff04  Marvel G200
 	0521  MGA G200 AGP
-		1014 ff03  Millennium G200 AGP
-		102b 48e9  Mystique G200 AGP
-		102b 48f8  Millennium G200 SD AGP
-		102b 4a60  Millennium G200 LE AGP
-		102b 4a64  Millennium G200 AGP
-		102b c93c  Millennium G200 AGP
-		102b c9b0  Millennium G200 AGP
-		102b c9bc  Millennium G200 AGP
-		102b ca60  Millennium G250 LE AGP
-		102b ca6c  Millennium G250 AGP
-		102b dbbc  Millennium G200 AGP
-		102b dbc2  Millennium G200 MMS (Dual G200)
-		102b dbc3  G200 Multi-Monitor
-		102b dbc8  Millennium G200 MMS (Dual G200)
-		102b dbd2  G200 Multi-Monitor
-		102b dbd3  G200 Multi-Monitor
-		102b dbd4  G200 Multi-Monitor
-		102b dbd5  G200 Multi-Monitor
-		102b dbd8  G200 Multi-Monitor
-		102b dbd9  G200 Multi-Monitor
-		102b dbe2  Millennium G200 MMS (Quad G200)
-		102b dbe3  G200 Multi-Monitor
-		102b dbe8  Millennium G200 MMS (Quad G200)
-		102b dbf2  G200 Multi-Monitor
-		102b dbf3  G200 Multi-Monitor
-		102b dbf4  G200 Multi-Monitor
-		102b dbf5  G200 Multi-Monitor
-		102b dbf8  G200 Multi-Monitor
-		102b dbf9  G200 Multi-Monitor
-		102b f806  Mystique G200 Video AGP
-		102b ff00  MGA-G200 AGP
-		102b ff02  Mystique G200 AGP
-		102b ff03  Millennium G200A AGP
-		102b ff04  Marvel G200 AGP
-		110a 0032  MGA-G200 AGP
 	0522  MGA G200e [Pilot] ServerEngines (SEP1)
-		103c 31fa  ProLiant DL140 G3
 	0525  MGA G400/G450
-		0e11 b16f  MGA-G400 AGP
-		102b 0328  Millennium G400 16Mb SDRAM
-		102b 0338  Millennium G400 16Mb SDRAM
-		102b 0378  Millennium G400 32Mb SDRAM
-		102b 0541  Millennium G450 Dual Head
-		102b 0542  Millennium G450 Dual Head LX
-		102b 0543  Millennium G450 Single Head LX
-		102b 0641  Millennium G450 32Mb SDRAM Dual Head
-		102b 0642  Millennium G450 32Mb SDRAM Dual Head LX
-		102b 0643  Millennium G450 32Mb SDRAM Single Head LX
-		102b 07c0  Millennium G450 Dual Head LE
-		102b 07c1  Millennium G450 SDR Dual Head LE
-		102b 0d41  Millennium G450 Dual Head PCI
-		102b 0d42  Millennium G450 Dual Head LX PCI
-		102b 0d43  Millennium G450 32Mb Dual Head PCI
-		102b 0e00  Marvel G450 eTV
-		102b 0e01  Marvel G450 eTV
-		102b 0e02  Marvel G450 eTV
-		102b 0e03  Marvel G450 eTV
-		102b 0f80  Millennium G450 Low Profile
-		102b 0f81  Millennium G450 Low Profile
-		102b 0f82  Millennium G450 Low Profile DVI
-		102b 0f83  Millennium G450 Low Profile DVI
-		102b 19d8  Millennium G400 16Mb SGRAM
-		102b 19f8  Millennium G400 32Mb SGRAM
-		102b 2159  Millennium G400 Dual Head 16Mb
-		102b 2179  Millennium G400 MAX/Dual Head 32Mb
-		102b 217d  Millennium G400 Dual Head Max
-		102b 23c0  Millennium G450
-		102b 23c1  Millennium G450
-		102b 23c2  Millennium G450 DVI
-		102b 23c3  Millennium G450 DVI
-		102b 2f58  Millennium G400
-		102b 2f78  Millennium G400
-		102b 3693  Marvel G400 AGP
-		102b 5dd0  4Sight II
-		102b 5f50  4Sight II
-		102b 5f51  4Sight II
-		102b 5f52  4Sight II
-		102b 9010  Millennium G400 Dual Head
-		1458 0400  GA-G400
-		1705 0001  Millennium G450 32MB SGRAM
-		1705 0002  Millennium G450 16MB SGRAM
-		1705 0003  Millennium G450 32MB
-		1705 0004  Millennium G450 16MB
 	0527  Parhelia
-		102b 0840  Parhelia 128Mb
-		102b 0850  Parhelia 256MB
-		102b 0870  MED2mp-DVI
-		102b 0880  P-256 Edge Overlap Controller
 	0528  Parhelia
-		102b 1020  Parhelia 128MB
-		102b 1030  Parhelia 256 MB Dual DVI
-		102b 1040  MED2mp-DVI
-		102b 1050  Sono S20
-		102b 1060  PJ-30L
-		102b 1070  PJ-40L
-		102b 1421  MED5mp
-		102b 1431  MED3mp-DVI
-		102b 1451  MED5mp-DVI
-		102b 1491  MED2mp-DVI
-		102b 14b1  MED3mp-DVI
-		102b 14c1  MED5mp-DVI
-		102b 14e1  Parhelia PCI 256MB
-		102b 14f1  Parhelia Precision SGT
-		102b 1501  ATC-4MP
-		102b 1511  ATC-4MP
-		102b 1521  TheatreVUE T30
-		102b 1531  TheatreVUE T20
-		102b 1541  MED2mp-DVI
-		102b 1551  MED3mp-DVI
-		102b 1561  MED5mp-DVI
-		102b 1571  Parhelia DL256 PCI
-		102b 1591  Parhelia Precision SDT
-		102b 15a1  MED4mp-DVI
-		102b 2011  Parhelia HR256
-		102b 2021  QID Pro
-		102b 2061  PJ-40LP
-		102b 2081  EWS Quad
-		102b 2411  PPX-OUT8
-		102b 2421  VPX-OUT8
-		102b 2441  PPX-OUT4
-		102b 2451  VPX-OUT4
-		102b 2491  LPX-OUT4
 	0530  MGA G200EV
 	0532  MGA G200eW WPCM450
-		1028 0235  PowerEdge R710 MGA G200eW WPCM450
-		1028 0236  PowerEdge R610 MGA G200eW WPCM450
-		1028 0237  PowerEdge T610 MGA G200eW WPCM450
-		1028 0287  PowerEdge M610 MGA G200eW WPCM450
-		1028 028c  PowerEdge R410 MGA G200eW WPCM450
-		1028 028d  PowerEdge T410 MGA G200eW WPCM450
-		1028 029c  PowerEdge M710 MGA G200eW WPCM450
-		1028 02a4  PowerEdge T310 MGA G200eW WPCM450
-		15d9 0624  X9SCM-F Motherboard
-		15d9 a811  H8DGU
 	0533  MGA G200EH
-		103c 3381  iLO4
 	0534  G200eR2
 	0536  Integrated Matrox G200eW3 Graphics Controller
 	0538  G200eH
-		1590 00e4  iLO5 VGA
 	0540  M91XX
-		102b 2080  M9140 LP PCIe x16
-		102b 20c0  Xenia
-		102b 20c1  Xenia Pro
-		102b 2100  M9120 PCIe x16
-		102b 2140  M9125 PCIe x16
-		102b 2180  M9120 Plus LP PCIe x16
-		102b 21c0  M9120 Plus LP PCIe x1
-		102b 2200  VDA1164 Output Board
-		102b 2240  M9148 LP PCIe x16
-		102b 2241  M9138 LP PCIe x16
-		102b 2280  M9188 ATX PCIe x16
-		102b 22c0  M9128 LP PCIe x16
 	0550  SV2
-		102b 00c0  MURA-IPX-I4EF
-		102b 00c1  MURA-IPX-I4DF
-		102b 00c3  MURA-IPX-I4DHF
-		102b 00c5  MURA-IPX-I4EHF
 	0d10  MGA Ultima/Impression
 	1000  MGA G100 [Productiva]
-		102b ff01  Productiva G100
-		102b ff05  Productiva G100 Multi-Monitor
 	1001  MGA G100 [Productiva] AGP
-		102b 1001  MGA-G100 AGP
-		102b ff00  MGA-G100 AGP
-		102b ff01  MGA-G100 Productiva AGP
-		102b ff03  Millennium G100 AGP
-		102b ff04  MGA-G100 AGP
-		102b ff05  MGA-G100 Productiva AGP Multi-Monitor
-		110a 001e  MGA-G100 AGP
 	2007  MGA Mistral
 	2527  Millennium G550
-# PCI\VEN_102B&DEV_2527&SUBSYS_0F42102B&REV_01
-		102b 0f42  Matrox G550 Low Profile PCI
-		102b 0f83  Millennium G550
-		102b 0f84  Millennium G550 Dual Head DDR 32Mb
-		102b 1e41  Millennium G550
-		102b 2300  Millennium G550 LP PCIE
 	2537  Millennium P650/P750
-		102b 1820  Millennium P750 64MB
-		102b 1830  Millennium P650 64MB
-		102b 1850  RAD2mp
-		102b 1860  RAD3mp
-		102b 1880  Sono S10
-		102b 1c10  QID 128MB
-		102b 2811  Millennium P650 Low-profile PCI 64MB
-		102b 2821  Millennium P650 Low-profile PCI
-		102b 2841  RAD PCI
-		102b 2851  Spectrum PCI
-		102b 2871  EpicA TC2
-		102b 2c11  QID Low-profile PCI
-		102b 2c21  QID LP PCI LW
-		102b 2c31  QID LP PCI
-		102b 2c41  EpicA TC4
-		102b 3001  Extio F1400
-		102b 3011  Extio F1220
-		102b 3041  RG-200DL
-		102b 3051  RG-400SL
-		102b 3061  Extio F1420
-		102b 3081  Extio F1240
 	2538  Millennium P650 PCIe
-		102b 0847  RAD PCIe
-		102b 08c7  Millennium P650 PCIe 128MB
-		102b 0907  Millennium P650 PCIe 64MB
-		102b 0947  Parhelia APVe
-		102b 0987  ATC PCIe 4MP
-		102b 1047  Millennium P650 LP PCIe 128MB
-		102b 1087  Millennium P650 LP PCIe 64MB
-		102b 1801  Millennium P650 PCIe x1
-		102b 2538  Parhelia APVe
-		102b 3007  QID Low-profile PCIe
-		102b 3087  Aurora VX3mp
-		102b 30c7  QID LP PCIe
 	2539  Millennium P690
-		102b 0040  Millennium P690 PCIe x16
-		102b 0042  ONYX
-		102b 0043  SPECTRA
-		102b 0080  Millennium P690 Plus LP PCIe x16
-		102b 0081  Millennium P690 LP PCIe x16
-		102b 0082  RAD LPX PCIe x16
-		102b 00c0  Millennium P690 Plus LP PCI
-		102b 00c2  Millennium P690 LP PCI
-		102b 00c3  RAD LPX PCI
-		102b 0101  Millennium P690 PCI
-		102b 0140  Millennium P690 LP PCIe x1
-		102b 0180  Display Wall IP Decode 128 MB
 	4164  Morphis QxT frame grabber
 	43b4  Morphis Qxt encoding engine
 	4510  Morphis COM port
@@ -4689,40 +1839,12 @@ var pciids = []byte(`#
 	4686  Concord GX (customized Intel 82541)
 	475b  Solios eCL/XCL-B frame grabber
 	475d  Vio frame grabber family
-		102b 4b90  Vio Duo frame grabber (single channel)
-		102b 4b91  Vio Duo frame grabber
-		102b 4b92  Vio Analog frame grabber
-		102b 4b93  Vio SDI Frame Grabber
-		102b 4b94  Vio DVI-A frame grabber
 	475f  Solios (single-Full) CL frame grabber
-		102b 475f  Solios eCL/XCL-F frame grabber
-		102b 4d5f  Solios eV-CL (single-Full) frame grabber
-		102b 4e5f  Solios eM-CL (single-Full) frame grabber
 	47a1  Solios eA/XA frame grabber
-		102b 4be0  Solios eA/XA (single) frame grabber
-		102b 4be1  Solios eA/XA (dual) frame grabber
-		102b 4be2  Solios eA/XA (quad) frame grabber
 	47a2  Solios COM port
 	47c1  Solios (dual-Base/single-Medium) CL frame grabber
-		102b 0000  Solios frame grabber
-		102b 4b80  Solios eCL/XCL (single-Medium) frame grabber
-		102b 4b81  Solios eCL/XCL (dual-Base) frame grabber
-		102b 4d80  Solios eV-CL (single-Medium) frame grabber
-		102b 4d81  Solios eV-CL (dual-Base) frame grabber
-		102b 4e80  Solios eM-CL (single-Medium) frame grabber
-		102b 4e81  Solios eM-CL (dual-Base) frame grabber
 	47c2  Solios COM port
 	4949  Radient frame grabber family
-		102b 0010  Radient eCL (Single-full) frame grabber
-		102b 0011  Radient eCLV (Single-full) frame grabber
-		102b 0020  Radient eCL (Dual-base) frame grabber
-		102b 0030  Radient eCL (Dual-full) frame grabber
-		102b 0040  Radient eCL (Quad-base) frame grabber
-		102b 0050  Radient eCL (Golden) frame grabber
-		102b 1010  Radient eV-CXP (quad CXP-6) frame grabber
-		102b 1015  Radient eV-CXP (dual CXP-6) frame grabber
-		102b 1020  Radient eV-CXP (quad CXP-3) frame grabber
-		102b 1050  Radient eV-CXP (Golden) frame grabber
 	4cdc  Morphis JPEG2000 accelerator
 	4f54  Morphis (e)Quad frame grabber
 	4fc5  Morphis (e)Dual frame grabber
@@ -4731,29 +1853,16 @@ var pciids = []byte(`#
 102c  Chips and Technologies
 	00b8  F64310
 	00c0  F69000 HiQVideo
-		102c 00c0  F69000 HiQVideo
-		4c53 1000  CC7/CR7/CP7/VC7/VP7/VR7 mainboard
-		4c53 1010  CP5/CR6 mainboard
-		4c53 1020  VR6 mainboard
-		4c53 1030  PC5 mainboard
-		4c53 1050  CT7 mainboard
-		4c53 1051  CE7 mainboard
 	00d0  F65545
 	00d8  F65545
 	00dc  F65548
 	00e0  F65550
 	00e4  F65554
 	00e5  F65555 HiQVPro
-		0e11 b049  Armada 1700 Laptop Display Controller
-		1179 0001  Satellite Pro/Satellite
 	00f0  F68554
 	00f4  F68554 HiQVision
 	00f5  F68555
 	0c30  F69030
-		4c53 1000  CC7/CR7/CP7/VC7/VP7/VR7 mainboard
-		4c53 1050  CT7 mainboard
-		4c53 1051  CE7 mainboard
-		4c53 1080  CT8 mainboard
 102d  Wyse Technology Inc.
 	50dc  3328 Audio
 102e  Olivetti Advanced Technology
@@ -4761,7 +1870,6 @@ var pciids = []byte(`#
 	0009  r4x00
 	000a  TX3927 MIPS RISC PCI Controller
 	0020  ATM Meteor 155
-		102f 00f8  ATM Meteor 155
 	0030  TC35815CF PCI 10/100 Mbit Ethernet Controller
 	0031  TC35815CF PCI 10/100 Mbit Ethernet Controller with WOL
 	0032  TC35815CF PCI 10/100 Mbit Ethernet Controller on TX4939
@@ -4801,47 +1909,21 @@ var pciids = []byte(`#
 	002c  Star Alpha 2
 	002d  PCI to C-bus Bridge
 	0035  OHCI USB Controller
-		1033 0035  USB Controller
-		103c 1293  USB add-in card
-		103c 1294  USB 2.0 add-in card
-		1179 0001  USB
-		1186 0035  DUB-C2 USB 2.0 2-port 32-bit cardbus controller
-		12ee 7000  Root Hub
-		14c2 0105  PTI-205N USB 2.0 Host Controller
-		1799 0001  Root Hub
-		1931 000a  GlobeTrotter Fusion Quad Lite (PPP data)
-		1931 000b  GlobeTrotter Fusion Quad Lite (GSM data)
-		807d 0035  PCI-USB2 (OHCI subsystem)
 	003b  PCI to C-bus Bridge
 	003e  NAPCCARD Cardbus Controller
 	0046  PowerVR PCX2 [midas]
 	005a  Vrc5074 [Nile 4]
 	0063  uPD72862 [Firewarden] IEEE1394 OHCI 1.0 Link Controller
 	0067  PowerVR Neon 250 Chipset
-		1010 0020  PowerVR Neon 250 AGP 32Mb
-		1010 0080  PowerVR Neon 250 AGP 16Mb
-		1010 0088  PowerVR Neon 250 16Mb
-		1010 0090  PowerVR Neon 250 AGP 16Mb
-		1010 0098  PowerVR Neon 250 16Mb
-		1010 00a0  PowerVR Neon 250 AGP 32Mb
-		1010 00a8  PowerVR Neon 250 32Mb
-		1010 0120  PowerVR Neon 250 AGP 32Mb
 	0072  uPD72874 IEEE1394 OHCI 1.1 3-port PHY-Link Ctrlr
 	0074  56k Voice Modem
-		1033 8014  RCV56ACF 56k Voice Modem
 	009b  Vrc5476
 	00a5  VRC4173
 	00a6  VRC5477 AC97
 	00cd  uPD72870 [Firewarden] IEEE1394a OHCI 1.0 Link/3-port PHY Controller
-		12ee 8011  Root hub
 	00ce  uPD72871 [Firewarden] IEEE1394a OHCI 1.0 Link/1-port PHY Controller
 	00df  Vr4131
 	00e0  uPD72010x USB 2.0 Controller
-		1186 f100  DUB-C2 USB 2.0 2-port 32-bit cardbus controller
-		12ee 7001  Root hub
-		14c2 0205  PTI-205N USB 2.0 Host Controller
-		1799 0002  Root Hub
-		807d 1043  PCI-USB2 (EHCI subsystem)
 	00e7  uPD72873 [Firewarden] IEEE1394a OHCI 1.1 Link/2-port PHY Controller
 	00f2  uPD72874 [Firewarden] IEEE1394a OHCI 1.1 Link/3-port PHY Controller
 	00f3  uPD6113x Multimedia Decoder/Processor [EMMA2]
@@ -4849,13 +1931,6 @@ var pciids = []byte(`#
 	0125  uPD720400 PCI Express - PCI/PCI-X Bridge
 	013a  Dual Tuner/MPEG Encoder
 	0194  uPD720200 USB 3.0 Host Controller
-		1028 04a3  Precision M4600
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		1043 8413  P8P67 Deluxe Motherboard
-		104d 907a  Vaio VPCF1
-		1af4 1100  QEMU Virtual Machine
-		1b96 0001  USB 3.0 PCIe Card
 	01e7  uPD72873 [Firewarden] IEEE1394a OHCI 1.1 Link/2-port PHY Controller
 	01f2  uPD72874 [Firewarden] IEEE1394a OHCI 1.1 Link/3-port PHY Controller
 1034  Framatome Connectors USA Inc.
@@ -4869,29 +1944,23 @@ var pciids = []byte(`#
 	0002  AGP Port (virtual PCI-to-PCI bridge)
 	0003  AGP Port (virtual PCI-to-PCI bridge)
 	0004  PCI-to-PCI bridge
-		1039 0000  PCIe x16 port
 	0006  85C501/2/3
 	0008  SiS85C503/5513 (LPC Bridge)
 	0009  5595 Power Management Controller
 	000a  PCI-to-PCI bridge
-		1039 0000  PCIe x1 port
 	0016  SiS961/2/3 SMBus controller
 	0018  SiS85C503/5513 (LPC Bridge)
 	0163  163 802.11b/g Wireless LAN Adapter
 	0180  RAID bus controller 180 SATA/PATA  [SiS]
 	0181  SATA
 	0182  182 SATA/RAID Controller
-		1734 1095  D2030-A1
 	0186  AHCI Controller (0106)
 	0190  190 Ethernet Adapter
 	0191  191 Gigabit Ethernet Adapter
-		1043 8139  P5SD2-FM/S mainboard
 	0200  5597/5598/6326 VGA
-		1039 0000  SiS5597 SVGA (Shared RAM)
 	0204  82C204
 	0205  SG86C205
 	0300  300/305 PCI/AGP VGA Display Adapter
-		107d 2720  Leadtek WinFast VR300
 	0310  315H PCI/AGP VGA Display Adapter
 	0315  315 PCI/AGP VGA Display Adapter
 	0325  315PRO PCI/AGP VGA Display Adapter
@@ -4923,19 +1992,12 @@ var pciids = []byte(`#
 	0735  735 Host
 	0740  740 Host
 	0741  741/741GX/M741 Host
-		1849 0741  K7S41/K7S41GX motherboard
 	0745  745 Host
 	0746  746 Host
 	0755  755 Host
 	0760  760/M760 Host
 	0761  761/M761 Host
-		1734 1099  D2030-A1 Motherboard
 	0900  SiS900 PCI Fast Ethernet
-		1019 0a14  K7S5A motherboard
-		1039 0900  SiS900 10/100 Ethernet Adapter onboard
-		1043 8035  CUSI-FX motherboard
-		1043 80a7  Motherboard P4S800D-X
-		1462 0900  MS-6701 motherboard
 	0961  SiS961 [MuTIOL Media IO]
 	0962  SiS962 [MuTIOL Media IO] LPC Controller
 	0963  SiS963 [MuTIOL Media IO] LPC Controller
@@ -4945,9 +2007,7 @@ var pciids = []byte(`#
 	0968  SiS968 [MuTIOL Media IO]
 	1180  SATA Controller / IDE mode
 	1182  SATA Controller / RAID mode
-		1039 0180  SiS 966 4-port SATA controller
 	1183  SATA Controller / IDE mode
-		1039 0180  SiS 966 4-port SATA controller
 	1184  AHCI Controller / RAID mode
 	1185  AHCI IDE Controller (0106)
 	3602  83C602
@@ -4957,12 +2017,6 @@ var pciids = []byte(`#
 	5401  486 PCI Chipset
 	5511  5511/5512
 	5513  5513 IDE Controller
-		1019 0970  P6STP-FL motherboard
-		1039 5513  SiS5513 EIDE Controller (A,B step)
-		1043 8035  CUSI-FX motherboard
-		1462 7010  MS-6701 motherboard
-		1631 5513  GA-8SIML Rev1.0 Motherboard
-		1734 1095  D2030-A1 Motherboard
 	5517  5517
 	5571  5571
 	5581  5581 Pentium Chipset
@@ -4975,83 +2029,21 @@ var pciids = []byte(`#
 	6205  VGA Controller
 	6236  6236 3D-AGP
 	6300  630/730 PCI/AGP VGA Display Adapter
-		1019 0970  P6STP-FL motherboard
-		1043 8035  CUSI-FX motherboard
-		104d 80e2  VAIO PCV-J200
 	6306  530/620 PCI/AGP VGA Display Adapter
 	6325  65x/M650/740 PCI/AGP VGA Display Adapter
-		1039 6325  SiS 651 onboard [Asus P4SC-EA]
-		1631 1004  SiS 651C onboard [Gigabyte GA-8SIML Rev1.0]
 	6326  86C326 5598/6326
-		1039 6326  SiS6326 GUI Accelerator
-		1092 0a50  SpeedStar A50
-		1092 0a70  SpeedStar A70
-		1092 4910  SpeedStar A70
-		1092 4920  SpeedStar A70
-		10b0 6326  S6110-B (AGP)
-		1569 6326  SiS6326 GUI Accelerator
 	6330  661/741/760 PCI/AGP or 662/761Gx PCIE VGA Display Adapter
-		1039 6330  [M]661xX/[M]741[GX]/[M]760 PCI/AGP VGA Adapter
-		1043 8113  SiS Real 256E (ASUS P5S800-VM motherboard)
-		1458 d000  SiS661FX GUI 2D/3D Accelerator
-		1734 1099  D2030-A1
 	6350  770/670 PCIE VGA Display Adapter
 	6351  771/671 PCIE VGA Display Adapter
 	7001  USB 1.1 Controller
-		1019 0a14  K7S5A motherboard
-		1039 7000  Onboard USB Controller
-		1462 5470  ECS K7SOM+ motherboard
-		1462 7010  MS-6701 motherboard
-		1734 1095  D2030-A1 Motherboard
 	7002  USB 2.0 Controller
-		1462 5470  K7SOM+ 5.2C Motherboard
-		1462 7010  MS-6701 motherboard
-		1509 7002  Onboard USB Controller
-		1734 1095  D2030-A1
 	7007  FireWire Controller
-		1462 701d  MS-6701
 	7012  SiS7012 AC'97 Sound Controller
-		1019 0f05  A928 (i-Buddie)
-		1039 7012  SiS 7012 onboard [Asus P4SC-EA] AC'97 Sound Controller
-		1043 818f  A8S-X Motherboard
-		13f6 0300  CMI9739(A) on ECS K7S series motherboard
-		1462 5850  MSI 648 Max (MS-6585)
-		1462 7010  MS-6701 motherboard
-		15bd 1001  DFI 661FX motherboard
-		1734 109f  D2030-A1 Motherboard
-		1849 7012  K7S41GX motherboard
-# There are may be different modem codecs here (Intel537 compatible and incompatible)
 	7013  AC'97 Modem Controller
 	7016  SiS7016 PCI Fast Ethernet Adapter
-		1039 7016  SiS7016 10/100 Ethernet Adapter
 	7018  SiS PCI Audio Accelerator
-		1014 01b6  SiS PCI Audio Accelerator
-		1014 01b7  SiS PCI Audio Accelerator
-		1019 7018  SiS PCI Audio Accelerator
-		1025 000e  SiS PCI Audio Accelerator
-		1025 0018  SiS PCI Audio Accelerator
-		1039 7018  SiS PCI Audio Accelerator
-		1043 1453  SiS PCI Audio Accelerator
-		1043 800b  SiS PCI Audio Accelerator
-		104d 80e2  VAIO PCV-J200
-		1054 7018  SiS PCI Audio Accelerator
-		107d 5330  SiS PCI Audio Accelerator
-		107d 5350  SiS PCI Audio Accelerator
-		1170 3209  SiS PCI Audio Accelerator
-		1462 400a  SiS PCI Audio Accelerator
-		14a4 2089  SiS PCI Audio Accelerator
-		14cd 2194  SiS PCI Audio Accelerator
-		14ff 1100  SiS PCI Audio Accelerator
-		152d 8808  SiS PCI Audio Accelerator
-		1558 1103  SiS PCI Audio Accelerator
-		1558 2200  SiS PCI Audio Accelerator
-		1563 7018  SiS PCI Audio Accelerator
-		15c5 0111  SiS PCI Audio Accelerator
-		270f a171  SiS PCI Audio Accelerator
-		a0a0 0022  SiS PCI Audio Accelerator
 	7019  SiS7019 Audio Accelerator
 	7502  Azalia Audio Controller
-		1043 81a1  P5SD2-FM/S mainboard
 103a  Seiko Epson Corporation
 103b  Tatung Corp. Of America
 103c  Hewlett-Packard Company
@@ -5059,30 +2051,13 @@ var pciids = []byte(`#
 	1008  Visualize FX
 	1028  Tach TL Fibre Channel Host Adapter
 	1029  Tach XL2 Fibre Channel Host Adapter
-		107e 000f  Interphase 5560 Fibre Channel Adapter
-		9004 9210  1Gb/2Gb Family Fibre Channel Controller
-		9004 9211  1Gb/2Gb Family Fibre Channel Controller
 	102a  Tach TS Fibre Channel Host Adapter
-		107e 000e  Interphase 5540/5541 Fibre Channel Adapter
-		9004 9110  1Gb/2Gb Family Fibre Channel Controller
-		9004 9111  1Gb/2Gb Family Fibre Channel Controller
 	1030  J2585A DeskDirect 10/100VG NIC
 	1031  J2585B HP 10/100VG PCI LAN Adapter
-		103c 1040  J2973A DeskDirect 10BaseT NIC
-		103c 1041  J2585B DeskDirect 10/100VG NIC
-		103c 1042  J2970A DeskDirect 10BaseT/2 NIC
 	1040  J2973A DeskDirect 10BaseT NIC
 	1041  J2585B DeskDirect 10/100 NIC
 	1042  J2970A DeskDirect 10BaseT/2 NIC
 	1048  Diva Serial [GSP] Multiport UART
-		103c 1049  Tosca Console
-		103c 104a  Tosca Secondary
-		103c 104b  Maestro SP2
-		103c 1223  Superdome Console
-		103c 1226  Keystone SP2
-		103c 1227  Powerbar SP2
-		103c 1282  Everest SP2
-		103c 1301  Diva RMP3
 	1054  PCI Local Bus Adapter
 	1064  79C970 PCnet Ethernet Controller
 	108b  Visualize FXe
@@ -5100,7 +2075,6 @@ var pciids = []byte(`#
 	127b  sx1000 System Bus Adapter
 	127c  sx1000 I/O Controller
 	1290  Auxiliary Diva Serial Port
-		103c 1291  Diva SP2
 	1291  Auxiliary Diva Serial Port
 	12b4  zx1 QuickSilver AGP8x Local Bus Adapter
 	12eb  sx2000 System Bus Adapter
@@ -5109,97 +2083,26 @@ var pciids = []byte(`#
 	1302  RMP-3 Shared Memory Driver
 	1303  RMP-3 (Remote Management Processor)
 	22f6  iLO5 Virtual USB Controller
-		1590 00e4  iLO5 Standard Virtual USB Controller
 	2910  E2910A PCIBus Exerciser
 	2925  E2925A 32 Bit, 33 MHzPCI Exerciser & Analyzer
 	3206  Adaptec Embedded Serial ATA HostRAID
 	3220  Smart Array P600
-		103c 3225  3 Gb/s SAS RAID
 	3230  Smart Array Controller
-		103c 3223  Smart Array P800
-		103c 3234  P400 SAS Controller
-		103c 3235  P400i SAS Controller
-		103c 3237  E500 SAS Controller
-		103c 323d  P700m SAS Controller
 	3238  Smart Array E200i (SAS Controller)
-		103c 3211  Smart Array E200i
-		103c 3212  Smart Array E200
 	3239  Smart Array Gen9 Controllers
-		103c 21bd  P244br
-		103c 21be  P741m
-		103c 21bf  H240ar
-		103c 21c0  P440ar
-		103c 21c1  P840ar
-		103c 21c2  P440
-		103c 21c3  P441
-		103c 21c4  Smart Array
-		103c 21c5  P841
-		103c 21c6  H244br
-		103c 21c7  H240
-		103c 21c8  H241
-		103c 21c9  Smart Array
-		103c 21ca  P246br
-		103c 21cb  P840
-		103c 21cc  Smart Array
-		103c 21cd  P240nr
-		103c 21ce  H240nr
 	323a  Smart Array G6 controllers
-		103c 3241  Smart Array P212
-		103c 3243  Smart Array P410
-		103c 3245  Smart Array P410i
-		103c 3247  Smart Array P411
-		103c 3249  Smart Array P812
-		103c 324a  Smart Array 712m (Mezzanine RAID controller)
-		103c 324b  Smart Array P711m (Mezzanine RAID controller)
 	323b  Smart Array Gen8 Controllers
-		103c 3350  P222
-		103c 3351  P420
-		103c 3352  P421
-		103c 3354  P420i
-		103c 3355  P220i
 	323c  Smart Array Gen8+ Controllers
-		103c 1920  P430i
-		103c 1921  P830i
-		103c 1922  P430
-		103c 1923  P431
-		103c 1924  P830
-		103c 1925  Smart Array
-		103c 1926  P731m
-		103c 1928  P230i
 	3300  Integrated Lights-Out Standard Virtual USB Controller
-		103c 3304  iLO2
-		103c 3305  iLO2
-		103c 3309  iLO2 GXL/iLO3 GXE
-		103c 330e  iLO3
-		103c 3381  iLO4
 	3301  Integrated Lights-Out Standard Serial Port
-		103c 3304  iLO2
-		103c 3305  iLO2
-		103c 330e  iLO3
-		103c 3381  iLO4
-# Virtual serial port which is presented on a Java applet
 	3302  Integrated Lights-Out Standard KCS Interface
-		103c 3304  iLO2
-		103c 3305  iLO2
-		103c 330e  iLO3
-		103c 3381  iLO4
 	3305  Integrated Lights-Out (iLO2) Controller
 	3306  Integrated Lights-Out Standard Slave Instrumentation & System Support
-		103c 330e  iLO3
-		103c 3381  iLO4
 	3307  Integrated Lights-Out Standard Management Processor Support and Messaging
-# HP DL380 G6
-		103c 3309  iLO 2
-		103c 330e  iLO3
-		103c 3381  iLO4
 	3308  Integrated Lights-Out Standard MS Watchdog Timer
-		103c 330e  iLO3
-		103c 3381  iLO4
-	402f  PCIe Root Port
 	4030  zx2 System Bus Adapter
 	4031  zx2 I/O Controller
 	4037  PCIe Local Bus Adapter
-	403b  PCIe Root Port
 103e  Solliday Engineering
 103f  Synopsys/Logic Modeling Group
 1040  Accelgraphics Inc.
@@ -5213,56 +2116,13 @@ var pciids = []byte(`#
 1043  ASUSTeK Computer Inc.
 	0464  Radeon R9 270x GPU
 	0675  ISDNLink P-IN100-ST-D
-		0675 1704  ISDN Adapter (PCI Bus, D, C)
-		0675 1707  ISDN Adapter (PCI Bus, DV, W)
-		10cf 105e  ISDN Adapter (PCI Bus, DV, W)
-	13a0  Transformer Book T101HA-GR030R
-# Should be 1022:9602
 	9602  AMD RS780/RS880 PCI to PCI bridge (int gfx)
-		1043 83a2  M4A785TD Motherboard
 1044  Adaptec (formerly DPT)
 	1012  Domino RAID Engine
 	a400  SmartCache/Raid I-IV Controller
 	a500  PCI Bridge
 	a501  SmartRAID V Controller
-		1044 c001  PM1554U2 Ultra2 Single Channel
-		1044 c002  PM1654U2 Ultra2 Single Channel
-		1044 c003  PM1564U3 Ultra3 Single Channel
-		1044 c004  PM1564U3 Ultra3 Dual Channel
-		1044 c005  PM1554U2 Ultra2 Single Channel (NON ACPI)
-		1044 c00a  PM2554U2 Ultra2 Single Channel
-		1044 c00b  PM2654U2 Ultra2 Single Channel
-		1044 c00c  PM2664U3 Ultra3 Single Channel
-		1044 c00d  PM2664U3 Ultra3 Dual Channel
-		1044 c00e  PM2554U2 Ultra2 Single Channel (NON ACPI)
-		1044 c00f  PM2654U2 Ultra2 Single Channel (NON ACPI)
-		1044 c014  PM3754U2 Ultra2 Single Channel (NON ACPI)
-		1044 c015  PM3755U2B Ultra2 Single Channel (NON ACPI)
-		1044 c016  PM3755F Fibre Channel (NON ACPI)
-		1044 c01e  PM3757U2 Ultra2 Single Channel
-		1044 c01f  PM3757U2 Ultra2 Dual Channel
-		1044 c020  PM3767U3 Ultra3 Dual Channel
-		1044 c021  PM3767U3 Ultra3 Quad Channel
-		1044 c028  PM2865U3 Ultra3 Single Channel
-		1044 c029  PM2865U3 Ultra3 Dual Channel
-		1044 c02a  PM2865F Fibre Channel
-		1044 c03c  2000S Ultra3 Single Channel
-		1044 c03d  2000S Ultra3 Dual Channel
-		1044 c03e  2000F Fibre Channel
-		1044 c046  3000S Ultra3 Single Channel
-		1044 c047  3000S Ultra3 Dual Channel
-		1044 c048  3000F Fibre Channel
-		1044 c050  5000S Ultra3 Single Channel
-		1044 c051  5000S Ultra3 Dual Channel
-		1044 c052  5000F Fibre Channel
-		1044 c05a  2400A UDMA Four Channel
-		1044 c05b  2400A UDMA Four Channel DAC
-		1044 c064  3010S Ultra3 Dual Channel
-		1044 c065  3410S Ultra160 Four Channel
-		1044 c066  3010S Fibre Channel
 	a511  SmartRAID V Controller
-		1044 c032  ASR-2005S I2O Zero Channel
-		1044 c035  ASR-2010S I2O Zero Channel
 	c066  3010S Ultra3 Dual Channel
 1045  OPTi Inc.
 	a0f8  82C750 [Vendetta] USB Controller
@@ -5296,20 +2156,12 @@ var pciids = []byte(`#
 	1000  QuickStep 1000
 	3000  QuickStep 3000
 	8901  Gloria XL
-		1048 0935  GLoria XL (Virge)
 1049  Fountain Technologies, Inc.
-# nee SGS Thomson Microelectronics
 104a  STMicroelectronics
 	0000  STLS2F Host Bridge
 	0008  STG 2000X
 	0009  STG 1764X
 	0010  STG4000 [3D Prophet Kyro Series]
-		104a 4018  ST PowerVR Kyro (64MB AGP TVO)
-# 64MB AGP
-		1681 0010  PowerVR Kyro II [3D Prophet 4500]
-		1681 0028  3D Prophet 4000XT
-		1681 c010  3D Prophet 4500 TV-Out
-		1681 c069  3D Prophet 4000XT
 	0201  STPC Vega Northbridge
 	0209  STPC Consumer/Industrial North- and Southbridge
 	020a  STPC Atlas/ConsumerS/Consumer IIA Northbridge
@@ -5323,7 +2175,6 @@ var pciids = []byte(`#
 	0230  STPC Atlas/Vega OHCI USB Controller
 	0238  STPC Vega LAN
 	0500  ST70137 [Unicorn] ADSL DMT Transceiver
-		104a 0500  BeWAN ADSL PCI st
 	0564  STPC Client Northbridge
 	0981  21x4x DEC-Tulip compatible 10/100 Ethernet
 	1746  STG 1764X
@@ -5341,216 +2192,66 @@ var pciids = []byte(`#
 	104c  PCI1510 PC card Cardbus Controller
 	3d04  TVP4010 [Permedia]
 	3d07  TVP4020 [Permedia 2]
-		1011 4d10  Comet
-		1040 000f  AccelStar II
-		1040 0011  AccelStar II
-		1048 0a31  WINNER 2000
-		1048 0a32  GLoria Synergy
-		1048 0a34  GLoria Synergy
-		1048 0a35  GLoria Synergy
-		1048 0a36  GLoria Synergy
-		1048 0a43  GLoria Synergy
-		1048 0a44  GLoria Synergy
-		107d 2633  WinFast 3D L2300
-		1092 0126  FIRE GL 1000 PRO
-		1092 0127  FIRE GL 1000 PRO
-		1092 0136  FIRE GL 1000 PRO
-		1092 0141  FIRE GL 1000 PRO
-		1092 0146  FIRE GL 1000 PRO
-		1092 0148  FIRE GL 1000 PRO
-		1092 0149  FIRE GL 1000 PRO
-		1092 0152  FIRE GL 1000 PRO
-		1092 0154  FIRE GL 1000 PRO
-		1092 0155  FIRE GL 1000 PRO
-		1092 0156  FIRE GL 1000 PRO
-		1092 0157  FIRE GL 1000 PRO
-		1097 3d01  Jeronimo Pro
-		1102 100f  Graphics Blaster Extreme
-		3d3d 0100  Reference Permedia 2 3D
 	8000  PCILynx/PCILynx2 IEEE 1394 Link Layer Controller
-		105e 8003  FireBoard200
-		1443 8003  FireBoard200
-		1443 8005  FireBoard400
-		1443 8006  FireBoard400
-		e4bf 1010  CF1-1-SNARE
-		e4bf 1020  CF1-2-SNARE
-		e4bf 1040  FireCompact400
 	8009  TSB12LV22 IEEE-1394 Controller
-		104d 8032  8032 OHCI i.LINK (IEEE 1394) Controller
-		1443 8010  FireBoard400-OHCI
 	8017  PCI4410 FireWire Controller
 	8019  TSB12LV23 IEEE-1394 Controller
-		11bd 000a  Studio DV500-1394
-		11bd 000e  Studio DV
-		1443 8010  FireBoard400-OHCI
-		e4bf 1010  CF2-1-CYMBAL
 	8020  TSB12LV26 IEEE-1394 Controller (Link)
-		1028 00d8  Precision 530
-		104d 80e2  VAIO PCV-J200
-		11bd 000f  Studio DV500-1394
-		11bd 001c  Excalibur 4.1
-		1443 8010  FireBoard400-OHCI
 	8021  TSB43AA22 IEEE-1394 Controller (PHY/Link Integrated)
-		104d 80df  Vaio PCG-FX403
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
 	8022  TSB43AB22 IEEE-1394a-2000 Controller (PHY/Link) [iOHCI-Lynx]
-		104c 8023  TSB43AB22/A IEEE-1394a-2000 Controller (PHY/Link)
 	8023  TSB43AB22A IEEE-1394a-2000 Controller (PHY/Link) [iOHCI-Lynx]
-		1028 0168  Precision Workstation 670 Mainboard
-		103c 088c  NC8000 laptop
-		1043 808b  K8N4/A8N Series Mainboard
-		1043 815b  P5W DH Deluxe Motherboard
-		1443 8023  FireCard400
-		8086 5044  Desktop Board DP35DP
 	8024  TSB43AB23 IEEE-1394a-2000 Controller (PHY/Link)
-		107d 6620  Winfast DV2000 FireWire Controller
-		1443 8024  FireBoard Blue
-		1458 1000  Motherboard
 	8025  TSB82AA2 IEEE-1394b Link Layer Controller
-		1043 813c  P5P series mainboard
-		1443 8025  FireBoard800
-		1458 1000  GA-K8N Ultra-9 Mainboard
-		1546 8025  FWB-PCI01
-		17fc 8025  GIC3800
 	8026  TSB43AB21 IEEE-1394a-2000 Controller (PHY/Link)
-		1025 0035  TravelMate 660
-		1025 003c  Aspire 2001WLCi (Compaq CL50 motherboard)
-		103c 0025  XE4500 Notebook
-		103c 006a  NX9500
-		1043 808d  A7V333 mainboard.
 	8027  PCI4451 IEEE-1394 Controller
-		1028 00e5  Latitude C810
-		1028 00e6  PCI4451 IEEE-1394 Controller (Dell Inspiron 8100)
 	8029  PCI4510 IEEE-1394 Controller
-		1028 0163  Latitude D505
-		1028 0196  Inspiron 5160
-		1071 8160  MIM2900
 	802b  PCI7410,7510,7610 OHCI-Lynx Controller
-		1028 0139  Latitude D400
-		1028 014e  PCI7410,7510,7610 OHCI-Lynx Controller (Latitude D800)
 	802e  PCI7x20 1394a-2000 OHCI Two-Port PHY/Link-Layer Controller
-		1028 018d  Inspiron 700m/710m
 	8031  PCIxx21/x515 Cardbus Controller
-		1025 0064  Extensa 3000 series laptop
-		1025 0080  Aspire 5024WLMi
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		103c 308b  MX6125
 	8032  OHCI Compliant IEEE 1394 Host Controller
-		1025 0064  Extensa 3000 series laptop
-		1025 0080  Aspire 5024WLMi
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		103c 308b  MX6125
 	8033  PCIxx21 Integrated FlashMedia Controller
-		1025 0064  Extensa 3000 series laptop
-		1025 0080  Aspire 5024WLMi
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		103c 308b  MX6125
 	8034  PCI6411/6421/6611/6621/7411/7421/7611/7621 Secure Digital Controller
-		1025 0080  Aspire 5024WLMi
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		103c 308b  MX6125
 	8035  PCI6411/6421/6611/6621/7411/7421/7611/7621 Smart Card Controller
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
 	8036  PCI6515 Cardbus Controller
 	8038  PCI6515 SmartCard Controller
 	8039  PCIxx12 Cardbus Controller
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		104d 902d  VAIO VGN-NR120E
 	803a  PCIxx12 OHCI Compliant IEEE 1394 Host Controller
-		103c 309f  nx9420
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		104d 902d  VAIO VGN-NR120E
 	803b  5-in-1 Multimedia Card Reader (SD/MMC/MS/MS PRO/xD)
-		103c 309f  nx9420
-		103c 30a3  Compaq nw8440
-		104d 8212  VAIO VGN-N21E
-		104d 902d  VAIO VGN-NR120E
 	803c  PCIxx12 SDA Standard Compliant SD Host Controller
-		103c 309f  nx9420
-		103c 30a3  Compaq nw8440
 	803d  PCIxx12 GemCore based SmartCard controller
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  nc8430
-		103c 30aa  nc6310
 	8101  TSB43DB42 IEEE-1394a-2000 Controller (PHY/Link)
 	8201  PCI1620 Firmware Loading Function
 	8204  PCI7410/7510/7610 PCI Firmware Loading Function
-		1028 0139  Latitude D400
-		1028 014e  Latitude D800
 	8231  XIO2000(A)/XIO2200A PCI Express-to-PCI Bridge
-		5678 1234  DC-1394 PCIe
 	8232  XIO3130 PCI Express Switch (Upstream)
 	8233  XIO3130 PCI Express Switch (Downstream)
 	8235  XIO2200A IEEE-1394a-2000 Controller (PHY/Link)
-		5678 1234  DC-1394 PCIe
 	823e  XIO2213A/B/XIO2221 PCI Express to PCI Bridge [Cheetah Express]
 	823f  XIO2213A/B/XIO2221 IEEE-1394b OHCI Controller [Cheetah Express]
-		1546 803c  FWB-PCIE1X11B
 	8240  XIO2001 PCI Express-to-PCI Bridge
 	8241  TUSB73x0 SuperSpeed USB 3.0 xHCI Host Controller
-		1014 04b2  S824 (8286-42A)
 	8400  ACX 100 22Mbps Wireless Interface
-		1186 3b00  DWL-650+ PC Card cardbus 22Mbs Wireless Adapter [AirPlus]
-		1186 3b01  DWL-520+ 22Mbps PCI Wireless Adapter
-		1395 2201  WL22-PC
-		16ab 8501  WL-8305 IEEE802.11b+ Wireless LAN PCI Adapter
 	8401  ACX 100 22Mbps Wireless Interface
 	8888  Multicore DSP+ARM KeyStone II SOC
 	9000  Wireless Interface (of unknown type)
 	9065  TMS320DM642
 	9066  ACX 111 54Mbps Wireless Interface
-		0308 3404  G-102 v1 802.11g Wireless Cardbus Adapter
-		0308 3406  G-162 v2 802.11g Wireless Cardbus Adapter
-		104c 9066  WL212 Sitecom Wireless Network PCI-Card 100M (Version 1)
-# Found in Philips ADSL ANNEX A WLAN Router SNA6500/18 sold by Belgacom
-		104c 9067  TNETW1130GVF
-		104c 9096  Trendnet TEW-412PC Wireless PCI Adapter (Version A)
-		1186 3b04  DWL-G520+ Wireless PCI Adapter
-		1186 3b05  DWL-G650+ AirPlusG+ CardBus Wireless LAN
-		1186 3b08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.B1)
-		1385 4c00  WG311v2 802.11g Wireless PCI Adapter
-		13d1 aba0  SWLMP-54108 108Mbps Wireless mini PCI card 802.11g+
-		14ea ab07  GW-NS54GM Wireless Cardbus Adapter
-		16ec 010d  USR5416 802.11g Wireless Turbo PCI Adapter
-		16ec 010e  USR5410 802.11g Wireless Cardbus Adapter
-		1737 0033  WPC54G v2 802.11g Wireless-G Notebook Adapter
-		17cf 0032  G-162 v1 802.11g Wireless Cardbus Adapter
-		17cf 0033  Z-Com XG650 Wireless miniPCI 802.11b/g
-		187e 340b  G-302 v2 802.11g Wireless PCI Adapter
-		187e 340c  G-360 v2 802.11g Wireless PCI Adapter
 	a001  TDC1570
 	a100  TDC1561
 	a102  TNETA1575 HyperSAR Plus w/PCI Host i/f & UTOPIA i/f
 	a106  TMS320C6414 TMS320C6415 TMS320C6416
-		175c 5000  ASI50xx Audio Adapter
-		175c 6400  ASI6400 Cobranet series
-		175c 8700  ASI87xx Radio Tuner card
 	ac10  PCI1050
 	ac11  PCI1053
 	ac12  PCI1130
 	ac13  PCI1031
 	ac15  PCI1131
 	ac16  PCI1250
-		1014 0092  ThinkPad 600
 	ac17  PCI1220
 	ac18  PCI1260
 	ac19  PCI1221
 	ac1a  PCI1210
 	ac1b  PCI1450
-		0e11 b113  Armada M700
-		1014 0130  ThinkPad 600X/A21m/T20/T22
 	ac1c  PCI1225
-		0e11 b121  Armada E500
-		1028 0088  Latitude CPi A400XT
 	ac1d  PCI1251A
 	ac1e  PCI1211
 	ac1f  PCI1251B
@@ -5564,60 +2265,25 @@ var pciids = []byte(`#
 	ac40  PCI4450 PC card Cardbus Controller
 	ac41  PCI4410 PC card Cardbus Controller
 	ac42  PCI4451 PC card Cardbus Controller
-		1028 00e6  PCI4451 PC card CardBus Controller (Inspiron 8100)
 	ac44  PCI4510 PC card Cardbus Controller
-		1028 0149  Inspiron 5100
-		1028 0163  Latitude D505
-		1028 0196  Inspiron 5160
-		1071 8160  MIM2000
 	ac46  PCI4520 PC card Cardbus Controller
-		1014 0552  ThinkPad
 	ac47  PCI7510 PC card Cardbus Controller
-		1028 0139  Latitude D400
-		1028 013f  Precision M60
-		1028 014e  Latitude D800
 	ac48  PCI7610 PC Card Cardbus Controller
 	ac49  PCI7410 PC Card Cardbus Controller
 	ac4a  PCI7510/7610 CardBus Bridge
-		1028 0139  Latitude D400
-		1028 014e  Latitude D800
 	ac4b  PCI7610 SD/MMC controller
 	ac4c  PCI7610 Memory Stick controller
 	ac50  PCI1410 PC card Cardbus Controller
 	ac51  PCI1420 PC card Cardbus Controller
-		0e11 004e  Evo N600c
-		1014 0148  ThinkPad A20m
-		1014 023b  ThinkPad T23
-		1028 00b1  Latitude C600
-		1028 012a  Latitude C640
-		1033 80cd  Versa Note VXi
-		10cf 1095  Lifebook S-4510/C6155
-		e4bf 1000  CP2-2-HIPHOP
 	ac52  PCI1451 PC card Cardbus Controller
 	ac53  PCI1421 PC card Cardbus Controller
 	ac54  PCI1620 PC Card Controller
-		103c 08b0  tc1100 tablet
 	ac55  PCI1520 PC card Cardbus Controller
-		1014 0512  ThinkPad T30/T40
-		103c 0025  XE4500 Notebook
 	ac56  PCI1510 PC card Cardbus Controller
-		1014 0512  ThinkPad R50e
-		1014 0528  ThinkPad R40e
-		17aa 2012  ThinkPad T60/R60 series
 	ac60  PCI2040 PCI to DSP Bridge Controller
-		175c 5100  ASI51xx Audio Adapter
-		175c 6100  ASI61xx Audio Adapter
-		175c 6200  ASI62xx Audio Adapter
-		175c 8800  ASI88xx Audio Adapter
-		186f 3001  WR-G303 PCI radio receiver
-		186f 3005  WR-G305 PCI radio receiver
-		186f 3101  WR-G313 PCI radio receiver
-		186f 3105  WR-G315 PCI radio receiver
 	ac8d  PCI 7620
 	ac8e  PCI7420 CardBus Controller
-		1028 018d  Inspiron 700m/710m
 	ac8f  PCI7420/7620 SD/MS-Pro Controller
-		1028 018d  Inspiron 700m/710m
 	b001  TMS320C6424
 	fe00  FireWire Host Controller
 	fe03  12C01A FireWire Host Controller
@@ -5628,9 +2294,7 @@ var pciids = []byte(`#
 	8056  Rockwell HCF 56K modem
 	808a  Memory Stick Controller
 	81ce  SxS Pro memory card
-# 2nd ID
 	905c  SxS Pro memory card
-# 2nd ID
 	907f  SxS Pro+ memory card
 	908f  Aeolia ACPI
 	909e  Aeolia Ethernet Controller (Marvell Yukon 2 Family)
@@ -5655,17 +2319,9 @@ var pciids = []byte(`#
 	0033  W89C33D 802.11 a/b/g BB/MAC
 	0105  W82C105
 	0840  W89C840
-		1050 0001  W89C840 Ethernet Adapter
-		1050 0840  W89C840 Ethernet Adapter
 	0940  W89C940
 	5a5a  W89C940F
 	6692  W6692
-		1043 1702  ISDN Adapter (PCI Bus, D, W)
-		1043 1703  ISDN Adapter (PCI Bus, DV, W)
-		1043 1707  ISDN Adapter (PCI Bus, DV, W)
-		144f 1702  ISDN Adapter (PCI Bus, D, W)
-		144f 1703  ISDN Adapter (PCI Bus, DV, W)
-		144f 1707  ISDN Adapter (PCI Bus, DV, W)
 	9921  W99200F MPEG-1 Video Encoder
 	9922  W99200F/W9922PF MPEG-1/2 Video Encoder
 	9970  W9970CF
@@ -5696,7 +2352,6 @@ var pciids = []byte(`#
 	9463  SLC90E66 [Victory66] ACPI
 	e420  LAN9420/LAN9420i
 1056  ICL
-# Motorola made a mistake and used 1507 instead of 1057 in some chips. Please look at the 1507 entry as well when updating this.
 1057  Motorola
 	0001  MPC105 [Eagle]
 	0002  MPC106 [Grackle]
@@ -5711,69 +2366,16 @@ var pciids = []byte(`#
 	1073  Nokia N770
 	1219  Nokia N800
 	1801  DSP56301 Digital Signal Processor
-		14fb 0101  Transas Radar Imitator Board [RIM]
-		14fb 0102  Transas Radar Imitator Board [RIM-2]
-		14fb 0202  Transas Radar Integrator Board [RIB-2]
-		14fb 0611  1 channel CAN bus Controller [CanPci-1]
-		14fb 0612  2 channels CAN bus Controller [CanPci-2]
-		14fb 0613  3 channels CAN bus Controller [CanPci-3]
-		14fb 0614  4 channels CAN bus Controller [CanPci-4]
-		14fb 0621  1 channel CAN bus Controller [CanPci2-1]
-		14fb 0622  2 channels CAN bus Controller [CanPci2-2]
-		14fb 0810  Transas VTS Radar Integrator Board [RIB-4]
-		175c 4200  ASI4215 Audio Adapter
-		175c 4300  ASI43xx Audio Adapter
-		175c 4400  ASI4401 Audio Adapter
-		ecc0 0010  Darla
-		ecc0 0020  Gina
-		ecc0 0030  Layla rev.0
-		ecc0 0031  Layla rev.1
-		ecc0 0040  Darla24 rev.0
-		ecc0 0041  Darla24 rev.1
-		ecc0 0050  Gina24 rev.0
-		ecc0 0051  Gina24 rev.1
-		ecc0 0070  Mona rev.0
-		ecc0 0071  Mona rev.1
-		ecc0 0072  Mona rev.2
 	18c0  MPC8265A/8266/8272
 	18c1  MPC8271/MPC8272
 	3052  SM56 Data Fax Modem
 	3410  DSP56361 Digital Signal Processor
-		ecc0 0050  Gina24 rev.0
-		ecc0 0051  Gina24 rev.1
-		ecc0 0060  Layla24
-		ecc0 0070  Mona rev.0
-		ecc0 0071  Mona rev.1
-		ecc0 0072  Mona rev.2
-		ecc0 0080  Mia rev.0
-		ecc0 0081  Mia rev.1
-		ecc0 0090  Indigo
-		ecc0 00a0  Indigo IO
-		ecc0 00b0  Indigo DJ
-		ecc0 0100  3G
 	4801  Raven
 	4802  Falcon
 	4803  Hawk
 	4806  CPX8216
 	4d68  20268
 	5600  SM56 PCI Modem
-		1057 0300  SM56 PCI Speakerphone Modem
-		1057 0301  SM56 PCI Voice Modem
-		1057 0302  SM56 PCI Fax Modem
-		1057 5600  SM56 PCI Voice modem
-		13d2 0300  SM56 PCI Speakerphone Modem
-		13d2 0301  SM56 PCI Voice modem
-		13d2 0302  SM56 PCI Fax Modem
-		1436 0300  SM56 PCI Speakerphone Modem
-		1436 0301  SM56 PCI Voice modem
-		1436 0302  SM56 PCI Fax Modem
-		144f 100c  SM56 PCI Fax Modem
-		1494 0300  SM56 PCI Speakerphone Modem
-		1494 0301  SM56 PCI Voice modem
-		14c8 0300  SM56 PCI Speakerphone Modem
-		14c8 0302  SM56 PCI Fax Modem
-		1668 0300  SM56 PCI Speakerphone Modem
-		1668 0302  SM56 PCI Fax Modem
 	5608  Wildcard X100P
 	5803  MPC5200
 	5806  MCF54 Coldfire
@@ -5785,23 +2387,14 @@ var pciids = []byte(`#
 1059  Kontron
 105a  Promise Technology, Inc.
 	0d30  PDC20265 (FastTrak100 Lite/Ultra100)
-		1043 8042  AV7266-E South Bridge Promise RAID
-		105a 4d33  Ultra100
 	0d38  20263
-		105a 4d39  Fasttrak66
 	1275  20275
 	3318  PDC20318 (SATA150 TX4)
 	3319  PDC20319 (FastTrak S150 TX4)
-		105a 3319  FastTrak S150 TX4 4 port SATA PCI board
-		8086 3427  S875WP1-E mainboard
 	3371  PDC20371 (FastTrak S150 TX2plus)
 	3373  PDC20378 (FastTrak 378/SATA 378)
-		1043 80f5  K8V Deluxe/PC-DL Deluxe motherboard
-		1462 590d  KT6 Delta-FIS2R (MS-6590)
-		1462 702e  K8T NEO FIS2R motherboard
 	3375  PDC20375 (SATA150 TX2plus)
 	3376  PDC20376 (FastTrak 376)
-		1043 809e  A7V8X motherboard
 	3515  PDC40719 [FastTrak TX4300/TX4310]
 	3519  PDC40519 (FastTrak TX4200)
 	3570  PDC20771 [FastTrak TX2300]
@@ -5815,29 +2408,14 @@ var pciids = []byte(`#
 	3f20  PDC42819 [FastTrak TX2650/TX4650]
 	4302  80333 [SuperTrak EX4350]
 	4d30  PDC20267 (FastTrak100/Ultra100)
-		105a 4d33  Ultra100
-		105a 4d39  FastTrak100
-		8086 5744  S845WD1-E mainboard
 	4d33  20246
-		105a 4d33  20246 IDE Controller
 	4d38  PDC20262 (FastTrak66/Ultra66)
-		105a 4d30  Ultra Device on SuperTrak
-		105a 4d33  Ultra66
-		105a 4d39  FastTrak66
 	4d68  PDC20268 [Ultra100 TX2]
-		105a 4d68  Ultra100 TX2
 	4d69  20269
-		105a 4d68  Ultra133TX2
 	5275  PDC20276 (MBFastTrak133 Lite)
-		1043 807e  A7V333 motherboard.
-		105a 0275  SuperTrak SX6000 IDE
-		105a 1275  MBFastTrak133 Lite (tm) Controller (RAID mode)
-		1458 b001  MBUltra 133
 	5300  DC5300
 	6268  PDC20270 (FastTrak100 LP/TX2/TX4)
-		105a 4d68  FastTrak100 TX2
 	6269  PDC20271 (FastTrak TX2000)
-		105a 6269  FastTrak TX2/TX2000
 	6300  PDC81731 [FastTrak SX8300]
 	6621  PDC20621 (FastTrak S150 SX4/FastTrak SX4000 lite)
 	6622  PDC20621 [SATA150 SX4] 4 Channel IDE RAID Controller
@@ -5848,19 +2426,6 @@ var pciids = []byte(`#
 	8002  SATAII150 SX8
 	8350  80333 [SuperTrak EX8350/EX16350], 80331 [SuperTrak EX8300/EX16300]
 	8650  81384 [SuperTrak EX SAS and SATA RAID Controller]
-		105a 4600  SuperTrak EX4650A
-		105a 4601  SuperTrak EX4650
-		105a 4610  SuperTrak EX4650EL
-		105a 8600  SuperTrak EX8650EL
-		105a 8601  SuperTrak EX8650A
-		105a 8602  SuperTrak EX8654
-		105a 8603  SuperTrak EX8658
-		105a 8604  SuperTrak EX8650
-		105a 8610  SuperTrak EX8650M
-		105a a600  SuperTrak EX12650
-		105a b600  SuperTrak EX16650
-		105a b601  SuperTrak EX16654
-		105a b602  SuperTrak EX16658
 	8760  PM8010 [SuperTrak EX SAS and SATA 6G RAID Controller]
 	c350  80333 [SuperTrak EX12350]
 	e350  80333 [SuperTrak EX24350]
@@ -5869,40 +2434,8 @@ var pciids = []byte(`#
 105d  Number 9 Computer Company
 	2309  Imagine 128
 	2339  Imagine 128-II
-		105d 0000  Imagine 128 series 2 4Mb VRAM
-		105d 0001  Imagine 128 series 2 4Mb VRAM
-		105d 0002  Imagine 128 series 2 4Mb VRAM
-		105d 0003  Imagine 128 series 2 4Mb VRAM
-		105d 0004  Imagine 128 series 2 4Mb VRAM
-		105d 0005  Imagine 128 series 2 4Mb VRAM
-		105d 0006  Imagine 128 series 2 4Mb VRAM
-		105d 0007  Imagine 128 series 2 4Mb VRAM
-		105d 0008  Imagine 128 series 2e 4Mb DRAM
-		105d 0009  Imagine 128 series 2e 4Mb DRAM
-		105d 000a  Imagine 128 series 2 8Mb VRAM
-		105d 000b  Imagine 128 series 2 8Mb H-VRAM
-		11a4 000a  Barco Metheus 5 Megapixel
-		13cc 0000  Barco Metheus 5 Megapixel
-		13cc 0004  Barco Metheus 5 Megapixel
-		13cc 0005  Barco Metheus 5 Megapixel
-		13cc 0006  Barco Metheus 5 Megapixel
-		13cc 0008  Barco Metheus 5 Megapixel
-		13cc 0009  Barco Metheus 5 Megapixel
-		13cc 000a  Barco Metheus 5 Megapixel
-		13cc 000c  Barco Metheus 5 Megapixel
 	493d  Imagine 128 T2R [Ticket to Ride]
-		11a4 000a  Barco Metheus 5 Megapixel, Dual Head
-		11a4 000b  Barco Metheus 5 Megapixel, Dual Head
-		13cc 0002  Barco Metheus 4 Megapixel, Dual Head
-		13cc 0003  Barco Metheus 5 Megapixel, Dual Head
-		13cc 0007  Barco Metheus 5 Megapixel, Dual Head
-		13cc 0008  Barco Metheus 5 Megapixel, Dual Head
-		13cc 0009  Barco Metheus 5 Megapixel, Dual Head
-		13cc 000a  Barco Metheus 5 Megapixel, Dual Head
 	5348  Revolution 4
-		105d 0037  Revolution IV-FP AGP (For SGI 1600SW)
-		11a4 0028  PVS5600M
-		11a4 0038  PVS5600D
 105e  Vtech Computers Ltd
 105f  Infotronic America Inc
 1060  United Microelectronics [UMC]
@@ -5956,25 +2489,10 @@ var pciids = []byte(`#
 	0010  DAC960PG
 	0020  DAC960LA
 	0050  AcceleRAID 352/170/160 support Device
-		1069 0050  AcceleRAID 352 support Device
-		1069 0052  AcceleRAID 170 support Device
-		1069 0054  AcceleRAID 160 support Device
 	b166  AcceleRAID 600/500/400/Sapphire support Device
-		1014 0242  iSeries 2872 DASD IOA
-		1014 0266  Dual Channel PCI-X U320 SCSI Adapter
-		1014 0278  Dual Channel PCI-X U320 SCSI RAID Adapter
-		1014 02d3  Dual Channel PCI-X U320 SCSI Adapter
-		1014 02d4  Dual Channel PCI-X U320 SCSI RAID Adapter
-		1069 0200  AcceleRAID 400, Single Channel, PCI-X, U320, SCSI RAID
-		1069 0202  AcceleRAID Sapphire, Dual Channel, PCI-X, U320, SCSI RAID
-		1069 0204  AcceleRAID 500, Dual Channel, Low-Profile, PCI-X, U320, SCSI RAID
-		1069 0206  AcceleRAID 600, Dual Channel, PCI-X, U320, SCSI RAID
 	ba55  eXtremeRAID 1100 support Device
 	ba56  eXtremeRAID 2000/3000 support Device
-		1069 0030  eXtremeRAID 3000 support Device
-		1069 0040  eXtremeRAID 2000 support Device
 	ba57  eXtremeRAID 4000/5000 support Device
-		1069 0072  eXtremeRAID 5000 support Device
 106a  Aten Research Inc
 106b  Apple Inc.
 	0001  Bandit PowerPC host bridge
@@ -6004,7 +2522,6 @@ var pciids = []byte(`#
 	002f  UniNorth 1.5 Internal PCI
 	0030  UniNorth/Pangea FireWire
 	0031  UniNorth 2 FireWire
-		106b 5811  iBook G4 2004
 	0032  UniNorth 2 GMAC (Sun GEM)
 	0033  UniNorth 2 ATA/100
 	0034  UniNorth 2 AGP
@@ -6013,7 +2530,6 @@ var pciids = []byte(`#
 	003b  UniNorth/Intrepid ATA/100
 	003e  KeyLargo/Intrepid Mac I/O
 	003f  KeyLargo/Intrepid USB
-		1af4 1100  QEMU Virtual Machine
 	0040  K2 KeyLargo USB
 	0041  K2 KeyLargo Mac/IO
 	0042  K2 FireWire
@@ -6045,7 +2561,6 @@ var pciids = []byte(`#
 	006a  Intrepid2 Firewire
 	006b  Intrepid2 GMAC (Sun GEM)
 	0074  U4 HT Bridge
-# should be 14e4:1645
 	1645  Broadcom NetXtreme BCM5701 Gigabit Ethernet
 	2001  S1X NVMe Controller
 	2002  S3ELab NVMe Controller
@@ -6070,29 +2585,17 @@ var pciids = []byte(`#
 	0002  YGV615 [RPA3 3D-Graphics Controller]
 	0003  YMF-740
 	0004  YMF-724
-		1073 0004  YMF724-Based PCI Audio Adapter
 	0005  DS1 Audio
-		1073 0005  DS-XG PCI Audio CODEC
 	0006  DS1 Audio
 	0008  DS1 Audio
-		1073 0008  DS-XG PCI Audio CODEC
 	000a  DS1L Audio
-		1073 0004  DS-XG PCI Audio CODEC
-		1073 000a  DS-XG PCI Audio CODEC
-		8086 4d55  DS-XG PCI Audio CODEC [Intel MU440EX]
 	000c  YMF-740C [DS-1L Audio Controller]
-		107a 000c  DS-XG PCI Audio CODEC
 	000d  YMF-724F [DS-1 Audio Controller]
-		1073 000d  DS-XG PCI Audio CODEC
 	0010  YMF-744B [DS-1S Audio Controller]
-		1073 0006  DS-XG PCI Audio CODEC
-		1073 0010  DS-XG PCI Audio CODEC
 	0012  YMF-754 [DS-1E Audio Controller]
-		1073 0012  DS-XG PCI Audio Codec
 	0020  DS-1 Audio
 	1000  SW1000XG [XG Factory]
 	2000  DS2416 Digital Mixing Card
-		1073 2000  DS2416 Digital Mixing Card
 1074  NexGen Microsystems
 	4e78  82c500/1
 1075  Advanced Integrations Research
@@ -6103,84 +2606,27 @@ var pciids = []byte(`#
 	1022  ISP1022 Fast-wide SCSI
 	1080  ISP1080 SCSI Host Adapter
 	1216  ISP12160 Dual Channel Ultra3 SCSI Processor
-		101e 8471  QLA12160 on AMI MegaRAID
-		101e 8493  QLA12160 on AMI MegaRAID
 	1240  ISP1240 SCSI Host Adapter
 	1280  ISP1280 SCSI Host Adapter
 	1634  FastLinQ QL45000 Series 40GbE Controller
-		1077 e4f1  FastLinQ QL45212H 40GbE Adapter
-		1077 e4f2  FastLinQ QL45211H 40GbE Adapter
-		1077 e4f3  FastLinQ QL45412H 40GbE Adapter
-		1077 e4f4  FastLinQ QL45411H 40GbE Adapter
 	1644  FastLinQ QL45000 Series 100GbE Controller
-		1077 e4f8  FastLinQ QL45611H 100GbE Adapter
 	1654  FastLinQ QL45000 Series 50GbE Controller
-		1590 0223  Synergy 6810C 25/50Gb Ethernet Adapter
 	1656  FastLinQ QL45000 Series 25GbE Controller
-		1077 02a7  QL45212-DE 25GbE Adapter
-		1077 e4f6  FastLinQ QL45211H 25GbE Adapter
-		1077 e4f7  FastLinQ QL45212H 25GbE Adapter
 	165c  FastLinQ QL45000 Series 10/25/40/50GbE Controller (FCoE)
-		1077 e4f1  FastLinQ QL45462H 40GbE FCoE Adapter
-		1077 e4f2  FastLinQ QL45461H 40GbE FCoE Adapter
 	165e  FastLinQ QL45000 Series 10/25/40/50GbE Controller (iSCSI)
-		1077 e4f1  FastLinQ QL45462H 40GbE iSCSI Adapter
-		1077 e4f2  FastLinQ QL45461H 40GbE iSCSI Adapter
 	1664  FastLinQ QL45000 Series Gigabit Ethernet Controller (SR-IOV VF)
-		1077 e4f1  FastLinQ QL45462H 40GbE Adapter (SR-IOV VF)
-		1077 e4f2  FastLinQ QL45461H 40GbE Adapter (SR-IOV VF)
-		1077 e4f3  FastLinQ QL45412H 40GbE Adapter (SR-IOV VF)
-		1077 e4f4  FastLinQ QL45411H 40GbE Adapter (SR-IOV VF)
-		1077 e4f6  FastLinQ QL45211H 25GbE Adapter (SR-IOV VF)
-		1077 e4f7  FastLinQ QL45212H 25GbE Adapter (SR-IOV VF)
-		1077 e4f8  FastLinQ QL45611H 100GbE Adapter (SR-IOV VF)
 	2020  ISP2020A Fast!SCSI Basic Adapter
 	2031  ISP8324-based 16Gb Fibre Channel to PCI Express Adapter
-		103c 17e7  SN1000Q 16Gb Single Port Fibre Channel Adapter
-		103c 17e8  SN1000Q 16Gb Dual Port Fibre Channel Adapter
-		103c 1939  QMH2672 16Gb Dual Port Fibre Channel Adapter
-		103c 8002  3830C 16G Fibre Channel Host Bus Adapter
 	2071  ISP2714-based 16/32Gb Fibre Channel to PCIe Adapter
-		1077 0283  QLE2764 Quad Port 32Gb Fibre Channel to PCIe Adapter
-		1077 029e  QLE2694 Quad Port 16Gb Fibre Channel to PCIe Adapter
-		1077 02a2  QLE2694L Quad Port 16Gb Fibre Channel to PCIe Adapter
-		1077 02ad  QLE2694U Quad Port 16/32Gb Fibre Channel to PCIe Adapter
 	2100  QLA2100 64-bit Fibre Channel Adapter
-		1077 0001  QLA2100 64-bit Fibre Channel Adapter
 	2200  QLA2200 64-bit Fibre Channel Adapter
-		1077 0002  QLA2200
 	2261  ISP2722-based 16/32Gb Fibre Channel to PCIe Adapter
-		1077 0299  QLE2740 Single Port 32Gb Fibre Channel to PCIe Adapter
-		1077 029a  QLE2742 Dual Port 32Gb Fibre Channel to PCIe Adapter
-		1077 029b  QLE2690 Single Port 16Gb Fibre Channel to PCIe Adapter
-		1077 029c  QLE2692 Dual Port 16Gb Fibre Channel to PCIe Adapter
-		1077 02a7  QLE2690 Single Port 16Gb FC to PCIe Gen3 x8 Adapter
-		1077 02a8  QLE2692 Dual Port 16Gb FC to PCIe Gen3 x8 Adapter
-		1077 02ab  QLE2740 Single Port 32Gb FC to PCIe Gen3 x8 Adapter
-		1077 02ac  QLE2742 Dual Port 32Gb FC to PCIe Gen3 x8 Adapter
-		1590 00f9  StoreFabric SN1100Q 16Gb Single Port Fibre Channel Host Bus Adapter
-		1590 00fa  StoreFabric SN1100Q 16Gb Dual Port Fibre Channel Host Bus Adapter
-		1590 0203  StoreFabric SN1600Q 32Gb Single Port Fibre Channel Host Bus Adapter
-		1590 0204  StoreFabric SN1600Q 32Gb Dual Port Fibre Channel Host Bus Adapter
 	2300  QLA2300 64-bit Fibre Channel Adapter
 	2312  ISP2312-based 2Gb Fibre Channel to PCI-X HBA
-		103c 0131  2Gb Fibre Channel - Single port [A7538A]
-		103c 12ba  2Gb Fibre Channel - Dual port [A6826A]
 	2322  ISP2322-based 2Gb Fibre Channel to PCI-X HBA
 	2422  ISP2422-based 4Gb Fibre Channel to PCI-X HBA
-		103c 12d7  4Gb Fibre Channel [AB379A]
-		103c 12dd  4Gb Fibre Channel [AB429A]
 	2432  ISP2432-based 4Gb Fibre Channel to PCI Express HBA
-		103c 7040  FC1142SR 4Gb 1-port PCIe Fibre Channel Host Bus Adapter [HPAE311A]
 	2532  ISP2532-based 8Gb Fibre Channel to PCI Express HBA
-		1014 041e  FC EN0Y/EN12 PCIe2 LP 8 Gb 4-port Fibre Channel Adapter for POWER
-		103c 3262  StorageWorks 81Q
-		103c 3263  StorageWorks 82Q
-		1077 015c  QLE2560 PCI Express to 8Gb FC Single Channel
-		1077 015d  QLE2562 PCI Express to 8Gb FC Dual Channel
-		1077 015e  QLE2564 PCI Express to 8Gb FC Quad Channel
-		1077 0167  QME2572 Dual Port FC8 HBA Mezzanine
-		1590 00fc  StoreFabric 84Q 8Gb Quad Port Fibre Channel Host Bus Adapter
 	2971  ISP2684
 	3022  ISP4022-based Ethernet NIC
 	3032  ISP4032-based Ethernet IPv6 NIC
@@ -6194,55 +2640,16 @@ var pciids = []byte(`#
 	7322  IBA7322 QDR InfiniBand HCA
 	8000  10GbE Converged Network Adapter (TCP/IP Networking)
 	8001  10GbE Converged Network Adapter (FCoE)
-		1014 03af  FC 5708/5270 10 Gb FCoE PCIe Dual Port Adapter for POWER
 	8020  cLOM8214 1/10GbE Controller
-		1028 1f64  QMD8262-k 10G DP bNDC KR
-		103c 3346  CN1000Q Dual Port Converged Network Adapter
-		103c 3733  NC523SFP 10Gb 2-port Server Adapter
-		1077 0203  8200 Series Single Port 10GbE Converged Network Adapter (TCP/IP Networking)
-		1077 0207  8200 Series Dual Port 10GbE Converged Network Adapter (TCP/IP Networking)
-		1077 020b  3200 Series Dual Port 10Gb Intelligent Ethernet Adapter
-		1077 020c  3200 Series Quad Port 1Gb Intelligent Ethernet Adapter
-		1077 020f  3200 Series Single Port 10Gb Intelligent Ethernet Adapter
-		1077 0210  QME8242-k 10GbE Dual Port Mezzanine Card
-		1077 0233  QME8262-k 10GbE Dual Port Mezzanine Card
 	8021  8200 Series 10GbE Converged Network Adapter (FCoE)
-		103c 3348  CN1000Q Dual Port Converged Network Adapter
-		1077 0211  QME8242-k 10GbE Dual Port Mezzanine Card, FCoE
 	8022  8200 Series 10GbE Converged Network Adapter (iSCSI)
-		103c 3347  CN1000Q Dual Port Converged Network Adapter
-		1077 0212  QME8242-k 10GbE Dual Port Mezzanine Card, iSCSI
 	8030  ISP8324 1/10GbE Converged Network Controller
-		1077 0243  8300 Series Single Port 10GbE Converged Network Adapter (TCP/IP Networking)
-		1077 0246  8300 Series Dual Port 10GbE Converged Network Adapter (TCP/IP Networking)
 	8031  8300 Series 10GbE Converged Network Adapter (FCoE)
 	8032  8300 Series 10GbE Converged Network Adapter (iSCSI)
 	8070  FastLinQ QL41000 Series 10/25/40/50GbE Controller
-		1077 0001  10GE 2P QL41162HxRJ-DE Adapter
-		1077 0002  10GE 2P QL41112HxCU-DE Adapter
-		1077 000b  25GE 2P QL41262HxCU-DE Adapter
-		1077 0011  FastLinQ QL41212H 25GbE Adapter
-		1077 0012  FastLinQ QL41112H 10GbE Adapter
 	8080  FastLinQ QL41000 Series 10/25/40/50GbE Controller (FCoE)
-		1077 0001  10GE 2P QL41162HxRJ-DE Adapter
-		1077 0002  10GE 2P QL41112HxCU-DE Adapter
-		1077 000b  25GE 2P QL41262HxCU-DE Adapter
-		1077 000d  FastLinQ QL41262H 25GbE FCoE Adapter
-		1077 000e  FastLinQ QL41162H 10GbE FCoE Adapter
 	8084  FastLinQ QL41000 Series 10/25/40/50GbE Controller (iSCSI)
-		1077 0001  10GE 2P QL41162HxRJ-DE Adapter
-		1077 0002  10GE 2P QL41112HxCU-DE Adapter
-		1077 000b  25GE 2P QL41262HxCU-DE Adapter
-		1077 000d  FastLinQ QL41262H 25GbE iSCSI Adapter
-		1077 000e  FastLinQ QL41162H 10GbE iSCSI Adapter
 	8090  FastLinQ QL41000 Series Gigabit Ethernet Controller (SR-IOV VF)
-		1077 0001  25GE 2P QL41262HxCU-DE Adapter
-		1077 0002  10GE 2P QL41112HxCU-DE Adapter
-		1077 000b  25GE 2P QL41262HxCU-DE Adapter
-		1077 000d  FastLinQ QL41262H 25GbE FCoE Adapter (SR-IOV VF)
-		1077 000e  FastLinQ QL41162H 10GbE iSCSI Adapter (SR-IOV VF)
-		1077 0011  FastLinQ QL41212H 25GbE Adapter (SR-IOV VF)
-		1077 0012  FastLinQ QL41112H 10GbE Adapter (SR-IOV VF)
 	8430  ISP8324 1/10GbE Converged Network Controller (NIC VF)
 	8431  8300 Series 10GbE Converged Network Adapter (FCoE VF)
 	8432  ISP2432M-based 10GbE Converged Network Adapter (CNA)
@@ -6261,7 +2668,6 @@ var pciids = []byte(`#
 	0403  ZFMicro Expansion Bus
 1079  I-Bus
 107a  NetWorth
-# formerly Gateway 2000 / acquired by Acer Inc.
 107b  Gateway, Inc.
 107c  LG Electronics [Lucky Goldstar Co. Ltd]
 107d  LeadTek Research Inc.
@@ -6299,7 +2705,6 @@ var pciids = []byte(`#
 1087  Cache Computer
 1088  Microcomputer Systems (M) Son
 1089  Data General Corporation
-# Formerly Bit3 Computer Corp.
 108a  SBS Technologies
 	0001  VME Bridge Model 617
 	0010  VME Bridge Model 618
@@ -6310,20 +2715,15 @@ var pciids = []byte(`#
 	0001  Token-Ring 16/4 PCI Adapter (3136/3137)
 	0002  16/4 Token Ring
 	0004  RapidFire OC-3139/3140 Token-Ring 16/4 PCI Adapter
-		108d 0004  OC-3139/3140 RapidFire Token-Ring 16/4 Adapter
 	0005  GoCard 3250 Token-Ring 16/4 CardBus PC Card
 	0006  OC-3530 RapidFire Token-Ring 100
 	0007  RapidFire 3141 Token-Ring 16/4 PCI Fiber Adapter
-		108d 0007  OC-3141 RapidFire Token-Ring 16/4 Adapter
 	0008  RapidFire 3540 HSTR 100/16/4 PCI Adapter
-		108d 0008  OC-3540 RapidFire HSTR 100/16/4 Adapter
 	0011  OC-2315
 	0012  OC-2325
 	0013  OC-2183/2185
 	0014  OC-2326
 	0019  OC-2327/2250 10/100 Ethernet Adapter
-		108d 0016  OC-2327 Rapidfire 10/100 Ethernet Adapter
-		108d 0017  OC-2250 GoCard 10/100 Ethernet Adapter
 	0021  OC-6151/6152 [RapidFire ATM 155]
 	0022  ATM Adapter
 108e  Oracle/SUN
@@ -6331,20 +2731,15 @@ var pciids = []byte(`#
 	1000  EBUS
 	1001  Happy Meal 10/100 Ethernet [hme]
 	1100  RIO EBUS
-		108e 1100  RIO EBUS on Blade 100 motherboard
 	1101  RIO 10/100 Ethernet [eri]
-		108e 1101  RIO GEM on Blade 100 motherboard
 	1102  RIO 1394
-		108e 1102  RIO 1394 on Blade 100 motherboard
 	1103  RIO USB
-		108e 1103  RIO USB on Blade 100 motherboard
 	1647  Broadcom 570x 10/100/1000 Ethernet [bge]
 	1648  Broadcom 570x 10/100/1000 Ethernet [bge]
 	16a7  Broadcom 570x 10/100/1000 Ethernet [bge]
 	16a8  Broadcom 570x 10/100/1000 Ethernet [bge]
 	2bad  GEM 10/100/1000 Ethernet [ge]
 	5000  Simba Advanced PCI Bridge
-		108e 5000  Netra AX1105-500
 	5043  SunPCI Co-processor
 	5ca0  Crypto Accelerator 6000 [mca]
 	6300  Intel 21554 PCI-PCI bus bridge [db21554]
@@ -6378,7 +2773,6 @@ var pciids = []byte(`#
 	9102  Davicom Fast Ethernet driver for Davicom DM9102A [dmfe]
 	a000  Psycho UPA-PCI Bus Module [pcipsy]
 	a001  Psycho UPA-PCI Bus Module [pcipsy]
-		108e a001  Ultra IIe on Blade 100 motherboard
 	a801  Schizo Fireplane-PCI bus bridge module [pcisch]
 	aaaa  Multithreaded Shared 10GbE Ethernet Network Controller
 	abba  Cassini 10/100/1000
@@ -6401,7 +2795,6 @@ var pciids = []byte(`#
 	1091  Sun Expert3D Graphics Accelerator
 1092  Diamond Multimedia Systems
 	0028  Viper V770
-		1092 4a00  Viper V770 32MB
 	00a0  Speedstar Pro SE
 	00a8  Speedstar 64
 	0550  Viper V550
@@ -6749,12 +3142,6 @@ var pciids = []byte(`#
 	727b  PCI-6239
 	727c  PXI-6239
 	727e  SMBus Controller
-		1093 75ac  PXIe-8388
-		1093 75ad  PXIe-8389
-		1093 7650  PXIe-8381
-		1093 8360  PXIe-8360
-		1093 8370  PXIe-8370
-		1093 8375  PXIe-8375
 	7281  PCI-6236
 	7282  PXI-6236
 	7283  PXI-2554
@@ -6987,160 +3374,6 @@ var pciids = []byte(`#
 	b0c1  PXI-1409
 	b0e1  PCI-1428
 	c4c4  PXIe/PCIe Device
-		1093 728a  PXIe-5421
-		1093 728b  PXIe-5442
-		1093 728d  PXIe-5451
-		1093 72a2  PXIe-5122
-		1093 72da  PXIe-5422
-		1093 72f7  PXIe-6535
-		1093 72f8  PXIe-6536
-		1093 72f9  PXIe-6537
-		1093 7326  PCIe-6509
-		1093 736c  PXIe-4140
-		1093 738b  PXIe-5622
-		1093 73c4  PXIe-5450
-		1093 73c7  PXIe-6545
-		1093 73d4  PXIe-6544
-		1093 7425  PCIe-6320
-		1093 7427  PCIe-6321
-		1093 7428  PXIe-6323
-		1093 7429  PCIe-6323
-		1093 742a  PXIe-6341
-		1093 742b  PCIe-6341
-		1093 742c  PXIe-6343
-		1093 742d  PCIe-6343
-		1093 742f  PCIe-6351
-		1093 7431  PCIe-6353
-		1093 7432  PXIe-6361
-		1093 7433  PCIe-6361
-		1093 7434  PXIe-6363
-		1093 7435  PCIe-6363
-		1093 7436  PXIe-6356
-		1093 7437  PXIe-6358
-		1093 7438  PXIe-6366
-		1093 7439  PXIe-6368
-		1093 7468  PXIe-5185
-		1093 7469  PXIe-5186
-		1093 7492  PXIe-4300
-		1093 7498  PXIe-6548
-		1093 7499  PXIe-6547
-		1093 74a8  PXIe-4330
-		1093 74a9  PXIe-4331
-		1093 74b1  PXIe-4154
-		1093 74b2  PXIe-4353
-		1093 74b6  PCIe-1433
-		1093 74cd  PXIe-5643R
-		1093 74d0  PXIe-7961R
-		1093 74dd  PXIe-6376
-		1093 74de  PXIe-6378
-		1093 74e2  PXIe-7962R
-		1093 74e3  PXIe-7965R
-		1093 74e5  PXIe-4844
-		1093 74f3  PCIe-5140
-		1093 753c  PXIe-1435
-		1093 7548  PXIe-5622 (25MHz DDC)
-		1093 754d  PCIe-5155
-		1093 7551  PXIe-6556
-		1093 7553  PCIe-1473R
-		1093 7570  PCIe-1474R
-		1093 7571  PXIe-1475R
-		1093 7572  PXIe-1476R
-		1093 75a2  PXIe-5693
-		1093 75a3  PXIe-5694
-		1093 75a5  PXIe-4141
-		1093 75ce  PXIe-7966R
-		1093 75cf  PXIe-4357
-		1093 75d2  PXIe-RevB-5643R
-		1093 75d3  PXIe-5644R
-		1093 75ee  PXIe-5645R
-		1093 7613  PXIe-6555
-		1093 7619  PXIe-5185
-		1093 761a  PXIe-5186
-		1093 7629  PXIe-4142
-		1093 762a  PXIe-4143
-		1093 762b  PXIe-4138
-		1093 762c  PXIe-4144
-		1093 762d  PXIe-4145
-		1093 762e  PXIe-5606
-		1093 7644  PXIe-4841
-		1093 764a  PCIe-8237R-S
-		1093 7658  PXIe-5162 (4CH)
-		1093 76ab  PXIe-4322
-		1093 76ad  PXIe-4112
-		1093 76ae  PXIe-4113
-		1093 76b5  PXIe-7971R
-		1093 76b6  PXIe-7972R
-		1093 76b7  PXIe-7975R
-		1093 76b8  PXIe-5696
-		1093 76b9  PXIe-5654
-		1093 76c8  PXIe-6614
-		1093 76c9  PXIe-6612
-		1093 76cb  PXIe-5646R
-		1093 76cc  PXIe-5162 (2CH)
-		1093 76ce  CVS-1459
-		1093 76d0  PXIe-5160 (2CH)
-		1093 76d1  PXIe-5160 (4CH)
-		1093 76dc  PXIe-4610
-		1093 76ec  PXIe-2524
-		1093 76ed  PXIe-2525
-		1093 76ee  PXIe-2526
-		1093 76ef  PXIe-2737
-		1093 76f0  PXIe-2738
-		1093 76f1  PXIe-2739
-		1093 76fb  PCIe-1473R-LX110
-		1093 76fc  PXIe-5105
-		1093 76fd  PXIe-5114
-		1093 76fe  PXIe-5644R
-		1093 76ff  PXIe-5644R
-		1093 7700  PXIe-5644R
-		1093 7701  PXIe-5645R
-		1093 7702  PXIe-5645R
-		1093 7703  PXIe-5645R
-		1093 770c  PXIe-4139
-		1093 7711  PXIe-4464
-		1093 7712  PXIe-4463
-		1093 7716  PCIe-6612
-		1093 771d  Unconfigured CA4 Switch
-		1093 771e  PXIe-4339
-		1093 7735  cRIO-9033
-		1093 773e  PXIe-5624R
-		1093 774b  cRIO-9031
-		1093 774d  cRIO-9034
-		1093 7755  cRIO-9030
-		1093 7768  PXIe-2747
-		1093 7769  PXIe-2748
-		1093 776a  PXIe-2746
-		1093 7777  PXIe-7976R
-		1093 7782  PXIe-5646R
-		1093 7783  PXIe-5646R
-		1093 7784  PXIe-5646R
-		1093 7790  PXIe-5170R (4CH)
-		1093 7791  PXIe-5170R (8CH)
-		1093 7793  PXIe-5171R (8CH)
-		1093 77a5  PXIe-6345
-		1093 77a6  PXIe-6355
-		1093 77a7  PXIe-6365
-		1093 77a8  PXIe-6375
-		1093 77aa  CVS-1458
-		1093 77ad  IC-3173
-		1093 77b4  PXIe-7820R
-		1093 77b5  PXIe-7821R
-		1093 77b6  PXIe-7822R
-		1093 77b9  cRIO-9038
-		1093 77ba  PXIe-4136
-		1093 77bb  PXIe-4137
-		1093 77c0  PXIe-5624R
-		1093 77c1  PXIe-5624R
-		1093 77c2  PXIe-5624R
-		1093 77ca  PXIe-6738
-		1093 77cb  PXIe-6739
-		1093 77db  cRIO-9035
-		1093 77dc  cRIO-9036
-		1093 77dd  cRIO-9039
-		1093 7802  PXIe-4302
-		1093 7803  PXIe-4303
-		1093 7805  PXIe-4305
-		1093 788e  PXIe-4304
 	c801  PCI-GPIB
 	c811  PCI-GPIB+
 	c821  PXI-GPIB
@@ -7186,7 +3419,6 @@ var pciids = []byte(`#
 	fe61  VXIpc-850
 	fe70  VXIpc-880
 1094  First International Computers [FIC]
-# nee CMD Technology Inc
 1095  Silicon Image, Inc.
 	0240  Adaptec AAR-1210SA SATA HostRAID Controller
 	0640  PCI0640
@@ -7194,34 +3426,17 @@ var pciids = []byte(`#
 	0646  PCI0646
 	0647  PCI0647
 	0648  PCI0648
-		1043 8025  CUBX motherboard
 	0649  SiI 0649 Ultra ATA/100 PCI to ATA Host Controller
-		0e11 005d  Integrated Ultra ATA-100 Dual Channel Controller
-		0e11 007e  Integrated Ultra ATA-100 IDE RAID Controller
-		101e 0649  AMI MegaRAID IDE 100 Controller
 	0650  PBC0650A
 	0670  USB0670
-		1095 0670  USB0670
 	0673  USB0673
 	0680  PCI0680 Ultra ATA-133 Host Controller
-		1095 0680  SiI 0680 ATA/133 Controller
-		1095 3680  Winic W-680 (Silicon Image 680 based)
 	3112  SiI 3112 [SATALink/SATARaid] Serial ATA Controller
-		1095 3112  SiI 3112 SATALink Controller
-		1095 6112  SiI 3112 SATARaid Controller
-		9005 0250  SATAConnect 1205SA Host Controller
 	3114  SiI 3114 [SATALink/SATARaid] Serial ATA Controller
-		1043 8167  A8N-SLI Deluxe/Premium Mainboard
-		1095 3114  SiI 3114 SATALink Controller
-		1095 6114  SiI 3114 SATARaid Controller
 	3124  SiI 3124 PCI-X Serial ATA Controller
-		1095 3124  SiI 3124 PCI-X Serial ATA Controller
 	3132  SiI 3132 Serial ATA Raid II Controller
 	3512  SiI 3512 [SATALink/SATARaid] Serial ATA Controller
-		1095 3512  SiI 3512 SATALink Controller
-		1095 6512  SiI 3512 SATARaid Controller
 	3531  SiI 3531 [SATALink/SATARaid] Serial ATA Controller
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 1096  Alacron
 1097  Appian Technology
 1098  Quantum Designs (H.K.) Ltd
@@ -7238,158 +3453,12 @@ var pciids = []byte(`#
 	0350  Bt848 Video Capture
 	0351  Bt849A Video capture
 	0369  Bt878 Video Capture
-		1002 0001  TV-Wonder
-		1002 0003  TV-Wonder/VE
 	036c  Bt879(??) Video Capture
-		13e9 0070  Win/TV (Video Section)
 	036e  Bt878 Video Capture
-		0070 13eb  WinTV Series
-		0070 ff01  Viewcast Osprey 200
-		0071 0101  DigiTV PCI
-		107d 6606  WinFast TV 2000
-		11bd 0012  PCTV pro (TV + FM stereo receiver)
-		11bd 001c  PCTV Sat (DBC receiver)
-		127a 0001  Bt878 Mediastream Controller NTSC
-		127a 0002  Bt878 Mediastream Controller PAL BG
-		127a 0003  Bt878a Mediastream Controller PAL BG
-		127a 0048  Bt878/832 Mediastream Controller
-		144f 3000  MagicTView CPH060 - Video
-		1461 0002  TV98 Series (TV/No FM/Remote)
-		1461 0003  AverMedia UltraTV PCI 350
-		1461 0004  AVerTV WDM Video Capture
-		1461 0761  AverTV DVB-T
-		1461 0771  AverMedia AVerTV DVB-T 771
-		14f1 0001  Bt878 Mediastream Controller NTSC
-		14f1 0002  Bt878 Mediastream Controller PAL BG
-		14f1 0003  Bt878a Mediastream Controller PAL BG
-		14f1 0048  Bt878/832 Mediastream Controller
-		1822 0001  VisionPlus DVB card
-		1851 1850  FlyVideo'98 - Video
-		1851 1851  FlyVideo II
-		1852 1852  FlyVideo'98 - Video (with FM Tuner)
-		18ac d500  DViCO FusionHDTV5 Lite
-		270f fc00  Digitop DTT-1000
-# Vendor/ID appear to be randomly chosen
-		aa00 1460  Spectra8 CardA Input0
-# Vendor/ID appear to be randomly chosen
-		aa01 1461  Spectra8 CardA Input1
-# Vendor/ID appear to be randomly chosen
-		aa02 1462  Spectra8 CardA Input2
-# Vendor/ID appear to be randomly chosen
-		aa03 1463  Spectra8 CardA Input3
-# Vendor/ID appear to be randomly chosen
-		aa04 1464  Spectra8 CardB Input0
-# Vendor/ID appear to be randomly chosen
-		aa05 1465  Spectra8 CardB Input1
-# Vendor/ID appear to be randomly chosen
-		aa06 1466  Spectra8 CardB Input2
-# Vendor/ID appear to be randomly chosen
-		aa07 1467  Spectra8 CardB Input3
-# Vendor/ID appear to be randomly chosen
-		aa08 1468  Spectra8 CardC Input0
-# Vendor/ID appear to be randomly chosen
-		aa09 1469  Spectra8 CardC Input1
-# Vendor/ID appear to be randomly chosen
-		aa0a 146a  Spectra8 CardC Input2
-# Vendor/ID appear to be randomly chosen
-		aa0b 146b  Spectra8 CardC Input3
-# Vendor/ID appear to be randomly chosen
-		aa0c 146c  Spectra8 CardD Input0
-# Vendor/ID appear to be randomly chosen
-		aa0d 146d  Spectra8 CardD Input1
-# Vendor/ID appear to be randomly chosen
-		aa0e 146e  Spectra8 CardD Input2
-# Vendor/ID appear to be randomly chosen
-		aa0f 146f  Spectra8 CardD Input3
-		bd11 1200  PCTV pro (TV + FM stereo receiver)
 	036f  Bt879 Video Capture
-		127a 0044  Bt879 Video Capture NTSC
-		127a 0122  Bt879 Video Capture PAL I
-		127a 0144  Bt879 Video Capture NTSC
-		127a 0222  Bt879 Video Capture PAL BG
-		127a 0244  Bt879a Video Capture NTSC
-		127a 0322  Bt879 Video Capture NTSC
-		127a 0422  Bt879 Video Capture NTSC
-		127a 1122  Bt879 Video Capture PAL I
-		127a 1222  Bt879 Video Capture PAL BG
-		127a 1322  Bt879 Video Capture NTSC
-		127a 1522  Bt879a Video Capture PAL I
-		127a 1622  Bt879a Video Capture PAL BG
-		127a 1722  Bt879a Video Capture NTSC
-		14f1 0044  Bt879 Video Capture NTSC
-		14f1 0122  Bt879 Video Capture PAL I
-		14f1 0144  Bt879 Video Capture NTSC
-		14f1 0222  Bt879 Video Capture PAL BG
-		14f1 0244  Bt879a Video Capture NTSC
-		14f1 0322  Bt879 Video Capture NTSC
-		14f1 0422  Bt879 Video Capture NTSC
-		14f1 1122  Bt879 Video Capture PAL I
-		14f1 1222  Bt879 Video Capture PAL BG
-		14f1 1322  Bt879 Video Capture NTSC
-		14f1 1522  Bt879a Video Capture PAL I
-		14f1 1622  Bt879a Video Capture PAL BG
-		14f1 1722  Bt879a Video Capture NTSC
-		1851 1850  FlyVideo'98 - Video
-		1851 1851  FlyVideo II
-		1852 1852  FlyVideo'98 - Video (with FM Tuner)
 	0370  Bt880 Video Capture
-		1851 1850  FlyVideo'98
-		1851 1851  FlyVideo'98 EZ - video
-		1852 1852  FlyVideo'98 (with FM Tuner)
 	0878  Bt878 Audio Capture
-		0070 13eb  WinTV Series
-		0070 ff01  Viewcast Osprey 200
-		0071 0101  DigiTV PCI
-		1002 0001  TV-Wonder
-		1002 0003  TV-Wonder/VE
-		11bd 0012  PCTV pro (TV + FM stereo receiver, audio section)
-		11bd 001c  PCTV Sat (DBC receiver)
-		127a 0001  Bt878 Video Capture (Audio Section)
-		127a 0002  Bt878 Video Capture (Audio Section)
-		127a 0003  Bt878 Video Capture (Audio Section)
-		127a 0048  Bt878 Video Capture (Audio Section)
-		13e9 0070  Win/TV (Audio Section)
-		144f 3000  MagicTView CPH060 - Audio
-		1461 0002  Avermedia PCTV98 Audio Capture
-		1461 0003  UltraTV PCI 350
-		1461 0004  AVerTV WDM Audio Capture
-		1461 0761  AVerTV DVB-T
-		1461 0771  AverMedia AVerTV DVB-T 771
-		14f1 0001  Bt878 Video Capture (Audio Section)
-		14f1 0002  Bt878 Video Capture (Audio Section)
-		14f1 0003  Bt878 Video Capture (Audio Section)
-		14f1 0048  Bt878 Video Capture (Audio Section)
-		1822 0001  VisionPlus DVB Card
-		18ac d500  DViCO FusionHDTV5 Lite
-		270f fc00  Digitop DTT-1000
-		bd11 1200  PCTV pro (TV + FM stereo receiver, audio section)
 	0879  Bt879 Audio Capture
-		127a 0044  Bt879 Video Capture (Audio Section)
-		127a 0122  Bt879 Video Capture (Audio Section)
-		127a 0144  Bt879 Video Capture (Audio Section)
-		127a 0222  Bt879 Video Capture (Audio Section)
-		127a 0244  Bt879 Video Capture (Audio Section)
-		127a 0322  Bt879 Video Capture (Audio Section)
-		127a 0422  Bt879 Video Capture (Audio Section)
-		127a 1122  Bt879 Video Capture (Audio Section)
-		127a 1222  Bt879 Video Capture (Audio Section)
-		127a 1322  Bt879 Video Capture (Audio Section)
-		127a 1522  Bt879 Video Capture (Audio Section)
-		127a 1622  Bt879 Video Capture (Audio Section)
-		127a 1722  Bt879 Video Capture (Audio Section)
-		14f1 0044  Bt879 Video Capture (Audio Section)
-		14f1 0122  Bt879 Video Capture (Audio Section)
-		14f1 0144  Bt879 Video Capture (Audio Section)
-		14f1 0222  Bt879 Video Capture (Audio Section)
-		14f1 0244  Bt879 Video Capture (Audio Section)
-		14f1 0322  Bt879 Video Capture (Audio Section)
-		14f1 0422  Bt879 Video Capture (Audio Section)
-		14f1 1122  Bt879 Video Capture (Audio Section)
-		14f1 1222  Bt879 Video Capture (Audio Section)
-		14f1 1322  Bt879 Video Capture (Audio Section)
-		14f1 1522  Bt879 Video Capture (Audio Section)
-		14f1 1622  Bt879 Video Capture (Audio Section)
-		14f1 1722  Bt879 Video Capture (Audio Section)
 	0880  Bt880 Audio Capture
 	2115  BtV 2115 Mediastream controller
 	2125  BtV 2125 Mediastream controller
@@ -7421,7 +3490,6 @@ var pciids = []byte(`#
 	0007  RPCEX
 	0008  DiVO VIP
 	0009  AceNIC Gigabit Ethernet
-		10a9 8002  AceNIC Gigabit Ethernet
 	0010  AMP Video I/O
 	0011  GRIP
 	0012  SGH PSHAC GSN
@@ -7442,7 +3510,6 @@ var pciids = []byte(`#
 	4002  TIO-CE PCI Express Port
 	8001  O2 1394
 	8002  G-net NT
-# PCIe x1 Low Profile
 	802b  REACT external interrupt controller
 10aa  ACC Microelectronics
 	0000  ACCM 2188
@@ -7467,13 +3534,10 @@ var pciids = []byte(`#
 	b106  DB87144
 10b4  STB Systems Inc
 	1b1d  Velocity 128 3D
-		10b4 237e  Velocity 4400
 10b5  PLX Technology, Inc.
 	0001  i960 PCI bus interface
 	0557  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 9030  Digium Tormenta 2 T400P-SS7 or E400P-SS7 Quad T1 or E1 PCI card
 	1000  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 9030  ATCOM AT400P Quad T1 PCI card
 	1024  Acromag, Inc. IndustryPack Carrier Card
 	1042  Brandywine / jxi2, Inc. - PMC-SyncClock32, IRIG A & B, Nasa 36
 	106a  Dual OX16C952 4 port serial adapter [Megawolf Romulus/4]
@@ -7484,16 +3548,12 @@ var pciids = []byte(`#
 	1146  VScom 010 1 port parallel adaptor
 	1147  VScom 020 2 port parallel adaptor
 	2000  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 9030  ATCOM AE400P Quad E1 PCI card
 	2540  IXXAT CAN-Interface PC-I 04/PCI
 	2724  Thales PCSM Security Card
 	3376  Cosateq 4 Port CAN Card
 	4000  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 9030  Tormenta 3 Varion V400P/ATCOM TE400P Quad E1/T1/J1 PCI card
 	4001  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 9030  ATCOM A400PE Quad E1 PCI card
 	4002  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 9030  ATCOM A400PT Quad T1 PCI card
 	6140  PCI6140 32-bit 33MHz PCI-to-PCI Bridge
 	6150  PCI6150 32-bit 33MHz PCI-to-PCI Bridge
 	6152  PCI6152 32-bit 66MHz PCI-to-PCI Bridge
@@ -7502,14 +3562,8 @@ var pciids = []byte(`#
 	6466  PCI6466 64-bit 66MHz PCI-to-PCI Bridge
 	6520  PCI6520 64-bit 133MHz PCI-X-to-PCI-X Bridge
 	6540  PCI6540 64-bit 133MHz PCI-X-to-PCI-X Bridge
-		1775 1100  CR11 Single Board Computer
-		4c53 10e0  PSL09 PrPMC
 	6541  PCI6540/6466 PCI-PCI bridge (non-transparent mode, primary side)
-		1775 1100  CR11 Single Board Computer
-		4c53 10e0  PSL09 PrPMC
 	6542  PCI6540/6466 PCI-PCI bridge (non-transparent mode, secondary side)
-		1775 1100  CR11 Single Board Computer
-		4c53 10e0  PSL09 PrPMC
 	8111  PEX 8111 PCI Express-to-PCI Bridge
 	8112  PEX8112 x1 Lane PCI Express-to-PCI Bridge
 	8114  PEX 8114 PCI Express-to-PCI/PCI-X Bridge
@@ -7542,7 +3596,6 @@ var pciids = []byte(`#
 	8618  PEX 8618 16-lane, 16-Port PCI Express Gen 2 (5.0 GT/s) Switch
 	8619  PEX 8619 16-lane, 16-Port PCI Express Gen 2 (5.0 GT/s) Switch with DMA
 	8624  PEX 8624 24-lane, 6-Port PCI Express Gen 2 (5.0 GT/s) Switch [ExpressLane]
-		13a3 1845  DX1845 Acceleration Card
 	8625  PEX 8625 24-lane, 24-Port PCI Express Gen 2 (5.0 GT/s) Switch
 	8632  PEX 8632 32-lane, 12-Port PCI Express Gen 2 (5.0 GT/s) Switch
 	8636  PEX 8636 36-lane, 24-Port PCI Express Gen 2 (5.0 GT/s) Switch
@@ -7559,214 +3612,56 @@ var pciids = []byte(`#
 	8734  PEX 8734 32-lane, 8-Port PCI Express Gen 3 (8.0GT/s) Switch
 	8747  PEX 8747 48-Lane, 5-Port PCI Express Gen 3 (8.0 GT/s) Switch
 	8748  PEX 8748 48-Lane, 12-Port PCI Express Gen 3 (8 GT/s) Switch, 27 x 27mm FCBGA
-# This is the Non-Transparent-Bridge Virtualized Port as presented by the PLX PEX 8732 chip, the physical bridges show up at 10b5:8732
 	87b0  PEX 8732 32-lane, 8-Port PCI Express Gen 3 (8.0 GT/s) Switch
-		1093 7761  PXIe-8830mc
 	9016  PLX 9016 8-port serial controller
 	9030  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 2695  Hilscher CIF50-PB/DPS Profibus
-		10b5 2862  Alpermann+Velte PCL PCI LV (3V/5V): Timecode Reader Board
-		10b5 2906  Alpermann+Velte PCI TS (3V/5V): Time Synchronisation Board
-		10b5 2940  Alpermann+Velte PCL PCI D (3V/5V): Timecode Reader Board
-		10b5 2977  IXXAT iPC-I XC16/PCI CAN Board
-		10b5 2978  SH ARC-PCIu/SH ARC-PCI104/SH ARC-PCIe SOHARD ARCNET card
-		10b5 3025  Alpermann+Velte PCL PCI L (3V/5V): Timecode Reader Board
-		10b5 3068  Alpermann+Velte PCL PCI HD (3V/5V): Timecode Reader Board
-		10b5 3463  Alpermann+Velte PCL PCI D (v2) (3V/5V): Timecode Reader Board
-		10b5 3591  PLURA PCL PCI L (v2) (3.3V/5V): Time Code Reader Board
-		12fe 0111  CPCI-ASIO4 (ESD 4-port Serial Interface Board)
-		1369 9c01  VX222v2
-		1369 9d01  VX222-Mic
-		1369 9d02  VX222-Mic
-		1369 9e01  PCX924v2
-		1369 9f01  PCX924-Mic
-		1369 9f02  PCX924-Mic
-		1369 a001  PCX22v2
-		1369 a701  LCM220v2
-		1369 a801  LCM200
-		1397 3136  4xS0-ISDN PCI Adapter
-		1397 3137  S2M-E1-ISDN PCI Adapter
-		1518 0200  ThinkIO-C
-		15ed 1002  MCCS 8-port Serial Hot Swap
-		15ed 1003  MCCS 16-port Serial Hot Swap
-# MIL-STD-1553B Board
-		e1c5 0001  TE1-PCI
-		e1c5 0005  TA1-PCI
-		e1c5 0006  TA1-PCI4
 	9036  9036
 	9050  PCI <-> IOBus Bridge
-		10b5 1067  IXXAT CAN i165
-		10b5 114e  Wasco WITIO PCI168extended
-		10b5 1169  Wasco OPTOIO32standard 32 digital in, 32 digital out
-		10b5 1172  IK220 (Heidenhain)
-		10b5 2036  SatPak GPS
-		10b5 2221  Alpermann+Velte PCL PCI LV: Timecode Reader Board
-		10b5 2273  SH ARC-PCI SOHARD ARCNET card
-		10b5 2431  Alpermann+Velte PCL PCI D: Timecode Reader Board
-		10b5 2905  Alpermann+Velte PCI TS: Time Synchronisation Board
-		10b5 3196  Goramo PLX200SYN sync serial card
-		10b5 9050  PCI-I04 PCI Passive PC/CAN Interface
-		1369 8901  PCX11+ PCI
-		1369 8f01  VX222
-		1369 9401  PCX924
-		1369 9501  PCX22
-		1498 0362  TPMC866 8 Channel Serial Card
-		1522 0001  RockForce 4 Port V.90 Data/Fax/Voice Modem
-		1522 0002  RockForce 2 Port V.90 Data/Fax/Voice Modem
-		1522 0003  RockForce 6 Port V.90 Data/Fax/Voice Modem
-		1522 0004  RockForce 8 Port V.90 Data/Fax/Voice Modem
-		1522 0010  RockForce2000 4 Port V.90 Data/Fax/Voice Modem
-		1522 0020  RockForce2000 2 Port V.90 Data/Fax/Voice Modem
-		15ed 1000  Macrolink MCCS 8-port Serial
-		15ed 1001  Macrolink MCCS 16-port Serial
-		15ed 1002  Macrolink MCCS 8-port Serial Hot Swap
-		15ed 1003  Macrolink MCCS 16-port Serial Hot Swap
-		5654 2036  OpenSwitch 6 Telephony card
-		5654 3132  OpenSwitch 12 Telephony card
-		5654 5634  OpenLine4 Telephony Card
-		d531 c002  PCIntelliCAN 2xSJA1000 CAN bus
-		d84d 4006  EX-4006 1P
-		d84d 4008  EX-4008 1P EPP/ECP
-		d84d 4014  EX-4014 2P
-		d84d 4018  EX-4018 3P EPP/ECP
-		d84d 4025  EX-4025 1S(16C550) RS-232
-		d84d 4027  EX-4027 1S(16C650) RS-232
-		d84d 4028  EX-4028 1S(16C850) RS-232
-		d84d 4036  EX-4036 2S(16C650) RS-232
-		d84d 4037  EX-4037 2S(16C650) RS-232
-		d84d 4038  EX-4038 2S(16C850) RS-232
-		d84d 4052  EX-4052 1S(16C550) RS-422/485
-		d84d 4053  EX-4053 2S(16C550) RS-422/485
-		d84d 4055  EX-4055 4S(16C550) RS-232
-		d84d 4058  EX-4055 4S(16C650) RS-232
-		d84d 4065  EX-4065 8S(16C550) RS-232
-		d84d 4068  EX-4068 8S(16C650) RS-232
-		d84d 4078  EX-4078 2S(16C552) RS-232+1P
 	9052  PCI9052 PCI <-> IOBus Bridge
 	9054  PCI9054 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 2455  Wessex Techology PHIL-PCI
-		10b5 2696  Innes Corp AM Radcap card
-		10b5 2717  Innes Corp Auricon card
-		10b5 2844  Innes Corp TVS Encoder card
-		12c7 4001  Intel Dialogic DM/V960-4T1 PCI
-		12d9 0002  PCI Prosody Card rev 1.5
-		14b4 d100  Dektec DTA-100
-		14b4 d114  Dektec DTA-120
-		16df 0011  PIKA PrimeNet MM PCI
-		16df 0012  PIKA PrimeNet MM cPCI 8
-		16df 0013  PIKA PrimeNet MM cPCI 8 (without CAS Signaling)
-		16df 0014  PIKA PrimeNet MM cPCI 4
-		16df 0015  PIKA Daytona MM
-		16df 0016  PIKA InLine MM
 	9056  PCI9056 32-bit 66MHz PCI <-> IOBus Bridge
-		10b5 2979  CellinkBlade 11 - CPCI board VoATM AAL1
-		10b5 3268  IXXAT iPC-I XC16/PCIe CAN Board
-		10b5 3352  Alpermann+Velte PCL PCIe HD: Timecode Reader Board
-		10b5 3353  Alpermann+Velte PCL PCIe D: Timecode Reader Board
-		10b5 3354  Alpermann+Velte PCL PCIe LV: Timecode Reader Board
-		10b5 3355  Alpermann+Velte PCL PCIe L: Timecode Reader Board
-		10b5 3415  Alpermann+Velte PCIe TS: Time Synchronisation Board
-		10b5 3493  Alpermann+Velte PCL PCIe 3G: Timecode Reader Board
-		1369 c001  LX6464ES
-		1369 c201  LX1616ES
-		14b4 d10a  DekTec DTA-110T
-		14b4 d128  Dektec DTA-140
-		14b4 d140  Dektec DTA-140
-		1a0e 006f  Dektec DTA-111
 	9060  PCI9060 32-bit 33MHz PCI <-> IOBus Bridge
 	906d  9060SD
-		125c 0640  Aries 16000P
 	906e  9060ES
 	9080  PCI9080 32-bit; 33MHz PCI <-> IOBus Bridge
-		103c 10eb  (Agilent) E2777B 83K Series Optical Communication Interface
-		103c 10ec  (Agilent) E6978-66442 PCI CIC
-		10b5 1123  Sectra KK631 encryption board
-		10b5 9080  9080 [real subsystem ID not set]
-		12d9 0002  PCI Prosody Card
-		12df 4422  4422PCI ["Do-All" Telemetry Data Acquisition System]
-		1369 9601  PCX822np
-		1369 a102  PCX822v2
-		1369 a201  PCX442
-		1369 a301  LCM440v2
-		1369 a401  VX822
-		1369 a402  VX822v2
-		1369 a901  LCM420
-		1369 aa01  VX820v2
-		1517 000b  ECSG-1R3ADC-PMC Clock synthesizer
 	9656  PCI9656 PCI <-> IOBus Bridge
-		1517 000f  ECDR-GC314-PMC Receiver
-		1885 0700  Tsunami FPGA PMC with Altera Stratix S40
-		1885 0701  Tsunami FPGA PMC with Altera Stratix S30
 	9733  PEX 9733 33-lane, 9-port PCI Express Gen 3 (8.0 GT/s) Switch
-		1d49 0001  ThinkSystem 1610-4P NVMe Switch Adapter
-		1d49 0002  ThinkSystem 810-4P NVMe Switch Adapter
 	9749  PEX 9749 49-lane, 13-port PCI Express Gen 3 (8.0 GT/s) Switch
 	a100  Blackmagic Design DeckLink
 	bb04  B&B 3PCIOSD1A Isolated PCI Serial
 	c001  CronyxOmega-PCI (8-port RS232)
 	d00d  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 9030  Digium Tormenta 2 T400P or E400P Quad T1 or E1 PCI card
 	d33d  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 9030  Tormenta 3 Varion V401PT Quad T1/J1 PCI card
 	d44d  PCI9030 32-bit 33MHz PCI <-> IOBus Bridge
-		10b5 17f6  Allo CP100P/E 1-port E1/T1/J1 PCI/PCIe card
-		10b5 17f7  Allo CP400P/E 4-port E1/T1/J1 PCI/PCIe card
-		10b5 17f8  Allo CP200P/E 2-port E1/T1/J1 PCI/PCIe card
-		10b5 9030  Tormenta 3 Varion V401PE Quad E1 PCI card
 10b6  Madge Networks
 	0001  Smart 16/4 PCI Ringnode
 	0002  Smart 16/4 PCI Ringnode Mk2
-		10b6 0002  Smart 16/4 PCI Ringnode Mk2
-		10b6 0006  16/4 CardBus Adapter
 	0003  Smart 16/4 PCI Ringnode Mk3
-		0e11 b0fd  Compaq NC4621 PCI, 4/16, WOL
-		10b6 0003  Smart 16/4 PCI Ringnode Mk3
-		10b6 0007  Presto PCI Plus Adapter
 	0004  Smart 16/4 PCI Ringnode Mk1
 	0006  16/4 Cardbus Adapter
-		10b6 0006  16/4 CardBus Adapter
 	0007  Presto PCI Adapter
-		10b6 0007  Presto PCI
 	0009  Smart 100/16/4 PCI-HS Ringnode
-		10b6 0009  Smart 100/16/4 PCI-HS Ringnode
 	000a  Token Ring 100/16/4 Ringnode/Ringrunner
-		10b6 000a  Token Ring 100/16/4 Ringnode/Ringrunner
 	000b  16/4 CardBus Adapter Mk2
-		10b6 0008  16/4 CardBus Adapter Mk2
-		10b6 000b  16/4 Cardbus Adapter Mk2
 	000c  RapidFire 3140V2 16/4 TR Adapter
-		10b6 000c  RapidFire 3140V2 16/4 TR Adapter
 	1000  Collage 25/155 ATM Client Adapter
 	1001  Collage 155 ATM Server Adapter
 10b7  3Com Corporation
 	0001  3c985 1000BaseSX (SX/TX)
-# wrong ID?
-		9850 0001  3c985B-SX
 	0013  AR5212 802.11abg NIC (3CRDAG675)
-		10b7 2031  3CRDAG675 11a/b/g Wireless PCI Adapter
 	0910  3C910-A01
 	1006  MINI PCI type 3B Data Fax Modem
 	1007  Mini PCI 56k Winmodem
-		10b7 615b  Mini PCI 56K Modem
-		10b7 615c  Mini PCI 56K Modem
 	1201  3c982-TXM 10/100baseTX Dual Port A [Hydra]
 	1202  3c982-TXM 10/100baseTX Dual Port B [Hydra]
 	1700  3c940 10/100/1000Base-T [Marvell]
-		1043 80eb  A7V600/P4P800/K8V motherboard
-		10b7 0010  3C940 Gigabit LOM Ethernet Adapter
-		10b7 0020  3C941 Gigabit LOM Ethernet Adapter
-		147b 1407  KV8-MAX3 motherboard
 	3390  3c339 TokenLink Velocity
 	3590  3c359 TokenLink Velocity XL
-		10b7 3590  TokenLink Velocity XL Adapter (3C359/359B)
 	4500  3c450 HomePNA [Tornado]
 	5055  3c555 Laptop Hurricane
 	5057  3c575 Megahertz 10/100 LAN CardBus [Boomerang]
-		10b7 5a57  3C575 Megahertz 10/100 LAN Cardbus PC Card
 	5157  3cCFE575BT Megahertz 10/100 LAN CardBus [Cyclone]
-		10b7 5b57  3C575 Megahertz 10/100 LAN Cardbus PC Card
 	5257  3cCFE575CT CardBus [Cyclone]
-		10b7 5c57  FE575C-3Com 10/100 LAN CardBus-Fast Ethernet
 	5900  3c590 10BaseT [Vortex]
 	5920  3c592 EISA 10mbps Demon/Vortex
 	5950  3c595 100BaseTX [Vortex]
@@ -7774,20 +3669,14 @@ var pciids = []byte(`#
 	5952  3c595 100Base-MII [Vortex]
 	5970  3c597 EISA Fast Demon/Vortex
 	5b57  3c595 Megahertz 10/100 LAN CardBus [Boomerang]
-		10b7 5b57  3C575 Megahertz 10/100 LAN Cardbus PC Card
 	6000  3CRSHPW796 [OfficeConnect Wireless CardBus]
 	6001  3com 3CRWE154G72 [Office Connect Wireless LAN Adapter]
 	6055  3c556 Hurricane CardBus [Cyclone]
 	6056  3c556B CardBus [Tornado]
-		10b7 6556  10/100 Mini PCI Ethernet Adapter
 	6560  3cCFE656 CardBus [Cyclone]
-		10b7 656a  3CCFEM656 10/100 LAN+56K Modem CardBus
 	6561  3cCFEM656 10/100 LAN+56K Modem CardBus
-		10b7 656b  3CCFEM656 10/100 LAN+56K Modem CardBus
 	6562  3cCFEM656B 10/100 LAN+Winmodem CardBus [Cyclone]
-		10b7 656b  3CCFEM656B 10/100 LAN+56K Modem CardBus
 	6563  3cCFEM656B 10/100 LAN+56K Modem CardBus
-		10b7 656b  3CCFEM656 10/100 LAN+56K Modem CardBus
 	6564  3cXFEM656C 10/100 LAN+Winmodem CardBus [Tornado]
 	7646  3cSOHO100-TX Hurricane
 	7770  3CRWE777 PCI Wireless Adapter [Airconnect]
@@ -7799,104 +3688,42 @@ var pciids = []byte(`#
 	9000  3c900 10BaseT [Boomerang]
 	9001  3c900 10Mbps Combo [Boomerang]
 	9004  3c900B-TPO Etherlink XL [Cyclone]
-		10b7 9004  3C900B-TPO Etherlink XL TPO 10Mb
 	9005  3c900B-Combo Etherlink XL [Cyclone]
-		10b7 9005  3C900B-Combo Etherlink XL Combo
 	9006  3c900B-TPC Etherlink XL [Cyclone]
 	900a  3c900B-FL 10base-FL [Cyclone]
 	9050  3c905 100BaseTX [Boomerang]
 	9051  3c905 100BaseT4 [Boomerang]
 	9054  3C905B-TX Fast Etherlink XL PCI
-		10b7 9054  3C905B-TX Fast Etherlink XL PCI
 	9055  3c905B 100BaseTX [Cyclone]
-		1028 0080  3C905B Fast Etherlink XL 10/100
-		1028 0081  3C905B Fast Etherlink XL 10/100
-		1028 0082  3C905B Fast Etherlink XL 10/100
-		1028 0083  3C905B Fast Etherlink XL 10/100
-		1028 0084  3C905B Fast Etherlink XL 10/100
-		1028 0085  3C905B Fast Etherlink XL 10/100
-		1028 0086  3C905B Fast Etherlink XL 10/100
-		1028 0087  3C905B Fast Etherlink XL 10/100
-		1028 0088  3C905B Fast Etherlink XL 10/100
-		1028 0089  3C905B Fast Etherlink XL 10/100
-		1028 0090  3C905B Fast Etherlink XL 10/100
-		1028 0091  3C905B Fast Etherlink XL 10/100
-		1028 0092  3C905B Fast Etherlink XL 10/100
-		1028 0093  3C905B Fast Etherlink XL 10/100
-		1028 0094  3C905B Fast Etherlink XL 10/100
-		1028 0095  3C905B Fast Etherlink XL 10/100
-		1028 0096  3C905B Fast Etherlink XL 10/100
-		1028 0097  3C905B Fast Etherlink XL 10/100
-		1028 0098  3C905B Fast Etherlink XL 10/100
-		1028 0099  3C905B Fast Etherlink XL 10/100
-		10b7 9055  3C905B Fast Etherlink XL 10/100
 	9056  3c905B-T4 Fast EtherLink XL [Cyclone]
 	9058  3c905B Deluxe Etherlink 10/100/BNC [Cyclone]
 	905a  3c905B-FX Fast Etherlink XL FX 100baseFx [Cyclone]
 	9200  3c905C-TX/TX-M [Tornado]
-		1028 0095  3C920 Integrated Fast Ethernet Controller
-		1028 0097  3C920 Integrated Fast Ethernet Controller
-		1028 00b4  OptiPlex GX110
-		1028 00d8  Precision 530
-		1028 00fe  Optiplex GX240
-		1028 012a  3C920 Integrated Fast Ethernet Controller [Latitude C640]
-		10b7 1000  3C905CX-TX/TX-M Fast Etherlink for PC Management NIC
-		10b7 7000  10/100 Mini PCI Ethernet Adapter
-		10f1 2466  Tiger MPX S2466 (3C920 Integrated Fast Ethernet Controller)
-		144d c005  X10 Laptop
 	9201  3C920B-EMB Integrated Fast Ethernet Controller [Tornado]
-		1043 80ab  A7N8X Deluxe onboard 3C920B-EMB Integrated Fast Ethernet Controller
 	9202  3Com 3C920B-EMB-WNM Integrated Fast Ethernet Controller
 	9210  3C920B-EMB-WNM Integrated Fast Ethernet Controller
 	9300  3CSOHO100B-TX 910-A01 [tulip]
 	9800  3c980-TX Fast Etherlink XL Server Adapter [Cyclone]
-		10b7 9800  3c980-TX Fast Etherlink XL Server Adapter
 	9805  3c980-C 10/100baseTX NIC [Python-T]
-		10b7 1201  EtherLink Server 10/100 Dual Port A
-		10b7 1202  EtherLink Server 10/100 Dual Port B
-		10b7 9805  3c980 10/100baseTX NIC [Python-T]
-		10f1 2462  Thunder K7 S2462
 	9900  3C990-TX [Typhoon]
 	9902  3CR990-TX-95 [Typhoon 56-bit]
 	9903  3CR990-TX-97 [Typhoon 168-bit]
 	9904  3C990B-TX-M/3C990BSVR [Typhoon2]
-		10b7 1000  3CR990B-TX-M [Typhoon2]
-		10b7 2000  3CR990BSVR [Typhoon2 Server]
 	9905  3CR990-FX-95/97/95 [Typhon Fiber]
-		10b7 1101  3CR990-FX-95 [Typhoon Fiber 56-bit]
-		10b7 1102  3CR990-FX-97 [Typhoon Fiber 168-bit]
-		10b7 2101  3CR990-FX-95 Server [Typhoon Fiber 56-bit]
-		10b7 2102  3CR990-FX-97 Server [Typhoon Fiber 168-bit]
 	9908  3CR990SVR95 [Typhoon Server 56-bit]
 	9909  3CR990SVR97 [Typhoon Server 168-bit]
 	990a  3C990SVR [Typhoon Server]
 	990b  3C990SVR [Typhoon Server]
 10b8  Standard Microsystems Corp [SMC]
 	0005  83c170 EPIC/100 Fast Ethernet Adapter
-		1055 e000  LANEPIC 10/100 [EVB171Q-PCI]
-		1055 e002  LANEPIC 10/100 [EVB171G-PCI]
-		10b8 a011  EtherPower II 10/100
-		10b8 a014  EtherPower II 10/100
-		10b8 a015  EtherPower II 10/100
-		10b8 a016  EtherPower II 10/100
-		10b8 a017  EtherPower II 10/100
 	0006  83c175 EPIC/100 Fast Ethernet Adapter
-		1055 e100  LANEPIC Cardbus Fast Ethernet Adapter
-		1055 e102  LANEPIC Cardbus Fast Ethernet Adapter
-		1055 e300  LANEPIC Cardbus Fast Ethernet Adapter
-		1055 e302  LANEPIC Cardbus Fast Ethernet Adapter
-		10b8 a012  LANEPIC Cardbus Fast Ethernet Adapter
-		13a2 8002  LANEPIC Cardbus Fast Ethernet Adapter
-		13a2 8006  LANEPIC Cardbus Fast Ethernet Adapter
 	1000  FDC 37c665
 	1001  FDC 37C922
 	a011  83C170QF
 	b106  SMC34C90
-# Split off ALi Corporation in 2003
 10b9  ULi Electronics Inc.
 	0101  CMI8338/C3DX PCI Audio Device
 	0111  C-Media CMI8738/C3DX Audio Device (OEM)
-		10b9 0111  C-Media CMI8738/C3DX Audio Device (OEM)
 	0780  Multi-IO Card
 	0782  Multi-IO Card
 	1435  M1435
@@ -7909,19 +3736,12 @@ var pciids = []byte(`#
 	1512  M1512 [Aladdin]
 	1513  M1513 [Aladdin]
 	1521  M1521 [Aladdin III]
-		10b9 1521  ALI M1521 Aladdin III CPU Bridge
 	1523  M1523
-		10b9 1523  ALI M1523 ISA Bridge
 	1531  M1531 [Aladdin IV]
 	1533  M1533/M1535/M1543 PCI to ISA Bridge [Aladdin IV/V/V+]
-		1014 053b  ThinkPad R40e
-		10b9 1533  ALi M1533 Aladdin IV/V ISA Bridge
 	1541  M1541
-		10b9 1541  ALI M1541 Aladdin V/V+ AGP System Controller
 	1543  M1543
 	1563  M1563 HyperTransport South Bridge
-		10b9 1563  ASRock 939Dual-SATA2 Motherboard
-		1849 1563  ASRock 939Dual-SATA2 Motherboard
 	1573  PCI to LPC Controller
 	1575  M1575 South Bridge
 	1621  M1621
@@ -7955,23 +3775,9 @@ var pciids = []byte(`#
 	5225  M5225
 	5228  M5228 ALi ATA/RAID Controller
 	5229  M5229 IDE
-		1014 050f  ThinkPad R30
-		1014 053d  ThinkPad R40e
-		103c 0024  Pavilion ze4400 builtin IDE
-		103c 0025  XE4500 Notebook
-		1043 8053  A7A266 Motherboard IDE
-		1849 5229  ASRock 939Dual-SATA2 Motherboard IDE (PATA)
 	5235  M5225
 	5237  USB 1.1 Controller
-		1014 0540  ThinkPad R40e
-		103c 0024  Pavilion ze4400 builtin USB
-		103c 0025  XE4500 Notebook
-		104d 810f  VAIO PCG-U1 USB/OHCI Revision 1.0
-		10b9 5237  ASRock 939Dual-SATA2 Motherboard
-		1849 5237  ASRock 939Dual-SATA2 Motherboard
 	5239  USB 2.0 Controller
-		10b9 5239  ASRock 939Dual-SATA2 Motherboard
-		1849 5239  ASRock 939Dual-SATA2 Motherboard
 	5243  M1541 PCI to AGP Controller
 	5246  AGP8X Controller
 	5247  PCI to AGP Controller
@@ -7987,38 +3793,22 @@ var pciids = []byte(`#
 	5281  ALi M5281 Serial ATA / RAID Host Controller
 	5287  ULi 5287 SATA
 	5288  ULi M5288 SATA
-		1043 8056  A8R-MVP Mainboard
 	5289  ULi 5289 SATA
 	5450  Lucent Technologies Soft Modem AMR
 	5451  M5451 PCI AC-Link Controller Audio Device
-		1014 0506  ThinkPad R30
-		1014 053e  ThinkPad R40e
-		103c 0024  Pavilion ze4400 builtin Audio
-		103c 0025  XE4500 Notebook
 	5453  M5453 PCI AC-Link Controller Modem Device
 	5455  M5455 PCI AC-Link Controller Audio Device
-		10b9 5455  ASRock 939Dual-SATA2 Motherboard
-		1849 0850  ASRock 939Dual-SATA2 Motherboard
 	5457  M5457 AC'97 Modem Controller
-		1014 0535  ThinkPad R40e
-		103c 0024  Pavilion ze4400 builtin Modem Device
-		103c 0025  XE4500 Notebook
 	5459  SmartLink SmartPCI561 56K Modem
 	545a  SmartLink SmartPCI563 56K Modem
 	5461  HD Audio Controller
 	5471  M5471 Memory Stick Controller
 	5473  M5473 SD-MMC Controller
 	7101  M7101 Power Management Controller [PMU]
-		1014 0510  ThinkPad R30
-		1014 053c  ThinkPad R40e
-		103c 0024  Pavilion ze4400
-		103c 0025  XE4500 Notebook
-		1849 7101  ASRock 939Dual-SATA2 Motherboard
 10ba  Mitsubishi Electric Corp.
 	0301  AccelGraphics AccelECLIPSE
 	0304  AccelGALAXY A2100 [OEM Evans & Sutherland]
 	0308  Tornado 3000 [OEM Evans & Sutherland]
-		10dd 0024  Tornado 3000
 	1002  VG500 [VolumePro Volume Rendering Accelerator]
 10bb  Dapha Electronics Corporation
 10bc  Advanced Logic Research
@@ -8039,52 +3829,17 @@ var pciids = []byte(`#
 	0002  NM2090 [MagicGraph 128V]
 	0003  NM2093 [MagicGraph 128ZV]
 	0004  NM2160 [MagicGraph 128XD]
-		1014 00ba  MagicGraph 128XD
-		1025 1007  MagicGraph 128XD
-		1028 0074  MagicGraph 128XD
-		1028 0075  MagicGraph 128XD
-		1028 007d  MagicGraph 128XD
-		1028 007e  MagicGraph 128XD
-		1033 802f  MagicGraph 128XD
-		104d 801b  MagicGraph 128XD
-		104d 802f  MagicGraph 128XD
-		104d 830b  MagicGraph 128XD
-		10ba 0e00  MagicGraph 128XD
-		10c8 0004  MagicGraph 128XD
-		10cf 1029  MagicGraph 128XD
-		10f7 8308  MagicGraph 128XD
-		10f7 8309  MagicGraph 128XD
-		10f7 830b  MagicGraph 128XD
-		10f7 830d  MagicGraph 128XD
-		10f7 8312  MagicGraph 128XD
 	0005  NM2200 [MagicGraph 256AV]
-		1014 00dd  ThinkPad 570
-		1028 0088  Latitude CPi A
 	0006  NM2360 [MagicMedia 256ZX]
-		1014 0152  ThinkPad 600X
 	0016  NM2380 [MagicMedia 256XL+]
-		10c8 0016  MagicMedia 256XL+
 	0025  NM2230 [MagicGraph 256AV+]
 	0083  NM2093 [MagicGraph 128ZV+]
 	8005  NM2200 [MagicMedia 256AV Audio]
-		0e11 b0d1  MagicMedia 256AV Audio Device on Discovery
-		0e11 b126  MagicMedia 256AV Audio Device on Durango
-		1014 00dd  ThinkPad 390/i1720/i1721
-		1025 1003  MagicMedia 256AV Audio Device on TravelMate 720
-		1028 0088  Latitude CPi A
-		1028 008f  MagicMedia 256AV Audio Device on Colorado Inspiron
-		103c 0007  MagicMedia 256AV Audio Device on Voyager II
-		103c 0008  MagicMedia 256AV Audio Device on Voyager III
-		103c 000d  MagicMedia 256AV Audio Device on Omnibook 900
-		10c8 8005  MagicMedia 256AV Audio Device on FireAnt
-		110a 8005  MagicMedia 256AV Audio Device
-		14c0 0004  MagicMedia 256AV Audio Device
 	8006  NM2360 [MagicMedia 256ZX Audio]
 	8016  NM2380 [MagicMedia 256XL+ Audio]
 10c9  Dataexpert Corporation
 10ca  Fujitsu Microelectr., Inc.
 10cb  Omron Corporation
-# nee Mentor ARC Inc
 10cc  Mai Logic Incorporated
 	0660  Articia S Host Bridge
 	0661  Articia S PCI Bridge
@@ -8092,13 +3847,10 @@ var pciids = []byte(`#
 	1100  ASC1100
 	1200  ASC1200 [(abp940) Fast SCSI-II]
 	1300  ASC1300 / ASC3030 [ABP940-U / ABP960-U / ABP3925]
-		10cd 1310  ASC1300/3030 SCSI adapter
-		1195 1320  Ultra-SCSI CardBus PC Card REX CB31
 	2300  ABP940-UW
 	2500  ABP940-U2W
 	2700  ABP3950-U3W
 10ce  Radius
-# nee Citicorp TTI
 10cf  Fujitsu Limited.
 	01ef  PCEA4 PCI-Express Dual Port ESCON Adapter
 	1414  On-board USB 1.1 companion controller
@@ -8125,7 +3877,6 @@ var pciids = []byte(`#
 	0431  MX98715
 	0512  MX98713
 	0531  MX987x5
-		1186 1200  DFE-540TX ProFAST 10/100 Adapter
 	8625  MX86250
 	8626  Macronix MX86251 + 3Dfx Voodoo Rush
 	8888  MX86200
@@ -8141,106 +3892,16 @@ var pciids = []byte(`#
 	10dc  ATT2C15-3 FPGA
 10dd  Evans & Sutherland
 	0100  Lightning 1200
-		10dd 0023  Lightning 1200 15+16M
 10de  NVIDIA Corporation
 	0008  NV1 [EDGE 3D]
 	0009  NV1 [EDGE 3D]
 	0020  NV4 [Riva TNT]
-		1043 0200  V3400 TNT
-		1048 0c18  Erazor II SGRAM
-		1048 0c19  Erazor II
-		1048 0c1b  Erazor II
-		1048 0c1c  Erazor II
-		1092 0550  Viper V550
-		1092 0552  Viper V550
-		1092 4804  Viper V550
-		1092 4808  Viper V550
-		1092 4810  Viper V550
-		1092 4812  Viper V550
-		1092 4815  Viper V550
-		1092 4820  Viper V550 with TV out
-		1092 4822  Viper V550
-		1092 4904  Viper V550
-		1092 4914  Viper V550
-		1092 8225  Viper V550
-		10b4 273d  Velocity 4400
-		10b4 273e  Velocity 4400
-		10b4 2740  Velocity 4400
-		10de 0020  Riva TNT
-		1102 1015  Graphics Blaster CT6710
-		1102 1016  Graphics Blaster RIVA TNT
 	0028  NV5 [Riva TNT2 / TNT2 Pro]
-		1043 0200  AGP-V3800 SGRAM
-		1043 0201  AGP-V3800 SDRAM
-		1043 0205  PCI-V3800
-		1043 4000  AGP-V3800PRO
-		1048 0c21  Synergy II
-		1048 0c28  Erazor III
-		1048 0c29  Erazor III
-		1048 0c2a  Erazor III
-		1048 0c2b  Erazor III
-		1048 0c31  Erazor III Pro
-		1048 0c32  Erazor III Pro
-		1048 0c33  Erazor III Pro
-		1048 0c34  Erazor III Pro
-		107d 2134  WinFast 3D S320 II + TV-Out
-		1092 4804  Viper V770
-		1092 4a00  Viper V770
-		1092 4a02  Viper V770 Ultra
-		1092 5a00  RIVA TNT2/TNT2 Pro
-		1092 5a40  Viper V770D AGP
-		1092 6a02  Viper V770 Ultra
-		1092 7a02  Viper V770 Ultra
-		10de 0005  RIVA TNT2 Pro
-		10de 000f  Compaq NVIDIA TNT2 Pro
-		1102 1020  3D Blaster RIVA TNT2
-		1102 1026  3D Blaster RIVA TNT2 Digital
-		1462 8806  MS-8806 AGPhantom Graphics Card
-		14af 5810  Maxi Gamer Xentor
 	0029  NV5 [Riva TNT2 Ultra]
-		1043 0200  AGP-V3800 Deluxe
-		1043 0201  AGP-V3800 Ultra SDRAM
-		1043 0205  PCI-V3800 Ultra
-		1048 0c2e  Erazor III Ultra
-		1048 0c2f  Erazor III Ultra
-		1048 0c30  Erazor III Ultra
-		1102 1021  3D Blaster RIVA TNT2 Ultra
-		1102 1029  3D Blaster RIVA TNT2 Ultra
-		1102 102f  3D Blaster RIVA TNT2 Ultra
-		14af 5820  Maxi Gamer Xentor 32
-		4843 4f34  Dynamite
 	002a  NV5 [Riva TNT2]
 	002b  NV5 [Riva TNT2]
 	002c  NV5 [Vanta / Vanta LT]
-		1043 0200  AGP-V3800 Combat SDRAM
-		1043 0201  AGP-V3800 Combat
-		1048 0c20  TNT2 Vanta
-		1048 0c21  TNT2 Vanta
-		1048 0c25  TNT2 Vanta 16MB
-		1092 6820  Viper V730
-		1102 1031  CT6938 VANTA 8MB
-		1102 1034  CT6894 VANTA 16MB
-		14af 5008  Maxi Gamer Phoenix 2
 	002d  NV5 [Riva TNT2 Model 64 / Model 64 Pro]
-		1043 0200  AGP-V3800M
-		1043 0201  AGP-V3800M
-		1048 0c3a  Erazor III LT
-		1048 0c3b  Erazor III LT
-		107d 2137  WinFast 3D S325
-		10de 0006  RIVA TNT2 Model 64/Model 64 Pro
-		10de 001e  M64 AGP4x
-		1102 1023  CT6892 RIVA TNT2 Value
-		1102 1024  CT6932 RIVA TNT2 Value 32Mb
-		1102 102c  CT6931 RIVA TNT2 Value [Jumper]
-		1102 1030  CT6931 RIVA TNT2 Value
-# S26361-D1243-V116
-		110a 006f  GM1000-16
-# S26361-D1243-V216
-		110a 0081  GM1000-16
-		1462 8808  MSI-8808
-		14af 5620  Gamer Cougar Video Edition
-		1554 1041  Pixelview RIVA TNT2 M64
-		1569 002d  Palit Microsystems Daytona TNT2 M64
 	0034  MCP04 SMBus
 	0035  MCP04 IDE
 	0036  MCP04 Serial ATA Controller
@@ -8253,156 +3914,47 @@ var pciids = []byte(`#
 	003e  MCP04 Serial ATA Controller
 	0040  NV40 [GeForce 6800 Ultra]
 	0041  NV40 [GeForce 6800]
-		1043 817b  V9999 Gamer Edition
-		107d 2992  WinFast A400
-		1458 310f  Geforce 6800 GV-N6812
 	0042  NV40 [GeForce 6800 LE]
-		107d 299b  WinFast A400 LE
 	0043  NV40 [GeForce 6800 XE]
 	0044  NV40 [GeForce 6800 XT]
 	0045  NV40 [GeForce 6800 GT]
-		1043 817d  V9999GT
-		1458 3140  GV-N68T256D
 	0047  NV40 [GeForce 6800 GS]
-		1682 2109  GeForce 6800 GS
 	0048  NV40 [GeForce 6800 XT]
 	004e  NV40GL [Quadro FX 4000]
 	0050  CK804 ISA Bridge
-		1043 815a  K8N4/A8N Series Mainboard
-		10f1 2865  Tomcat K8E (S2865)
-		1458 0c11  GA-K8N Ultra-9 Mainboard
-		1462 7100  MSI K8N Diamond
-		1462 7125  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 3402  NF4 AM2L Mainboard
 	0051  CK804 ISA Bridge
-		1028 0225  PowerEdge T105 ISA Bridge
 	0052  CK804 SMBus
-		1028 0225  PowerEdge T105 SMBus
-		1043 815a  K8N4/A8N Series Mainboard
-		10f1 2865  Tomcat K8E (S2865)
-		1458 0c11  GA-K8N Ultra-9 Mainboard
-		1462 7100  MSI K8N Diamond
-		1462 7125  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 3402  NF4 AM2L Mainboard
 	0053  CK804 IDE
-		1043 815a  K8N4/A8N Series Mainboard
-		10f1 2865  Tomcat K8E (S2865)
-		1458 5002  GA-K8N Ultra-9 Mainboard
-		1462 7100  MSI K8N Diamond
-		1462 7125  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 3402  NF4 AM2L Mainboard
 	0054  CK804 Serial ATA Controller
-		1028 0225  PowerEdge T105 Serial ATA
-		1043 815a  A8N Series Mainboard
-		10f1 2865  Tomcat K8E (S2865)
-		1458 b003  GA-K8N Ultra-9 Mainboard
-		1462 7100  MSI K8N Diamond
-		1462 7125  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 5401  NF4 AM2L Mainboard
 	0055  CK804 Serial ATA Controller
-		1028 0225  PowerEdge T105 Serial ATA
-		1043 815a  K8N4/A8N Series Mainboard
-		10f1 2865  Tomcat K8E (S2865)
-		1458 b003  GA-K8N Ultra-9 Mainboard
-		1462 7125  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 5401  NF4 AM2L Mainboard
 	0056  CK804 Ethernet Controller
 	0057  CK804 Ethernet Controller
-		1043 8141  K8N4/A8N Series Mainboard
-		10de cb84  NF4 Lanparty
-		10f1 2865  Tomcat K8E (S2865)
-		1458 e000  GA-K8N Ultra-9 Mainboard
-		1462 7100  MSI K8N Diamond
-		1462 7125  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 2501  NF4 AM2L Mainboard
 	0058  CK804 AC'97 Modem
 	0059  CK804 AC'97 Audio Controller
-		1043 812a  K8N4/A8N Series Mainboard
-		10f1 2865  Tomcat K8E (S2865)
-		1462 7585  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 8211  NF4 AM2L Mainboard
 	005a  CK804 USB Controller
-		1028 0225  PowerEdge T105 onboard USB
-		1043 815a  K8N4/A8N Series Mainboard
-		10f1 2865  Tomcat K8E (S2865)
-		1458 5004  GA-K8N Ultra-9 Mainboard
-		1462 7100  MSI K8N Diamond
-		1462 7125  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 3402  NF4 AM2L Mainboard
 	005b  CK804 USB Controller
-		1028 0225  PowerEdge T105 onboard USB
-		1043 815a  K8N4/A8N Series Mainboard
-		10f1 2865  Tomcat K8E (S2865)
-		1458 5004  GA-K8N Ultra-9 Mainboard
-		1462 7100  MSI K8N Diamond
-		1462 7125  K8N Neo4-F mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 3402  NF4 AM2L Mainboard
 	005c  CK804 PCI Bridge
 	005d  CK804 PCIE Bridge
 	005e  CK804 Memory Controller
-		1028 0225  PowerEdge T105 Memory Controller
-		1043 815a  A8N Series Mainboard
-		10de 005e  ECS Elitegroup NFORCE3-A939 motherboard.
-		10f1 2865  Tomcat K8E (S2865)
-		10f1 2891  Thunder K8SRE Mainboard
-		1458 5000  GA-K8N Ultra-9 Mainboard
-		1462 7100  K8N Diamond Mainboard
-		1462 7125  K8N Neo4-F Mainboard
-		147b 1c1a  KN8-Ultra Mainboard
-		1565 3402  NF4 AM2L Mainboard
 	005f  CK804 Memory Controller
 	0060  nForce2 ISA Bridge
-		1043 80ad  A7N8X Mainboard
-		147b 1c02  NF7-S/NF7 (nVidia-nForce2) 2.X
-		a0a0 03ba  UK79G-1394 motherboard
 	0064  nForce2 SMBus (MCP)
-		147b 1c02  NF7-S/NF7 (nVidia-nForce2) 2.X
-		a0a0 03bb  UK79G-1394 motherboard
 	0065  nForce2 IDE
-		10de 0c11  nForce 2 EIDE Controller
-		a0a0 03b2  UK79G-1394 motherboard
 	0066  nForce2 Ethernet Controller
-		1043 80a7  A7N8X Mainboard onboard nForce2 Ethernet
-		10de 0c11  nForce MCP-T Networking Adapter
-		a0a0 03b3  UK79G-1394 motherboard
 	0067  nForce2 USB Controller
-		1043 0c11  A7N8X Mainboard
-		a0a0 03b4  UK79G-1394 motherboard
 	0068  nForce2 USB Controller
-		1043 0c11  A7N8X Mainboard
-		a0a0 03b4  UK79G-1394 motherboard
 	006a  nForce2 AC97 Audio Controler (MCP)
-		1043 8095  nForce2 AC97 Audio Controller (MCP)
-		a0a0 0304  UK79G-1394 motherboard
 	006b  nForce Audio Processing Unit
-		10de 006b  nForce2 MCP Audio Processing Unit
-		a0a0 0304  UK79G-1394 motherboard
 	006c  nForce2 External PCI Bridge
 	006d  nForce2 PCI Bridge
 	006e  nForce2 FireWire (IEEE 1394) Controller
-		a0a0 0306  UK79G-1394 motherboard
 	0080  MCP2A ISA bridge
-		147b 1c09  NV7 Motherboard
 	0084  MCP2A SMBus
-		147b 1c09  NV7 Motherboard
 	0085  MCP2A IDE
-		147b 1c09  NV7 Motherboard
 	0086  MCP2A Ethernet Controller
 	0087  MCP2A USB Controller
-		147b 1c09  NV7 Motherboard
 	0088  MCP2A USB Controller
-		147b 1c09  NV7 Motherboard
 	008a  MCP2S AC'97 Audio Controller
-		147b 1c09  NV7 Motherboard
 	008b  MCP2A PCI Bridge
 	008c  MCP2A Ethernet Controller
 	008e  nForce2 Serial ATA Controller
@@ -8416,7 +3968,6 @@ var pciids = []byte(`#
 	0099  G70M [GeForce Go 7800 GTX]
 	009d  G70GL [Quadro FX 4500]
 	00a0  NV5 [Aladdin TNT2]
-		14af 5810  Maxi Gamer Xentor
 	00c0  NV41 [GeForce 6800 GS]
 	00c1  NV41 [GeForce 6800]
 	00c2  NV41 [GeForce 6800 LE]
@@ -8428,7 +3979,6 @@ var pciids = []byte(`#
 	00c9  NV41M [GeForce Go 6800 Ultra]
 	00cc  NV41GLM [Quadro FX Go1400]
 	00cd  NV42GL [Quadro FX 3450/4000 SDI]
-		10de 029b  Quadro FX 3450
 	00ce  NV41GL [Quadro FX 1400]
 	00cf  NV41
 	00d0  nForce3 LPC Bridge
@@ -8444,77 +3994,26 @@ var pciids = []byte(`#
 	00da  nForce3 Audio
 	00dd  nForce3 PCI Bridge
 	00df  CK8S Ethernet Controller
-		1043 80a7  K8N-E
-		105b 0c43  Winfast NF3250K8AA
-		147b 1c0b  NF8 Mainboard
 	00e0  nForce3 250Gb LPC Bridge
-		1043 813f  K8N-E
-		10de 0c11  Winfast NF3250K8AA
-		1462 7030  K8N Neo-FSR v2.0
-		147b 1c0b  NF8 Mainboard
-		1849 00e0  Motherboard (one of many)
 	00e1  nForce3 250Gb Host Bridge
-		1043 813f  K8N-E
-		1462 7030  K8N Neo-FSR v2.0
-		147b 1c0b  NF8 Mainboard
-		1849 00e1  Motherboard (one of many)
 	00e2  nForce3 250Gb AGP Host to PCI Bridge
 	00e3  nForce3 Serial ATA Controller
-		1043 813f  K8N-E
-		105b 0c43  Winfast NF3250K8AA
-		147b 1c0b  NF8 Mainboard
-		1849 00e3  Motherboard (one of many)
 	00e4  nForce 250Gb PCI System Management
-		1043 813f  K8N-E
-		105b 0c43  Winfast NF3250K8AA
-		1462 7030  K8N Neo-FSR v2.0
-		147b 1c0b  NF8 Mainboard
-		1849 00e4  Motherboard (one of many)
 	00e5  CK8S Parallel ATA Controller (v2.5)
-		1043 813f  K8N-E
-		105b 0c43  Winfast NF3250K8AA
-		1462 7030  K8N Neo-FSR v2.0
-		147b 1c0b  NF8 Mainboard
-		1849 00e5  Motherboard (one of many)
-		f849 00e5  Motherboard (one of many)
 	00e6  CK8S Ethernet Controller
 	00e7  CK8S USB Controller
-		1043 813f  K8N-E
-		105b 0c43  Winfast NF3250K8AA
-		1462 7030  K8N Neo-FSR v2.0
-		147b 1c0b  NF8 Mainboard
-		1849 00e7  Motherboard (one of many)
 	00e8  nForce3 EHCI USB 2.0 Controller
-		1043 813f  K8N-E
-		105b 0c43  Winfast NF3250K8AA
-		1462 7030  K8N Neo-FSR v2.0
-		147b 1c0b  NF8 Mainboard
-		1849 00e8  Motherboard (one of many)
 	00ea  nForce3 250Gb AC'97 Audio Controller
-		1043 819d  K8N-E
-		105b 0c43  Winfast NF3250K8AA
-		1462 b010  K8N Neo-FSR v2.0
-		147b 1c0b  NF8 Mainboard
 	00ed  nForce3 250Gb PCI-to-PCI Bridge
 	00ee  nForce3 Serial ATA Controller 2
 	00f1  NV43 [GeForce 6600 GT]
-		1043 81a6  N6600GT TD 128M AGP
-		1043 81c6  N6600GT TD 128M AGP
-		1458 3150  GV-N66T128VP
-		1554 1191  PixelView PV-N43UA (128KD)
-		1682 2119  GeForce 6600 GT AGP
 	00f2  NV43 [GeForce 6600]
-		1554 1194  PixelView PV-N43AT (256KD)
-		1682 211c  GeForce 6600 256MB DDR DUAL DVI TV
 	00f3  NV43 [GeForce 6200]
 	00f4  NV43 [GeForce 6600 LE]
 	00f5  G71 [GeForce 7800 GS]
 	00f6  NV43 [GeForce 6800 GS/XT]
-		1682 217e  XFX GeForce 6800 XTreme 256MB DDR3 AGP
 	00f8  NV40GL [Quadro FX 3400/4400]
 	00f9  NV40 [GeForce 6800 GT/GTO/Ultra]
-		10de 00f9  NV40 [GeForce 6800 GT]
-		1682 2120  GEFORCE 6800 GT PCI-E
 	00fa  NV36 [GeForce PCX 5750]
 	00fb  NV38 [GeForce PCX 5900]
 	00fc  NV37GL [Quadro FX 330/GeForce PCX 5300]
@@ -8522,61 +4021,14 @@ var pciids = []byte(`#
 	00fe  NV38GL [Quadro FX 1300]
 	00ff  NV18 [GeForce PCX 4300]
 	0100  NV10 [GeForce 256 SDR]
-		1043 0200  AGP-V6600 SGRAM
-		1043 0201  AGP-V6600 SDRAM
-		1043 4008  AGP-V6600 SGRAM
-		1043 4009  AGP-V6600 SDRAM
-		1048 0c41  Erazor X
-		1048 0c43  ERAZOR X PCI
-		1048 0c48  Synergy Force
-		1102 102d  CT6941 GeForce 256
-		14af 5022  3D Prophet SE
 	0101  NV10 [GeForce 256 DDR]
-		1043 0202  AGP-V6800 DDR
-		1043 400a  AGP-V6800 DDR SGRAM
-		1043 400b  AGP-V6800 DDR SDRAM
-		1048 0c42  Erazor X
-		107d 2822  WinFast GeForce 256
-		1102 102e  CT6970/CT6971
-		14af 5021  3D Prophet DDR-DVI
 	0103  NV10GL [Quadro]
-		1048 0c40  GLoria II-64
-		1048 0c44  GLoria II
-		1048 0c45  GLoria II
-		1048 0c4a  GLoria II-64 Pro
-		1048 0c4b  GLoria II-64 Pro DVII
-		10a9 9002  VPro VR3
 	0110  NV11 [GeForce2 MX/MX 400]
-		1043 4015  AGP-V7100 Pro
-		1043 4021  V7100 Deluxe Combo
-		1043 4031  V7100 Pro with TV output
-		1048 0c60  Gladiac MX
-		1048 0c61  Gladiac 511PCI
-		1048 0c63  Gladiac 511TV-OUT 32MB
-		1048 0c64  Gladiac 511TV-OUT 64MB
-		1048 0c65  Gladiac 511TWIN
-		1048 0c66  Gladiac 311
-		10b0 0001  GeForce2 MX Jumbo TV
-		10de 0091  Dell OEM GeForce 2 MX 400
-		10de 00a1  Apple OEM GeForce2 MX
-		1462 8523  MS-8852
-		1462 8817  MSI GeForce2 MX400 Pro32S [MS-8817]
-		14af 7102  3D Prophet II MX
-		14af 7103  3D Prophet II MX Dual-Display
-		1545 0023  Xtasy Rev. B2
-		1554 1081  MVGA-NVG11AM(400)
 	0111  NV11 [GeForce2 MX200]
 	0112  NV11M [GeForce2 Go]
 	0113  NV11GL [Quadro2 MXR/EX/Go]
 	0140  NV43 [GeForce 6600 GT]
-		1458 3125  GV-NX66T128D
-		1458 3126  GV-NX66T256DE
-		1462 8939  MS-8983
 	0141  NV43 [GeForce 6600]
-		1043 81b0  EN6600 Silencer
-		107d 593a  LR2A22 128MB TV OUT
-		107d 597b  WINFAST PX6600
-		1458 3124  GV-NX66128DP Turbo Force Edition
 	0142  NV43 [GeForce 6600 LE]
 	0143  NV43 [GeForce 6600 VE]
 	0144  NV43M [GeForce Go 6600]
@@ -8591,21 +4043,8 @@ var pciids = []byte(`#
 	014e  NV43GL [Quadro FX 540]
 	014f  NV43 [GeForce 6200]
 	0150  NV15 [GeForce2 GTS/Pro]
-		1043 4016  V7700 AGP Video Card
-		1043 402a  AGP-V7700
-		1048 0c50  Gladiac
-		1048 0c52  Gladiac-64
-		107d 2840  WinFast GeForce2 GTS with TV output
-		107d 2842  WinFast GeForce 2 Pro
-		10de 002e  GeForce2 GTS
-		1462 815a  MS-8815
-		1462 8831  Creative GeForce2 Pro
 	0151  NV15 [GeForce2 Ti]
-		1043 405f  V7700Ti
-		1462 5506  Creative 3D Blaster GeForce2 Titanium
-		1462 8364  MS-8836
 	0152  NV15 [GeForce2 Ultra]
-		1048 0c56  GLADIAC Ultra
 	0153  NV15GL [Quadro2 Pro]
 	0160  NV44 [GeForce 6500]
 	0161  NV44 [GeForce 6200 TurboCache]
@@ -8622,41 +4061,20 @@ var pciids = []byte(`#
 	016e  NV44
 	016f  NV44
 	0170  NV17 [GeForce4 MX 460]
-		1462 8630  MS-8863
 	0171  NV17 [GeForce4 MX 440]
-		10b0 0002  Gainward Pro/600 TV
-		10de 0008  Apple OEM GeForce4 MX 440
-		1462 8661  G4MX440-VTP
-		1462 8730  MX440SES-T (MS-8873)
-		1462 8743  MS-8874
-		1462 8852  GeForce4 MX440 PCI
-		147b 8f00  Abit Siluro GeForce4MX440
 	0172  NV17 [GeForce4 MX 420]
-		1462 8730  MS-8873
-		1462 8784  MS-8878
 	0173  NV17 [GeForce4 MX 440-SE]
 	0174  NV17M [GeForce4 440 Go]
 	0175  NV17M [GeForce4 420 Go]
 	0176  NV17M [GeForce4 420 Go 32M]
-		103c 08b0  tc1100 tablet
-		144d c005  X10 Laptop
-		4c53 1090  Cx9 / Vx9 mainboard
 	0177  NV17M [GeForce4 460 Go]
 	0178  NV17GL [Quadro4 550 XGL]
 	0179  NV17M [GeForce4 440 Go 64M]
-		10de 0179  GeForce4 MX (Mac)
 	017a  NV17GL [Quadro NVS]
 	017b  NV17GL [Quadro4 550 XGL]
 	017c  NV17GL [Quadro4 500 GoGL]
 	017f  NV17
 	0181  NV18 [GeForce4 MX 440 AGP 8x]
-		1043 8063  GeForce4 MX 440 AGP 8X
-		1043 806f  V9180 Magic
-		1462 8880  MS-StarForce GeForce4 MX 440 with AGP8X
-		1462 8900  MS-8890 GeForce 4 MX440 AGP8X
-		1462 9350  MSI GeForce4 MX T8X with AGP8X
-		147b 8f0d  Siluro GF4 MX-8X
-		1554 1111  PixelView MVGA-NVG18A
 	0182  NV18 [GeForce4 MX 440SE AGP 8x]
 	0183  NV18 [GeForce4 MX 420 AGP 8x]
 	0184  NV18 [GeForce4 MX]
@@ -8674,7 +4092,6 @@ var pciids = []byte(`#
 	0191  G80 [GeForce 8800 GTX]
 	0192  G80 [GeForce 8800 GTS]
 	0193  G80 [GeForce 8800 GTS]
-		107d 20bd  WinFast PX 8800 GTS TDH
 	0194  G80 [GeForce 8800 Ultra]
 	0197  G80GL [Tesla C870]
 	019d  G80GL [Quadro FX 5600]
@@ -8696,76 +4113,47 @@ var pciids = []byte(`#
 	01c3  nForce Ethernet Controller
 	01d0  G72 [GeForce 7350 LE]
 	01d1  G72 [GeForce 7300 LE]
-		107d 5efa  WinFast PX7300LE-TD128
-		107d 5efb  WinFast PX7300LE-TD256
-		1462 0345  7300LE PCI Express Graphics Adapter
 	01d2  G72 [GeForce 7550 LE]
 	01d3  G72 [GeForce 7200 GS / 7300 SE]
-		1043 8203  EN7300SE
-		1043 8250  EN7200GS
 	01d5  G72
 	01d6  G72M [GeForce Go 7200]
 	01d7  G72M [Quadro NVS 110M/GeForce Go 7300]
 	01d8  G72M [GeForce Go 7400]
-		1028 01d7  XPS M1210
 	01d9  G72M [GeForce Go 7450]
 	01da  G72M [Quadro NVS 110M]
 	01db  G72M [Quadro NVS 120M]
 	01dc  G72GLM [Quadro FX 350M]
 	01dd  G72 [GeForce 7500 LE]
 	01de  G72GL [Quadro FX 350]
-		10de 01dc  Quadro  FX Go350M
 	01df  G72 [GeForce 7300 GS]
 	01e0  nForce2 IGP2
-		147b 1c09  NV7 Motherboard
 	01e8  nForce2 AGP
 	01ea  nForce2 Memory Controller 0
-		a0a0 03b9  UK79G-1394 motherboard
 	01eb  nForce2 Memory Controller 1
-		a0a0 03b9  UK79G-1394 motherboard
 	01ec  nForce2 Memory Controller 2
-		a0a0 03b9  UK79G-1394 motherboard
 	01ed  nForce2 Memory Controller 3
-		a0a0 03b9  UK79G-1394 motherboard
 	01ee  nForce2 Memory Controller 4
-		10de 01ee  MSI Delta-L nForce2 memory controller
-		a0a0 03b9  UK79G-1394 motherboard
 	01ef  nForce2 Memory Controller 5
-		a0a0 03b9  UK79G-1394 motherboard
 	01f0  C17 [GeForce4 MX IGP]
-		a0a0 03b5  UK79G-1394 motherboard
 	0200  NV20 [GeForce3]
-		1043 402f  AGP-V8200 DDR
-		1048 0c70  GLADIAC 920
 	0201  NV20 [GeForce3 Ti 200]
 	0202  NV20 [GeForce3 Ti 500]
-		1043 405b  V8200 T5
-		1545 002f  Xtasy 6964
 	0203  NV20GL [Quadro DCC]
 	0211  NV48 [GeForce 6800]
 	0212  NV48 [GeForce 6800 LE]
 	0215  NV48 [GeForce 6800 GT]
 	0218  NV48 [GeForce 6800 XT]
 	0221  NV44A [GeForce 6200]
-		1043 81e1  N6200/TD/256M/A
-		3842 a341  256A8N341DX
 	0222  NV44 [GeForce 6200 A-LE]
 	0224  NV44
 	0240  C51PV [GeForce 6150]
-		1043 81cd  A8N-VM CSM
-		1462 7207  K8NGM2 series
 	0241  C51 [GeForce 6150 LE]
 	0242  C51G [GeForce 6100]
-		105b 0cad  Winfast 6100K8MB
 	0243  C51 PCI Express Bridge
 	0244  C51 [GeForce Go 6150]
-		103c 30b5  Presario V3242AU
-		103c 30b7  Presario V6133CL
-		10de 0244  GeForce Go 6150
 	0245  C51 [Quadro NVS 210S/GeForce 6150LE]
 	0246  C51 PCI Express Bridge
 	0247  C51 [GeForce Go 6100]
-		1043 1382  MCP51 PCI-X GeForce Go 6100
 	0248  C51 PCI Express Bridge
 	0249  C51 PCI Express Bridge
 	024a  C51 PCI Express Bridge
@@ -8776,102 +4164,32 @@ var pciids = []byte(`#
 	024f  C51 PCI Express Bridge
 	0250  NV25 [GeForce4 Ti 4600]
 	0251  NV25 [GeForce4 Ti 4400]
-		1043 8023  v8440 GeForce 4 Ti4400
-		10de 0251  PNY GeForce4 Ti 4400
-		1462 8710  PNY GeForce4 Ti 4400
 	0252  NV25 [GeForce4 Ti]
 	0253  NV25 [GeForce4 Ti 4200]
-		107d 2896  WinFast A250 LE TD (Dual VGA/TV-out/DVI)
-		147b 8f09  Siluro (Dual VGA/TV-out/DVI)
 	0258  NV25GL [Quadro4 900 XGL]
 	0259  NV25GL [Quadro4 750 XGL]
 	025b  NV25GL [Quadro4 700 XGL]
 	0260  MCP51 LPC Bridge
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81bc  A8N-VM CSM Mainboard
-		1458 5001  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	0261  MCP51 LPC Bridge
-		105b 0cad  Winfast 6100K8MB
 	0262  MCP51 LPC Bridge
 	0263  MCP51 LPC Bridge
 	0264  MCP51 SMBus
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81bc  A8N-VM CSM Mainboard
-		105b 0cad  Winfast 6100K8MB
-		1462 7207  K8NGM2 series
 	0265  MCP51 IDE
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81bc  A8N-VM CSM Mainboard
-		1462 7207  K8NGM2 series
-# Foxconn has used a wrong vendor ID for this one
-		f05b 0cad  Winfast 6100K8MB
 	0266  MCP51 Serial ATA Controller
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81bc  A8N-VM CSM Mainboard
-		1462 7207  K8NGM2 series
 	0267  MCP51 Serial ATA Controller
-		103c 2a34  Pavilion a1677c
-		1043 81bc  A8N-VM CSM Mainboard
-		1462 7207  K8NGM2 series
 	0268  MCP51 Ethernet Controller
 	0269  MCP51 Ethernet Controller
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 8141  A8N-VM CSM Mainboard
-		1462 7207  K8NGM2 series
 	026a  MCP51 MCI
 	026b  MCP51 AC97 Audio Controller
-		105b 0cad  Winfast 6100K8MB
 	026c  MCP51 High Definition Audio
-		103c 2a34  Pavilion a1677c
-		103c 30b5  Presario V3242AU
-		103c 30b7  Presario V6133CL
-		10de cb84  ASUSTeK Computer Inc. A8N-VM CSM Mainboard
-		1462 7207  K8NGM2 series
 	026d  MCP51 USB Controller
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81bc  A8N-VM CSM Mainboard
-		105b 0cad  Winfast 6100K8MB
-		1462 7207  K8NGM2 series
 	026e  MCP51 USB Controller
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81bc  A8N-VM CSM Mainboard
-		105b 0cad  Winfast 6100K8MB
-		1462 7207  K8NGM2 series
 	026f  MCP51 PCI Bridge
-		103c 30b7  Presario V6133CL
 	0270  MCP51 Host Bridge
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81bc  A8N-VM CSM Mainboard
-		105b 0cad  Winfast 6100K8MB
-		1458 5001  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	0271  MCP51 PMU
-		103c 30b5  Presario V3242AU
-		103c 30b7  Presario V6133CL
 	0272  MCP51 Memory Controller 0
-		103c 2a34  Pavilion a1677c
-		105b 0cad  Winfast 6100K8MB
 	027e  C51 Memory Controller 2
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81cd  A8N-VM CSM Mainboard
-		1458 5000  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	027f  C51 Memory Controller 3
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81cd  A8N-VM CSM Mainboard
-		1458 5000  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	0280  NV28 [GeForce4 Ti 4800]
 	0281  NV28 [GeForce4 Ti 4200 AGP 8x]
 	0282  NV28 [GeForce4 Ti 4800 SE]
@@ -8881,14 +4199,10 @@ var pciids = []byte(`#
 	028c  NV28GLM [Quadro4 Go700]
 	0290  G71 [GeForce 7900 GTX]
 	0291  G71 [GeForce 7900 GT/GTO]
-		10de 042b  NX7900GTO-T2D512E [7900 GTO]
 	0292  G71 [GeForce 7900 GS]
 	0293  G71 [GeForce 7900 GX2]
 	0294  G71 [GeForce 7950 GX2]
 	0295  G71 [GeForce 7950 GT]
-		1043 8225  GeForce 7950 GT
-		107d 2a68  WinFast PX7950GT TDH
-		1462 0663  NX7950GT-VT2D512EZ-HD
 	0297  G71M [GeForce Go 7950 GTX]
 	0298  G71M [GeForce Go 7900 GS]
 	0299  G71M [GeForce Go 7900 GTX]
@@ -8896,29 +4210,18 @@ var pciids = []byte(`#
 	029b  G71GLM [Quadro FX 1500M]
 	029c  G71GL [Quadro FX 5500]
 	029d  G71GL [Quadro FX 3500]
-		1028 019b  G71GLM [Quadro FX 3500M]
 	029e  G71GL [Quadro FX 1500]
 	029f  G71GL [Quadro FX 4500 X2]
-# Xbox Graphics Processing Unit (Integrated). GeForce3 derivative (NV20 < NV2A < NV25).
 	02a0  NV2A [XGPU]
 	02a5  MCPX CPU Bridge
 	02a6  MCPX Memory Controller
 	02e0  G73 [GeForce 7600 GT]
-		02e0 2249  GF 7600GT 560M 256MB DDR3 DUAL DVI TV
 	02e1  G73 [GeForce 7600 GS]
-		1682 222b  PV-T73K-UAL3 (256MB)
-		1682 2247  GF 7600GS 512MB DDR2
 	02e2  G73 [GeForce 7300 GT]
 	02e3  G71 [GeForce 7900 GS]
 	02e4  G71 [GeForce 7950 GT]
-		1682 2271  PV-T71A-YDF7 (512MB)
 	02f0  C51 Host Bridge
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81cd  A8N-VM CSM Mainboard
-		1462 7207  K8NGM2 series
 	02f1  C51 Host Bridge
-		1458 5000  GA-M55plus-S3G
 	02f2  C51 Host Bridge
 	02f3  C51 Host Bridge
 	02f4  C51 Host Bridge
@@ -8926,40 +4229,13 @@ var pciids = []byte(`#
 	02f6  C51 Host Bridge
 	02f7  C51 Host Bridge
 	02f8  C51 Memory Controller 5
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81cd  A8N-VM CSM Mainboard
-		1458 5000  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	02f9  C51 Memory Controller 4
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81cd  A8N-VM CSM Mainboard
-		1458 5000  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	02fa  C51 Memory Controller 0
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81cd  A8N-VM CSM Mainboard
-		1458 5000  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	02fb  C51 PCI Express Bridge
 	02fc  C51 PCI Express Bridge
-		103c 30b7  Presario V6133CL
 	02fd  C51 PCI Express Bridge
-		103c 30b7  Presario V6133CL
 	02fe  C51 Memory Controller 1
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81cd  A8N-VM CSM Mainboard
-		1458 5000  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	02ff  C51 Host Bridge
-		103c 2a34  Pavilion a1677c
-		103c 30b7  Presario V6133CL
-		1043 81cd  A8N-VM CSM Mainboard
-		1458 5000  GA-M55plus-S3G
-		1462 7207  K8NGM2 series
 	0300  NV30 [GeForce FX]
 	0301  NV30 [GeForce FX 5800 Ultra]
 	0302  NV30 [GeForce FX 5800]
@@ -8968,7 +4244,6 @@ var pciids = []byte(`#
 	0311  NV31 [GeForce FX 5600 Ultra]
 	0312  NV31 [GeForce FX 5600]
 	0314  NV31 [GeForce FX 5600XT]
-		1043 814a  V9560XT/TD
 	0316  NV31M
 	0318  NV31GL
 	031a  NV31M [GeForce FX Go5600]
@@ -8977,26 +4252,13 @@ var pciids = []byte(`#
 	0320  NV34 [GeForce FX 5200]
 	0321  NV34 [GeForce FX 5200 Ultra]
 	0322  NV34 [GeForce FX 5200]
-		1043 02fb  V9250 Magic
-		1043 8180  V9520-X/TD/128M
-		107d 2967  WinFast A340T 128MB
-		1462 9110  MS-8911 (FX5200-TD128)
-		1462 9171  MS-8917 (FX5200-T128)
-		1462 9360  MS-8936 (FX5200-T128)
-		1682 1351  GeForce FX 5200
 	0323  NV34 [GeForce FX 5200LE]
 	0324  NV34M [GeForce FX Go5200 64M]
-		1028 0196  Inspiron 5160
-		103c 006a  Pavilion ZD7000 laptop
-		1071 8160  MIM2000
 	0325  NV34M [GeForce FX Go5250]
 	0326  NV34 [GeForce FX 5500]
-		1458 310d  GeForce FX 5500 128 MB
-		1682 2034  GeForce 5500 256 MB
 	0327  NV34 [GeForce FX 5100]
 	0328  NV34M [GeForce FX Go5200 32M/64M]
 	0329  NV34M [GeForce FX Go5200]
-		10de 0010  Powerbook G4
 	032a  NV34GL [Quadro NVS 280 PCI]
 	032b  NV34GL [Quadro FX 500/600 PCI]
 	032c  NV34M [GeForce FX Go5300 / Go5350]
@@ -9004,61 +4266,40 @@ var pciids = []byte(`#
 	032e  NV34
 	032f  NV34 [GeForce FX 5200]
 	0330  NV35 [GeForce FX 5900 Ultra]
-		1043 8137  V9950 Ultra / 256 MB
 	0331  NV35 [GeForce FX 5900]
-		1043 8145  V9950GE
 	0332  NV35 [GeForce FX 5900XT]
 	0333  NV38 [GeForce FX 5950 Ultra]
 	0334  NV35 [GeForce FX 5900ZT]
-		1462 9373  FX5900ZT-VTD128 (MS-8937)
 	0338  NV35GL [Quadro FX 3000]
 	033f  NV35GL [Quadro FX 700]
 	0341  NV36 [GeForce FX 5700 Ultra]
-		1462 9380  MS-8938 (FX5700U-TD128)
 	0342  NV36 [GeForce FX 5700]
 	0343  NV36 [GeForce FX 5700LE]
 	0344  NV36 [GeForce FX 5700VE]
 	0347  NV36M [GeForce FX Go5700]
-		103c 006a  NX9500
 	0348  NV36M [GeForce FX Go5700]
 	034c  NV36 [Quadro FX Go1000]
 	034d  NV36
 	034e  NV36GL [Quadro FX 1100]
 	0360  MCP55 LPC Bridge
 	0361  MCP55 LPC Bridge
-		1028 0221  PowerEdge R805 MCP55 LPC Bridge
 	0362  MCP55 LPC Bridge
-		147b 1c24  KN9 series mainboard
 	0363  MCP55 LPC Bridge
 	0364  MCP55 LPC Bridge
-		1028 0221  PowerEdge R805 MCP55 LPC Bridge
 	0365  MCP55 LPC Bridge
 	0366  MCP55 LPC Bridge
 	0367  MCP55 LPC Bridge
 	0368  MCP55 SMBus Controller
-		1028 020c  PowerEdge M605 MCP55 SMBus
-		1028 0221  PowerEdge R805 MCP55 SMBus
-		147b 1c24  KN9 series mainboard
 	0369  MCP55 Memory Controller
-		147b 1c24  KN9 series mainboard
 	036a  MCP55 Memory Controller
 	036b  MCP55 SMU
 	036c  MCP55 USB Controller
-		1028 020c  PowerEdge M605 MCP55 USB Controller
-		1028 0221  PowerEdge R805 MCP55 USB Controller
-		147b 1c24  KN9 series mainboard
 	036d  MCP55 USB Controller
-		1028 020c  PowerEdge M605 MCP55 USB Controller
-		1028 0221  PowerEdge R805 MCP55 USB Controller
-		147b 1c24  KN9 series mainboard
 	036e  MCP55 IDE
-		147b 1c24  KN9 series mainboard
 	0370  MCP55 PCI bridge
 	0371  MCP55 High Definition Audio
-		147b 1c24  KN9 series mainboard
 	0372  MCP55 Ethernet
 	0373  MCP55 Ethernet
-		147b 1c24  KN9 series mainboard
 	0374  MCP55 PCI Express bridge
 	0375  MCP55 PCI Express bridge
 	0376  MCP55 PCI Express bridge
@@ -9067,29 +4308,20 @@ var pciids = []byte(`#
 	037a  MCP55 Memory Controller
 	037e  MCP55 SATA Controller
 	037f  MCP55 SATA Controller
-		1028 0221  PowerEdge R805 MCP55 SATA Controller
-		147b 1c24  KN9 series mainboard
 	038b  G73 [GeForce 7650 GS]
 	0390  G73 [GeForce 7650 GS]
 	0391  G73 [GeForce 7600 GT]
-		1458 3427  GV-NX76T128D-RH
-		1462 0452  NX7600GT-VT2D256E
 	0392  G73 [GeForce 7600 GS]
-		1462 0622  NX7600GS-T2D256EH
 	0393  G73 [GeForce 7300 GT]
-		10de 0412  NX7300GT-TD256EH
-		1462 0412  NX7300GT-TD256EH
 	0394  G73 [GeForce 7600 LE]
 	0395  G73 [GeForce 7300 GT]
 	0396  G73
 	0397  G73M [GeForce Go 7700]
 	0398  G73M [GeForce Go 7600]
-		1025 006c  Aspire 9814WKMi
 	0399  G73M [GeForce Go 7600 GT]
 	039a  G73M [Quadro NVS 300M]
 	039b  G73M [GeForce Go 7900 SE]
 	039c  G73GLM [Quadro FX 550M]
-		10de 039c  Quadro FX 560M
 	039d  G73
 	039e  G73GL [Quadro FX 560]
 	039f  G73
@@ -9123,81 +4355,38 @@ var pciids = []byte(`#
 	03bb  C55 PCI Express bridge
 	03bc  C55 Memory Controller
 	03d0  C61 [GeForce 6150SE nForce 430]
-		1028 020e  Inspiron 531
 	03d1  C61 [GeForce 6100 nForce 405]
 	03d2  C61 [GeForce 6100 nForce 400]
 	03d5  C61 [GeForce 6100 nForce 420]
 	03d6  C61 [GeForce 7025 / nForce 630a]
 	03e0  MCP61 LPC Bridge
-		1028 020e  Inspiron 531
-		1849 03e0  939NF6G-VSTA Board
 	03e1  MCP61 LPC Bridge
-		1043 83a4  M4N68T series motherboard
 	03e2  MCP61 Host Bridge
-		1043 83a4  M4N68T series motherboard
 	03e3  MCP61 LPC Bridge
 	03e4  MCP61 High Definition Audio
 	03e5  MCP61 Ethernet
 	03e6  MCP61 Ethernet
 	03e7  MCP61 SATA Controller
 	03e8  MCP61 PCI Express bridge
-		1028 020e  Inspiron 531
-		1849 03e8  939NF6G-VSTA Board
 	03e9  MCP61 PCI Express bridge
-		1028 020e  Inspiron 531
-		1849 03e9  939NF6G-VSTA Board
 	03ea  MCP61 Memory Controller
-		1028 020e  Inspiron 531
-		1849 03ea  939NF6G-VSTA Board
 	03eb  MCP61 SMBus
-		1028 020e  Inspiron 531
-		1043 83a4  M4N68T series motherboard
-		1849 03eb  939NF6G-VSTA Board
 	03ec  MCP61 IDE
-		1025 0392  ET1350
-		1028 020e  Inspiron 531
-		1043 83a4  M4N68T series motherboard
-		1849 03ec  939NF6G-VSTA Board
 	03ee  MCP61 Ethernet
 	03ef  MCP61 Ethernet
-		1025 8000  ET1350
-		1028 020e  Inspiron 531
-		1043 83a4  M4N68T series motherboard
-		1849 03ef  939NF6G-VSTA Board
 	03f0  MCP61 High Definition Audio
-		1028 020e  Inspiron 531
-		1043 8415  M4N68T series motherboard
-		1849 0888  939NF6G-VSTA Board
 	03f1  MCP61 USB 1.1 Controller
-		1028 020e  Inspiron 531
-		1043 83a4  M4N68T series motherboard
-		1849 03f1  939NF6G-VSTA Board
 	03f2  MCP61 USB 2.0 Controller
-		1028 020e  Inspiron 531
-		1043 83a4  M4N68T series motherboard
-		1849 03f2  939NF6G-VSTA Board
 	03f3  MCP61 PCI bridge
-		1028 020e  Inspiron 531
-		1849 03f3  939NF6G-VSTA Board
 	03f4  MCP61 SMU
 	03f5  MCP61 Memory Controller
-		1028 020e  Inspiron 531
-		1043 83a4  M4N68T series motherboard
-		1849 03eb  939NF6G-VSTA Board
 	03f6  MCP61 SATA Controller
-		1028 020e  Inspiron 531
-		1043 83a4  M4N68T series motherboard
-		1849 03f6  939NF6G-VSTA Board
 	03f7  MCP61 SATA Controller
 	0400  G84 [GeForce 8600 GTS]
-		1043 8241  EN8600GTS
 	0401  G84 [GeForce 8600 GT]
 	0402  G84 [GeForce 8600 GT]
-		1458 3455  GV-NX86T512H
-		1462 0910  NX8600GT-T2D256EZ
 	0403  G84 [GeForce 8600 GS]
 	0404  G84 [GeForce 8400 GS]
-		1462 1230  NX8400GS-TD256E
 	0405  G84M [GeForce 9500M GS]
 	0406  G84 [GeForce 8300 GS]
 	0407  G84M [GeForce 8600M GT]
@@ -9206,7 +4395,6 @@ var pciids = []byte(`#
 	040a  G84GL [Quadro FX 370]
 	040b  G84GLM [Quadro NVS 320M]
 	040c  G84GLM [Quadro FX 570M]
-		17aa 20d9  ThinkPad T61p
 	040d  G84GLM [Quadro FX 1600M]
 	040e  G84GL [Quadro FX 570]
 	040f  G84GL [Quadro FX 1700]
@@ -9214,19 +4402,14 @@ var pciids = []byte(`#
 	0414  G92 [GeForce 9800 GT]
 	0420  G86 [GeForce 8400 SE]
 	0421  G86 [GeForce 8500 GT]
-		1462 0960  NX8500GT-TD512EH/M2
 	0422  G86 [GeForce 8400 GS]
 	0423  G86 [GeForce 8300 GS]
 	0424  G86 [GeForce 8400 GS]
 	0425  G86M [GeForce 8600M GS]
-		1025 0121  Aspire 5920G
 	0426  G86M [GeForce 8400M GT]
 	0427  G86M [GeForce 8400M GS]
-		103c 30cc  Pavilion dv6700
-		103c 30cf  Pavilion dv9668eg Laptop
 	0428  G86M [GeForce 8400M G]
 	0429  G86M [Quadro NVS 140M]
-		17aa 20d8  ThinkPad T61
 	042a  G86M [Quadro NVS 130M]
 	042b  G86M [Quadro NVS 135M]
 	042c  G86 [GeForce 9400 GT]
@@ -9236,116 +4419,67 @@ var pciids = []byte(`#
 	0440  MCP65 LPC Bridge
 	0441  MCP65 LPC Bridge
 	0442  MCP65 LPC Bridge
-		103c 30cf  Pavilion dv9668eg Laptop
 	0443  MCP65 LPC Bridge
 	0444  MCP65 Memory Controller
-		103c 30cf  Pavilion dv9668eg Laptop
 	0445  MCP65 Memory Controller
 	0446  MCP65 SMBus
-		103c 30cf  Pavilion dv9668eg Laptop
 	0447  MCP65 SMU
-		103c 30cf  Pavilion dv9500/9600/9700 series
 	0448  MCP65 IDE
-		103c 30cf  Pavilion dv9668eg Laptop
 	0449  MCP65 PCI bridge
-		10de cb84  HP Pavilion dv9668eg Laptop
 	044a  MCP65 High Definition Audio
-		103c 30cf  Pavilion dv9668eg Laptop
 	044b  MCP65 High Definition Audio
 	044c  MCP65 AHCI Controller
 	044d  MCP65 AHCI Controller
 	044e  MCP65 AHCI Controller
 	044f  MCP65 AHCI Controller
 	0450  MCP65 Ethernet
-		103c 30cf  Pavilion dv9668eg Laptop
 	0451  MCP65 Ethernet
 	0452  MCP65 Ethernet
 	0453  MCP65 Ethernet
 	0454  MCP65 USB 1.1 OHCI Controller
-		103c 30cf  Pavilion dv9668eg Laptop
 	0455  MCP65 USB 2.0 EHCI Controller
-		103c 30cf  Pavilion dv9668eg Laptop
 	0456  MCP65 USB Controller
 	0457  MCP65 USB Controller
 	0458  MCP65 PCI Express bridge
-		10de 0000  MCP65 PCI Express bridge
 	0459  MCP65 PCI Express bridge
-		10de 0000  MCP65 PCI Express bridge
 	045a  MCP65 PCI Express bridge
-		10de 0000  MCP65 PCI Express bridge
 	045b  MCP65 PCI Express bridge
-		10de 0000  MCP65 PCI Express bridge
 	045c  MCP65 SATA Controller
 	045d  MCP65 SATA Controller
-		103c 30cf  Pavilion dv9668eg Laptop
 	045e  MCP65 SATA Controller
 	045f  MCP65 SATA Controller
 	0531  C67 [GeForce 7150M / nForce 630M]
 	0533  C67 [GeForce 7000M / nForce 610M]
 	053a  C68 [GeForce 7050 PV / nForce 630a]
 	053b  C68 [GeForce 7050 PV / nForce 630a]
-		1043 8308  M2N68-AM Motherboard
 	053e  C68 [GeForce 7025 / nForce 630a]
 	0541  MCP67 Memory Controller
 	0542  MCP67 SMBus
-		1043 8308  M2N68-AM Motherboard
 	0543  MCP67 Co-processor
 	0547  MCP67 Memory Controller
-		1043 8308  M2N68-AM Motherboard
-		1849 0547  ALiveNF7G-HDready
 	0548  MCP67 ISA Bridge
-		1043 8308  M2N68-AM Motherboard
 	054c  MCP67 Ethernet
-		1043 8308  M2N68-AM Motherboard
-		1849 054c  ALiveNF7G-HDready, MCP67 Gigabit Ethernet
 	054d  MCP67 Ethernet
 	054e  MCP67 Ethernet
 	054f  MCP67 Ethernet
 	0550  MCP67 AHCI Controller
-		1043 8308  M2N68-AM Motherboard
 	0554  MCP67 AHCI Controller
-		1043 8308  M2N68-AM Motherboard
 	0555  MCP67 SATA Controller
-		1043 8308  M2N68-AM Motherboard
 	055c  MCP67 High Definition Audio
-		1043 8290  M2N68-AM Motherboard
 	055d  MCP67 High Definition Audio
 	055e  MCP67 OHCI USB 1.1 Controller
-		1043 8308  M2N68-AM Motherboard
 	055f  MCP67 EHCI USB 2.0 Controller
-		1043 8308  M2N68-AM Motherboard
 	0560  MCP67 IDE Controller
-		f043 8308  M2N68-AM Motherboard
 	0561  MCP67 PCI Bridge
 	0562  MCP67 PCI Express Bridge
-		1849 0562  ALiveNF7G-HDready
 	0563  MCP67 PCI Express Bridge
 	0568  MCP78S [GeForce 8200] Memory Controller
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0568  K10N78FullHD-hSLI R3.0 Memory Controller
 	0569  MCP78S [GeForce 8200] PCI Express Bridge
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0569  K10N78FullHD-hSLI R3.0 PCI Express Bridge
 	056a  MCP73 [nForce 630i] USB 2.0 Controller (EHCI)
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
 	056c  MCP73 IDE Controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	056d  MCP73 PCI Express bridge
-		1019 297a  MCP73PVT-SM
-		10de cb73  MCP73 PCI Bridge
 	056e  MCP73 PCI Express bridge
-		1019 297a  MCP73PVT-SM
-		10de 0000  MCP73 PCIe x16 port
 	056f  MCP73 PCI Express bridge
-		1019 297a  MCP73PVT-SM
-		10de 0000  MCP73 PCIe x1 port
 	05b1  NF200 PCIe 2.0 switch
 	05b8  NF200 PCIe 2.0 switch for GTX 295
 	05be  NF200 PCIe 2.0 switch for Quadro Plex S4 / Tesla S870 / Tesla S1070 / Tesla S2050
@@ -9353,14 +4487,8 @@ var pciids = []byte(`#
 	05e1  GT200 [GeForce GTX 280]
 	05e2  GT200 [GeForce GTX 260]
 	05e3  GT200b [GeForce GTX 285]
-		1682 2490  GX-285N-ZDF
 	05e6  GT200b [GeForce GTX 275]
 	05e7  GT200GL [Tesla C1060 / M1060]
-		10de 0595  Tesla T10 Processor
-		10de 068f  Tesla T10 Processor
-		10de 0697  Tesla M1060
-		10de 0714  Tesla M1060
-		10de 0743  Tesla M1060
 	05ea  GT200 [GeForce GTX 260]
 	05eb  GT200 [GeForce GTX 295]
 	05ed  GT200GL [Quadro Plex 2200 D2]
@@ -9381,28 +4509,17 @@ var pciids = []byte(`#
 	0607  G92 [GeForce GTS 240]
 	0608  G92M [GeForce 9800M GTX]
 	0609  G92M [GeForce 8800M GTS]
-		106b 00a7  GeForce 8800 GS
 	060a  G92M [GeForce GTX 280M]
 	060b  G92M [GeForce 9800M GT]
 	060c  G92M [GeForce 8800M GTX]
 	060d  G92 [GeForce 8800 GS]
 	060f  G92M [GeForce GTX 285M]
 	0610  G92 [GeForce 9600 GSO]
-		1682 2385  GeForce 9600 GSO 768mb
 	0611  G92 [GeForce 8800 GT]
-		107d 2ab0  Winfast PX8800 GT PCI-E
-		19da 1040  ZT-88TES2P-FSP
 	0612  G92 [GeForce 9800 GTX / 9800 GTX+]
 	0613  G92 [GeForce 9800 GTX+]
 	0614  G92 [GeForce 9800 GT]
-		107d 2ab3  WinFast PX9800 GT (S-Fanpipe)
 	0615  G92 [GeForce GTS 250]
-		3842 1150  GeForce GTS 250 P/N 512-P3-1150-TR
-# Overclocked
-		3842 1151  GeForce GTS 250 P/N 512-P3-1151-TR
-		3842 1155  GeForce GTS 250 P/N 01G-P3-1155-TR
-# Overclocked
-		3842 1156  GeForce GTS 250 P/N 01G-P3-1156-TR
 	0617  G92M [GeForce 9800M GTX]
 	0618  G92M [GeForce GTX 260M]
 	0619  G92GL [Quadro FX 4700 X2]
@@ -9415,8 +4532,6 @@ var pciids = []byte(`#
 	0620  G94 [GeForce 9800 GT]
 	0621  G94 [GeForce GT 230]
 	0622  G94 [GeForce 9600 GT]
-		107d 2ac1  WinFast PX9600GT 1024MB
-		1458 3481  GV-NX96T512HP
 	0623  G94 [GeForce 9600 GS]
 	0624  G94 [GeForce 9600 GT Green Edition]
 	0625  G94 [GeForce 9600 GSO 512]
@@ -9428,7 +4543,6 @@ var pciids = []byte(`#
 	062c  G94M [GeForce 9800M GTS]
 	062d  G94 [GeForce 9600 GT]
 	062e  G94 [GeForce 9600 GT]
-		106b 0605  GeForce GT 130
 	062f  G94 [GeForce 9800 S]
 	0630  G94 [GeForce 9600 GT]
 	0631  G94M [GeForce GTS 160M]
@@ -9441,17 +4555,14 @@ var pciids = []byte(`#
 	063f  G94 [GeForce 9600 GE]
 	0640  G96 [GeForce 9500 GT]
 	0641  G96 [GeForce 9400 GT]
-		1682 4009  PV-T94G-ZAFG
 	0642  G96 [D9M-10]
 	0643  G96 [GeForce 9500 GT]
 	0644  G96 [GeForce 9500 GS]
-		174b 9600  Geforce 9500GS 512M DDR2 V/D/HDMI
 	0645  G96 [GeForce 9500 GS]
 	0646  G96 [GeForce GT 120]
 	0647  G96M [GeForce 9600M GT]
 	0648  G96M [GeForce 9600M GS]
 	0649  G96M [GeForce 9600M GT]
-		1043 202d  GeForce GT 220M
 	064a  G96M [GeForce 9700M GT]
 	064b  G96M [GeForce 9500M G]
 	064c  G96M [GeForce 9650M GT]
@@ -9459,11 +4570,8 @@ var pciids = []byte(`#
 	064e  G96 [GeForce 9600 GT / 9800 GT]
 	0651  G96M [GeForce G 110M]
 	0652  G96M [GeForce GT 130M]
-		152d 0850  GeForce GT 240M LE
 	0653  G96M [GeForce GT 120M]
 	0654  G96M [GeForce GT 220M]
-		1043 14a2  GeForce GT 320M
-		1043 14d2  GeForce GT 320M
 	0655  G96 [GeForce GT 120]
 	0656  G96 [GeForce 9650 S]
 	0658  G96GL [Quadro FX 380]
@@ -9479,45 +4587,24 @@ var pciids = []byte(`#
 	06cb  GF100 [GeForce GTX 480]
 	06cd  GF100 [GeForce GTX 470]
 	06d1  GF100GL [Tesla C2050 / C2070]
-		10de 0771  Tesla C2050
-		10de 0772  Tesla C2070
 	06d2  GF100GL [Tesla M2070]
-		10de 0774  Tesla M2070
-		10de 0830  Tesla M2070
-		10de 0842  Tesla M2070
-		10de 088f  Tesla X2070
-		10de 0908  Tesla M2070
 	06d8  GF100GL [Quadro 6000]
 	06d9  GF100GL [Quadro 5000]
 	06da  GF100GLM [Quadro 5000M]
 	06dc  GF100GL [Quadro 6000]
 	06dd  GF100GL [Quadro 4000]
 	06de  GF100GL [Tesla T20 Processor]
-		10de 0773  Tesla S2050
-		10de 082f  Tesla M2050
-		10de 0840  Tesla X2070
-		10de 0842  Tesla M2050
-		10de 0846  Tesla M2050
-		10de 0866  Tesla M2050
-		10de 0907  Tesla M2050
-		10de 091e  Tesla M2050
 	06df  GF100GL [Tesla M2070-Q]
-		10de 084d  Tesla M2070-Q
-		10de 087f  Tesla M2070-Q
 	06e0  G98 [GeForce 9300 GE]
-		107d 5a96  Geforce 9300GE
 	06e1  G98 [GeForce 9300 GS]
 	06e2  G98 [GeForce 8400]
 	06e3  G98 [GeForce 8300 GS]
 	06e4  G98 [GeForce 8400 GS Rev. 2]
-		1458 3475  GV-NX84S256HE [GeForce 8400 GS]
 	06e5  G98M [GeForce 9300M GS]
 	06e6  G98 [GeForce G 100]
 	06e7  G98 [GeForce 9300 SE]
 	06e8  G98M [GeForce 9200M GS]
-		103c 360b  GeForce 9200M GE
 	06e9  G98M [GeForce 9300M GS]
-		1043 19b2  U6V laptop
 	06ea  G98M [Quadro NVS 150M]
 	06eb  G98M [Quadro NVS 160M]
 	06ec  G98M [GeForce G 105M]
@@ -9531,207 +4618,79 @@ var pciids = []byte(`#
 	06fb  G98GLM [Quadro FX 370M]
 	06fd  G98 [Quadro NVS 295]
 	06ff  G98 [HICx16 + Graphics]
-		10de 0711  HICx8 + Graphics
 	0751  MCP78S [GeForce 8200] Memory Controller
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0751  K10N78FullHD-hSLI R3.0 Memory Controller
 	0752  MCP78S [GeForce 8200] SMBus
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0752  K10N78FullHD-hSLI R3.0 SMBus
 	0753  MCP78S [GeForce 8200] Co-Processor
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0753  K10N78FullHD-hSLI R3.0 Co-Processor
 	0754  MCP78S [GeForce 8200] Memory Controller
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0754  K10N78FullHD-hSLI R3.0 Memory Controller
 	0759  MCP78S [GeForce 8200] IDE
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0759  K10N78FullHD-hSLI R3.0 IDE
 	075a  MCP78S [GeForce 8200] PCI Bridge
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1849 075a  K10N78FullHD-hSLI R3.0 PCI Bridge
 	075b  MCP78S [GeForce 8200] PCI Express Bridge
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 075b  K10N78FullHD-hSLI R3.0 PCI Express Bridge
 	075c  MCP78S [GeForce 8200] LPC Bridge
-		103c 2a9e  Pavilion p6310f
-		1462 7508  K9N2GM-FIH
-		1849 075c  K10N78FullHD-hSLI R3.0 LPC Bridge
 	075d  MCP78S [GeForce 8200] LPC Bridge
-		1043 82e8  M3N72-D
 	0760  MCP77 Ethernet
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0760  K10N78FullHD-hSLI R3.0 Ethernet
 	0761  MCP77 Ethernet
 	0762  MCP77 Ethernet
 	0763  MCP77 Ethernet
 	0774  MCP72XE/MCP72P/MCP78U/MCP78S High Definition Audio
-		103c 2a9e  Pavilion p6310f
-# has a Realtek ALC1200 HDAudio Codec
-		1043 82fe  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 3662  K10N78FullHD-hSLI R3.0 High Definition Audio
 	0778  MCP78S [GeForce 8200] PCI Express Bridge
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 0778  K10N78FullHD-hSLI R3.0 PCI Express Bridge
 	077a  MCP78S [GeForce 8200] PCI Bridge
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 077a  K10N78FullHD-hSLI R3.0 PCI Bridge
 	077b  MCP78S [GeForce 8200] OHCI USB 1.1 Controller
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 077b  K10N78FullHD-hSLI R3.0 OHCI USB 1.1 Controller
 	077c  MCP78S [GeForce 8200] EHCI USB 2.0 Controller
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 077c  K10N78FullHD-hSLI R3.0 EHCI USB 2.0 Controller
 	077d  MCP78S [GeForce 8200] OHCI USB 1.1 Controller
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 077d  K10N78FullHD-hSLI R3.0 OHCI USB 1.1 Controller
 	077e  MCP78S [GeForce 8200] EHCI USB 2.0 Controller
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1462 7508  K9N2GM-FIH
-		1849 077e  K10N78FullHD-hSLI R3.0 EHCI USB 2.0 Controller
 	07c0  MCP73 Host Bridge
-		1afa 7150  JW-IN7150-HD
 	07c1  MCP73 Host Bridge
-		1019 297a  MCP73PVT-SM
 	07c2  MCP73 Host Bridge
 	07c3  MCP73 Host Bridge
-		147b 1c3e  I-N73V motherboard
 	07c5  MCP73 Host Bridge
 	07c8  MCP73 Memory Controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07cb  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07cd  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07ce  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07cf  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07d0  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07d1  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07d2  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07d3  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07d6  nForce 610i/630i memory controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07d7  MCP73 LPC Bridge
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07d8  MCP73 SMBus
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07d9  MCP73 Memory Controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	07da  MCP73 Co-processor
-		1afa 7150  JW-IN7150-HD
 	07dc  MCP73 Ethernet
-		147b 1c3e  I-N73V motherboard
 	07dd  MCP73 Ethernet
 	07de  MCP73 Ethernet
 	07df  MCP73 Ethernet
 	07e0  C73 [GeForce 7150 / nForce 630i]
-		1afa 7150  JW-IN7150-HD
 	07e1  C73 [GeForce 7100 / nForce 630i]
-		1019 297a  MCP73PVT-SM
 	07e2  C73 [GeForce 7050 / nForce 630i]
 	07e3  C73 [GeForce 7050 / nForce 610i]
-		147b 1c3e  I-N73V motherboard
 	07e5  C73 [GeForce 7100 / nForce 620i]
 	07f0  MCP73 SATA Controller (IDE mode)
-		147b 1c3e  I-N73V motherboard
 	07f4  GeForce 7100/nForce 630i SATA
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
 	07f8  MCP73 SATA RAID Controller
-		147b 1c3e  I-N73V motherboard
 	07fc  MCP73 High Definition Audio
-		1019 297a  MCP73PVT-SM
-		10de 07fc  MCP73 High Definition Audio
-		147b 1c3e  I-N73V motherboard
 	07fe  MCP73 OHCI USB 1.1 Controller
-		1019 297a  MCP73PVT-SM
-		147b 1c3e  I-N73V motherboard
-		1afa 7150  JW-IN7150-HD
 	0840  C77 [GeForce 8200M]
 	0844  C77 [GeForce 9100M G]
 	0845  C77 [GeForce 8200M G]
 	0846  C77 [GeForce 9200]
 	0847  C78 [GeForce 9100]
-		103c 2a9e  Pavilion p6310f
 	0848  C77 [GeForce 8300]
 	0849  C77 [GeForce 8200]
-		1462 7508  K9N2GM-FIH
-		1849 0849  K10N78FullHD-hSLI R3.0 GeForce 8200
 	084a  C77 [nForce 730a]
 	084b  C77 [GeForce 8200]
 	084c  C77 [nForce 780a/980a SLI]
 	084d  C77 [nForce 750a SLI]
-		1043 82e8  M3N72-D mGPU
 	084f  C77 [GeForce 8100 / nForce 720a]
 	0860  C79 [GeForce 9300]
 	0861  C79 [GeForce 9400]
 	0862  C79 [GeForce 9400M G]
 	0863  C79 [GeForce 9400M]
-		106b 00aa  MacBook5,1
 	0864  C79 [GeForce 9300]
 	0865  C79 [GeForce 9300/ION]
 	0866  C79 [GeForce 9400M G]
-		106b 00b1  GeForce 9400M
 	0867  C79 [GeForce 9400]
-		106b 00ad  iMac 9,1
 	0868  C79 [nForce 760i SLI]
 	0869  MCP7A [GeForce 9400]
 	086a  C79 [GeForce 9400]
@@ -9742,19 +4701,11 @@ var pciids = []byte(`#
 	0870  C79 [GeForce 9400M]
 	0871  C79 [GeForce 9200]
 	0872  C79 [GeForce G102M]
-		1043 19b4  GeForce G102M
-		1043 1aa2  GeForce G102M
-		1043 1c02  GeForce G102M
-		1043 1c42  GeForce G205M
 	0873  C79 [GeForce G102M]
-		1043 19b4  GeForce G102M
-		1043 1c12  GeForce G102M
-		1043 1c52  GeForce G205M
 	0874  C79 [ION]
 	0876  ION VGA [GeForce 9400M]
 	087a  C79 [GeForce 9400]
 	087d  ION VGA
-		19da a123  IONITX-F-E
 	087e  ION LE VGA
 	087f  ION LE VGA
 	08a0  MCP89 [GeForce 320M]
@@ -9763,7 +4714,6 @@ var pciids = []byte(`#
 	08a4  MCP89 [GeForce 320M]
 	08a5  MCP89 [GeForce 320M]
 	0a20  GT216 [GeForce GT 220]
-		1043 8311  ENGT220/DI/1GD3(LP)/V2
 	0a21  GT216M [GeForce GT 330M]
 	0a22  GT216 [GeForce 315]
 	0a23  GT216 [GeForce 210]
@@ -9786,16 +4736,12 @@ var pciids = []byte(`#
 	0a63  GT218 [GeForce 310]
 	0a64  GT218 [ION]
 	0a65  GT218 [GeForce 210]
-		1043 8334  EN210 SILENT
-		1462 8094  N210 [Geforce 210] PCIe graphics adapter
 	0a66  GT218 [GeForce 310]
 	0a67  GT218 [GeForce 315]
 	0a68  GT218M [GeForce G 105M]
 	0a69  GT218M [GeForce G 105M]
 	0a6a  GT218M [NVS 2100M]
 	0a6c  GT218M [NVS 3100M]
-		1028 040b  Latitude E6510
-		17aa 2142  ThinkPad T410
 	0a6e  GT218M [GeForce 305M]
 	0a6f  GT218 [ION]
 	0a70  GT218M [GeForce 310M]
@@ -9803,52 +4749,10 @@ var pciids = []byte(`#
 	0a72  GT218M [GeForce 310M]
 	0a73  GT218M [GeForce 305M]
 	0a74  GT218M [GeForce G210M]
-		1b0a 903a  GeForce G210
 	0a75  GT218M [GeForce 310M]
 	0a76  GT218 [ION 2]
 	0a78  GT218GL [Quadro FX 380 LP]
 	0a7a  GT218M [GeForce 315M]
-		104d 907e  GeForce 315M
-		1179 fc50  GeForce 315M
-		1179 fc61  GeForce 315M
-		1179 fc71  GeForce 315M
-		1179 fc90  GeForce 315M
-		1179 fcc0  GeForce 315M
-		1179 fcd0  GeForce 315M
-		1179 fce2  GeForce 315M
-		1179 fcf2  GeForce 315M
-		1179 fd16  GeForce 315M
-		1179 fd40  GeForce 315M
-		1179 fd50  GeForce 315M
-		1179 fd52  GeForce 315M
-		1179 fd61  GeForce 315M
-		1179 fd71  GeForce 315M
-		1179 fd92  GeForce 315M
-		1179 fd96  GeForce 315M
-		1179 fdd0  GeForce 315M
-		1179 fdd2  GeForce 315M
-		1179 fdfe  GeForce 315M
-		144d c0a2  GeForce 315M
-		144d c0b2  GeForce 315M
-		144d c581  GeForce 315M
-		144d c587  GeForce 315M
-		144d c588  GeForce 315M
-		144d c597  GeForce 315M
-		144d c606  GeForce 315M
-		1462 aa51  GeForce 405
-		1462 aa58  GeForce 405
-		1462 ac71  GeForce 405
-		1462 ac81  GeForce 315M
-		1462 ac82  GeForce 405
-		1462 ae33  GeForce 405
-		1642 3980  GeForce 405
-		17aa 3950  GeForce 405M
-		17aa 397d  GeForce 405M
-		1b0a 2091  GeForce 315M
-		1b0a 90b4  GeForce 405
-		1bfd 0003  GeForce 405
-		1bfd 8006  GeForce 405
-		1bfd 8007  GeForce 315M
 	0a7b  GT218 [GeForce 505]
 	0a7c  GT218GLM [Quadro FX 380M]
 	0a80  MCP79 Host Bridge
@@ -9862,53 +4766,31 @@ var pciids = []byte(`#
 	0a88  MCP79 Memory Controller
 	0a89  MCP79 Memory Controller
 	0a98  MCP79 Memory Controller
-		10de cb79  iMac 9,1
 	0aa0  MCP79 PCI Express Bridge
-		10de cb79  Apple iMac 9,1
 	0aa2  MCP79 SMBus
-		10de cb79  Apple iMac 9,1
-		19da a123  IONITX-F-E
 	0aa3  MCP79 Co-processor
-		10de cb79  Apple iMac 9,1
-		19da a123  IONITX-F-E
 	0aa4  MCP79 Memory Controller
-		19da a123  IONITX-F-E
 	0aa5  MCP79 OHCI USB 1.1 Controller
-		10de cb79  Apple iMac 9,1
-		19da a123  IONITX-F-E
 	0aa6  MCP79 EHCI USB 2.0 Controller
-		10de cb79  Apple iMac 9,1
-		19da a123  IONITX-F-E
 	0aa7  MCP79 OHCI USB 1.1 Controller
-		10de cb79  Apple iMac 9,1
-		19da a123  IONITX-F-E
 	0aa8  MCP79 OHCI USB 1.1 Controller
 	0aa9  MCP79 EHCI USB 2.0 Controller
-		10de cb79  Apple iMac 9,1
-		19da a123  IONITX-F-E
 	0aaa  MCP79 EHCI USB 2.0 Controller
 	0aab  MCP79 PCI Bridge
-		10de cb79  Apple iMac 9,1
 	0aac  MCP79 LPC Bridge
 	0aad  MCP79 LPC Bridge
-		19da a123  IONITX-F-E
 	0aae  MCP79 LPC Bridge
-		10de cb79  Apple iMac 9,1
 	0aaf  MCP79 LPC Bridge
 	0ab0  MCP79 Ethernet
-		10de cb79  Apple iMac 9,1
-		19da a123  IONITX-F-E
 	0ab1  MCP79 Ethernet
 	0ab2  MCP79 Ethernet
 	0ab3  MCP79 Ethernet
 	0ab4  MCP79 SATA Controller
-		19da a123  IONITX-F-E
 	0ab5  MCP79 SATA Controller
 	0ab6  MCP79 SATA Controller
 	0ab7  MCP79 SATA Controller
 	0ab8  MCP79 AHCI Controller
 	0ab9  MCP79 AHCI Controller
-		10de cb79  Apple iMac 9,1
 	0aba  MCP79 AHCI Controller
 	0abb  MCP79 AHCI Controller
 	0abc  MCP79 RAID Controller
@@ -9916,41 +4798,24 @@ var pciids = []byte(`#
 	0abe  MCP79 RAID Controller
 	0abf  MCP79 RAID Controller
 	0ac0  MCP79 High Definition Audio
-		10de cb79  Apple iMac 9,1
 	0ac1  MCP79 High Definition Audio
 	0ac2  MCP79 High Definition Audio
 	0ac3  MCP79 High Definition Audio
 	0ac4  MCP79 PCI Express Bridge
-		10de cb79  Apple iMac 9,1
 	0ac5  MCP79 PCI Express Bridge
 	0ac6  MCP79 PCI Express Bridge
-		10de cb79  Apple iMac 9,1
 	0ac7  MCP79 PCI Express Bridge
-		10de cb79  Apple iMac 9,1
 	0ac8  MCP79 PCI Express Bridge
 	0ad0  MCP78S [GeForce 8200] SATA Controller (non-AHCI mode)
-		1462 7508  K9N2GM-FIH
-		1849 0ad0  K10N78FullHD-hSLI R3.0 IDE
 	0ad4  MCP78S [GeForce 8200] AHCI Controller
-		103c 2a9e  Pavilion p6310f
-		1043 82e8  M3N72-D
-		1849 0ad4  K10N78FullHD-hSLI R3.0 AHCI Controller
 	0ad8  MCP78S [GeForce 8200] SATA Controller (RAID mode)
 	0be2  GT216 HDMI Audio Controller
-		1043 8311  ENGT220/DI/1GD3(LP)/V2
 	0be3  High Definition Audio Controller
-		1028 040b  Latitude E6510
-		10de 066d  G98 [GeForce 8400GS]
-		1462 8094  N210 [Geforce 210] PCIe graphics adapter
 	0be4  High Definition Audio Controller
 	0be5  GF100 High Definition Audio Controller
 	0be9  GF106 High Definition Audio Controller
-		1558 8687  CLEVO/KAPOK W860CU
-		3842 1452  GeForce GTS 450
 	0bea  GF108 High Definition Audio Controller
-		3842 1430  GeForce GT 430
 	0beb  GF104 High Definition Audio Controller
-		1462 2322  N460GTX Cyclone 1GD5/OC
 	0bee  GF116 High Definition Audio Controller
 	0bf0  Tegra2 PCIe x4 Bridge
 	0bf1  Tegra2 PCIe x2 Bridge
@@ -9990,16 +4855,13 @@ var pciids = []byte(`#
 	0dcd  GF106M [GeForce GT 555M]
 	0dce  GF106M [GeForce GT 555M]
 	0dd1  GF106M [GeForce GTX 460M]
-		1558 8687  CLEVO/KAPOK W860CU
 	0dd2  GF106M [GeForce GT 445M]
 	0dd3  GF106M [GeForce GT 435M]
 	0dd6  GF106M [GeForce GT 550M]
 	0dd8  GF106GL [Quadro 2000]
-		10de 0914  Quadro 2000D
 	0dda  GF106GLM [Quadro 2000M]
 	0de0  GF108 [GeForce GT 440]
 	0de1  GF108 [GeForce GT 430]
-		3842 1430  GeForce GT 430
 	0de2  GF108 [GeForce GT 420]
 	0de3  GF108M [GeForce GT 635M]
 	0de4  GF108 [GeForce GT 520]
@@ -10007,21 +4869,7 @@ var pciids = []byte(`#
 	0de7  GF108 [GeForce GT 610]
 	0de8  GF108M [GeForce GT 620M]
 	0de9  GF108M [GeForce GT 620M/630M/635M/640M LE]
-		1025 0692  GeForce GT 620M
-		1025 0725  GeForce GT 620M
-		1025 0728  GeForce GT 620M
-		1025 072b  GeForce GT 620M
-		1025 072e  GeForce GT 620M
-		1025 0753  GeForce GT 620M
-		1025 0754  GeForce GT 620M
-		17aa 3977  GeForce GT 640M LE
-		1b0a 2210  GeForce GT 635M
 	0dea  GF108M [GeForce 610M]
-		17aa 365a  GeForce 615
-		17aa 365b  GeForce 615
-		17aa 365e  GeForce 615
-		17aa 3660  GeForce 615
-		17aa 366c  GeForce 615
 	0deb  GF108M [GeForce GT 555M]
 	0dec  GF108M [GeForce GT 525M]
 	0ded  GF108M [GeForce GT 520M]
@@ -10032,8 +4880,6 @@ var pciids = []byte(`#
 	0df2  GF108M [GeForce GT 435M]
 	0df3  GF108M [GeForce GT 420M]
 	0df4  GF108M [GeForce GT 540M]
-		152d 0952  GeForce GT 630M
-		152d 0953  GeForce GT 630M
 	0df5  GF108M [GeForce GT 525M]
 	0df6  GF108M [GeForce GT 550M]
 	0df7  GF108M [GeForce GT 520M]
@@ -10042,9 +4888,6 @@ var pciids = []byte(`#
 	0dfa  GF108GLM [Quadro 1000M]
 	0dfc  GF108GLM [NVS 5200M]
 	0e08  GF119 HDMI Audio Controller
-		1043 83a0  ENGT520 SILENT
-# 1024MB with passive cooling (heatsink)
-		10b0 104a  Gainward GeForce GT 610
 	0e09  GF110 High Definition Audio Controller
 	0e0a  GK104 HDMI Audio Controller
 	0e0b  GK106 HDMI Audio Controller
@@ -10054,12 +4897,9 @@ var pciids = []byte(`#
 	0e13  TegraK1 PCIe x1 Bridge
 	0e1a  GK110 HDMI Audio
 	0e1b  GK107 HDMI Audio Controller
-		103c 197b  ZBook 15
-		1043 8428  GTX650-DC-1GD5
 	0e1c  Tegra3+ PCIe x4 Bridge
 	0e1d  Tegra3+ PCIe x2 Bridge
 	0e22  GF104 [GeForce GTX 460]
-		1462 2322  N460GTX Cyclone 1GD5/OC
 	0e23  GF104 [GeForce GTX 460 SE]
 	0e24  GF104 [GeForce GTX 460 OEM]
 	0e30  GF104M [GeForce GTX 470M]
@@ -10078,22 +4918,12 @@ var pciids = []byte(`#
 	0fc1  GK107 [GeForce GT 640]
 	0fc2  GK107 [GeForce GT 630 OEM]
 	0fc6  GK107 [GeForce GTX 650]
-		1043 8428  GTX650-DC-1GD5
 	0fc8  GK107 [GeForce GT 740]
 	0fc9  GK107 [GeForce GT 730]
 	0fcd  GK107M [GeForce GT 755M]
 	0fce  GK107M [GeForce GT 640M LE]
 	0fd1  GK107M [GeForce GT 650M]
-		1043 1597  GeForce GT 650M
-		1043 15a7  GeForce GT 650M
-		1043 2103  N56VZ
-		1043 2105  GeForce GT 650M
-		1043 2141  GeForce GT 650M
 	0fd2  GK107M [GeForce GT 640M]
-		1028 054f  GeForce GT 640M
-		1028 055f  GeForce GT 640M
-		1028 0595  GeForce GT 640M LE
-		1028 05b2  GeForce GT 640M LE
 	0fd3  GK107M [GeForce GT 640M LE]
 	0fd4  GK107M [GeForce GTX 660M]
 	0fd5  GK107M [GeForce GT 650M Mac Edition]
@@ -10105,14 +4935,10 @@ var pciids = []byte(`#
 	0fe1  GK107M [GeForce GT 730M]
 	0fe2  GK107M [GeForce GT 745M]
 	0fe3  GK107M [GeForce GT 745M]
-		103c 2b16  GeForce GT 745A
-		17aa 3675  GeForce GT 745A
 	0fe4  GK107M [GeForce GT 750M]
 	0fe5  GK107 [GeForce K340 USM]
 	0fe6  GK107 [GRID K1 NVS USM]
-# GRID K1 USM
 	0fe7  GK107GL [GRID K100 vGPU]
-		10de 101e  GRID K100
 	0fe9  GK107M [GeForce GT 750M Mac Edition]
 	0fea  GK107M [GeForce GT 755M Mac Edition]
 	0fec  GK107M [GeForce 710A]
@@ -10124,10 +4950,7 @@ var pciids = []byte(`#
 	0ff3  GK107GL [Quadro K420]
 	0ff5  GK107GL [GRID K1 Tesla USM]
 	0ff6  GK107GLM [Quadro K1100M]
-		103c 197b  ZBook 15
-# GRID K1 Quadro USM
 	0ff7  GK107GL [GRID K140Q vGPU]
-		10de 1037  GRID K140Q
 	0ff8  GK107GLM [Quadro K500M]
 	0ff9  GK107GL [Quadro K2000D]
 	0ffa  GK107GL [Quadro K600]
@@ -10139,23 +4962,7 @@ var pciids = []byte(`#
 	1001  GK110B [GeForce GTX TITAN Z]
 	1003  GK110 [GeForce GTX Titan LE]
 	1004  GK110 [GeForce GTX 780]
-		3842 0784  GK110B [GeForce GTX 780 SC w/ ACX Cooler]
-		3842 1784  GK110B [GeForce GTX 780 Dual FTW w/ ACX Cooler]
-		3842 1788  GK110B [GeForce GTX 780 Dual Classified w/ ACX Cooler]
 	1005  GK110 [GeForce GTX TITAN]
-		1043 8451  GTXTITAN-6GD5
-# Reference Model
-		10de 1035  GeForce GTX Titan
-# 06G-P4-2790-KR
-		3842 2790  GeForce GTX Titan
-# 06G-P4-2791-KR
-		3842 2791  GeForce GTX Titan SC
-# 06G-P4-2793-KR
-		3842 2793  GeForce GTX Titan SC Signature
-# 06G-P4-2794-KR
-		3842 2794  GeForce GTX Titan SC Hydro Copper
-# 06G-P4-2795-KR
-		3842 2795  GeForce GTX Titan SC Hydro Copper Signature
 	1007  GK110 [GeForce GTX 780 Rev. 2]
 	1008  GK110 [GeForce GTX 780 Ti Rev. 2]
 	100a  GK110B [GeForce GTX 780 Ti]
@@ -10166,7 +4973,6 @@ var pciids = []byte(`#
 	1021  GK110GL [Tesla K20Xm]
 	1022  GK110GL [Tesla K20c]
 	1023  GK110BGL [Tesla K40m]
-		10de 097e  12GB Computational Accelerator
 	1024  GK110BGL [Tesla K40c]
 	1026  GK110GL [Tesla K20s]
 	1027  GK110BGL [Tesla K40st]
@@ -10178,13 +4984,10 @@ var pciids = []byte(`#
 	103a  GK110GL [Quadro K6000]
 	103c  GK110GL [Quadro K5200]
 	1040  GF119 [GeForce GT 520]
-		1043 83a0  ENGT520 SILENT
 	1042  GF119 [GeForce 510]
 	1048  GF119 [GeForce 605]
 	1049  GF119 [GeForce GT 620 OEM]
 	104a  GF119 [GeForce GT 610]
-# 1024MB with passive cooling (heatsink)
-		10b0 104a  Gainward GeForce GT 610
 	104b  GF119 [GeForce GT 625 OEM]
 	104c  GF119 [GeForce GT 705]
 	104d  GF119 [GeForce GT 710]
@@ -10196,32 +4999,13 @@ var pciids = []byte(`#
 	1056  GF119M [NVS 4200M]
 	1057  GF119M [Quadro NVS 4200M]
 	1058  GF119M [GeForce 610M]
-		103c 2aed  GeForce 610
-		103c 2af1  GeForce 610
-		1043 10ac  GeForce GT 610M
-		1043 10bc  GeForce GT 610M
-		1043 1652  GeForce GT 610M
-		17aa 367a  GeForce 610M
-		17aa 3682  GeForce 800A
-		17aa 3687  GeForce 800A
-		17aa 3692  GeForce 705A
-		17aa 3695  GeForce 800A
-		17aa a117  GeForce 610M
 	1059  GF119M [GeForce 610M]
 	105a  GF119M [GeForce 610M]
-		1043 2111  GeForce GT 610M
-		1043 2112  GeForce GT 610M
 	105b  GF119M [GeForce 705M]
-		103c 2afb  GeForce 705A
-		17aa 309d  GeForce 705A
-		17aa 30b1  GeForce 800A
-		17aa 30f3  GeForce 705A
-		17aa 36a1  GeForce 800A
 	107c  GF119 [NVS 315]
 	107d  GF119 [NVS 310]
 	1080  GF110 [GeForce GTX 580]
 	1081  GF110 [GeForce GTX 570]
-		10de 087e  Leadtek WinFast GTX 570
 	1082  GF110 [GeForce GTX 560 Ti OEM]
 	1084  GF110 [GeForce GTX 560 OEM]
 	1086  GF110 [GeForce GTX 570 Rev. 2]
@@ -10231,18 +5015,10 @@ var pciids = []byte(`#
 	108b  GF110 [GeForce GTX 580]
 	108e  GF110GL [Tesla C2090]
 	1091  GF110GL [Tesla M2090]
-		10de 088e  Tesla X2090
-		10de 0891  Tesla X2090
-		10de 0974  Tesla X2090
-		10de 098d  Tesla X2090
 	1094  GF110GL [Tesla M2075]
-		10de 0888  Tesla M2075
 	1096  GF110GL [Tesla C2050 / C2075]
-		10de 0910  Tesla C2075
-		10de 0911  Tesla C2050
 	109a  GF100GLM [Quadro 5010M]
 	109b  GF100GL [Quadro 7000]
-		10de 0918  Quadro 7000
 	10c0  GT218 [GeForce 9300 GS Rev. 2]
 	10c3  GT218 [GeForce 8400 GS Rev. 3]
 	10c5  GT218 [GeForce 405]
@@ -10251,367 +5027,18 @@ var pciids = []byte(`#
 	10f0  GP104 High Definition Audio Controller
 	10f1  GP106 High Definition Audio Controller
 	1140  GF117M [GeForce 610M/710M/810M/820M / GT 620M/625M/630M/720M]
-		1019 0799  GeForce 820M
-		1019 999f  GeForce GT 720M
-		1025 0600  GeForce GT 620M
-		1025 0606  GeForce GT 620M
-		1025 064a  GeForce GT 620M
-		1025 064c  GeForce GT 620M
-		1025 067a  GeForce GT 620M
-		1025 0680  GeForce GT 620M
-		1025 0686  GeForce 710M
-		1025 0689  GeForce 710M
-		1025 068b  GeForce 710M
-		1025 068d  GeForce 710M
-		1025 068e  GeForce 710M
-		1025 0691  GeForce 710M
-		1025 0692  GeForce GT 620M
-		1025 0694  GeForce GT 620M
-		1025 0702  GeForce GT 620M
-		1025 0719  GeForce GT 620M
-		1025 0725  GeForce GT 620M
-		1025 0728  GeForce GT 620M
-		1025 072b  GeForce GT 620M
-		1025 072e  GeForce GT 620M
-		1025 0732  GeForce GT 620M
-		1025 0763  GeForce GT 720M
-		1025 0773  GeForce 710M
-		1025 0774  GeForce 710M
-		1025 0776  GeForce GT 720M
-		1025 077a  GeForce 710M
-		1025 077b  GeForce 710M
-		1025 077c  GeForce 710M
-		1025 077d  GeForce 710M
-		1025 077e  GeForce 710M
-		1025 077f  GeForce 710M
-		1025 0781  GeForce GT 720M
-		1025 0798  GeForce GT 720M
-		1025 0799  GeForce GT 720M
-		1025 079b  GeForce GT 720M
-		1025 079c  GeForce GT 720M
-		1025 0807  GeForce GT 720M
-		1025 0821  GeForce GT 720M
-		1025 0823  GeForce GT 720M
-		1025 0830  GeForce GT 720M
-		1025 0833  GeForce GT 720M
-		1025 0837  GeForce GT 720M
-		1025 083e  GeForce 820M
-		1025 0841  GeForce 710M
-		1025 0854  GeForce 820M
-		1025 0855  GeForce 820M
-		1025 0856  GeForce 820M
-		1025 0857  GeForce 820M
-		1025 0858  GeForce 820M
-		1025 0863  GeForce 820M
-		1025 0868  GeForce 820M
-		1025 0869  GeForce 810M
-		1025 0873  GeForce 820M
-		1025 0878  GeForce 820M
-		1025 087b  GeForce 820M
-		1025 087c  GeForce 810M
-		1025 0881  GeForce 820M
-		1025 088a  GeForce 820M
-		1025 089b  GeForce 820M
-		1025 090f  GeForce 820M
-		1025 0921  GeForce 820M
-		1025 092e  GeForce 810M
-		1025 092f  GeForce 820M
-		1025 0932  GeForce 820M
-		1025 093a  GeForce 820M
-		1025 093c  GeForce 820M
-		1025 093f  GeForce 820M
-		1025 0941  GeForce 820M
-		1025 0945  GeForce 820M
-		1025 0954  GeForce 820M
-		1025 0965  GeForce 820M
-		1028 054d  GeForce GT 630M
-		1028 054e  GeForce GT 630M
-		1028 0554  GeForce GT 620M
-		1028 0557  GeForce GT 620M
-		1028 0562  GeForce GT 625M
-		1028 0565  GeForce GT 630M
-		1028 0568  GeForce GT 630M
-		1028 0590  GeForce GT 630M
-		1028 0592  GeForce GT 625M
-		1028 0594  GeForce GT 625M
-		1028 0595  GeForce GT 625M
-		1028 05a2  GeForce GT 625M
-		1028 05b1  GeForce GT 625M
-		1028 05b3  GeForce GT 625M
-		1028 05da  GeForce GT 630M
-		1028 05de  GeForce GT 720M
-		1028 05e0  GeForce GT 720M
-		1028 05e8  GeForce GT 630M
-		1028 05f4  GeForce GT 720M
-		1028 060f  GeForce GT 720M
-		1028 064e  GeForce 820M
-		1028 0652  GeForce 820M
-		1028 0653  GeForce 820M
-		1028 0655  GeForce 820M
-		1028 065e  GeForce 820M
-		1028 0662  GeForce 820M
-		1028 068d  GeForce 820M
-		1028 06ad  GeForce 820M
-		1028 06ae  GeForce 820M
-		1028 06af  GeForce 820M
-		1028 06b0  GeForce 820M
-		1028 06c0  GeForce 820M
-		1028 06c1  GeForce 820M
-		103c 18ef  GeForce GT 630M
-		103c 18f9  GeForce GT 630M
-		103c 18fb  GeForce GT 630M
-		103c 18fd  GeForce GT 630M
-		103c 18ff  GeForce GT 630M
-		103c 218a  GeForce 820M
-		103c 21bb  GeForce 820M
-		103c 21bc  GeForce 820M
-		103c 220e  GeForce 820M
-		103c 2210  GeForce 820M
-		103c 2212  GeForce 820M
-		103c 2214  GeForce 820M
-		103c 2218  GeForce 820M
-		103c 225b  GeForce 820M
-		103c 225d  GeForce 820M
-		103c 226d  GeForce 820M
-		103c 226f  GeForce 820M
-		103c 22d2  GeForce 820M
-		103c 22d9  GeForce 820M
-		103c 2335  GeForce 820M
-		103c 2337  GeForce 820M
-		103c 2aef  GeForce GT 720A
-		103c 2af9  GeForce 710A
-		1043 10dd  NVS 5200M
-		1043 10ed  NVS 5200M
-		1043 11fd  GeForce GT 720M
-		1043 124d  GeForce GT 720M
-		1043 126d  GeForce GT 720M
-		1043 131d  GeForce GT 720M
-		1043 13fd  GeForce GT 720M
-		1043 14c7  GeForce GT 720M
-		1043 1507  GeForce GT 620M
-		1043 15ad  GeForce 820M
-		1043 15ed  GeForce 820M
-		1043 160d  GeForce 820M
-		1043 163d  GeForce 820M
-		1043 166d  GeForce 820M
-		1043 16cd  GeForce 820M
-		1043 16dd  GeForce 820M
-		1043 170d  GeForce 820M
-		1043 176d  GeForce 820M
-		1043 178d  GeForce 820M
-		1043 179d  GeForce 820M
-		1043 17dd  GeForce 820M
-		1043 2132  GeForce GT 620M
-		1043 2136  NVS 5200M
-		1043 21ba  GeForce GT 720M
-		1043 21fa  GeForce GT 720M
-		1043 220a  GeForce GT 720M
-		1043 221a  GeForce GT 720M
-		1043 223a  GeForce GT 710M
-		1043 224a  GeForce GT 710M
-		1043 227a  GeForce 820M
-		1043 228a  GeForce 820M
-		1043 232a  GeForce 820M
-		1043 233a  GeForce 820M
-		1043 235a  GeForce 820M
-		1043 236a  GeForce 820M
-		1043 238a  GeForce 820M
-		1043 8595  GeForce GT 720M
-		1043 85ea  GeForce GT 720M
-		1043 85eb  GeForce 820M
-		1043 85ec  GeForce 820M
-		1043 85ee  GeForce GT 720M
-		1043 85f3  GeForce 820M
-		1043 860e  GeForce 820M
-		1043 861a  GeForce 820M
-		1043 861b  GeForce 820M
-		1043 8628  GeForce 820M
-		1043 8643  GeForce 820M
-		1043 864c  GeForce 820M
-		1043 8652  GeForce 820M
-		1043 8660  GeForce 820M
-		1043 8661  GeForce 820M
-		105b 0dac  GeForce GT 720M
-		105b 0dad  GeForce GT 720M
-		105b 0ef3  GeForce GT 720M
-		1072 152d  GeForce GT 720M
-		10cf 17f5  GeForce GT 720M
-		1179 fa01  GeForce 710M
-		1179 fa02  GeForce 710M
-		1179 fa03  GeForce 710M
-		1179 fa05  GeForce 710M
-		1179 fa11  GeForce 710M
-		1179 fa13  GeForce 710M
-		1179 fa18  GeForce 710M
-		1179 fa19  GeForce 710M
-		1179 fa21  GeForce 710M
-		1179 fa23  GeForce 710M
-		1179 fa2a  GeForce 710M
-		1179 fa32  GeForce 710M
-		1179 fa33  GeForce 710M
-		1179 fa36  GeForce 710M
-		1179 fa38  GeForce 710M
-		1179 fa42  GeForce 710M
-		1179 fa43  GeForce 710M
-		1179 fa45  GeForce 710M
-		1179 fa47  GeForce 710M
-		1179 fa49  GeForce 710M
-		1179 fa58  GeForce 710M
-		1179 fa59  GeForce 710M
-		1179 fa88  GeForce 710M
-		1179 fa89  GeForce 710M
-		144d b092  GeForce GT 620M
-		144d c0d5  GeForce GT 630M
-		144d c0d7  GeForce GT 620M
-		144d c0e2  NVS 5200M
-		144d c0e3  NVS 5200M
-		144d c0e4  NVS 5200M
-		144d c10d  GeForce 820M
-		144d c652  GeForce GT 620M on NP300E5C series laptop
-		144d c709  GeForce 710M
-		144d c711  GeForce 710M
-		144d c736  GeForce 710M
-		144d c737  GeForce 710M
-		144d c745  GeForce 820M
-		144d c750  GeForce 820M
-		1462 10b8  GeForce GT 710M
-		1462 10e9  GeForce GT 720M
-		1462 1116  GeForce 820M
-		1462 aa33  GeForce 720M
-		1462 aaa2  GeForce GT 720M
-		1462 aaa3  GeForce 820M
-		1462 acb2  GeForce GT 720M
-		1462 acc1  GeForce GT 720M
-		1462 ae61  GeForce 720M
-		1462 ae65  GeForce GT 720M
-		1462 ae6a  GeForce 820M
-		1462 ae71  GeForce GT 720M
-		14c0 0083  GeForce 820M
-		152d 0926  GeForce 620M
-		152d 0982  GeForce GT 630M
-		152d 0983  GeForce GT 630M
-		152d 1005  GeForce GT 820M
-		152d 1012  GeForce 710M
-		152d 1019  GeForce 820M
-		152d 1030  GeForce GT 630M
-		152d 1055  GeForce 710M
-		152d 1067  GeForce GT 720M
-		152d 1072  GeForce GT 720M
-		152d 1086  GeForce 820M
-		152d 1092  GeForce 820M
-		17aa 2200  NVS 5200M
-		17aa 2213  GeForce GT 720M
-		17aa 2220  GeForce GT 720M
-		17aa 309c  GeForce GT 720A
-		17aa 30b4  GeForce 820A
-		17aa 30b7  GeForce 720A
-		17aa 30e4  GeForce 820A
-		17aa 361b  GeForce 820A
-		17aa 361c  GeForce 820A
-		17aa 361d  GeForce 820A
-		17aa 3656  GeForce GT 620M
-		17aa 365a  GeForce 705M
-		17aa 365e  GeForce 800M
-		17aa 3661  GeForce 820A
-		17aa 366c  GeForce 800M
-		17aa 3685  GeForce 800M
-		17aa 3686  GeForce 800M
-		17aa 3687  GeForce 705A
-		17aa 3696  GeForce 820A
-		17aa 369b  GeForce 820A
-		17aa 369c  GeForce 820A
-		17aa 369d  GeForce 820A
-		17aa 369e  GeForce 820A
-		17aa 36a9  GeForce 820A
-		17aa 36af  GeForce 820A
-		17aa 36b0  GeForce 820A
-		17aa 36b6  GeForce 820A
-		17aa 3800  GeForce GT 720M
-		17aa 3801  GeForce GT 720M
-		17aa 3802  GeForce GT 720M
-		17aa 3803  GeForce GT 720M
-		17aa 3804  GeForce GT 720M
-		17aa 3806  GeForce GT 720M
-		17aa 3808  GeForce GT 720M
-		17aa 380d  GeForce 820M
-		17aa 380e  GeForce 820M
-		17aa 380f  GeForce 820M
-		17aa 3811  GeForce 820M
-		17aa 3812  GeForce 820M
-		17aa 3813  GeForce 820M
-		17aa 3816  GeForce 820M
-		17aa 3818  GeForce 820M
-		17aa 381a  GeForce 820M
-		17aa 381c  GeForce 820M
-		17aa 3901  GeForce 610M / GT 620M
-		17aa 3902  GeForce 710M
-		17aa 3903  GeForce 610M/710M
-		17aa 3904  GeForce GT 620M/625M
-		17aa 3905  GeForce GT 720M
-		17aa 3907  GeForce 820M
-		17aa 3910  GeForce 720M
-		17aa 3912  GeForce 720M
-		17aa 3913  GeForce 820M
-		17aa 3915  GeForce 820M
-		17aa 3977  GeForce GT 720M
-		17aa 3983  GeForce 610M
-		17aa 5001  GeForce 610M
-		17aa 5003  GeForce GT 720M
-		17aa 5005  GeForce 705M
-		17aa 500d  GeForce GT 620M
-		17aa 5014  GeForce 710M
-		17aa 5017  GeForce 710M
-		17aa 5019  GeForce 710M
-		17aa 501a  GeForce 710M
-		17aa 501f  GeForce GT 720M
-		17aa 5025  GeForce 710M
-		17aa 5027  GeForce 710M
-		17aa 502a  GeForce 710M
-		17aa 502b  GeForce GT 720M
-		17aa 502d  GeForce 710M
-		17aa 502e  GeForce GT 720M
-		17aa 502f  GeForce GT 720M
-		17aa 5030  GeForce 705M
-		17aa 5031  GeForce 705M
-		17aa 5032  GeForce 820M
-		17aa 5033  GeForce 820M
-		17aa 503e  GeForce 710M
-		17aa 503f  GeForce 820M
-		17aa 5040  GeForce 820M
-		1854 0177  GeForce 710M
-		1854 0180  GeForce 710M
-		1854 0190  GeForce GT 720M
-		1854 0192  GeForce GT 720M
-		1854 0224  GeForce 820M
-		1b0a 01c0  GeForce 820M
-		1b0a 20dd  GeForce GT 620M
-		1b0a 20df  GeForce GT 620M
-		1b0a 210e  GeForce 820M
-		1b0a 2202  GeForce GT 720M
-		1b0a 90d7  GeForce 820M
-		1b0a 90dd  GeForce 820M
-		1b50 5530  GeForce 820M
-		1b6c 5531  GeForce GT 720M
-		1bab 0106  GeForce 820M
-		1d05 1013  GeForce 810M
 	1180  GK104 [GeForce GTX 680]
-		1043 83f1  GTX680-DC2-2GD5
-		3842 3682  GeForce GTX 680 Mac Edition
 	1182  GK104 [GeForce GTX 760 Ti]
 	1183  GK104 [GeForce GTX 660 Ti]
 	1184  GK104 [GeForce GTX 770]
 	1185  GK104 [GeForce GTX 660 OEM]
-		10de 106f  GK104 [GeForce GTX 760 OEM]
 	1187  GK104 [GeForce GTX 760]
 	1188  GK104 [GeForce GTX 690]
 	1189  GK104 [GeForce GTX 670]
-		10de 1074  GK104 [GeForce GTX 760 Ti OEM]
 	118a  GK104GL [GRID K520]
 	118b  GK104GL [GRID K2 GeForce USM]
 	118c  GK104 [GRID K2 NVS USM]
-# GRID K2 USM
 	118d  GK104GL [GRID K200 vGPU]
-		10de 101d  GRID K200
 	118e  GK104 [GeForce GTX 760 OEM]
 	118f  GK104GL [Tesla K10]
 	1191  GK104 [GeForce GTX 760 Rev. 2]
@@ -10628,12 +5055,8 @@ var pciids = []byte(`#
 	11a1  GK104M [GeForce GTX 670MX]
 	11a2  GK104M [GeForce GTX 675MX Mac Edition]
 	11a3  GK104M [GeForce GTX 680MX]
-		106b 010d  iMac 13,2
 	11a7  GK104M [GeForce GTX 675MX]
-# GRID K2 Quadro USM
 	11b0  GK104GL [GRID K240Q\K260Q vGPU]
-		10de 101a  GRID K240Q
-		10de 101b  GRID K260Q
 	11b1  GK104GL [GRID K2 Tesla USM]
 	11b4  GK104GL [Quadro K4200]
 	11b6  GK104GLM [Quadro K3100M]
@@ -10647,14 +5070,7 @@ var pciids = []byte(`#
 	11bf  GK104GL [GRID K2]
 	11c0  GK106 [GeForce GTX 660]
 	11c2  GK106 [GeForce GTX 650 Ti Boost]
-		1043 845b  GeForce GTX 650 Ti Boost DirectCU II OC
-		1462 2874  GeForce GTX 650 Ti Boost TwinFrozr II OC
-		1569 11c2  GeForce GTX 650 Ti Boost OC
-		19da 1281  GeForce GTX 650 Ti Boost OC
-		3842 3657  GeForce GTX 650 Ti Boost
-		3842 3658  GeForce GTX 650 Ti Boost Superclocked
 	11c3  GK106 [GeForce GTX 650 Ti OEM]
-		10de 1030  GeForce GTX 650 Ti OEM
 	11c4  GK106 [GeForce GTX 645 OEM]
 	11c5  GK106 [GeForce GT 740]
 	11c6  GK106 [GeForce GTX 650 Ti]
@@ -10665,7 +5081,6 @@ var pciids = []byte(`#
 	11e1  GK106M [GeForce GTX 765M]
 	11e2  GK106M [GeForce GTX 765M]
 	11e3  GK106M [GeForce GTX 760M]
-		17aa 3683  GeForce GTX 760A
 	11e7  GK106M
 	11fa  GK106GL [Quadro K4000]
 	11fc  GK106GLM [Quadro K2100M]
@@ -10687,31 +5102,10 @@ var pciids = []byte(`#
 	1245  GF116 [GeForce GTS 450 Rev. 2]
 	1246  GF116M [GeForce GT 550M]
 	1247  GF116M [GeForce GT 555M/635M]
-		1043 1752  GeForce GT 555M
-		1043 2050  GeForce GT 555M
-		1043 2051  GeForce GT 555M
-		1043 212a  GeForce GT 635M
-		1043 212b  GeForce GT 635M
-		1043 212c  GeForce GT 635M
-		152d 0930  GeForce GT 635M
 	1248  GF116M [GeForce GT 555M/635M]
-		152d 0930  GeForce GT 635M
-		17c0 10e7  GeForce GT 555M
-		17c0 10e8  GeForce GT 555M
-		17c0 10ea  GeForce GT 555M
-		1854 0890  GeForce GT 555M
-		1854 0891  GeForce GT 555M
-		1854 1795  GeForce GT 555M
-		1854 1796  GeForce GT 555M
-		1854 3005  GeForce GT 555M
 	1249  GF116 [GeForce GTS 450 Rev. 3]
 	124b  GF116 [GeForce GT 640 OEM]
 	124d  GF116M [GeForce GT 555M/635M]
-		1028 0491  GeForce GT 555M
-		1028 0570  GeForce GT 555M
-		1028 0571  GeForce GT 555M
-		1462 108d  GeForce GT 555M
-		1462 10cc  GeForce GT 635M
 	1251  GF116M [GeForce GT 560M]
 	1280  GK208 [GeForce GT 635]
 	1281  GK208 [GeForce GT 710]
@@ -10723,43 +5117,20 @@ var pciids = []byte(`#
 	1289  GK208 [GeForce GT 710]
 	128b  GK208B [GeForce GT 710]
 	1290  GK208M [GeForce GT 730M]
-		103c 2afa  GeForce GT 730A
-		103c 2b04  GeForce GT 730A
-		1043 13ad  GeForce GT 730M
-		1043 13cd  GeForce GT 730M
 	1291  GK208M [GeForce GT 735M]
 	1292  GK208M [GeForce GT 740M]
-		17aa 3675  GeForce GT 740A
-		17aa 367c  GeForce GT 740A
-		17aa 3684  GeForce GT 740A
 	1293  GK208M [GeForce GT 730M]
 	1294  GK208M [GeForce GT 740M]
 	1295  GK208M [GeForce 710M]
-		103c 2b0d  GeForce 710A
-		103c 2b0f  GeForce 710A
-		103c 2b11  GeForce 710A
-		103c 2b20  GeForce 810A
-		103c 2b21  GeForce 810A
-		103c 2b22  GeForce 810A
-		17aa 367a  GeForce 805A
-		17aa 367c  GeForce 710A
 	1296  GK208M [GeForce 825M]
 	1298  GK208M [GeForce GT 720M]
 	1299  GK208BM [GeForce 920M]
-		17aa 30bb  GeForce 920A
-		17aa 30df  GeForce 920A
-		17aa 36a7  GeForce 920A
-		17aa 36af  GeForce 920M
 	129a  GK208BM [GeForce 910M]
 	12a0  GK208
 	12b9  GK208GLM [Quadro K610M]
 	12ba  GK208GLM [Quadro K510M]
 	1340  GM108M [GeForce 830M]
-		103c 2b2b  GeForce 830A
 	1341  GM108M [GeForce 840M]
-		17aa 3697  GeForce 840A
-		17aa 3699  GeForce 840A
-		17aa 369c  GeForce 840A
 	1344  GM108M [GeForce 845M]
 	1346  GM108M [GeForce 930M]
 	1347  GM108M [GeForce 940M]
@@ -10767,11 +5138,9 @@ var pciids = []byte(`#
 	1349  GM108M [GeForce 930M]
 	134b  GM108M [GeForce 940MX]
 	134d  GM108M [GeForce 940MX]
-		17aa 2248  ThinkPad T570
 	134e  GM108M [GeForce 930MX]
 	134f  GM108M [GeForce 920MX]
 	137a  GM108GLM [Quadro K620M / Quadro M500M]
-		17aa 505a  Quadro M500M
 	137b  GM108GLM [Quadro M520 Mobile]
 	137d  GM108M [GeForce 940A]
 	1380  GM107 [GeForce GTX 750 Ti]
@@ -10780,20 +5149,11 @@ var pciids = []byte(`#
 	1389  GM107GL [GRID M30]
 	1390  GM107M [GeForce 845M]
 	1391  GM107M [GeForce GTX 850M]
-		17aa 3697  GeForce GTX 850A
-		17aa a125  GeForce GTX 850A
 	1392  GM107M [GeForce GTX 860M]
 	1393  GM107M [GeForce 840M]
 	1398  GM107M [GeForce 845M]
 	139a  GM107M [GeForce GTX 950M]
-		17aa 362c  GeForce GTX 950A
-		17aa 362f  GeForce GTX 950A
-		17aa 363f  GeForce GTX 950A
-		17aa 3640  GeForce GTX 950A
-		17aa 3647  GeForce GTX 950A
-		17aa 36b9  GeForce GTX 950A
 	139b  GM107M [GeForce GTX 960M]
-		103c 2b4c  GeForce GTX 960A
 	139c  GM107M [GeForce 940M]
 	139d  GM107M [GeForce GTX 750 Ti]
 	13b0  GM107GLM [Quadro M2000M]
@@ -10807,10 +5167,7 @@ var pciids = []byte(`#
 	13bb  GM107GL [Quadro K620]
 	13bc  GM107GL [Quadro K1200]
 	13bd  GM107GL [Tesla M10]
-		10de 110a  GRID M40
-		10de 1160  Tesla M10
 	13c0  GM204 [GeForce GTX 980]
-		1043 8504  GTX980-4GD5
 	13c1  GM204
 	13c2  GM204 [GeForce GTX 970]
 	13c3  GM204
@@ -10826,11 +5183,10 @@ var pciids = []byte(`#
 	13f8  GM204GLM [Quadro M5000M / M5000 SE]
 	13f9  GM204GLM [Quadro M4000M]
 	13fa  GM204GLM [Quadro M3000M]
-		10de 11c9  Quadro M3000 SE
 	13fb  GM204GLM [Quadro M5500]
 	1401  GM206 [GeForce GTX 960]
 	1402  GM206 [GeForce GTX 950]
-	1406  GM206 [GeForce GTX 960]
+	1406  GM206 [GeForce GTX 960 OEM]
 	1407  GM206 [GeForce GTX 750 v2]
 	1427  GM206M [GeForce GTX 965M]
 	1430  GM206GL [Quadro M2000]
@@ -10870,10 +5226,6 @@ var pciids = []byte(`#
 	1b87  GP104 [P104-100]
 	1ba0  GP104M [GeForce GTX 1080 Mobile]
 	1ba1  GP104M [GeForce GTX 1070 Mobile]
-		1458 1651  GeForce GTX 1070 Max-Q
-		1462 11e8  GeForce GTX 1070 Max-Q
-		1462 11e9  GeForce GTX 1070 Max-Q
-		1558 9501  GeForce GTX 1070 Max-Q
 	1bad  GP104 [GeForce GTX 1070 Engineering Sample]
 	1bb0  GP104GL [Quadro P5000]
 	1bb1  GP104GL [Quadro P4000]
@@ -10882,11 +5234,8 @@ var pciids = []byte(`#
 	1bb5  GP104GLM [Quadro P5200 Mobile]
 	1bb6  GP104GLM [Quadro P5000 Mobile]
 	1bb7  GP104GLM [Quadro P4000 Mobile]
-		1462 11e9  Quadro P4000 Max-Q
 	1bb8  GP104GLM [Quadro P3000 Mobile]
 	1be0  GP104M [GeForce GTX 1080 Mobile]
-		1028 07c0  GeForce GTX 1080 Max-Q
-		1458 355b  GeForce GTX 1080 Max-Q
 	1be1  GP104M [GeForce GTX 1070 Mobile]
 	1c00  GP106
 	1c01  GP106
@@ -10895,13 +5244,11 @@ var pciids = []byte(`#
 	1c07  GP106 [P106-100]
 	1c09  GP106 [P106-090]
 	1c20  GP106M [GeForce GTX 1060 Mobile]
-		17aa 39b9  GeForce GTX 1060 Max-Q 3GB
 	1c21  GP106M [GeForce GTX 1050 Ti Mobile]
 	1c22  GP106M [GeForce GTX 1050 Mobile]
 	1c30  GP106GL [Quadro P2000]
 	1c35  GP106
 	1c60  GP106M [GeForce GTX 1060 Mobile 6GB]
-		103c 8390  GeForce GTX 1060 Max-Q 6GB
 	1c61  GP106M [GeForce GTX 1050 Ti Mobile]
 	1c62  GP106M [GeForce GTX 1050 Mobile]
 	1c70  GP106GL
@@ -10924,15 +5271,6 @@ var pciids = []byte(`#
 	1db4  GV100 [Tesla V100 PCIe]
 10df  Emulex Corporation
 	0720  OneConnect NIC (Skyhawk)
-		103c 1934  FlexFabric 20Gb 2-port 650M Adapter
-		103c 1935  FlexFabric 20Gb 2-port 650FLB Adapter
-		103c 21d4  StoreFabric CN1200E 10Gb Converged Network Adapter
-		103c 220a  FlexFabric 10Gb 2-port 556FLR-SFP+ Adapter
-		103c 803f  Ethernet 10Gb 2-port 557SFP+ Adapter
-		17aa 1056  ThinkServer OCm14102-UX-L AnyFabric
-		17aa 1057  ThinkServer OCm14104-UX-L AnyFabric
-		17aa 1059  ThinkServer OCm14104-UT-L AnyFabric
-		17aa 4014  ThinkServer OCm14102-NX-L AnyFabric
 	0722  OneConnect iSCSI Initiator (Skyhawk)
 	0723  OneConnect iSCSI Initiator + Target (Skyhawk)
 	0724  OneConnect FCoE Initiator (Skyhawk)
@@ -10945,21 +5283,12 @@ var pciids = []byte(`#
 	e131  LightPulse 8Gb/s PCIe Shared I/O Fibre Channel Adapter
 	e180  Proteus-X: LightPulse IOV Fibre Channel Host Adapter
 	e200  LightPulse LPe16002
-		1014 03f1  PCIe2 16 Gb 2-port Fibre Channel Adapter (FC EL5B; CCIN 577F)
 	e208  LightPulse 16Gb Fibre Channel Host Adapter (Lancer-VF)
 	e220  OneConnect NIC (Lancer)
-		17aa 1054  ThinkServer LPm16002B-M6-L AnyFabric
-		17aa 1055  ThinkServer LPm16004B-M8-L AnyFabric
 	e240  OneConnect iSCSI Initiator (Lancer)
 	e260  OneConnect FCoE Initiator (Lancer)
 	e268  OneConnect 10Gb FCoE Converged Network Adapter (Lancer-VF)
 	e300  Lancer Gen6: LPe32000 Fibre Channel Host Adapter
-		10df e310  Lancer Gen6: LPe31000 Fibre Channel Host Adapter
-		10df e311  Lancer Gen6: LPe31000 Fibre Channel Host Adapter
-		10df e312  Lancer Gen6: LPe31000 Fibre Channel Host Adapter
-		10df e322  Lancer Gen6: LPe31000 Fibre Channel Host Adapter
-		10df e323  Lancer Gen6: LPe31000 Fibre Channel Host Adapter
-		10df e325  Lancer Gen6: LPe31000 Fibre Channel Host Adapter
 	f011  Saturn: LightPulse Fibre Channel Host Adapter
 	f015  Saturn: LightPulse Fibre Channel Host Adapter
 	f085  LP850 Fibre Channel Host Adapter
@@ -10974,14 +5303,10 @@ var pciids = []byte(`#
 	f0e5  Zephyr LightPulse Fibre Channel Host Adapter
 	f0f5  Neptune LightPulse Fibre Channel Host Adapter
 	f100  Saturn-X: LightPulse Fibre Channel Host Adapter
-		1014 038a  8Gb PCI Express Dual Port FC Adapter for POWER
-		103c 3282  8Gb Dual-port PCI-e FC HBA
 	f111  Saturn-X LightPulse Fibre Channel Host Adapter
 	f112  Saturn-X LightPulse Fibre Channel Host Adapter
 	f180  LPSe12002 EmulexSecure Fibre Channel Adapter
 	f400  LPe36000 Fibre Channel Host Adapter [Prism]
-		10df f401  LPe35000 Fibre Channel Host Adapter [Prism]
-		10df f402  LPe35000 Fibre Channel Host Adapter [Prism]
 	f700  LP7000 Fibre Channel Host Adapter
 	f701  LP7000 Fibre Channel Host Adapter Alternate ID (JX1:2-3, JX2:1-2)
 	f800  LP8000 Fibre Channel Host Adapter
@@ -10994,14 +5319,11 @@ var pciids = []byte(`#
 	fa00  Thor-X LightPulse Fibre Channel Host Adapter
 	fb00  Viper LightPulse Fibre Channel Host Adapter
 	fc00  Thor-X LightPulse Fibre Channel Host Adapter
-		10df fc00  LP10000 LightPulse Fibre Channel Host Adapter
 	fc10  Helios-X LightPulse Fibre Channel Host Adapter
 	fc20  Zephyr-X LightPulse Fibre Channel Host Adapter
 	fc40  Saturn-X: LightPulse Fibre Channel Host Adapter
 	fc50  Proteus-X: LightPulse IOV Fibre Channel Host Adapter
 	fd00  Helios-X LightPulse Fibre Channel Host Adapter
-# Also IBM FC 5759 / FC 1910 for POWER
-		10df fd02  LightPulse LP11002 Dual-port 4Gigabit PCI Fibre Channel Adapter
 	fd11  Helios-X LightPulse Fibre Channel Host Adapter
 	fd12  Helios-X LightPulse Fibre Channel Host Adapter
 	fe00  Zephyr-X LightPulse Fibre Channel Host Adapter
@@ -11018,7 +5340,6 @@ var pciids = []byte(`#
 	9128  IMS9128 [Twin turbo 128]
 10e1  Tekram Technology Co.,Ltd.
 	0391  TRM-S1040
-		10e1 0391  DC-315U SCSI-3 Host Adapter
 	690c  DC-690c
 	dc29  DC-290
 10e2  Aptix Corporation
@@ -11026,7 +5347,6 @@ var pciids = []byte(`#
 	0000  CA91C042 [Universe]
 	0108  Tsi108 Host Bridge for Single PowerPC
 	0148  Tsi148 [Tempe]
-		1775 1100  VR11 Single Board Computer
 	0860  CA91C860 [QSpan]
 	0862  CA91C862A [QSpan-II]
 	8260  CA91L8200B [Dual PCI PowerSpan II]
@@ -11081,7 +5401,6 @@ var pciids = []byte(`#
 	5000  CyberPro 5000
 	5050  CyberPro 5050
 	5202  CyberPro 5202
-# CyberPro5202 Audio Function
 	5252  CyberPro5252
 10eb  Artists Graphics
 	0101  3GA
@@ -11091,158 +5410,33 @@ var pciids = []byte(`#
 	5208  RTS5208 PCI Express Card Reader
 	5209  RTS5209 PCI Express Card Reader
 	5227  RTS5227 PCI Express Card Reader
-		17aa 220e  ThinkPad T440p
-		17aa 2214  ThinkPad X240
 	5229  RTS5229 PCI Express Card Reader
-		1025 0813  Aspire R7-571
-		103c 194e  ProBook 455 G1 Notebook
-		103c 1985  Pavilion 17-e163sg Notebook PC
-		17aa 3832  Yoga 520
 	522a  RTS522A PCI Express Card Reader
 	5249  RTS5249 PCI Express Card Reader
-		103c 1909  ZBook 15
 	524a  RTS524A PCI Express Card Reader
 	5250  RTS5250 PCI Express Card Reader
 	525a  RTS525A PCI Express Card Reader
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
 	5286  RTS5286 PCI Express Card Reader
 	5287  RTL8411B PCI Express Card Reader
 	5288  RTS5288 PCI Express Card Reader
 	5289  RTL8411 PCI Express Card Reader
-		1043 1457  K55A Laptop
 	8029  RTL-8029(AS)
-		10b8 2011  EZ-Card (SMC1208)
-		10ec 8029  RTL-8029(AS)
-		1113 1208  EN1208
-		1186 0300  DE-528
-		1259 2400  AT-2400
-		1af4 1100  QEMU Virtual Machine
 	8129  RTL-8129
-		10ec 8129  RT8129 Fast Ethernet Adapter
-		11ec 8129  RTL8111/8168 PCIe Gigabit Ethernet (misconfigured)
 	8136  RTL8101/2/6E PCI Express Fast Ethernet controller
-		103c 1985  RTL8106E on Pavilion 17-e163sg Notebook PC
-		103c 2a8c  Compaq 500B Microtower
-		103c 2ab1  Pavilion p6774
-		103c 30cc  Pavilion dv6700
-		1179 ff64  RTL8102E PCI-E Fast Ethernet NIC
-		17c0 1053  RTL8101e Medion WIM 2210 Notebook PC [MD96850]
 	8138  RT8139 (B/C) Cardbus Fast Ethernet Adapter
-		10ec 8138  RT8139 (B/C) Fast Ethernet Adapter
 	8139  RTL-8100/8101L/8139 PCI Fast Ethernet Adapter
-		0357 000a  TTP-Monitoring Card V2.0
-		1025 005a  TravelMate 290
-		1025 8920  ALN-325
-		1025 8921  ALN-325
-		103c 006a  NX9500
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 30d9  Presario C700
-		1043 1045  L8400B or L3C/S notebook
-		1043 8109  P5P800-MX Mainboard
-		1071 8160  MIM2000
-		10bd 0320  EP-320X-R
-		10ec 8139  RTL-8100/8101L/8139 PCI Fast Ethernet Adapter
-		10f7 8338  Panasonic CF-Y5 laptop
-		1113 ec01  LevelOne FNC-0107TX/FNC-0109TX
-		1186 1104  DFE-520TX Fast Ethernet PCI Adapter (rev. D1)
-		1186 1300  DFE-538TX
-		1186 1320  SN5200
-		1186 8139  DRN-32TX
-		11f6 8139  FN22-3(A) LinxPRO Ethernet Adapter
-		1259 2500  AT-2500TX
-		1259 2503  AT-2500TX/ACPI
-		1385 f31d  FA311 v2
-		1395 2100  AMB2100
-		1429 d010  ND010/ND012
-		1432 9130  EN-9130TX
-		1436 8139  RT8139
-		144d c00c  P30/P35 notebook
-		1458 e000  GA-7VM400M/7VT600 Motherboard
-		1462 0131  MS-1013 Notebook
-		1462 217c  Aspire L250
-		1462 788c  865PE Neo2-V Mainboard
-		146c 1439  FE-1439TX
-		1489 6001  GF100TXRII
-		1489 6002  GF100TXRA
-		149c 139a  LFE-8139ATX
-		149c 8139  LFE-8139TX
-		14cb 0200  LNR-100 Family 10/100 Base-TX Ethernet
-		1565 2300  P4TSV Onboard LAN (RTL8100B)
-		1631 7003  Onboard RTL8111 on GA-8SIML Rev1.0 Mainboard
-		1695 9001  Onboard RTL8101L 10/100 MBit
-		16ec 00ff  USR997900A
-		1799 5000  F5D5000 PCI Card/Desktop Network PCI Card
-		1799 5010  F5D5010 CardBus Notebook Network Card
-		187e 3303  FN312
-		1904 8139  RTL8139D Fast Ethernet Adapter
-		1af4 1100  QEMU Virtual Machine
-		2646 0001  KNE120TX
-		8e2e 7000  KF-230TX
-		8e2e 7100  KF-230TX/2
-		a0a0 0007  ALN-325C
 	8167  RTL-8110SC/8169SC Gigabit Ethernet
-		105b 0e10  RTL-8110SC-GR on a N15235/A74MX mainboard
-		1458 e000  GA-MA69G-S3H Motherboard
-		1462 235c  P965 Neo MS-7235 mainboard
-		1462 236c  945P Neo3-F motherboard
 	8168  RTL8111/8168/8411 PCI Express Gigabit Ethernet Controller
-		1019 8168  RTL8111/8168 PCI Express Gigabit Ethernet controller
-		1028 0283  Vostro 220
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		1028 06f3  Latitude 3570
-		103c 1611  Pavilion DM1Z-3000
-		103c 1950  ProBook 450/455
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 16d5  U6V/U31J laptop
-		1043 81aa  P5B
-		1043 82c6  M3A78 Series Motherboard
-		1043 83a3  M4A785TD Motherboard
-		1043 8432  P8P67 and other motherboards
-		1043 8505  P8 series motherboard
-		105b 0d7c  D270S/D250S Motherboard
-		10ec 8168  RTL8111/8168 PCI Express Gigabit Ethernet controller
-		144d c652  RTL8168 on a NP300E5C series laptop
-		1458 e000  Onboard Ethernet
-		1462 238c  Onboard RTL8111b on MSI P965 Platinum Mainboard
-		1462 368c  K9AG Neo2
-		1462 4180  Wind PC MS-7418
-		1462 7522  X58 Pro-E
-		1775 11cc  CC11/CL11
-		1849 8168  Motherboard (one of many)
-		7470 3468  TG-3468 Gigabit PCI Express Network Adapter
-		8086 2055  NUC Kit DN2820FYKH
-		8086 d615  Desktop Board D510MO/D525MW
 	8169  RTL8169 PCI Gigabit Ethernet Controller
-		1025 0079  Aspire 5024WLMi
-		10bd 3202  EP-320G-TX1 32-bit PCI Gigabit Ethernet Adapter
-		10ec 8169  RTL8169/8110 Family PCI Gigabit Ethernet NIC
-		1259 c107  CG-LAPCIGT
-		1371 434e  ProG-2000L
-		1385 311a  GA311
-		1385 5200  GA511 Gigabit PC Card
-		1458 e000  GA-8I915ME-G Mainboard
-		1462 030c  K8N Neo-FSR v2.0 mainboard
-		1462 065c  Hetis 865GV-E (MS-7065)
-		1462 702c  K8T NEO 2 motherboard
-		1462 7094  K8T Neo2-F V2.0
-		16ec 011f  USR997903
-		1734 1091  D2030-A1
-		a0a0 0449  AK86-L motherboard
 	8171  RTL8191SEvA Wireless LAN Controller
 	8172  RTL8191SEvB Wireless LAN Controller
 	8173  RTL8192SE Wireless LAN Controller
 	8174  RTL8192SE Wireless LAN Controller
 	8176  RTL8188CE 802.11b/g/n WiFi Adapter
-		1043 84b5  PCE-N10
-		1a3b 1139  AW-NE139H Half-size Mini PCIe Card
 	8177  RTL8191CE PCIe Wireless Network Adapter
 	8178  RTL8192CE PCIe Wireless Network Adapter
 	8179  RTL8188EE Wireless Network Adapter
-		103c 197d  RTL8188EE mini-PCIe card
 	8180  RTL8180L 802.11b MAC
-		1385 4700  MA521 802.11b Wireless PC Card
-		1737 0019  WPC11v4 802.11b Wireless-B Notebook Adapter
 	8185  RTL-8185 IEEE 802.11a/b/g Wireless LAN Controller
 	818b  RTL8192EE PCIe Wireless Network Adapter
 	8190  RTL8190 802.11n PCI Wireless Network Adapter
@@ -11252,13 +5446,11 @@ var pciids = []byte(`#
 	8196  RTL8196 Integrated PCI-e Bridge
 	8197  SmartLAN56 56K Modem
 	8199  RTL8187SE Wireless LAN Controller
-		1462 6894  MN54G2 / MS-6894 Wireless Mini PCIe Card
 	8723  RTL8723AE PCIe Wireless Network Adapter
 	8812  RTL8812AE 802.11ac PCIe Wireless Network Adapter
 	8813  RTL8813AE 802.11ac PCIe Wireless Network Adapter
 	8821  RTL8821AE 802.11ac PCIe Wireless Network Adapter
 	b723  RTL8723BE PCIe Wireless Network Adapter
-		10ec 8739  Dell Wireless 1801
 10ed  Ascii Corporation
 	7310  V7310
 10ee  Xilinx Corporation
@@ -11280,11 +5472,9 @@ var pciids = []byte(`#
 	3fc5  RME Hammerfall DSP
 	3fc6  RME Hammerfall DSP MADI
 	7038  FPGA Card XC7VX690T
-		17aa 402f  FPGA XC7VX690T-3FFG1157E
 	8380  Ellips ProfiXpress Profibus Master
 	8381  Ellips Santos Frame Grabber
 	d154  Copley Controls CAN card (PCI-CAN-02)
-# SED is assigned Xilinx PCI device IDs ebf0 through ebff
 	ebf0  SED Systems Modulator/Demodulator
 	ebf1  SED Systems Audio Interface Card
 	ebf2  SED Systems Common PCI Interface
@@ -11308,7 +5498,6 @@ var pciids = []byte(`#
 10fb  Thesys Gesellschaft fuer Mikroelektronik mbH
 	186f  TH 6255
 10fc  I-O Data Device, Inc.
-# What's in the cardbus end of a Sony ACR-A01 card, comes with newer Vaio CD-RW drives
 	0003  Cardbus IDE Controller
 	0005  Cardbus SCSI CBSC II
 10fd  Soyo Computer, Inc
@@ -11326,155 +5515,25 @@ var pciids = []byte(`#
 	9502  INI-950P Ultra Wide SCSI Adapter
 1102  Creative Labs
 	0002  EMU10k1 [Sound Blaster Live! Series]
-		100a 1102  SB Live! 5.1 Digital OEM SB0220 EMU10K1-JFF
-		1102 0020  CT4670/4850 SBLive! Value
-		1102 0021  CT4620 SBLive!
-		1102 002f  M002/M003 Integrated SBLive!
-		1102 100a  SB0220/0229 SBLive! 5.1 Digital OEM
-		1102 4001  E-mu APS
-		1102 8022  CT4780 SBLive! Value
-		1102 8023  CT4790 SoundBlaster PCI512
-		1102 8024  CT4760 SBLive!
-		1102 8025  CT1140/SB0040 Integrated SBLive!
-		1102 8026  CT4830 SBLive! Value
-		1102 8027  CT4832 SBLive! Value
-		1102 8028  CT4870 SBLive! Value
-		1102 8029  CT4872 SBLive! Value
-		1102 802a  CT4890 SoundBlaster PCI256
-		1102 802b  CT4891 SoundBlaster PCI256
-		1102 8031  CT4831 SBLive! Value
-		1102 8032  CT4871 SBLive! Value
-		1102 8033  CT4893 SoundBlaster PCI256
-		1102 8035  CT0060 SBLive!
-		1102 8040  CT4760 SBLive!
-		1102 8050  CT4750 SoundBlaster PCI512
-		1102 8051  CT4850 SBLive! Value
-		1102 8061  SB060 SBLive! Player 5.1
-		1102 8062  SB0100 SBLive! 5.1
-		1102 8063  DXW Integrated SBLive! 5.1
-		1102 8064  SB0100/SB0102 SBLive! 5.1
-		1102 8065  SB0220/0222 SBLive! 5.1 Digital
-		1102 8066  SB0228 SBLive! 5.1 Digital
-		1102 8067  SB0220 SBLive! 5.1
-		1102 8068  CT0061 SBLive!
-		1102 8069  SB0101 SBLive! 5.1 Value
-		1102 806a  SB0103 SBLive! 5.1
-		1102 806b  SB0105 SBLive! 5.1
-		1102 806c  SB0221 SBLive! 5.1
-		1102 8071  SB0150 SoundBlaster PCI512
-# EMU8008 PCI version of emu8000 chip
 	0003  SB AWE64(D)
 	0004  EMU10k2/CA0100/CA0102/CA10200 [Sound Blaster Audigy Series]
-		1102 0040  SB0090 Audigy Player
-# Probably an early engineering sample
-		1102 0041  CT4820 SBLive!2
-		1102 0042  CT0070 Audigy
-		1102 0043  CT0072 Audigy
-		1102 0051  SB0090 Audigy Player/Platinum (EX)
-		1102 0052  SB0162 Audigy ES
-		1102 0053  CT0090/SB0092 Audigy Player/OEM
-		1102 0054  SB0161 Audigy ES
-		1102 0055  SB0192 Audigy
-		1102 0056  SB0191 Audigy
-		1102 0057  SB0091 Audigy
-		1102 0058  SB0095 Audigy Player/OEM
-		1102 0059  SB0230 Audigy
-		1102 005a  SB0231 Audigy
-		1102 005b  SB0232 Audigy
-		1102 005c  SB0238 Audigy
-		1102 1002  SB0240 Audigy 2 Platinum 6.1
-		1102 1003  SB0350 Audigy 2 / SB0243 Audigy 2 OEM
-		1102 1004  SB0242 Audigy 2
-		1102 1005  SB0280 Audigy 2 Platinum Ex
-		1102 1006  SB0245 Audigy 2 OEM
-		1102 1007  SB0240/SB0244 Audigy 2 Platinum
-		1102 1008  SB0320 Audigy 2
-		1102 1009  SB0249 Audigy 2 OEM
-		1102 100a  SB0246 Audigy 2
-		1102 2001  SB0360 Audigy 2 ZS Platinum Pro
-		1102 2002  SB0350 Audigy 2 ZS
-		1102 2003  SB0352 Audigy 2 ZS
-		1102 2004  SB0355 Audigy 2 ZS
-		1102 2005  SB0359 Audigy 2 ZS
-		1102 2006  SB035x Audigy 2 OEM
-		1102 2007  SB0380 Audigy 4 Pro
-		1102 4001  E-MU 1010 [MAEM8810]
-		1102 4002  E-MU 0404
-		1102 4003  E-MU 1010
 	0005  EMU20k1 [Sound Blaster X-Fi Series]
-		1102 0021  X-Fi Platinum
-		1102 002c  X-Fi XtremeGamer FATAL1TY PRO
-		1102 1003  X-Fi XtremeMusic
 	0006  EMU10k1X [SB Live! Value/OEM Series]
 	0007  CA0106/CA0111 [SB Live!/Audigy/X-Fi Series]
-		1102 0007  SBLive! 24bit
-		1102 1001  SB0310 Audigy LS
-		1102 1002  SB0312 Audigy LS
-		1102 1006  SB0410 SBLive! 24-bit
-		1102 100a  SB0570 [SB Audigy SE]
-		1102 1012  SB0790 X-Fi XA
-		1102 1013  Soundblaster X-Fi Xtreme Audio
-		1462 1009  K8N Diamond
 	0008  CA0108/CA10300 [Sound Blaster Audigy Series]
-		1102 0008  EMU0404 Digital Audio System
-		1102 1001  SB0400 Audigy 2 Value
-		1102 1021  SB0610 Audigy 4 Value
-		1102 1022  SBxxx Audigy 2/4 Value
-		1102 1023  SB0612 Audigy 2 LS
-		1102 1024  SB1550 Audigy 5/Rx
-		1102 1101  SBxxxx Audigy 2 SA
-		1102 2001  SB0530 Audigy 2 ZS Notebook
-		1102 2021  SBxxxx Audigy 4 Notebook
-		1102 4002  E-MU 0404
-		1102 4003  E-MU 1010
-		1102 4004  EMU1010 Digital Audio System [MAEM8960]
-		1102 4005  E-MU 0404 [MAEM8984]
-		1102 4007  E-MU 1010 [MAEM8982]
-		1102 4201  E-MU 0202 [MAEM8950]
 	0009  CA0110 [Sound Blaster X-Fi Xtreme Audio]
-		1102 0010  MB0820 Integrated
-		1102 0018  SB1040 PCI Express
 	000b  EMU20k2 [Sound Blaster X-Fi Titanium Series]
-		1102 0041  SB0880 [SoundBlaster X-Fi Titanium PCI-e]
-		1102 0062  SB1270 [SoundBlaster X-Fi Titanium HD]
 	0012  Sound Core3D [Sound Blaster Recon3D / Z-Series]
-		1102 0010  SB1570 SB Audigy Fx
 	4001  SB Audigy FireWire Port
-		1102 0010  SB Audigy FireWire Port
 	7002  SB Live! Game Port
-		1102 0020  Gameport Joystick
 	7003  SB Audigy Game Port
-		1102 0040  SB Audigy Game Port
-		1102 0060  SB Audigy2 MIDI/Game Port
 	7004  [SB Live! Value] Input device controller
 	7005  SB Audigy LS Game Port
-		1102 1001  SB0310 Audigy LS MIDI/Game port
-		1102 1002  SB0312 Audigy LS MIDI/Game port
 	7006  [SB X-Fi Xtreme Audio] CA0110-IBG PCIe to PCI Bridge
 	8938  Ectiva EV1938
-		1033 80e5  SlimTower-Jim (NEC)
-		1071 7150  Mitac 7150
-		110a 5938  Siemens Scenic Mobile 510PIII
-		13bd 100c  Ceres-C (Sharp, Intel BX)
-		13bd 100d  Sharp, Intel Banister
-		13bd 100e  TwinHead P09S/P09S3 (Sharp)
-		13bd f6f1  Marlin (Sharp)
-		14ff 0e70  P88TE (TWINHEAD INTERNATIONAL Corp)
-		14ff c401  Notebook 9100/9200/2000 (TWINHEAD INTERNATIONAL Corp)
-		156d b400  G400 - Geo (AlphaTop (Taiwan))
-		156d b550  G560  (AlphaTop (Taiwan))
-		156d b560  G560  (AlphaTop (Taiwan))
-		156d b700  G700/U700  (AlphaTop (Taiwan))
-		156d b795  G795  (AlphaTop (Taiwan))
-		156d b797  G797  (AlphaTop (Taiwan))
-# nee Triones Technologies, Inc.
 1103  HighPoint Technologies, Inc.
 	0003  HPT343/345/346/363
 	0004  HPT366/368/370/370A/372/372N
-		1103 0001  HPT370A
-		1103 0004  HPT366 UDMA66 (r1) / HPT368 UDMA66 (r2) / HPT370 UDMA100 (r3) / HPT370 UDMA100 RAID (r4)
-		1103 0005  HPT370 UDMA100
-		1103 0006  HPT302/302N
 	0005  HPT372A/372N
 	0006  HPT302/302N
 	0007  HPT371/371N
@@ -11492,7 +5551,6 @@ var pciids = []byte(`#
 	1740  RocketRAID 1740
 	1742  RocketRAID 1742
 	2210  RocketRAID 2210 SATA-II Controller
-		11ab 11ab  88SX6042
 	2300  RocketRAID 230x 4 Port SATA-II Controller
 	2310  RocketRAID 2310 4 Port SATA-II Controller
 	2320  RocketRAID 2320 SATA-II Controller
@@ -11500,11 +5558,8 @@ var pciids = []byte(`#
 	2340  RocketRAID 2340 16 Port SATA-II Controller
 	2640  RocketRAID 2640 SAS/SATA Controller
 	2722  RocketRAID 2722
-# SFF-8087 Mini-SAS 16 port internal
 	2740  RocketRAID 2740
-# SFF-8088 Mini-SAS 16 port external
 	2744  RocketRaid 2744
-# SFF-8088 8 port external / SFF-8087 24 port internal
 	2782  RocketRAID 2782
 	3120  RocketRAID 3120
 	3220  RocketRAID 3220
@@ -11519,12 +5574,9 @@ var pciids = []byte(`#
 	8470  EM8470 REALmagic DVD/MPEG-4 A/V Decoder
 	8471  EM8471 REALmagic DVD/MPEG-4 A/V Decoder
 	8475  EM8475 REALmagic DVD/MPEG-4 A/V Decoder
-		1105 0001  REALmagic X-Card
 	8476  EM8476 REALmagic DVD/MPEG-4 A/V Decoder
-		127d 0000  CineView II
 	8485  EM8485 REALmagic DVD/MPEG-4 A/V Decoder
 	8486  EM8486 REALmagic DVD/MPEG-4 A/V Decoder
-# Found in Cisco DMP-4305G
 	c621  EM8621L Digital Media Processor
 	c622  EM8622L MPEG-4.10 (H.264) and SMPTE 421M (VC-1) A/V Decoder
 1106  VIA Technologies, Inc.
@@ -11538,19 +5590,11 @@ var pciids = []byte(`#
 	0259  CN333/CN400/PM880 Host Bridge
 	0269  KT880 Host Bridge
 	0282  K8T800Pro Host Bridge
-		1043 80a3  A8V Deluxe
 	0290  K8M890 Host Bridge
 	0293  PM896 Host Bridge
 	0296  P4M800 Host Bridge
 	0305  VT8363/8365 [KT133/KM133]
-		1019 0987  K7VZA Mainboard
-		1043 8033  A7V Mainboard
-		1043 803e  A7V-E Mainboard
-		1043 8042  A7V133/A7V133-C Mainboard
-		147b a401  KT7/KT7-RAID/KT7A/KT7A-RAID Mainboard
 	0308  PT880 Ultra/PT894 Host Bridge
-		1043 8199  P4V800D-X Mainboard
-		1849 0308  Motherboard
 	0314  CN700/VN800/P4M800CE/Pro Host Bridge
 	0324  CX700/VX700 Host Bridge
 	0327  P4M890 Host Bridge
@@ -11559,70 +5603,28 @@ var pciids = []byte(`#
 	0351  K8T890CF Host Bridge
 	0353  VX800 Host Bridge
 	0364  CN896/VN896/P4M900 Host Bridge
-		1043 81ce  P5VD2-VM mothervoard
 	0391  VT8371 [KX133]
 	0409  VX855/VX875 Host Bridge: Host Control
 	0410  VX900 Host Bridge: Host Control
 	0415  VT6415 PATA IDE Host Controller
-		1043 838f  Motherboard
 	0501  VT8501 [Apollo MVP4]
 	0505  VT82C505
-# Shares chip with :0576. The VT82C576M has :1571 instead of :0561.
 	0561  VT82C576MV
 	0571  VT82C586A/B/VT82C686/A/B/VT823x/A/C PIPC Bus Master IDE
-		1019 0985  P6VXA Motherboard
-		1019 0a81  L7VTA v1.0 Motherboard (KT400-8235)
-		1043 8052  VT8233A Bus Master ATA100/66/33 IDE
-		1043 808c  A7V8X / A7V333 motherboard
-		1043 80a1  A7V8X-X motherboard rev. 1.01
-		1043 80ed  A7V600/K8V-X/A8V Deluxe motherboard
-		1106 0571  VT82C586/B/VT82C686/A/B/VT8233/A/C/VT8235 PIPC Bus Master IDE
-		1179 0001  Magnia Z310
-		1297 f641  FX41 motherboard
-		1458 5002  GA-7VAX Mainboard
-		1462 5901  KT6 Delta-FIS2R (MS-6590)
-		1462 7020  K8T NEO 2 motherboard
-		1462 7094  K8T Neo2-F V2.0
-		1462 7120  KT4AV motherboard
-		1462 7181  K8MM3-V mainboard
-		147b 1407  KV8-MAX3 motherboard
-# probably all K7VT2/4*/6
-		1849 0571  K7VT series Motherboards
 	0576  VT82C576 3V [Apollo Master]
 	0581  CX700/VX700 RAID Controller
-# Upgrade bios to get correct ID: 5324 instead of 0581
-		1106 0581  Wrong IDE ID
 	0585  VT82C585VP [Apollo VP1/VPX]
 	0586  VT82C586/A/B PCI-to-ISA [Apollo VP]
-		1106 0000  MVP3 ISA Bridge
 	0591  VT8237A SATA 2-Port Controller
 	0595  VT82C595 [Apollo VP2]
 	0596  VT82C596 ISA [Mobile South]
-		1106 0000  VT82C596/A/B PCI to ISA Bridge
-		1458 0596  VT82C596/A/B PCI to ISA Bridge
 	0597  VT82C597 [Apollo VP3]
 	0598  VT82C598 [Apollo MVP3]
 	0601  VT8601 [Apollo ProMedia]
 	0605  VT8605 [ProSavage PM133]
-		103c 1254  D9840-60001 [Brio BA410 Motherboard]
-		1043 802c  CUV4X mainboard
 	0680  VT82C680 [Apollo P6]
 	0686  VT82C686 [Apollo Super South]
-		1019 0985  P6VXA Motherboard
-		103c 1256  D9840-60001 [Brio BA410 Motherboard]
-		1043 802c  CUV4X mainboard
-		1043 8033  A7V Mainboard
-		1043 803e  A7V-E Mainboard
-		1043 8040  A7M266 Mainboard
-		1043 8042  A7V133/A7V133-C Mainboard
-		1106 0000  VT82C686/A PCI to ISA Bridge
-		1106 0686  VT82C686/A PCI to ISA Bridge
-		1179 0001  Magnia Z310
-		147b a702  KG7-Lite Mainboard
 	0691  VT82C693A/694x [Apollo PRO133x]
-		1019 0985  P6VXA Motherboard
-		1179 0001  Magnia Z310
-		1458 0691  VT82C691 Apollo Pro System Controller
 	0693  VT82C693 [Apollo Pro Plus]
 	0698  VT82C693A [Apollo Pro133 AGP]
 	0709  VX11 Standard Host Bridge
@@ -11688,162 +5690,30 @@ var pciids = []byte(`#
 	287e  VT8237/8251 Ultra VLINK Controller
 	3022  CLE266
 	3038  VT82xx/62xx UHCI USB 1.1 Controller
-		0925 1234  onboard UHCI USB 1.1 Controller
-		1019 0985  P6VXA Motherboard
-		1019 0a81  L7VTA v1.0 Motherboard (KT400-8235)
-		1043 8080  A7V333 motherboard
-		1043 808c  VT6202 USB2.0 4 port controller
-		1043 80a1  A7V8X-X motherboard
-		1043 80ed  A7V600/K8V-X/A8V Deluxe motherboard
-		1179 0001  Magnia Z310
-		1458 5004  GA-7VAX Mainboard
-		1462 5901  KT6 Delta-FIS2R (MS-6590)
-		1462 7020  K8T NEO 2 motherboard
-		1462 7094  K8T Neo2-F V2.0
-		1462 7120  KT4AV motherboard
-		1462 7181  K8MM3-V mainboard
-		147b 1407  KV8-MAX3 motherboard
-		182d 201d  CN-029 USB2.0 4 port PCI Card
-# probably all K7VT2/4*/6
-		1849 3038  K7VT series Motherboards
-		19da a179  ZBOX nano VD01
-		1af4 1100  QEMU Virtual Machine
 	3040  VT82C586B ACPI
 	3043  VT86C100A [Rhine]
-		10bd 0000  VT86C100A Fast Ethernet Adapter
-		1106 0100  VT86C100A Fast Ethernet Adapter
-		1186 1400  DFE-530TX PCI Fast Ethernet Adapter (rev. A)
 	3044  VT6306/7/8 [Fire II(M)] IEEE 1394 OHCI Controller
-		0010 0001  IEEE 1394 4port DCST 1394-3+1B
-		1025 005a  TravelMate 290
-		103c 2a20  Pavilion t3030.de Desktop PC
-		103c 2a3b  Media Center PC m7590n
-		1043 808a  A8V/A8N/P4P800/P5SD2 series motherboard
-		1043 81fe  Motherboard
-		1458 1000  GA-7VT600-1394 Motherboard
-		1462 207d  K8NGM2 series motherboard
-		1462 217d  Aspire L250
-		1462 590d  KT6 Delta-FIS2R (MS-6590)
-		1462 702d  K8T NEO 2 motherboard
-		1462 971d  MS-6917
 	3050  VT82C596 Power Management
 	3051  VT82C596 Power Management
 	3053  VT6105M [Rhine-III]
-		1186 1404  DFE-530TX PCI Fast Ethernet Adapter (rev. D)
 	3057  VT82C686 [Apollo Super ACPI]
-		1019 0985  P6VXA Motherboard
-		1019 0987  K7VZA Motherboard
-		1043 8033  A7V Mainboard
-		1043 803e  A7V-E Mainboard
-		1043 8040  A7M266 Mainboard
-		1043 8042  A7V133/A7V133-C Mainboard
-		1179 0001  Magnia Z310
 	3058  VT82C686 AC97 Audio Controller
-		0e11 0097  SoundMax Digital Integrated Audio
-		0e11 b194  Soundmax integrated digital audio
-		1019 0985  P6VXA Motherboard
-		1019 0987  K7VZA Motherboard
-		103c 1251  D9840-60001 [Brio BA410 Motherboard]
-		1043 1106  A7V133/A7V133-C Mainboard
-		1106 4511  Onboard Audio on EP7KXA
-		1106 aa03  VT1612A AC'97 Audio Controller
-		11d4 5348  AD1881A audio
-		1458 7600  Onboard Audio
-		1462 3091  MS-6309 Onboard Audio
-		1462 3092  MS-6309 v2.x Mainboard (VIA VT1611A codec)
-		1462 3300  MS-6330 Onboard Audio
-		1462 3400  MS-6340 (VT8363) motherboard
-		15dd 7609  Onboard Audio
 	3059  VT8233/A/8235/8237 AC97 Audio Controller
-		1019 0a81  L7VTA v1.0 Motherboard (KT400-8235)
-		1019 1841  M811 (VT8367/VT8235/VT6103) [KT333] motherboard
-		1019 1877  K8M800-M2 (V2.0) onboard audio
-		1043 8095  A7V8X Motherboard (Realtek ALC650 codec)
-		1043 80a1  A7V8X-X Motherboard
-		1043 80b0  A7V600/K8V-X/K8V Deluxe motherboard (ADI AD1980 codec [SoundMAX])
-		1043 80f3  SK8V motherboard
-		1043 810d  P5VD1-X (AD1888 codec [SoundMax])
-		1043 812a  A8V Deluxe motherboard (Realtek ALC850 codec)
-		10ec 8168  High Definition Audio
-		1106 3059  L7VMM2 Motherboard
-		1106 4161  K7VT2 motherboard
-		1106 4170  PCPartner P4M800-8237R Motherboard
-		1106 4552  Soyo KT-600 Dragon Plus (Realtek ALC 650)
-		1297 c160  FX41 motherboard (Realtek ALC650 codec)
-		1413 147b  KV8 Pro motherboard onboard audio
-		1458 a002  GA-7VAX Onboard Audio (Realtek ALC650)
-		1462 0080  K8T NEO 2 motherboard
-		1462 3800  KT266 onboard audio
-		1462 5901  KT6 Delta-FIS2R (MS-6590)
-		1462 7181  K8MM3-V mainboard
-		147b 1407  KV8-MAX3 motherboard
-		1695 300c  Realtek ALC655 audio on EP-8KRA series mainboard
-		1849 0850  ASRock 775Dual-880 Pro onboard audio (Realtek ALC850)
-		1849 9739  P4VT8 Mainboard (C-Media CMI9739A codec)
-# probably all K7VT2/4*/6
-		1849 9761  K7VT series Motherboards
-		4005 4710  MSI K7T266 Pro2-RU (MSI-6380 v2) onboard audio (Realtek/ALC 200/200P)
-		a0a0 01b6  AK77-8XN onboard audio
-		a0a0 0342  AK86-L motherboard
 	3065  VT6102/VT6103 [Rhine-II]
-		1043 80a1  A7V8X-X Motherboard
-		1043 80ed  A7V600-X Motherboard
-		1106 0102  VT6102/6103 [Rhine II] Ethernet Controller
-		1186 1400  DFE-530TX PCI Fast Ethernet Adapter (rev. A)
-		1186 1401  DFE-530TX PCI Fast Ethernet Adapter (rev. B)
-		1186 1402  DFE-530TX PCI Fast Ethernet Adapter (rev. B)
-		13b9 1421  LD-10/100AL PCI Fast Ethernet Adapter (rev.B)
-		1462 7061  MS-7061
-		1462 7181  K8MM3-V mainboard
-		147b 1c09  NV7 Motherboard
-		1695 3005  VT6103
-# probably all K7VT2/4*/6
-		1849 3065  K7VT series Motherboards
-# This hosts more than just the Intel 537 codec, it also hosts PCtel (SIL33) and SmartLink (SIL34) codecs
 	3068  AC'97 Modem Controller
-		1462 309e  MS-6309 Saturn Motherboard
 	3074  VT8233 PCI to ISA Bridge
-		1043 8052  VT8233A
 	3091  VT8633 [Apollo Pro266]
 	3099  VT8366/A/7 [Apollo KT266/A/333]
-		1019 1841  M811 (VT8367/VT8235/VT6103) [KT333] motherboard
-		1043 8064  A7V266-E Mainboard
-		1043 807f  A7V333 Mainboard
-		1849 3099  K7VT2 motherboard
 	3101  VT8653 Host Bridge
 	3102  VT8662 Host Bridge
 	3103  VT8615 Host Bridge
 	3104  USB 2.0
-		0925 1234  onboard EHCI USB 2.0 Controller
-		1019 0a81  L7VTA v1.0 Motherboard (KT400-8235)
-		1043 808c  A7V8X motherboard
-		1043 80a1  A7V8X-X motherboard rev 1.01
-		1043 80ed  A7V600/K8V-X/A8V Deluxe motherboard
-		1106 3104  USB 2.0 Controller
-		1297 f641  FX41 motherboard
-		1458 5004  GA-7VAX Mainboard
-		1462 5901  KT6 Delta-FIS2R (MS-6590)
-		1462 7020  K8T NEO 2 motherboard
-		1462 7094  K8T Neo2-F V2.0
-		1462 7120  KT4AV motherboard
-		1462 7181  K8MM3-V mainboard
-		147b 1407  KV8-MAX3 motherboard
-		182d 201d  CN-029 USB 2.0 4 port PCI Card
-# probably all K7VT2/4*/6
-		1849 3104  K7VT series Motherboards
-		19da a179  ZBOX nano VD01
 	3106  VT6105/VT6106S [Rhine-III]
-		1106 0105  VT6106S [Rhine-III]
-		1186 1403  DFE-530TX PCI Fast Ethernet Adapter (rev. C)
-		1186 1405  DFE-520TX Fast Ethernet PCI Adapter
-		1186 1406  DFE-530TX+ rev F2
-		1186 1407  DFE-538TX
 	3108  K8M800/K8N800/K8N800A [S3 UniChrome Pro]
 	3109  VT8233C PCI to ISA Bridge
 	3112  VT8361 [KLE133] Host Bridge
 	3113  VPX/VPX2 PCI to PCI Bridge Controller
 	3116  VT8375 [KM266/KL266] Host Bridge
-		1297 f641  FX41 motherboard
 	3118  CN400/PM800/PM880/PN800/PN880 [S3 UniChrome Pro]
 	3119  VT6120/VT6121/VT6122 Gigabit Ethernet Adapter
 	3122  VT8623 [Apollo CLE266] integrated CastleRock graphics
@@ -11852,46 +5722,16 @@ var pciids = []byte(`#
 	3133  VT3133 Host Bridge
 	3142  VT6651 WiFi Adapter, 802.11b
 	3147  VT8233A ISA Bridge
-		1043 808c  A7V333 motherboard
 	3148  P4M266 Host Bridge
 	3149  VIA VT6420 SATA RAID Controller
-		1043 80ed  A7V600/K8V Deluxe/K8V-X/A8V Deluxe motherboard
-		1458 b003  GA-7VM400AM(F) Motherboard
-		1462 5901  KT6 Delta-FIS2R (MS-6590)
-		1462 7020  K8T Neo 2 Motherboard
-		1462 7094  K8T Neo2-F V2.0
-		1462 7181  K8MM3-V mainboard
-		147b 1407  KV8-MAX3 motherboard
-		147b 1408  KV7
-		1849 3149  K7VT6 motherboard
-		a0a0 04ad  AK86-L motherboard
 	3156  P/KN266 Host Bridge
 	3157  CX700/VX700 [S3 UniChrome Pro]
 	3164  VT6410 ATA133 RAID controller
-		1043 80f4  P4P800 Mainboard Deluxe ATX
-		1462 7028  915P/G Neo2
 	3168  P4X333/P4X400/PT800 AGP Bridge
-		1849 3168  P4VT8 Mainboard
 	3177  VT8235 ISA Bridge
-		1019 0a81  L7VTA v1.0 Motherboard (KT400-8235)
-		1019 1841  M811 (VT8367/VT8235/VT6103) [KT333] motherboard
-		1043 808c  A7V8X motherboard
-		1043 80a1  A7V8X-X motherboard
-		1106 0000  KT4AV motherboard
-		1297 f641  FX41 motherboard
-		1458 5001  GA-7VAX Mainboard
-# probably all K7VT2/4*/6
-		1849 3177  K7VT series Motherboards
 	3178  ProSavageDDR P4N333 Host Bridge
 	3188  VT8385 [K8T800 AGP] Host Bridge
-		1043 80a3  K8V Deluxe/K8V-X motherboard
-		147b 1407  KV8-MAX3 motherboard
 	3189  VT8377 [KT400/KT600 AGP] Host Bridge
-		1043 807f  A7V8X motherboard
-		1106 0000  KT4AV motherboard (KT400A)
-		1458 5000  GA-7VAX Mainboard
-# probably all K7VT2/4*/6
-		1849 3189  K7VT series Motherboards
 	31b0  VX11 Standard Host Bridge
 	31b1  VX11 Standard Host Bridge
 	31b2  VX11 DRAM Controller
@@ -11902,20 +5742,13 @@ var pciids = []byte(`#
 	31b8  VX11 PCI to PCI Bridge
 	3204  K8M800 Host Bridge
 	3205  VT8378 [KM400/A] Chipset Host Bridge
-		1458 5000  GA-7VM400M Motherboard
 	3208  PT890 Host Bridge
 	3213  VPX/VPX2 PCI to PCI Bridge Controller
 	3218  K8T800M Host Bridge
 	3227  VT8237 ISA bridge [KT600/K8T800/K8T890 South]
-		1043 80ed  A7V600/K8V-X/A8V Deluxe motherboard
-		1106 3227  DFI KT600-AL / Soltek SL-B9D-FGR Motherboard
-		1458 5001  GA-7VT600 Motherboard
-		147b 1407  KV8-MAX3 motherboard
-		1849 3227  K7VT4 motherboard
 	3230  K8M890CE/K8N890CE [Chrome 9]
 	3238  K8T890 Host Bridge
 	3249  VT6421 IDE/SATA Controller
-		1106 3249  VT6421 IDE/SATA Controller
 	324a  CX700/VX700 PCI to PCI Bridge
 	324b  CX700/VX700 Host Bridge
 	324e  CX700/VX700 Internal Module Bus
@@ -11927,7 +5760,6 @@ var pciids = []byte(`#
 	3282  K8T800Pro Host Bridge
 	3287  VT8251 PCI to ISA Bridge
 	3288  VT8237A/VT8251 HDA Controller
-		19da a179  ZBOX VD01
 	3290  K8M890 Host Bridge
 	3296  P4M800 Host Bridge
 	3324  CX700/VX700 Host Bridge
@@ -11946,11 +5778,8 @@ var pciids = []byte(`#
 	337a  VT8237A PCI to PCI Bridge
 	337b  VT8237A Host Bridge
 	3403  VT6315 Series Firewire Controller
-		1043 8374  M5A88-V EVO
-		1043 8384  P8P67 Deluxe Motherboard
 	3409  VX855/VX875 DRAM Bus Control
 	3410  VX900 DRAM Bus Control
-		19da a179  ZBOX nano VD01
 	3432  VL80x xHCI USB 3.0 Controller
 	3456  VX11 Standard Host Bridge
 	345b  VX11 Miscellaneous Bus
@@ -11978,7 +5807,6 @@ var pciids = []byte(`#
 	4364  CN896/VN896/P4M900 Host Bridge
 	4409  VX855/VX875 Power Management Control
 	4410  VX900 Power Management and Chip Testing Control
-		19da a179  ZBOX nano VD01
 	5030  VT82C596 ACPI [Apollo PRO]
 	5122  VX855/VX875 Chrome 9 HCM Integrated Graphics
 	5208  PT890 I/O APIC Interrupt Controller
@@ -12004,12 +5832,9 @@ var pciids = []byte(`#
 	6364  CN896/VN896/P4M900 Security Device
 	6409  VX855/VX875 Scratch Registers
 	6410  VX900 Scratch Registers
-		19da a179  ZBOX nano VD01
 	7122  VX900 Graphics [Chrome9 HD]
 	7204  K8M800 Host Bridge
 	7205  KM400/KN400/P4M800 [S3 UniChrome]
-		1458 d000  Gigabyte GA-7VM400(A)M(F) Motherboard
-		1462 7061  MS-7061
 	7208  PT890 Host Bridge
 	7238  K8T890 Host Bridge
 	7258  PT880 Host Bridge
@@ -12030,7 +5855,6 @@ var pciids = []byte(`#
 	7364  CN896/VN896/P4M900 Host Bridge
 	7409  VX855/VX875 North-South Module Interface Control
 	7410  VX900 North-South Module Interface Control
-		19da a179  ZBOX nano VD01
 	8231  VT8231 [PCI-to-ISA Bridge]
 	8235  VT8235 ACPI
 	8305  VT8363/8365 [KT133/KM133 AGP]
@@ -12040,13 +5864,11 @@ var pciids = []byte(`#
 	8400  MVP4
 	8409  VX855/VX875 Bus Control and Power Management
 	8410  VX900 Bus Control and Power Management
-		19da a179  ZBOX VD01
 	8500  KLE133/PLE133/PLE133T
 	8501  VT8501 [Apollo MVP4 AGP]
 	8596  VT82C596 [Apollo PRO AGP]
 	8597  VT82C597 [Apollo VP3 AGP]
 	8598  VT82C598/694x [Apollo MVP3/Pro133x AGP]
-		1019 0985  P6VXA Motherboard
 	8601  VT8601 [Apollo ProMedia AGP]
 	8605  VT8605 [PM133 AGP]
 	8691  VT82C691 [Apollo Pro]
@@ -12078,7 +5900,6 @@ var pciids = []byte(`#
 	b115  VT8363/8365 [KT133/KM133] PCI Bridge
 	b168  VT8235 PCI Bridge
 	b188  VT8237/8251 PCI bridge [K8M890/K8T800/K8T890 South]
-		147b 1407  KV8-MAX3 motherboard
 	b198  VT8237/VX700 PCI Bridge
 	b213  VPX/VPX2 I/O APIC Interrupt Controller
 	b353  VX855/VX875/VX900 PCI to PCI Bridge
@@ -12130,7 +5951,6 @@ var pciids = []byte(`#
 	007c  FSC Remote Service Controller, shared memory device
 	007d  FSC Remote Service Controller, SMIC device
 	2101  HST SAPHIR V Primary PCI (ISDN/PMx)
-# Superfastcom-PCI (Commtech, Inc.) or DSCC4 WAN Adapter
 	2102  DSCC4 PEB/PEF 20534 DMA Supported Serial Communication Controller with 4 Channels
 	2104  Eicon Diva 2.02 compatible passive ISDN card
 	3141  SIMATIC NET CP 5611 / 5621
@@ -12138,14 +5958,10 @@ var pciids = []byte(`#
 	3143  SIMATIC NET CP 1613
 	4021  SIMATIC NET CP 5512 (Profibus and MPI Cardbus Adapter)
 	4029  SIMATIC NET CP 5613 A2
-		110a 4029  SIMATIC NET CP 5613 A2
-		110a c029  SIMATIC NET CP 5614 A2
 	4035  SIMATIC NET CP 1613 A2
 	4036  SIMATIC NET CP 1616
 	4038  SIMATIC NET CP 1604
 	4069  SIMATIC NET CP 5623
-		110a 4069  SIMATIC NET CP 5623
-		110a c069  SIMATIC NET CP 5624
 	407c  SIMATIC NET CP 5612
 	407d  SIMATIC NET CP 5613 A3
 	407e  SIMATIC NET CP 5622
@@ -12164,7 +5980,6 @@ var pciids = []byte(`#
 	6037  Firepower Powerized SMP I/O ASIC
 	6073  Firepower Powerized SMP I/O ASIC
 1111  Santa Cruz Operation
-# Also claimed to be RNS or Rockwell International, current PCISIG records list Osicom
 1112  Osicom Technologies Inc
 	2200  FDDI Adapter
 	2300  Fast Ethernet Adapter
@@ -12172,17 +5987,10 @@ var pciids = []byte(`#
 	2400  ATM Adapter
 1113  Accton Technology Corporation
 	1211  SMC2-1211TX
-		103c 1207  EN-1207D Fast Ethernet Adapter
-		1113 1211  EN-1207D Fast Ethernet Adapter
 	1216  EN-1216 Ethernet Adapter
-		1113 1216  EN1207F series PCI Fast Ethernet Adapter
-		1113 2220  EN2220A Cardbus Fast Ethernet Adapter
-		1113 2242  EN2242 10/100 Ethernet Mini-PCI Card
-		111a 1020  SpeedStream 1020 PCI 10/100 Ethernet Adaptor [EN-1207F-TX ?]
 	1217  EN-1217 Ethernet Adapter
 	5105  10Mbps Network card
 	9211  EN-1207D Fast Ethernet Adapter
-		1113 9211  EN-1207D Fast Ethernet Adapter
 	9511  21x4x DEC-Tulip compatible Fast Ethernet
 	d301  CPWNA100 (Philips wireless PCMCIA)
 	ec02  SMC 1244TX v3
@@ -12282,17 +6090,8 @@ var pciids = []byte(`#
 	0000  155P-MF1 (FPGA)
 	0002  155P-MF1 (ASIC)
 	0003  ENI-25P ATM
-		111a 0000  ENI-25p Miniport ATM Adapter
 	0005  SpeedStream (LANAI)
-		111a 0001  ENI-3010 ATM
-		111a 0009  ENI-3060 ADSL (VPI=0)
-		111a 0101  ENI-3010 ATM
-		111a 0109  ENI-3060CO ADSL (VPI=0)
-		111a 0809  ENI-3060 ADSL (VPI=0 or 8)
-		111a 0909  ENI-3060CO ADSL (VPI=0 or 8)
-		111a 0a09  ENI-3060 ADSL (VPI=<0..15>)
 	0007  SpeedStream ADSL
-		111a 1001  ENI-3061 ADSL [ASIC]
 	1020  SpeedStream PCI 10/100 Network Card
 	1203  SpeedStream 1023 Wireless PCI Adapter
 111b  Teledyne Electronic Systems
@@ -12340,20 +6139,11 @@ var pciids = []byte(`#
 	8061  PES12T3G2 PCI Express Gen2 Switch
 	8068  PES6T6G2 PCI Express Gen2 Switch
 	806a  PES24T3G2 PCI Express Gen2 Switch
-		14c1 000c  10G-PCIE2-8B2
 	806c  PES16T4A/4T4G2 PCI Express Gen2 Switch
 	806e  PES24T6G2 PCI Express Gen2 Switch
 	806f  HIO524G2 PCI Express Gen2 Switch
 	8088  PES32NT8BG2 PCI Express Switch
-		1093 752f  PXIe-8383mc Device
-		1093 7543  PXIe-8383mc System Host
-		1093 755c  PXIe-8364
-		1093 755d  PXIe-8374
-		1093 75ff  PXIe-8383mc DMA
-		1093 7600  PXIe-8383mc DMA
-		1093 7602  PXIe-8384
 	808e  PES24NT24G2 PCI Express Switch
-# 32 port / 8 lane PCIe Gen 2 packet switch
 	808f  PES32NT8AG2
 	80cf  F32P08xG3 [PCIe boot mode]
 	80d2  F32P08xG3 NVMe controller
@@ -12361,7 +6151,6 @@ var pciids = []byte(`#
 111f  Precision Digital Images
 	4a47  Precision MX Video engine interface
 	5243  Frame capture bus interface
-# formerly EMC Corporation
 1120  Dell EMC
 	2306  Unity Fibre Channel Controller
 	2501  Unity Ethernet Controller
@@ -12380,7 +6169,6 @@ var pciids = []byte(`#
 	0300  ForeRunner PCA-200EPC ATM
 	0310  ATM
 	0400  ForeRunnerHE ATM Adapter
-		1127 0400  ForeRunnerHE ATM
 1129  Firmworks
 112a  Hermes Electronics Company, Ltd.
 112b  Linotype - Hell AG
@@ -12394,244 +6182,23 @@ var pciids = []byte(`#
 1130  Computervision
 1131  Philips Semiconductors
 	1561  USB 1.1 Host Controller
-		1775 c200  C2K onboard USB 1.1 host controller
 	1562  USB 2.0 Host Controller
-		1775 c200  C2K onboard USB 2.0 host controller
 	3400  SmartPCI56(UCB1500) 56K Modem
 	5400  TriMedia TM1000/1100
-		12ca 0000  BlueICE
 	5402  TriMedia TM1300
-		1244 0f00  Fritz!Card DSL
-		15eb 1300  DT1300
-		15eb 1302  DT1302
-		15eb 1304  DT1304
-		15eb 1305  DT1305
-		15eb 1306  PMCDT1306
-		15eb 1308  DT1308
-		15eb 1331  DT1301 with SAA7121
-		15eb 1337  DT1301 with SAA7127
-		15eb 2d3d  X3D
-		15eb 7022  PTM1300
 	5405  TriMedia TM1500
-		1136 0005  LCP-1500
 	5406  TriMedia TM1700
 	540b  PNX1005 Media Processor
-		1131 0020  PNXLite PCI Demo Board
 	7130  SAA7130 Video Broadcast Decoder
-		0000 4016  Behold TV 401
-		0000 4051  Behold TV 405 FM
-		0000 5051  Behold TV 505 RDS
-		0000 505b  Behold TV 505 RDS
-		102b 48d0  Matrox CronosPlus
-		1048 226b  ELSA EX-VISION 300TV
-		107d 6655  WinFast DTV1000S
-		1131 0000  SAA7130-based TV tuner card
-		1131 2001  10MOONS PCI TV CAPTURE CARD
-		1131 2005  Techcom (India) TV Tuner Card (SSD-TV-670)
-		1458 9006  GT-PS700 DVB-S tuner
-		1461 050c  Nagase Sangyo TransGear 3000TV
-		1461 10ff  AVerMedia DVD EZMaker
-		1461 2108  AverMedia AverTV/305
-		1461 2115  AverMedia AverTV Studio 305
-		153b 1152  Terratec Cinergy 200 TV
-		185b c100  Compro VideoMate TV PVR/FM
-		185b c901  Videomate DVB-T200
-		5168 0138  LifeView FlyVIDEO2000
-		5ace 5010  Behold TV 501
-		5ace 5050  Behold TV 505 FM
 	7133  SAA7131/SAA7133/SAA7135 Video Broadcast Decoder
-		0000 4091  Beholder BeholdTV 409 FM
-		0000 5071  Behold TV 507 RDS
-		0000 507b  Behold TV 507 RDS
-		0000 5201  Behold TV Columbus
-		0070 6701  WinTV HVR-1110
-		1019 4cb5  Elitegroup ECS TVP3XP FM1236 Tuner Card (NTSC,FM)
-		1043 0210  FlyTV mini Asus Digimatrix
-		1043 4843  TV-FM 7133
-		1043 4845  TV-FM 7135
-		1043 4862  P7131 Dual
-		1043 4876  My Cinema-P7131 Hybrid
-		1131 0000  SAA713x-based TV tuner card
-		1131 2001  Proteus Pro [philips reference design]
-		1131 2018  Tiger reference design
-		1131 4ee9  MonsterTV Mobile
-		1131 7133  Pinnacle PCTV 301i
-		11bd 002b  PCTV Stereo
-		11bd 002e  PCTV 110i (saa7133)
-		12ab 0800  PURPLE TV
-		13c2 2804  Technotrend Budget T-3000 Hybrid
-		1421 0335  Instant TV DVB-T Cardbus
-		1421 1370  Instant TV (saa7135)
-		1435 7330  VFG7330
-		1435 7350  VFG7350
-		1458 9001  GC-PTV-TAF Hybrid TV card
-		1458 9002  GT-PTV-TAF-RH DVB-T/Analog TV/FM tuner
-		1458 9003  GT-PTV-AF-RH Analog TV/FM tuner
-		1458 9004  GT-P8000 DVB-T/Analog TV/FM tuner
-		1458 9005  GT-P6000 Analog TV/FM tuner
-		1458 9008  GT-P5100 Analog TV tuner
-		1461 1044  AVerTVHD MCE A180
-		1461 4836  M10D Hybrid DVBT
-		1461 861e  M105 PAL/SECAM/NTSC/FM Tuner
-		1461 a14b  AVerTV Studio 509
-		1461 a836  M115 DVB-T, PAL/SECAM/NTSC Tuner
-		1461 f01d  DVB-T Super 007
-		1461 f31f  Avermedia AVerTV GO 007 FM
-		1461 f936  Hybrid+FM PCI (rev A16D)
-		1462 6231  TV@nywhere Plus
-		1489 0214  LifeView FlyTV Platinum FM
-		14c0 1212  LifeView FlyTV Platinum Mini2
-		153b 1160  Cinergy 250 PCI TV
-		153b 1162  Terratec Cinergy 400 mobile
-		17de 7256  PlusTV All In One PI610 card
-		17de 7350  ATSC 110 Digital / Analog HDTV Tuner
-		17de 7352  ATSC 115 Digital / Analog HDTV Tuner
-		185b c100  VideoMate TV
-		185b c900  VideoMate T750
-		5168 0306  LifeView FlyDVB-T DUO
-		5168 0319  LifeView FlyDVB Trio
-		5168 0502  LifeView FlyDVB-T Duo CardBus
-		5168 0520  LifeView FlyDVB Trio CardBus
-		5168 1502  LifeView FlyTV CardBus
-		5168 2502  LifeView FlyDVB-T CardBus
-		5168 2520  LifeView FlyDVB-S Duo CardBus
-		5168 3502  LifeView FlyDVB-T Hybrid CardBus
-		5168 3520  LifeView FlyDVB Trio N CardBus
-		5ace 5030  Behold TV 503 FM
-		5ace 5090  Behold TV 509 FM
-		5ace 6090  Behold TV 609 FM
-		5ace 6091  Behold TV 609 FM
-		5ace 6092  Behold TV 609 RDS
-		5ace 6093  Behold TV 609 RDS
-		5ace 6190  Behold TV M6
-		5ace 6191  Behold TV M63
-		5ace 6193  Behold TV M6 Extra
-		5ace 6290  Behold TV H6
-		5ace 7090  Behold TV A7
-		5ace 7150  Behold TV H75
-		5ace 7151  Behold TV H75
-		5ace 7190  Behold TV H7
-		5ace 7191  Behold TV H7
-		5ace 7290  Behold TV T7
-		5ace 7591  Behold TV X7
-		5ace 7595  Behold TV X7
 	7134  SAA7134/SAA7135HL Video Broadcast Decoder
-		0000 4036  Behold TV 403
-		0000 4037  Behold TV 403 FM
-		0000 4071  Behold TV 407 FM
-		1019 4cb4  Elitegroup ECS TVP3XP FM1216 Tuner Card(PAL-BG,FM)
-		1043 0210  Digimatrix TV
-		1043 4840  TV-FM 7134
-		1043 4842  TV-FM 7134
-		1131 0000  SAA713x-based TV tuner card
-		1131 2004  EUROPA V3 reference design
-		1131 4e85  SKNet Monster TV
-		1131 6752  EMPRESS
-		11bd 002b  PCTV Stereo
-		11bd 002d  PCTV 300i DVB-T + PAL
-		1461 2c00  AverTV Hybrid+FM PCI
-		1461 9715  AVerTV Studio 307
-		1461 a70a  Avermedia AVerTV 307
-		1461 a70b  AverMedia M156 / Medion 2819
-		1461 d6ee  Cardbus TV/Radio (E500)
-		1471 b7e9  AVerTV Cardbus plus
-		153b 1142  Terratec Cinergy 400 TV
-		153b 1143  Terratec Cinergy 600 TV
-		153b 1158  Terratec Cinergy 600 TV MK3
-		1540 9524  ProVideo PV952
-		16be 0003  Medion 7134
-		185b c200  Compro VideoMate Gold+ Pal
-		185b c900  Videomate DVB-T300
-		1894 a006  KNC One TV-Station DVR
-		1894 fe01  KNC One TV-Station RDS / Typhoon TV Tuner RDS
-		5168 0138  FLY TV PRIME 34FM
-		5168 0300  FlyDVB-S
-		5ace 5070  Behold TV 507 FM
-		5ace 6070  Behold TV 607 FM
-		5ace 6071  Behold TV 607 FM
-		5ace 6072  Behold TV 607 RDS
-		5ace 6073  Behold TV 607 RDS
 	7145  SAA7145
 	7146  SAA7146
-		110a 0000  Fujitsu/Siemens DVB-C card rev1.5
-		110a ffff  Fujitsu/Siemens DVB-C card rev1.5
-		1124 2581  Leutron Vision PicPort
-		1131 4f56  KNC1 DVB-S Budget
-		1131 4f60  Fujitsu-Siemens Activy DVB-S Budget Rev AL
-		1131 4f61  Activy DVB-S Budget Rev GR
-		1131 5f61  Activy DVB-T Budget
-		114b 2003  DVRaptor Video Edit/Capture Card
-		11bd 0006  DV500 Overlay
-		11bd 000a  DV500 Overlay
-		11bd 000f  DV500 Overlay
-		13c2 0000  Siemens/Technotrend/Hauppauge DVB card rev1.3 or rev1.5
-		13c2 0001  Technotrend/Hauppauge DVB card rev1.3 or rev1.6
-		13c2 0002  Technotrend/Hauppauge DVB card rev2.1
-		13c2 0003  Technotrend/Hauppauge DVB card rev2.1
-		13c2 0004  Technotrend/Hauppauge DVB card rev2.1
-		13c2 0006  Technotrend/Hauppauge DVB card rev1.3 or rev1.6
-		13c2 0008  Technotrend/Hauppauge DVB-T
-		13c2 000a  Octal/Technotrend DVB-C for iTV
-		13c2 000e  Technotrend/Hauppauge DVB card rev2.3
-		13c2 1003  Technotrend-Budget/Hauppauge WinTV-NOVA-S DVB card
-		13c2 1004  Technotrend-Budget/Hauppauge WinTV-NOVA-C DVB card
-		13c2 1005  Technotrend-Budget/Hauppauge WinTV-NOVA-T DVB card
-		13c2 100c  Technotrend-Budget/Hauppauge WinTV-NOVA-CI DVB card
-		13c2 100f  Technotrend-Budget/Hauppauge WinTV-NOVA-CI DVB card
-		13c2 1010  DVB C-1500
-		13c2 1011  Technotrend-Budget/Hauppauge WinTV-NOVA-T DVB card
-		13c2 1012  DVB T-1500
-		13c2 1013  SATELCO Multimedia DVB
-		13c2 1016  WinTV-NOVA-SE DVB card
-		13c2 1018  DVB S-1401
-		13c2 1019  S2-3200
-		13c2 1102  Technotrend/Hauppauge DVB card rev2.1
-		153b 1155  Cinergy 1200 DVB-S
-		153b 1156  Cinergy 1200 DVB-C
-		153b 1157  Cinergy 1200 DVB-T
-		153b 1176  Cinergy 1200 DVB-C (MK3)
-		1894 0020  KNC One DVB-C V1.0
-		1894 0023  TVStation DVB-C plus
-# http://www.knc1.com/gb.htm
-		1894 0054  TV-Station DVB-S
 	7160  SAA7160
-		1458 9009  E8000 DVB-T/Analog TV/FM tuner
-		1461 1455  AVerTV Hybrid Speedy PCI-E (H788)
 	7162  SAA7162
-		11bd 0101  Pinnacle PCTV 7010iX TV Card
 	7164  SAA7164
-		0070 8800  WinTV HVR-2250
-		0070 8810  WinTV HVR-2250
-		0070 8851  WinTV HVR-2250
-		0070 8853  WinTV HVR-2250
-		0070 8880  WinTV HVR-2250
-		0070 8891  WinTV HVR-2250
-		0070 88a0  WinTV HVR-2250
-		0070 88a1  WinTV HVR-2250
-		0070 8900  WinTV HVR-2200
-		0070 8901  WinTV HVR-2200
-		0070 8940  WinTV HVR-2200 (submodel 89619)
-		0070 8951  WinTV HVR-2200
-		0070 8953  WinTV HVR-2200
-		0070 8980  WinTV HVR-2200
-		0070 8991  WinTV HVR-2200
-		0070 8993  WinTV HVR-2200
-		0070 89a0  WinTV HVR-2200
-		0070 89a1  WinTV HVR-2200
-		0070 f120  WinTV HVR-2205
-		0070 f123  WinTV HVR-2215
 	7231  SAA7231
-		5ace 8000  Behold TV H8
-		5ace 8001  Behold TV H8
-		5ace 8050  Behold TV H85
-		5ace 8051  Behold TV H85
-		5ace 8100  Behold TV A8
-		5ace 8101  Behold TV A8
-		5ace 8150  Behold TV A85
-		5ace 8151  Behold TV A85
-		5ace 8201  Behold TV T8
 	9730  SAA9730 Integrated Multimedia and Peripheral Controller
-		1131 0000  Integrated Multimedia and Peripheral Controller
 1132  Mitel Corp.
 1133  Dialogic Corporation
 	7701  Eiconcard C90
@@ -12669,61 +6236,27 @@ var pciids = []byte(`#
 	e00d  Diva Pro 3.0 PCI
 	e00e  Diva ISDN+CT S/T PCI Rev 2
 	e010  Diva Server BRI-2M PCI
-		110a 0021  Fujitsu Siemens ISDN S0
 	e011  Diva Server BRI S/T Rev 2
 	e012  Diva Server 4BRI-8M PCI
 	e013  4BRI
-		1133 1300  Diva V-4BRI-8 PCI v2
-		1133 e013  Diva 4BRI-8 PCI v2
 	e014  Diva Server PRI-30M PCI
 	e015  Diva PRI PCI v2
 	e016  Diva Server Voice 4BRI PCI
 	e017  Diva Server Voice 4BRI Rev 2
-		1133 e017  Diva Server Voice 4BRI-8M 2.0 PCI
 	e018  BRI
-		1133 1800  Diva V-BRI-2 PCI v2
-		1133 e018  Diva BRI-2 PCI v2
 	e019  Diva Server Voice PRI Rev 2
-		1133 e019  Diva Server Voice PRI 2.0 PCI
 	e01a  Diva BRI-2FX PCI v2
 	e01b  Diva Server Voice BRI-2M 2.0 PCI
-		1133 e01b  Diva Server Voice BRI-2M 2.0 PCI
 	e01c  PRI
-		1133 1c01  Diva PRI/E1/T1-8 PCI v3
-		1133 1c02  Diva PRI/T1-24 PCI(e) v3
-		1133 1c03  Diva PRI/E1-30 PCI(e) v3
-		1133 1c04  Diva PRI/E1/T1-CTI PCI(e) v3
-		1133 1c05  Diva V-PRI/T1-24 PCI(e) v3
-		1133 1c06  Diva V-PRI/E1-30 PCI(e) v3
-		1133 1c07  Diva Server PRI/E1/T1-8 Cornet NQ
-		1133 1c08  Diva Server PRI/T1-24 Cornet NQ
-		1133 1c09  Diva Server PRI/E1-30 Cornet NQ
-		1133 1c0a  Diva Server PRI/E1/T1 Cornet NQ
-		1133 1c0b  Diva Server V-PRI/T1-24 Cornet NQ
-		1133 1c0c  Diva Server V-PRI/E1-30 Cornet NQ
 	e01e  2PRI
-		1133 1e01  Diva 2PRI/E1/T1-60 PCI v1
-		1133 e01e  Diva V-2PRI/E1/T1-60 PCI v1
 	e020  4PRI
-		1133 2001  Diva 4PRI/E1/T1-120 PCI v1
-		1133 e020  Diva V-4PRI/E1/T1-120 PCI v1
 	e022  Analog-2
-		1133 2200  Diva V-Analog-2 PCI v1
-		1133 e022  Diva Analog-2 PCI v1
 	e024  Analog-4
-		1133 2400  Diva V-Analog-4 PCI v1
-		1133 e024  Diva Analog-4 PCI v1
 	e028  Analog-8
-		1133 2800  Diva V-Analog-8 PCI v1
-		1133 e028  Diva Analog-8 PCI v1
 	e02a  Diva IPM-300 PCI v1
 	e02c  Diva IPM-600 PCI v1
 	e02e  4BRI
-		1133 2e01  Diva V-4BRI-8 PCIe v2
-		1133 e02e  Diva 4BRI-8 PCIe v2
 	e032  BRI
-		1133 3201  Diva V-BRI-2 PCIe v2
-		1133 e032  Diva BRI-2 PCIe v2
 	e034  Diva BRI-CTI PCI v2
 1134  Mercury Computer Systems
 	0001  Raceway Bridge
@@ -12737,82 +6270,16 @@ var pciids = []byte(`#
 1137  Cisco Systems Inc
 	0023  VIC 81 PCIe Upstream Port
 	0040  VIC PCIe Upstream Port
-		1137 004f  VIC 1280 Dual 40Gb Mezzanine
-		1137 0084  VIC 1240 Dual 40Gb MLOM
-		1137 0085  VIC 1225 Dual 10Gb SFP+ PCIe
-		1137 00cd  VIC 1285 Dual 40Gb QSFP+ PCIe
-		1137 00ce  VIC 1225T Dual 10GBaseT PCIe
-		1137 012a  VIC M4308 Dual 40Gb
-		1137 012c  VIC 1340 Dual 40Gb MLOM
-		1137 012e  VIC 1227 Dual 10Gb SFP+ PCIe
-		1137 0137  VIC 1380 Dual 40Gb Mezzanine
-		1137 014d  VIC 1385 Dual 40Gb PCIe
 	0041  VIC PCIe Downstream Port
 	0042  VIC Management Controller
-		1137 0047  VIC P81E PCIe Management Controller
-		1137 0085  VIC 1225 PCIe Management Controller
-		1137 00cd  VIC 1285 PCIe Management Controller
-		1137 00ce  VIC 1225T PCIe Management Controller
-		1137 012e  VIC 1227 PCIe Management Controller
-		1137 014d  VIC 1385 PCIe Management Controller
 	0043  VIC Ethernet NIC
-		1137 0047  VIC P81E PCIe Ethernet NIC
-		1137 0048  VIC M81KR Mezzanine Ethernet NIC
-		1137 004f  VIC 1280 Mezzanine Ethernet NIC
-		1137 0084  VIC 1240 MLOM Ethernet NIC
-		1137 0085  VIC 1225 PCIe Ethernet NIC
-		1137 00cd  VIC 1285 PCIe Ethernet NIC
-		1137 00ce  VIC 1225T PCIe Ethernet NIC
-		1137 012a  VIC M4308 Ethernet NIC
-		1137 012c  VIC 1340 MLOM Ethernet NIC
-		1137 012e  VIC 1227 PCIe Ethernet NIC
-		1137 0137  VIC 1380 Mezzanine Ethernet NIC
-		1137 014d  VIC 1385 PCIe Ethernet NIC
 	0044  VIC Ethernet NIC Dynamic
-		1137 0047  VIC P81E PCIe Ethernet NIC Dynamic
-		1137 0048  VIC M81KR Mezzanine Ethernet NIC Dynamic
-		1137 004f  VIC 1280 Mezzanine Ethernet NIC Dynamic
-		1137 0084  VIC 1240 MLOM Ethernet NIC Dynamic
-		1137 0085  VIC 1225 PCIe Ethernet NIC Dynamic
-		1137 00cd  VIC 1285 PCIe Ethernet NIC Dynamic
-		1137 00ce  VIC 1225T PCIe Ethernet NIC Dynamic
-		1137 012a  VIC M4308 Ethernet NIC Dynamic
-		1137 012c  VIC 1340 MLOM Ethernet NIC Dynamic
-		1137 012e  VIC 1227 PCIe Ethernet NIC Dynamic
-		1137 0137  VIC 1380 Mezzanine Ethernet NIC Dynamic
-		1137 014d  VIC 1385 PCIe Ethernet NIC Dynamic
 	0045  VIC FCoE HBA
-		1137 0047  VIC P81E PCIe FCoE HBA
-		1137 0048  VIC M81KR Mezzanine FCoE HBA
-		1137 004f  VIC 1280 Mezzanine FCoE HBA
-		1137 0084  VIC 1240 MLOM FCoE HBA
-		1137 0085  VIC 1225 PCIe FCoE HBA
-		1137 00cd  VIC 1285 PCIe FCoE HBA
-		1137 00ce  VIC 1225T PCIe FCoE HBA
-		1137 012a  VIC M4308 FCoE HBA
-		1137 012c  VIC 1340 MLOM FCoE HBA
-		1137 012e  VIC 1227 PCIe FCoE HBA
-		1137 0137  VIC 1380 Mezzanine FCoE HBA
-		1137 014d  VIC 1385 PCIe FCoE HBA
 	0046  VIC SCSI Controller
-		1137 012a  VIC M4308 SCSI Controller
 	004e  VIC 82 PCIe Upstream Port
 	0071  VIC SR-IOV VF
 	007a  VIC 1300 PCIe Upstream Port
-		1137 012a  VIC M4308 Dual 40Gb
-		1137 012c  VIC 1340 Dual 40Gb MLOM
-		1137 0137  VIC 1380 Dual 40Gb Mezzanine
-		1137 014d  VIC 1385 Dual 40Gb PCIe
 	00cf  VIC Userspace NIC
-		1137 004f  VIC 1280 Mezzanine Userspace NIC
-		1137 0084  VIC 1240 MLOM Userspace NIC
-		1137 0085  VIC 1225 PCIe Userspace NIC
-		1137 00cd  VIC 1285 PCIe Userspace NIC
-		1137 00ce  VIC 1225T PCIe Userspace NIC
-		1137 012a  VIC M4308 Userspace NIC
-		1137 012c  VIC 1340 MLOM Userspace NIC
-		1137 012e  VIC 1227 PCIe Userspace NIC
-		1137 0137  VIC 1380 Mezzanine Userspace NIC
 1138  Ziatech Corporation
 	8905  8905 [STD 32 Bridge]
 1139  Dynamic Pictures, Inc
@@ -12860,75 +6327,16 @@ var pciids = []byte(`#
 	f103  NinjaPATA-32 Delkin Cardbus UDMA
 1146  Force Computers
 1147  Interface Corp
-# Nee Schneider & Koch
 1148  SysKonnect
 	4000  FDDI Adapter
-		0e11 b03b  Netelligent 100 FDDI DAS Fibre SC
-		0e11 b03c  Netelligent 100 FDDI SAS Fibre SC
-		0e11 b03d  Netelligent 100 FDDI DAS UTP
-		0e11 b03e  Netelligent 100 FDDI SAS UTP
-		0e11 b03f  Netelligent 100 FDDI SAS Fibre MIC
-		1148 5521  FDDI SK-5521 (SK-NET FDDI-UP)
-		1148 5522  FDDI SK-5522 (SK-NET FDDI-UP DAS)
-		1148 5541  FDDI SK-5541 (SK-NET FDDI-FP)
-		1148 5543  FDDI SK-5543 (SK-NET FDDI-LP)
-		1148 5544  FDDI SK-5544 (SK-NET FDDI-LP DAS)
-		1148 5821  FDDI SK-5821 (SK-NET FDDI-UP64)
-		1148 5822  FDDI SK-5822 (SK-NET FDDI-UP64 DAS)
-		1148 5841  FDDI SK-5841 (SK-NET FDDI-FP64)
-		1148 5843  FDDI SK-5843 (SK-NET FDDI-LP64)
-		1148 5844  FDDI SK-5844 (SK-NET FDDI-LP64 DAS)
 	4200  Token Ring adapter
 	4300  SK-9872 Gigabit Ethernet Server Adapter (SK-NET GE-ZX dual link)
-		1148 9821  SK-9821 Gigabit Ethernet Server Adapter (SK-NET GE-T)
-		1148 9822  SK-9822 Gigabit Ethernet Server Adapter (SK-NET GE-T dual link)
-		1148 9841  SK-9841 Gigabit Ethernet Server Adapter (SK-NET GE-LX)
-		1148 9842  SK-9842 Gigabit Ethernet Server Adapter (SK-NET GE-LX dual link)
-		1148 9843  SK-9843 Gigabit Ethernet Server Adapter (SK-NET GE-SX)
-		1148 9844  SK-9844 Gigabit Ethernet Server Adapter (SK-NET GE-SX dual link)
-		1148 9861  SK-9861 Gigabit Ethernet Server Adapter (SK-NET GE-SX Volition)
-		1148 9862  SK-9862 Gigabit Ethernet Server Adapter (SK-NET GE-SX Volition dual link)
-		1148 9871  SK-9871 Gigabit Ethernet Server Adapter (SK-NET GE-ZX)
-		1148 9872  SK-9872 Gigabit Ethernet Server Adapter (SK-NET GE-ZX dual link)
-		1259 2970  AT-2970SX Gigabit Ethernet Adapter
-		1259 2971  AT-2970LX Gigabit Ethernet Adapter
-		1259 2972  AT-2970TX Gigabit Ethernet Adapter
-		1259 2973  AT-2971SX Gigabit Ethernet Adapter
-		1259 2974  AT-2971T Gigabit Ethernet Adapter
-		1259 2975  AT-2970SX/2SC Gigabit Ethernet Adapter
-		1259 2976  AT-2970LX/2SC Gigabit Ethernet Adapter
-		1259 2977  AT-2970TX/2TX Gigabit Ethernet Adapter
 	4320  SK-9871 V2.0 Gigabit Ethernet 1000Base-ZX Adapter, PCI64, Fiber ZX/SC
-		1148 0121  Marvell RDK-8001 Adapter
-		1148 0221  Marvell RDK-8002 Adapter
-		1148 0321  Marvell RDK-8003 Adapter
-		1148 0421  Marvell RDK-8004 Adapter
-		1148 0621  Marvell RDK-8006 Adapter
-		1148 0721  Marvell RDK-8007 Adapter
-		1148 0821  Marvell RDK-8008 Adapter
-		1148 0921  Marvell RDK-8009 Adapter
-		1148 1121  Marvell RDK-8011 Adapter
-		1148 1221  Marvell RDK-8012 Adapter
-		1148 3221  SK-9521 V2.0 10/100/1000Base-T Adapter
-		1148 5021  SK-9821 V2.0 Gigabit Ethernet 10/100/1000Base-T Adapter
-		1148 5041  SK-9841 V2.0 Gigabit Ethernet 1000Base-LX Adapter
-		1148 5043  SK-9843 V2.0 Gigabit Ethernet 1000Base-SX Adapter
-		1148 5051  SK-9851 V2.0 Gigabit Ethernet 1000Base-SX Adapter
-		1148 5061  SK-9861 V2.0 Gigabit Ethernet 1000Base-SX Adapter
-		1148 5071  SK-9871 V2.0 Gigabit Ethernet 1000Base-ZX Adapter
-		1148 9521  SK-9521 10/100/1000Base-T Adapter
 	4400  SK-9Dxx Gigabit Ethernet Adapter
 	4500  SK-9Mxx Gigabit Ethernet Adapter
 	9000  SK-9S21 10/100/1000Base-T Server Adapter, PCI-X, Copper RJ-45
 	9843  [Fujitsu] Gigabit Ethernet
 	9e00  SK-9E21D 10/100/1000Base-T Adapter, Copper RJ-45
-		1148 2100  SK-9E21 Server Adapter
-		1148 21d0  SK-9E21D 10/100/1000Base-T Adapter
-		1148 2200  SK-9E22 Server Adapter
-		1148 8100  SK-9E81 Server Adapter
-		1148 8200  SK-9E82 Server Adapter
-		1148 9100  SK-9E91 Server Adapter
-		1148 9200  SK-9E92 Server Adapter
 	9e01  SK-9E21M 10/100/1000Base-T Adapter
 1149  Win System Corporation
 114a  VMIC
@@ -12962,14 +6370,8 @@ var pciids = []byte(`#
 	001b  AccelePort C/X (IBM)
 	001c  AccelePort Xr (SAIP)
 	001d  DataFire RAS T1/E1/PRI
-		114f 0050  DataFire RAS E1 Adapter
-		114f 0051  DataFire RAS Dual E1 Adapter
-		114f 0052  DataFire RAS T1 Adapter
-		114f 0053  DataFire RAS Dual T1 Adapter
 	0023  AccelePort RAS
 	0024  DataFire RAS B4 ST/U
-		114f 0030  DataFire RAS BRI U Adapter
-		114f 0031  DataFire RAS BRI S/T Adapter
 	0026  AccelePort 4r 920
 	0027  AccelePort Xr 920
 	0028  ClassicBoard 4
@@ -12977,11 +6379,6 @@ var pciids = []byte(`#
 	0034  AccelePort 2r 920
 	0035  DataFire DSP T1/E1/PRI cPCI
 	0040  AccelePort Xp
-		114f 0042  AccelePort 2p PCI
-		114f 0043  AccelePort 4p PCI
-		114f 0044  AccelePort 8p PCI
-		114f 0045  AccelePort 16p PCI
-		114f 004e  AccelePort 32p PCI
 	0042  AccelePort 2p
 	0043  AccelePort 4p
 	0044  AccelePort 8p
@@ -13025,41 +6422,14 @@ var pciids = []byte(`#
 115c  Photron Ltd.
 115d  Xircom
 	0003  Cardbus Ethernet 10/100
-		1014 0181  10/100 EtherJet Cardbus Adapter
-		1014 1181  10/100 EtherJet Cardbus Adapter
-		1014 8181  10/100 EtherJet Cardbus Adapter
-		1014 9181  10/100 EtherJet Cardbus Adapter
-		115d 0181  Cardbus Ethernet 10/100
-		115d 0182  RealPort2 CardBus Ethernet 10/100 (R2BE-100)
-		115d 1181  Cardbus Ethernet 10/100
-		1179 0181  Cardbus Ethernet 10/100
-		8086 8181  EtherExpress PRO/100 Mobile CardBus 32 Adapter
-		8086 9181  EtherExpress PRO/100 Mobile CardBus 32 Adapter
 	0005  Cardbus Ethernet 10/100
-		1014 0182  10/100 EtherJet Cardbus Adapter
-		1014 1182  10/100 EtherJet Cardbus Adapter
-		115d 0182  Cardbus Ethernet 10/100
-		115d 1182  Cardbus Ethernet 10/100
 	0007  Cardbus Ethernet 10/100
-		1014 0182  10/100 EtherJet Cardbus Adapter
-		1014 1182  10/100 EtherJet Cardbus Adapter
-		115d 0182  Cardbus Ethernet 10/100
-		115d 1182  Cardbus Ethernet 10/100
 	000b  Cardbus Ethernet 10/100
-		1014 0183  10/100 EtherJet Cardbus Adapter
-		115d 0183  Cardbus Ethernet 10/100
 	000c  Mini-PCI V.90 56k Modem
 	000f  Cardbus Ethernet 10/100
-		1014 0183  10/100 EtherJet Cardbus Adapter
-		115d 0183  Cardbus Ethernet 10/100
 	00d4  Mini-PCI K56Flex Modem
 	0101  Cardbus 56k modem
-		115d 1081  Cardbus 56k Modem
 	0103  Cardbus Ethernet + 56k Modem
-		1014 9181  Cardbus 56k Modem
-		1115 1181  Cardbus Ethernet 100 + 56k Modem
-		115d 1181  CBEM56G-100 Ethernet + 56k Modem
-		8086 9181  PRO/100 LAN + Modem56 CardBus
 115e  Peer Protocols Inc
 115f  Maxtor Corporation
 1160  Megasoft Inc
@@ -13068,11 +6438,9 @@ var pciids = []byte(`#
 1163  Rendition
 	0001  Verite 1000
 	2000  Verite V2000/V2100/V2200
-		1092 2000  Stealth II S220
 1164  Advanced Peripherals Technologies
 1165  Imagraph Corporation
 	0001  Motion TPEG Recorder/Player with audio
-# nee ServerWorks
 1166  Broadcom
 	0000  CMIC-LE
 	0005  CNB20-LE Host Bridge
@@ -13096,60 +6464,37 @@ var pciids = []byte(`#
 	0110  CIOB-E I/O Bridge with Gigabit Ethernet
 	0130  BCM5780 [HT2000] PCI-X bridge
 	0132  BCM5780 [HT2000] PCI-Express Bridge
-		1166 0132  HT2000 PCI-Express bridge
 	0140  HT2100 PCI-Express Bridge
 	0141  HT2100 PCI-Express Bridge
 	0142  HT2100 PCI-Express Bridge
 	0144  HT2100 PCI-Express Bridge
 	0200  OSB4 South Bridge
 	0201  CSB5 South Bridge
-		4c53 1080  CT8 mainboard
 	0203  CSB6 South Bridge
-		1734 1012  PRIMERGY RX/TX series
 	0205  BCM5785 [HT1000] Legacy South Bridge
 	0211  OSB4 IDE Controller
 	0212  CSB5 IDE Controller
-		1028 014a  PowerEdge 1750
-		1028 810b  PowerEdge 1650/2550
-		4c53 1080  CT8 mainboard
 	0213  CSB6 RAID/IDE Controller
-		1028 4134  PowerEdge 600SC
-		1028 c134  Poweredge SC600
-		1734 1012  PRIMERGY RX/TX series onboard IDE
 	0214  BCM5785 [HT1000] IDE
-		1028 0205  PowerEdge 2970 HT1000 IDE
 	0217  CSB6 IDE Controller
-		1028 4134  Poweredge SC600
 	021b  HT1100 HD Audio
 	0220  OSB4/CSB5 OHCI USB Controller
-		4c53 1080  CT8 mainboard
 	0221  CSB6 OHCI USB Controller
-		1734 1012  PRIMERGY RX/TX series onboard OHCI
 	0223  BCM5785 [HT1000] USB
-		1028 0205  PowerEdge 2970 HT1000 USB Controller
-		1028 020b  PowerEdge T605 HT1000 USB Controller
 	0225  CSB5 LPC bridge
 	0227  GCLE-2 Host Bridge
-		1734 1012  PRIMERGY RX/TX series
 	0230  CSB5 LPC bridge
-		4c53 1080  CT8 mainboard
 	0234  BCM5785 [HT1000] LPC
-		1028 0205  PowerEdge 2970 HT1000 LPC
-		1028 020b  PowerEdge T605 HT1000 LPC
 	0235  BCM5785 [HT1000] XIOAPIC0-2
 	0238  BCM5785 [HT1000] WDTimer
 	0240  K2 SATA
 	0241  RAIDCore RC4000
 	0242  RAIDCore BC4000
 	024a  BCM5785 [HT1000] SATA (Native SATA Mode)
-		1028 020b  PowerEdge T605 onboard SATA Controller
-# The device starts as 024A, and changes to 024B if set to PATA mode in BIOS
 	024b  BCM5785 [HT1000] SATA (PATA/IDE Mode)
-		1028 0205  PowerEdge 2970 HT1000 SATA controller
 	0406  HT1100 PCI-X Bridge
 	0408  HT1100 Legacy Device
 	040a  HT1100 ISA-LPC Bridge
-		1028 0223  PowerEdge R905 HT1100 ISA-LPC Bridge
 	0410  HT1100 SATA Controller (Native SATA Mode)
 	0411  HT1100 SATA Controller (PATA / IDE Mode)
 	0412  HT1100 USB OHCI Controller
@@ -13161,7 +6506,6 @@ var pciids = []byte(`#
 1167  Mutoh Industries Inc
 1168  Thine Electronics Inc
 1169  Centre for Development of Advanced Computing
-# nee Polaris Communications
 116a  Luminex Software, Inc.
 	6100  Bus/Tag Channel
 	6800  Escon Channel
@@ -13190,14 +6534,11 @@ var pciids = []byte(`#
 	0406  Tecra Video Capture device
 	0407  DVD Decoder card (Version 2)
 	0601  CPU to PCI bridge
-		1179 0001  Satellite Pro
 	0602  PCI to ISA bridge
 	0603  ToPIC95 PCI to CardBus Bridge for Notebooks
 	0604  PCI-Docking Host bridge
 	060a  ToPIC95
-		1179 0001  Satellite Pro
 	060f  ToPIC97
-		1179 0001  Satellite 4010
 	0617  ToPIC100 PCI to Cardbus Bridge with ZV Support
 	0618  CPU to PCI and PCI to ISA bridge
 	0701  FIR Port Type-O
@@ -13205,17 +6546,12 @@ var pciids = []byte(`#
 	0804  TC6371AF SmartMedia Controller
 	0805  SD TypA Controller
 	0d01  FIR Port Type-DO
-		1179 0001  FIR Port Type-DO
 117a  A-Trend Technology
 117b  L G Electronics, Inc.
 117c  ATTO Technology, Inc.
 	002c  ExpressSAS R380
 	002d  ExpressSAS R348
 	0030  Ultra320 SCSI Host Adapter
-		117c 8013  ExpressPCI UL4D
-		117c 8014  ExpressPCI UL4S
-		117c 8027  ExpressPCI UL5D
-		117c 802f  ExpressPCI UL5D Low Profile
 	0033  SAS Adapter
 	0041  ExpressSAS R30F
 	8013  ExpressPCI UL4D
@@ -13228,128 +6564,28 @@ var pciids = []byte(`#
 	0465  RL5c465
 	0466  RL5c466
 	0475  RL5c475
-		144d c006  vpr Matrix 170B4 CardBus bridge
 	0476  RL5c476 II
-		1014 0185  ThinkPad A/T/X Series
-		1014 0555  ThinkPad X41
-		1014 056c  ThinkPad Z60t
-		1028 014f  Latitude X300 laptop
-		1028 0188  Inspiron 6000 laptop
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		1043 1237  A6J-Q008
-		1043 1967  V6800V
-		1043 1987  A4K and Z81K notebooks, possibly others ( mid-2005 machines )
-		104d 80df  Vaio PCG-FX403
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		104d 814e  VAIO GRZ390Z
-		10f7 8338  Panasonic CF-Y5 laptop
-		144d c005  X10 Laptop
-		144d c00c  P30/P35 notebook
-		14ef 0220  PCD-RP-220S
-		17aa 201c  ThinkPad X60/X60s
-		17aa 20c4  ThinkPad T61/R61
-		17aa 20c6  ThinkPad R61
 	0477  RL5c477
 	0478  RL5c478
-		1014 0184  ThinkPad A30p
 	0511  R5C511
 	0522  R5C522 IEEE 1394 Controller
-		1014 01cf  ThinkPad A30p
-		1043 1967  V6800V
 	0551  R5C551 IEEE 1394 Controller
-		144d c006  vpr Matrix 170B4
 	0552  R5C552 IEEE 1394 Controller
-		1014 0511  ThinkPad A/T/X Series
-		1028 014f  Latitude X300 laptop
-		1028 0188  Inspiron 6000 laptop
-		1043 1237  A6J-Q008
-		1043 1757  M2400N laptop
-		144d c005  X10 Laptop
-		144d c00c  P30/P35 notebook
-		17aa 201e  ThinkPad X60/X60s
 	0554  R5C554
 	0575  R5C575 SD Bus Host Adapter
 	0576  R5C576 SD Bus Host Adapter
 	0592  R5C592 Memory Stick Bus Host Adapter
-		1025 0121  Aspire 5920G
-		1028 01d7  XPS M1210
-		1028 01f3  Inspiron 1420
-		103c 30b5  Presario V3242AU
-		103c 30b7  Presario V6133CL
-		103c 30cc  Pavilion dv6700
-		103c 30cf  Pavilion dv95xx/96xx/97xx/98xx series
-		1043 1237  A6J-Q008
-		1043 1967  V6800V
-		144d c018  X20 IV
-		17aa 20ca  ThinkPad T61
 	0811  R5C811
 	0822  R5C822 SD/SDIO/MMC/MS/MSPro Host Adapter
-		1014 0556  ThinkPad X40 / X41 / X60s / Z60t
-		1014 0598  ThinkPad Z60m
-		1025 0121  Aspire 5920G
-		1028 0188  Inspiron 6000 laptop
-		1028 01a2  Inspiron 9200
-		1028 01d7  XPS M1210
-		1028 01f3  Inspiron 1420
-		103c 03b5  Presario V3242AU
-		103c 30b7  Presario V6133CL
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30cf  Pavilion dv9668eg Laptop
-		1043 1237  A6J-Q008
-		1043 1967  V6800V
-		10f7 8338  Panasonic CF-Y5 laptop
-		144d c018  X20 IV
-		17aa 201d  ThinkPad X60/X60s
-		17aa 20c7  ThinkPad T61
-		17aa 20c8  ThinkPad W500
 	0832  R5C832 IEEE 1394 Controller
-		1025 0121  Aspire 5920G
-		1028 01d7  XPS M1210
-		1028 01f3  Inspiron 1420
-		1028 024d  Latitude E4300
-		103c 30b5  Presario V3242AU
-		103c 30b7  Presario V6133CL
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30cf  Pavilion dv9668eg Laptop
-		17aa 20c5  ThinkPad R61
-		17aa 20c7  ThinkPad R61
 	0841  R5C841 CardBus/SD/SDIO/MMC/MS/MSPro/xD/IEEE1394
 	0843  R5C843 MMC Host Controller
-		1025 0121  Aspire 5920G
-		1028 01d7  XPS M1210
-		1028 01f3  Inspiron 1420
-		1028 01f5  Inspiron 1501
-		1028 024f  Latitude e6500
-		103c 03b5  Presario V3242AU
-		103c 30b7  Presario V6133CL
-		103c 30cf  Pavilion dv9500/9600/9700 series
-		1183 0843  Alienware Aurora m9700
 	0852  xD-Picture Card Controller
-		1025 0121  Aspire 5920G
-		1028 01f3  Inspiron 1420
-		103c 30b5  Presario V3242AU
-		103c 30b7  Presario V6133CL
-		103c 30cc  Pavilion dv6700
-		103c 30cf  Pavilion dv9668eg Laptop
-		1043 1967  V6800V
-		1180 0852  Pavilion 2410us
-		1324 10cf  P7120
 	e230  R5U2xx (R5U230 / R5U231 / R5U241) [Memory Stick Host Controller]
 	e476  CardBus bridge
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
 	e822  MMC/SD Host Controller
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
 	e823  PCIe SDXC/MMC Host Controller
-		17aa 21cf  ThinkPad T520
 	e832  R5C832 PCIe IEEE 1394 Controller
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		17aa 21cf  ThinkPad T520
 	e852  PCIe xD-Picture Card Controller
 1181  Telmatics International
 1183  Fujikura Ltd
@@ -13357,39 +6593,27 @@ var pciids = []byte(`#
 1185  Dataworld International Ltd
 1186  D-Link System Inc
 	1002  DL10050 Sundance Ethernet
-		1186 1002  DFE-550TX/FX
-		1186 1012  DFE-580TX
 	1025  AirPlus Xtreme G DWL-G650 Adapter
 	1026  AirXpert DWL-AG650 Wireless Cardbus Adapter
 	1043  AirXpert DWL-AG650 Wireless Cardbus Adapter
 	1300  RTL8139 Ethernet
-		1186 1300  DFE-538TX 10/100 Ethernet Adapter
-		1186 1301  DFE-530TX+ 10/100 Ethernet Adapter
-		1186 1303  DFE-528TX 10/100 Fast Ethernet PCI Adapter
 	1340  DFE-690TXD CardBus PC Card
 	1540  DFE-680TX
 	1541  DFE-680TXD CardBus PC Card
 	1561  DRP-32TXD Cardbus PC Card
 	3300  DWL-510 / DWL-610 802.11b [Realtek RTL8180L]
-		1186 3300  DWL-610 Wireless Cardbus Adapter
-		1186 3301  DWL-510 Wireless PCI Adapter
 	3a10  AirXpert DWL-AG650 Wireless Cardbus Adapter(rev.B)
 	3a11  AirXpert DWL-AG520 Wireless PCI Adapter(rev.B)
 	4000  DL2000-based Gigabit Ethernet
 	4001  DGE-550SX PCI-X Gigabit Ethernet Adapter
 	4200  DFE-520TX Fast Ethernet PCI Adapter
-		1186 1103  DFE-520TX Fast Ethernet PCI Adapter (rev. C1)
 	4300  DGE-528T Gigabit Ethernet Adapter
-		1186 4300  DGE-528T PCI Gigabit Ethernet Adapter
-# rev. B1; RealTek RTL8168E.
-		1186 4b10  DGE-560T PCI Express (x1) Gigabit Ethernet Adapter
 	4302  DGE-530T Gigabit Ethernet Adapter (rev.C1) [Realtek RTL8169]
 	4b00  DGE-560T PCI Express Gigabit Ethernet Adapter
 	4b01  DGE-530T Gigabit Ethernet Adapter (rev 11)
 	4b02  DGE-560SX PCI Express Gigabit Ethernet Adapter
 	4b03  DGE-550T Gigabit Ethernet Adapter V.B1
 	4c00  Gigabit Ethernet Adapter
-		1186 4c00  DGE-530T Gigabit Ethernet Adapter
 	8400  D-Link DWL-650+ CardBus PC Card
 1187  Advanced Technology Laboratories, Inc.
 1188  Shima Seiki Manufacturing Ltd.
@@ -13477,27 +6701,17 @@ var pciids = []byte(`#
 11a9  InnoSys Inc.
 	4240  AMCC S933Q Intelligent Serial Card
 11aa  Actel
-# Nee Galileo Technology, Inc.
 11ab  Marvell Technology Group Ltd.
 	0146  GT-64010/64010A System Controller
 	0f53  88E6318 Link Street network controller
 	11ab  MV88SE614x SATA II PCI-E controller
 	138f  W8300 802.11 Adapter (rev 07)
 	1fa6  Marvell W8300 802.11 Adapter
-		1186 3b08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.A1)
 	1fa7  88W8310 and 88W8000G [Libertas] 802.11g client chipset
 	1faa  88w8335 [Libertas] 802.11b/g Wireless
-		1385 4e00  WG511v2 54 Mbps Wireless PC Card
-		1385 6b00  WG311v3 802.11g Wireless PCI Adapter
-		1737 0040  WPC54G v5 802.11g Wireless-G Notebook Adapter
 	2211  88SB2211 PCI Express to PCI Bridge
 	2a01  88W8335 [Libertas] 802.11b/g Wireless
 	2a02  88W8361 [TopDog] 802.11n Wireless
-		07d1 3b02  DIR-615 rev. A1 Mini PCI Wireless Module
-		1385 7c00  WN511T RangeMax Next 300 Mbps Wireless PC Card
-		1385 7c01  WN511T RangeMax Next 300 Mbps Wireless Notebook Adapter
-		1385 7e00  WN311T RangeMax Next 300 Mbps Wireless PCI Adapter
-		1799 801b  F5D8011 v2 802.11n N1 Wireless Notebook Card
 	2a08  88W8362e [TopDog] 802.11a/b/g/n Wireless
 	2a0a  88W8363 [TopDog] 802.11n Wireless
 	2a0c  88W8363 [TopDog] 802.11n Wireless
@@ -13514,24 +6728,6 @@ var pciids = []byte(`#
 	2b40  88W8964 [Avastar] 802.11ac Wireless
 	4101  OLPC Cafe Controller Secure Digital Controller
 	4320  88E8001 Gigabit Ethernet Controller
-		1019 0f38  Marvell 88E8001 Gigabit Ethernet Controller (ECS)
-		1019 8001  Marvell 88E8001 Gigabit Ethernet Controller (ECS)
-		1043 173c  Marvell 88E8001 Gigabit Ethernet Controller (Asus)
-		1043 811a  Marvell 88E8001 Gigabit Ethernet Controller (Asus)
-		105b 0c19  Marvell 88E8001 Gigabit Ethernet Controller (Foxconn)
-		10b8 b452  EZ Card 1000 (SMC9452TXV.2)
-		11ab 0121  Marvell RDK-8001
-		11ab 0321  Marvell RDK-8003
-		11ab 1021  Marvell RDK-8010
-		11ab 4320  Marvell Yukon Gigabit Ethernet 10/100/1000Baset-T Constroller (Asus)
-		11ab 5021  Marvell Yukon Gigabit Ethernet 10/100/1000Base-T Controller (64 bit)
-		11ab 9521  Marvell Yukon Gigabit Ethernet 10/100/1000Base-T Controller (32 bit)
-		1458 e000  Marvell 88E8001 Gigabit Ethernet Controller (Gigabyte)
-		147b 1406  Marvell 88E8001 Gigabit Ethernet Controller (Abit)
-		15d4 0047  Marvell 88E8001 Gigabit Ethernet Controller (Iwill)
-		1695 9025  Marvell 88E8001 Gigabit Ethernet Controller (Epox)
-		17f2 1c03  Marvell 88E8001 Gigabit Ethernet Controller (Albatron)
-		270f 2803  Marvell 88E8001 Gigabit Ethernet Controller (Chaintech)
 	4340  88E8021 PCI-X IPMI Gigabit Ethernet Controller
 	4341  88E8022 PCI-X IPMI Gigabit Ethernet Controller
 	4342  88E8061 PCI-E IPMI Gigabit Ethernet Controller
@@ -13540,125 +6736,31 @@ var pciids = []byte(`#
 	4345  88E8022 PCI-X IPMI Gigabit Ethernet Controller
 	4346  88E8061 PCI-E IPMI Gigabit Ethernet Controller
 	4347  88E8062 PCI-E IPMI Gigabit Ethernet Controller
-		4c53 10d0  Telum ASLP10 PrAMC Gigabit Ethernet
 	4350  88E8035 PCI-E Fast Ethernet Controller
-		1179 0001  Marvell 88E8035 Fast Ethernet Controller (Toshiba)
-		11ab 3521  Marvell RDK-8035
-		1854 000d  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 000e  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 000f  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 0011  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 0012  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 0016  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 0017  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 0018  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 0019  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 001c  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 001e  Marvell 88E8035 Fast Ethernet Controller (LGE)
-		1854 0020  Marvell 88E8035 Fast Ethernet Controller (LGE)
 	4351  88E8036 PCI-E Fast Ethernet Controller
-		107b 4009  Marvell 88E8036 Fast Ethernet Controller (Wistron)
-		10f7 8338  Marvell 88E8036 Fast Ethernet Controller (Panasonic)
-		1179 0001  Marvell 88E8036 Fast Ethernet Controller (Toshiba)
-		1179 ff00  Marvell 88E8036 Fast Ethernet Controller (Compal)
-		1179 ff10  Marvell 88E8036 Fast Ethernet Controller (Inventec)
-		11ab 3621  Marvell RDK-8036
-		13d1 ac12  Abocom EFE3K - 10/100 Ethernet Expresscard
-		161f 203d  Marvell 88E8036 Fast Ethernet Controller (Arima)
-		1854 000d  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 000e  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 000f  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 0011  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 0012  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 0016  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 0017  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 0018  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 0019  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 001c  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 001e  Marvell 88E8036 Fast Ethernet Controller (LGE)
-		1854 0020  Marvell 88E8036 Fast Ethernet Controller (LGE)
 	4352  88E8038 PCI-E Fast Ethernet Controller
 	4353  88E8039 PCI-E Fast Ethernet Controller
-		104d 902d  VAIO VGN-NR120E
 	4354  88E8040 PCI-E Fast Ethernet Controller
-		144d c06a  R730 Laptop
-		144d c072  Notebook N150P
 	4355  88E8040T PCI-E Fast Ethernet Controller
-		1179 ff50  Satellite P305D-S8995E
 	4356  88EC033 PCI-E Fast Ethernet Controller
 	4357  88E8042 PCI-E Fast Ethernet Controller
 	435a  88E8048 PCI-E Fast Ethernet Controller
 	4360  88E8052 PCI-E ASF Gigabit Ethernet Controller
-		1043 8134  Marvell 88E8052 Gigabit Ethernet Controller (Asus)
-		107b 4009  Marvell 88E8052 Gigabit Ethernet Controller (Wistron)
-		11ab 5221  Marvell RDK-8052
-		1458 e000  Marvell 88E8052 Gigabit Ethernet Controller (Gigabyte)
-		1462 052c  Marvell 88E8052 Gigabit Ethernet Controller (MSI)
-		1849 8052  Marvell 88E8052 Gigabit Ethernet Controller (ASRock)
-		a0a0 0509  Marvell 88E8052 Gigabit Ethernet Controller (Aopen)
 	4361  88E8050 PCI-E ASF Gigabit Ethernet Controller
-		107b 3015  Marvell 88E8050 Gigabit Ethernet Controller (Gateway)
-		11ab 5021  Marvell 88E8050 Gigabit Ethernet Controller (Intel)
-		8086 3063  D925XCVLK mainboard
-		8086 3439  Marvell 88E8050 Gigabit Ethernet Controller (Intel)
 	4362  88E8053 PCI-E Gigabit Ethernet Controller
-		103c 2a0d  Marvell 88E8053 Gigabit Ethernet Controller (Asus)
-		1043 8142  Marvell 88E8053 Gigabit Ethernet controller PCIe (Asus)
-		109f 3197  Marvell 88E8053 Gigabit Ethernet Controller (Trigem)
-		10f7 8338  Marvell 88E8053 Gigabit Ethernet Controller (Panasonic)
-		10fd a430  Marvell 88E8053 Gigabit Ethernet Controller (SOYO)
-		1179 0001  Marvell 88E8053 Gigabit Ethernet Controller (Toshiba)
-		1179 ff00  Marvell 88E8053 Gigabit Ethernet Controller (Compal)
-		1179 ff10  Marvell 88E8053 Gigabit Ethernet Controller (Inventec)
-		11ab 5321  Marvell RDK-8053
-		1297 c240  Marvell 88E8053 Gigabit Ethernet Controller (Shuttle)
-		1297 c241  Marvell 88E8053 Gigabit Ethernet Controller (Shuttle)
-		1297 c242  Marvell 88E8053 Gigabit Ethernet Controller (Shuttle)
-		1297 c243  Marvell 88E8053 Gigabit Ethernet Controller (Shuttle)
-		1297 c244  Marvell 88E8053 Gigabit Ethernet Controller (Shuttle)
-		13d1 ac11  EGE5K - Giga Ethernet Expresscard
-		1458 e000  Marvell 88E8053 Gigabit Ethernet Controller (Gigabyte)
-		1462 058c  Marvell 88E8053 Gigabit Ethernet Controller (MSI)
-		14c0 0012  Marvell 88E8053 Gigabit Ethernet Controller (Compal)
-		1558 04a0  Marvell 88E8053 Gigabit Ethernet Controller (Clevo)
-		15bd 1003  Marvell 88E8053 Gigabit Ethernet Controller (DFI)
-		161f 203c  Marvell 88E8053 Gigabit Ethernet Controller (Arima)
-		161f 203d  Marvell 88E8053 Gigabit Ethernet Controller (Arima)
-		1695 9029  Marvell 88E8053 Gigabit Ethernet Controller (Epox)
-		17f2 2c08  Marvell 88E8053 Gigabit Ethernet Controller (Albatron)
-		17ff 0585  Marvell 88E8053 Gigabit Ethernet Controller (Quanta)
-		1849 8053  Marvell 88E8053 Gigabit Ethernet Controller (ASRock)
-		1854 000b  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 000c  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 0010  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 0013  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 0014  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 0015  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 001a  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 001b  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 001d  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 001f  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 0021  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		1854 0022  Marvell 88E8053 Gigabit Ethernet Controller (LGE)
-		270f 2801  Marvell 88E8053 Gigabit Ethernet Controller (Chaintech)
-		a0a0 0506  Marvell 88E8053 Gigabit Ethernet Controller (Aopen)
 	4363  88E8055 PCI-E Gigabit Ethernet Controller
 	4364  88E8056 PCI-E Gigabit Ethernet Controller
-		1043 81f8  Motherboard
-		11ba 00ba  8056 Gigabit Ethernet Controller
 	4365  88E8070 based Ethernet Controller
 	4366  88EC036 PCI-E Gigabit Ethernet Controller
 	4367  88EC032 Ethernet Controller
 	4368  88EC034 Ethernet Controller
 	4369  88EC042 Ethernet Controller
 	436a  88E8058 PCI-E Gigabit Ethernet Controller
-		11ab 00ba  Imac 8,1 Wired Ethernet Adapter
 	436b  88E8071 PCI-E Gigabit Ethernet Controller
 	436c  88E8072 PCI-E Gigabit Ethernet Controller
 	436d  88E8055 PCI-E Gigabit Ethernet Controller
 	4370  88E8075 PCI-E Gigabit Ethernet Controller
 	4380  88E8057 PCI-E Gigabit Ethernet Controller
-# AVB = "Audio Video Bridging"
 	4381  Yukon Optima 88E8059 [PCIe Gigabit Ethernet Controller with AVB]
 	4611  GT-64115 System Controller
 	4620  GT-64120/64120A/64121A System Controller
@@ -13675,7 +6777,6 @@ var pciids = []byte(`#
 	6042  88SX6042 PCI-X 4-Port SATA-II
 	6081  MV88SX6081 8-port SATA II PCI-X Controller
 	6101  88SE6101/6102 single-port PATA133 interface
-		1043 82e0  P5K PRO Motherboard
 	6111  88SE6111 1-port PATA133(IDE) and 1-port SATA II Controllers
 	6121  88SE6121 SATA II / PATA Controller
 	6141  88SE614x SATA II PCI-E controller
@@ -13683,16 +6784,13 @@ var pciids = []byte(`#
 	6180  88F6180 [Kirkwood] ARM SoC
 	6192  88F6190/6192 [Kirkwood] ARM SoC
 	6281  88F6281 [Kirkwood] ARM SoC
-# This device ID was used for earlier chips.
 	6381  MV78xx0 [Discovery Innovation] ARM SoC
 	6440  88SE6440 SAS/SATA PCIe controller
 	6450  64560 System Controller
 	6460  MV64360/64361/64362 System Controller
 	6480  MV64460/64461/64462 System Controller
-		1775 c200  C2K CompactPCI single board computer
 	6485  MV64460/64461/64462 System Controller, Revision B
 	7042  88SX7042 PCI-e 4-port SATA-II
-		16b8 434b  Tempo SATA E4P
 	7810  MV78100 [Discovery Innovation] ARM SoC
 	7820  MV78200 [Discovery Innovation] ARM SoC
 	7823  MV78230 [Armada XP] ARM SoC
@@ -13701,15 +6799,7 @@ var pciids = []byte(`#
 11ac  Canon Information Systems Research Aust.
 11ad  Lite-On Communications Inc
 	0002  LNE100TX
-		11ad 0002  LNE100TX
-		11ad 0003  LNE100TX
-		11ad f003  LNE100TX
-		11ad ffff  LNE100TX
-		1385 f004  FA310TX
-		2646 f002  KNE110TX EtheRx Fast Ethernet
 	c115  LNE100TX [Linksys EtherFast 10/100]
-		11ad c001  LNE100TX [ver 2.0]
-		2646 000b  KNE111TX
 11ae  Aztech System Ltd
 11af  Avid Technology Inc.
 	0001  Cinema
@@ -13738,110 +6828,31 @@ var pciids = []byte(`#
 11bd  Pinnacle Systems Inc.
 	002e  PCTV 40i
 	0040  Royal TS Function 1
-		11bd 0044  PCTV 2000i Dual DVB-T Pro PCI Tuner 1
-		11bd 0045  PCTV Dual Sat Pro PCI 4000i Tuner 1
 	0041  RoyalTS Function 2
-		11bd 0044  PCTV 2000i Dual DVB-T Pro PCI Tuner 2
-		11bd 0045  PCTV Dual Sat Pro PCI 4000i Tuner 2
 	0042  Royal TS Function 3
-		11bd 0044  PCTV 2000i Dual DVB-T Pro PCI Common
-		11bd 0045  PCTV Dual Sat Pro PCI 4000i Common
 	0051  PCTV HD 800i
 	bede  AV/DV Studio Capture Card
 11be  International Microcircuits Inc
 11bf  Astrodesign, Inc.
 11c0  Hewlett Packard
-# nee Agere Systems nee Lucent Microelectronics
 11c1  LSI Corporation
 	0440  56k WinModem
-		1033 8015  LT WinModem 56k Data+Fax+Voice+Dsvd
-		1033 8047  LT WinModem 56k Data+Fax+Voice+Dsvd
-		1033 804f  LT WinModem 56k Data+Fax+Voice+Dsvd
-		10cf 102c  LB LT Modem V.90 56k
-		10cf 104a  BIBLO LT Modem 56k
-		10cf 105f  LB2 LT Modem V.90 56k
-		1179 0001  Internal V.90 Modem
-		11c1 0440  LT WinModem 56k Data+Fax+Voice+Dsvd
-		122d 4101  MDP7800-U Modem
-		122d 4102  MDP7800SP-U Modem
-		13e0 0040  LT WinModem 56k Data+Fax+Voice+Dsvd
-		13e0 0440  LT WinModem 56k Data+Fax+Voice+Dsvd
-		13e0 0441  LT WinModem 56k Data+Fax+Voice+Dsvd
-		13e0 0450  LT WinModem 56k Data+Fax+Voice+Dsvd
-		13e0 f100  LT WinModem 56k Data+Fax+Voice+Dsvd
-		13e0 f101  LT WinModem 56k Data+Fax+Voice+Dsvd
-		144d 2101  LT56PV Modem
-		149f 0440  LT WinModem 56k Data+Fax+Voice+Dsvd
 	0441  56k WinModem
-		1033 804d  LT WinModem 56k Data+Fax
-		1033 8065  LT WinModem 56k Data+Fax
-		1092 0440  Supra 56i
-		1179 0001  Internal V.90 Modem
-		11c1 0440  LT WinModem 56k Data+Fax
-		11c1 0441  LT WinModem 56k Data+Fax
-		122d 4100  MDP7800-U Modem
-		13e0 0040  LT WinModem 56k Data+Fax
-		13e0 0100  LT WinModem 56k Data+Fax
-		13e0 0410  LT WinModem 56k Data+Fax
-		13e0 0420  TelePath Internet 56k WinModem
-		13e0 0440  LT WinModem 56k Data+Fax
-		13e0 0443  LT WinModem 56k Data+Fax
-		13e0 f102  LT WinModem 56k Data+Fax
-		1416 9804  CommWave 56k Modem
-		141d 0440  LT WinModem 56k Data+Fax
-		144f 0441  Lucent 56k V.90 DF Modem
-		144f 0449  Lucent 56k V.90 DF Modem
-		144f 110d  Lucent Win Modem
-		1468 0441  Presario 56k V.90 DF Modem
-		1668 0440  Lucent Win Modem
 	0442  56k WinModem
-		11c1 0440  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		11c1 0442  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		13e0 0412  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		13e0 0442  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		13fc 2471  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		144d 2104  LT56PT Modem
-		144f 1104  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		149f 0440  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		1668 0440  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
 	0443  LT WinModem
 	0444  LT WinModem
 	0445  LT WinModem
-		8086 2203  PRO/100+ MiniPCI (probably an Ambit U98.003.C.00 combo card)
-		8086 2204  PRO/100+ MiniPCI on Armada E500
 	0446  LT WinModem
 	0447  LT WinModem
 	0448  WinModem 56k
-		1014 0131  Lucent Win Modem
-		1033 8066  LT WinModem 56k Data+Fax+Voice+Dsvd
-		13e0 0030  56k Voice Modem
-		13e0 0040  LT WinModem 56k Data+Fax+Voice+Dsvd
-# Actiontech eth+modem card as used by Dell &c.
-		1668 2400  LT WinModem 56k (MiniPCI Ethernet+Modem)
 	0449  L56xM+S [Mars-2] WinModem 56k
-		0e11 b14d  56k V.90 Modem
-		1014 018c  ThinkPad 600X
-		13e0 0020  LT WinModem 56k Data+Fax
-		13e0 0041  TelePath Internet 56k WinModem
-		1436 0440  Lucent Win Modem
-		144f 0449  Lucent 56k V.90 DFi Modem
-		1468 0410  IBM ThinkPad T23
-		1468 0440  Lucent Win Modem
-		1468 0449  Presario 56k V.90 DFi Modem
 	044a  F-1156IV WinModem (V90, 56KFlex)
-		10cf 1072  LB Global LT Modem
-		13e0 0012  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		13e0 0042  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
-		144f 1005  LT WinModem 56k Data+Fax+Voice+VoiceView+Dsvd
 	044b  LT WinModem
 	044c  LT WinModem
 	044d  LT WinModem
 	044e  LT WinModem
 	044f  V90 WildWire Modem
 	0450  LT WinModem
-		1033 80a8  Versa Note Vxi
-		144f 4005  Magnia SG20
-		1468 0450  Evo N600c
 	0451  LT WinModem
 	0452  LT WinModem
 	0453  LT WinModem
@@ -13857,7 +6868,6 @@ var pciids = []byte(`#
 	0462  V90 WildWire Modem
 	0480  Venus Modem (V90, 56KFlex)
 	048c  V.92 56K WinModem
-# InPorte Home Internal 56k Modem/fax/answering machine/SMS Features
 	048f  V.92 56k WinModem
 	0620  Lucent V.92 Data/Fax Modem
 	2600  StarPro26XX family (SP2601, SP2603, SP2612) DSP
@@ -13867,29 +6877,14 @@ var pciids = []byte(`#
 	5802  USS-312 USB Controller
 	5803  USS-344S USB Controller
 	5811  FW322/323 [TrueFire] 1394a Controller
-		103c 2a34  Pavilion a1677c
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		103c 2a9e  Pavilion p6310f
-		1043 8294  LSI FW322/323 IEEE 1394a FireWire Controller
-		8086 524c  D865PERL mainboard
-		dead 0800  FireWire Host Bus Adapter
 	5901  FW643 [TrueFire] PCIe 1394b Controller
-		11c1 5900  FW643 [TrueFire] PCIe 1394b Controller
-		1443 0643  FireBoard800-e V.2
-		1546 0643  FWB-PCIE1X2x
 	5903  FW533 [TrueFire] PCIe 1394a Controller
 	8110  T8110 H.100/H.110 TDM switch
-		12d9 000c  E1/T1 PMXc cPCI carrier card
 	ab10  WL60010 Wireless LAN MAC
 	ab11  WL60040 Multimode Wireles LAN MAC
-		11c1 ab12  WaveLAN 11abg Cardbus card (Model 1102)
-		11c1 ab13  WaveLAN 11abg MiniPCI card (Model 0512)
-		11c1 ab15  WaveLAN 11abg Cardbus card (Model 1106)
-		11c1 ab16  WaveLAN 11abg MiniPCI card (Model 0516)
 	ab20  ORiNOCO PCI Adapter
 	ab21  Agere Wireless PCI Adapter
 	ab30  Hermes2 Mini-PCI WaveLAN a/b/g
-		14cd 2012  Hermes2 Mini-PCI WaveLAN a/b/g
 	ed00  ET-131x PCI-E Ethernet Controller
 	ed01  ET-131x PCI-E Ethernet Controller
 11c2  Sand Microelectronics
@@ -13908,8 +6903,6 @@ var pciids = []byte(`#
 11ca  LSI Systems, Inc
 11cb  Specialix Research Ltd.
 	2000  PCI_9050
-		11cb 0200  SX
-		11cb b008  I/O8+
 	4000  SUPI_1
 	8000  T225
 11cc  Michels & Kleberhoff Computer GmbH
@@ -13939,14 +6932,7 @@ var pciids = []byte(`#
 11de  Zoran Corporation
 	6017  miroVIDEO DC30
 	6057  ZR36057PQC Video cutting chipset
-		1031 7efe  DC10 Plus
-		1031 fc00  MiroVIDEO DC50, Motion JPEG Capture/CODEC Board
-		12f8 8a02  Tekram Video Kit
-		13ca 4231  JPEG/TV Card
 	6120  ZR36120
-		1328 f001  Cinemaster C DVD Decoder
-		13c2 0000  MediaFocus Satellite TV Card
-		1de1 9fff  Video Kit C210
 11df  New Wave PDG
 11e0  Cray Communications A/S
 11e1  GEC Plessey Semi Inc.
@@ -13990,9 +6976,7 @@ var pciids = []byte(`#
 	0113  FreedomLine 100
 	1401  ReadyLink 2000
 	2011  RL100-ATX 10/100
-		11f6 2011  RL100-ATX
 	2201  ReadyLink 100TX (Winbond W89C840)
-		11f6 2011  ReadyLink 100TX
 	9881  RL100TX Fast Ethernet
 11f7  Scientific Atlanta
 11f8  PMC-Sierra Inc.
@@ -14003,8 +6987,6 @@ var pciids = []byte(`#
 	8000  PM8000  [SPC - SAS Protocol Controller]
 	8009  PM8009 SPCve 8x6G
 	8032  ATTO Celerity FC8xEN
-		117c 003b  Celerity FC-82EN Fibre Channel Adapter
-		117c 003c  Celerity FC-84EN Fibre Channel Adapter
 	8053  PM8053 SXP 12G 24-port SAS/SATA expander
 	8054  PM8054 SXP 12G 36-port SAS/SATA expander
 	8055  PM8055 SXP 12G 48-port SAS/SATA expander
@@ -14064,10 +7046,6 @@ var pciids = []byte(`#
 1201  Vista Controls Corp
 1202  Network General Corp.
 	4300  Gigabit Ethernet Adapter
-		1202 9841  SK-9841 LX
-		1202 9842  SK-9841 LX dual link
-		1202 9843  SK-9843 SX
-		1202 9844  SK-9843 SX dual link
 1203  Bayer Corporation, Agfa Division
 1204  Lattice Semiconductor Corporation
 	1965  SB6501 802.11ad Wireless Network Adapter
@@ -14107,11 +7085,8 @@ var pciids = []byte(`#
 1216  Purup Prepress A/S
 1217  O2 Micro, Inc.
 	00f7  Firewire (IEEE 1394)
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		1179 ff50  Satellite P305D-S8995E
 	10f7  1394 OHCI Compliant Host Controller
 	11f7  OZ600 1394a-2000 Controller
-		1028 04a3  Precision M4600
 	13f7  1394 OHCI Compliant Host Controller
 	6729  OZ6729
 	673a  OZ6730
@@ -14120,25 +7095,13 @@ var pciids = []byte(`#
 	6872  OZ6812 CardBus Controller
 	6925  OZ6922 CardBus Controller
 	6933  OZ6933/711E1 CardBus/SmartCardBus Controller
-		1025 1016  Travelmate 612 TX
 	6972  OZ601/6912/711E0 CardBus/SmartCardBus Controller
-		1014 020c  ThinkPad R30
-		1028 0152  Latitude D500
-		1179 0001  Magnia Z310
 	7110  OZ711Mx 4-in-1 MemoryCardBus Accelerator
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		1734 106c  Amilo A1645
 	7112  OZ711EC1/M1 SmartCardBus/MemoryCardBus Controller
 	7113  OZ711EC1 SmartCardBus Controller
-		1025 0035  TravelMate 660
 	7114  OZ711M1/MC1 4-in-1 MemoryCardBus Controller
 	7120  Integrated MMC/SD Controller
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		1179 ff50  Satellite P305D-S8995E
 	7130  Integrated MS/xD Controller
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		1179 ff50  Satellite P305D-S8995E
 	7134  OZ711MP1/MS1 MemoryCardBus Controller
 	7135  Cardbus bridge
 	7136  OZ711SP1 Memory CardBus Controller
@@ -14146,19 +7109,14 @@ var pciids = []byte(`#
 	7212  OZ711M2 4-in-1 MemoryCardBus Controller
 	7213  OZ6933E CardBus Controller
 	7223  OZ711M3/MC3 4-in-1 MemoryCardBus Controller
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		10cf 11c4  Lifebook P5020D Laptop
 	7233  OZ711MP3/MS3 4-in-1 MemoryCardBus Controller
 	8120  Integrated MMC/SD Controller
 	8130  Integrated MS/MSPRO/xD Controller
 	8220  OZ600FJ1/OZ900FJ1 SD/MMC Card Reader Controller
 	8221  OZ600FJ0/OZ900FJ0/OZ600FJS SD/MMC Card Reader Controller
 	8320  OZ600RJ1/OZ900RJ1 SD/MMC Card Reader Controller
-		1028 04a3  Precision M4600
 	8321  OZ600RJ0/OZ900RJ0/OZ600RJS SD/MMC Card Reader Controller
 	8330  OZ600 MS/xD Controller
-		1028 04a3  Precision M4600
 	8331  O2 Flash Memory Card
 	8520  SD/MMC Card Reader Controller
 	8621  SD/MMC Card Reader Controller
@@ -14168,46 +7126,9 @@ var pciids = []byte(`#
 	0001  Voodoo
 	0002  Voodoo 2
 	0003  Voodoo Banshee
-		1092 0003  Monster Fusion
-		1092 4000  Monster Fusion
-		1092 4002  Monster Fusion
-		1092 4801  Monster Fusion AGP
-		1092 4803  Monster Fusion AGP
-		1092 8030  Monster Fusion
-		1092 8035  Monster Fusion AGP
-		10b0 0001  Dragon 4000
-		1102 1017  3D Blaster Banshee PCI (CT6760)
-		1102 1018  3D Blaster Banshee VE
-		121a 0001  Voodoo Banshee AGP
-		121a 0003  Voodoo Banshee AGP SGRAM
-		121a 0004  Voodoo Banshee
-		139c 0016  Raven
-		139c 0017  Raven
-		14af 0002  Maxi Gamer Phoenix
 	0004  Voodoo Banshee [Velocity 100]
 	0005  Voodoo 3
-		121a 0004  Voodoo3 AGP
-		121a 0030  Voodoo3 AGP
-		121a 0031  Voodoo3 AGP
-		121a 0034  Voodoo3 AGP
-		121a 0036  Voodoo3 2000 PCI
-		121a 0037  Voodoo3 AGP
-		121a 0038  Voodoo3 AGP
-		121a 003a  Voodoo3 AGP
-		121a 0044  Voodoo3
-		121a 004b  Velocity 100
-		121a 004c  Velocity 200
-		121a 004d  Voodoo3 AGP
-		121a 004e  Voodoo3 AGP
-		121a 0051  Voodoo3 AGP
-		121a 0052  Voodoo3 AGP
-		121a 0057  Voodoo3 3000 PCI
-		121a 0060  Voodoo3 3500 TV (NTSC)
-		121a 0061  Voodoo3 3500 TV (PAL)
-		121a 0062  Voodoo3 3500 TV (SECAM)
 	0009  Voodoo 4 / Voodoo 5
-		121a 0003  Voodoo5 PCI 5500
-		121a 0009  Voodoo5 AGP 5500/6000
 	0057  Voodoo 3/3000 [Avenger]
 121b  Advanced Telecommunications Modules
 121c  Nippon Texaco., Ltd
@@ -14251,9 +7172,7 @@ var pciids = []byte(`#
 	1206  368DSP
 	1400  Trident PCI288-Q3DII (NX)
 	50dc  3328 Audio
-		122d 0001  3328 Audio
 	80da  3328 Audio
-		122d 0001  3328 Audio
 122e  Xyratex
 	7722  Napatech XL1
 	7724  Napatech XL2/XA
@@ -14283,43 +7202,24 @@ var pciids = []byte(`#
 	0002  EasyConnect 8/64
 	0003  EasyIO
 123e  Simutech, Inc.
-# nee C-Cube Microsystems / acquired by Magnum Semiconductor
 123f  LSI Logic
 	00e4  MPEG
 	8120  DVxplore Codec
-		10de 01e1  NVTV PAL
-		10de 01e2  NVTV NTSC
-		10de 01e3  NVTV PAL
-		10de 0248  NVTV NTSC
-		10de 0249  NVTV PAL
-		11bd 0006  DV500 E4
-		11bd 000a  DV500 E4
-		11bd 000f  DV500 E4
-		1809 0016  Emuzed MAUI-III PCI PVR FM TV
 	8888  Cinemaster C 3.0 DVD Decoder
-		1002 0001  Cinemaster C 3.0 DVD Decoder
-		1002 0002  Cinemaster C 3.0 DVD Decoder
-		1328 0001  Cinemaster C 3.0 DVD Decoder
 1240  Marathon Technologies Corp.
 1241  DSC Communications
-# Formerly Jaycor Networks, Inc.
 1242  JNI Corporation
 	1560  JNIC-1560 PCI-X Fibre Channel Controller
-		1242 6562  FCX2-6562 Dual Channel PCI-X Fibre Channel Adapter
-		1242 656a  FCX-6562 PCI-X Fibre Channel Adapter
 	4643  FCI-1063 Fibre Channel Adapter
 	6562  FCX2-6562 Dual Channel PCI-X Fibre Channel Adapter
 	656a  FCX-6562 PCI-X Fibre Channel Adapter
 1243  Delphax
-# Audio-Visuelles Marketing und Computersysteme
 1244  AVM GmbH
 	0700  B1 ISDN
 	0800  C4 ISDN
 	0a00  A1 ISDN [Fritz]
-		1244 0a00  FRITZ!Card ISDN Controller
 	0e00  Fritz!Card PCI v2.0 ISDN
 	0e80  Fritz!Card PCI v2.1 ISDN
-		1244 0e00  PSB 3100F (AVM KAFKA) [Fritz!Card PCI v2.1]
 	1100  C2 ISDN
 	1200  T1 ISDN
 	2700  Fritz!Card DSL SL
@@ -14332,7 +7232,6 @@ var pciids = []byte(`#
 124a  AEG Electrocom GmbH
 124b  SBS/Greenspring Modular I/O
 	0040  PCI-40A or cPCI-200 Quad IndustryPack carrier
-		124b 9080  PCI9080 Bridge
 124c  Solitron Technologies, Inc.
 124d  Stallion Technologies, Inc.
 	0000  EasyConnection 8/32
@@ -14360,7 +7259,6 @@ var pciids = []byte(`#
 	5201  PCI-2000
 1257  Vertex Networks, Inc.
 1258  Gilbarco, Inc.
-# nee Allied Telesyn International
 1259  Allied Telesis
 	2560  AT-2560 Fast Ethernet Adapter (i82557B)
 	2801  AT-2801FX (RTL-8139)
@@ -14370,7 +7268,6 @@ var pciids = []byte(`#
 125a  ABB Power Systems
 125b  Asix Electronics Corporation
 	1400  AX88141 Fast Ethernet Controller
-		1186 1100  AX8814X Based PCI Fast Ethernet Adapter
 125c  Aurora Technologies, Inc.
 	0101  Saturn 4520P
 	0640  Aries 16000P
@@ -14378,95 +7275,31 @@ var pciids = []byte(`#
 	0000  ES336H Fax Modem (Early Model)
 	1948  ES1948 Maestro-1
 	1968  ES1968 Maestro 2
-		1028 0085  ES1968 Maestro-2 PCI
-		1033 8051  ES1968 Maestro-2 Audiodrive
 	1969  ES1938/ES1946/ES1969 Solo-1 Audiodrive
-		1014 0166  ES1969 SOLO-1 AudioDrive on IBM Aptiva Mainboard
-		125d 8888  Solo-1 Audio Adapter
-		125d 8898  ES1938S TTSOLO1-SL [TerraTec 128i PCI]
-		153b 111b  Terratec 128i PCI
 	1978  ES1978 Maestro 2E
-		0e11 b112  Armada M700/E500
-		1033 803c  ES1978 Maestro-2E Audiodrive
-		1033 8058  ES1978 Maestro-2E Audiodrive
-		1092 4000  Monster Sound MX400
-		1179 0001  ES1978 Maestro-2E Audiodrive
 	1988  ES1988 Allegro-1
-		0e11 0098  Evo N600c
-		1092 4100  Sonic Impact S100
-		125d 0431  Allegro AudioDrive
-		125d 1988  ESS Allegro-1 Audiodrive
-		125d 1998  Allegro AudioDrive
-		125d 1999  Allegro-1 AudioDrive
 	1989  ESS Modem
-		125d 1989  ESS Modem
 	1998  ES1983S Maestro-3i PCI Audio Accelerator
-		1028 00b1  Latitude C600
-		1028 00e5  Latitude C810
-		1028 00e6  ES1983S Maestro-3i (Dell Inspiron 8100)
 	1999  ES1983S Maestro-3i PCI Modem Accelerator
 	199a  ES1983S Maestro-3i PCI Audio Accelerator
 	199b  ES1983S Maestro-3i PCI Modem Accelerator
 	2808  ES336H Fax Modem (Later Model)
 	2838  ES2838/2839 SuperLink Modem
 	2898  ES2898 Modem
-		125d 0424  ES56-PI Data Fax Modem
-		125d 0425  ES56T-PI Data Fax Modem
-		125d 0426  ES56V-PI Data Fax Modem
-		125d 0427  VW-PI Data Fax Modem
-		125d 0428  ES56ST-PI Data Fax Modem
-		125d 0429  ES56SV-PI Data Fax Modem
-		147a c001  ES56-PI Data Fax Modem
-		148d 1030  HCF WV-PI56 [ESS ES56-PI Data Fax Modem]
-		14fe 0428  ES56-PI Data Fax Modem
-		14fe 0429  ES56-PI Data Fax Modem
 125e  Specialvideo Engineering SRL
 125f  Concurrent Technologies, Inc.
-# 4 x serial ports, 2 x printer ports
 	2071  CC PMC/232
-# 4 x serial ports, 2 x printer ports
 	2084  CC PMC/23P
-# 4 x serial ports, RS422
 	2091  CC PMC/422
 1260  Intersil Corporation
 	3872  ISL3872 [Prism 3]
-		1468 0202  LAN-Express IEEE 802.11b Wireless LAN
 	3873  ISL3874 [Prism 2.5]/ISL3872 [Prism 3]
-		10cf 1169  MBH7WM01-8734 802.11b Wireless Mini PCI Card [ISL3874]
-		1186 3501  DWL-520 Wireless PCI Adapter (rev A or B) [ISL3874]
-		1186 3700  DWL-520 Wireless PCI Adapter (rev E1) [ISL3872]
-		1385 4105  MA311 802.11b wireless adapter [ISL3874]
-		1668 0414  HWP01170-01 802.11b PCI Wireless Adapter
-		16a5 1601  AIR.mate PC-400 PCI Wireless LAN Adapter
-		1737 3874  WMP11 v1 802.11b Wireless-B PCI Adapter [ISL3874]
-		4033 7033  PCW200 802.11b Wireless PCI Adapter [ISL3874]
-		8086 2510  M3AWEB Wireless 802.11b MiniPCI Adapter
-		8086 2513  Wireless 802.11b MiniPCI Adapter
 	3877  ISL3877 [Prism Indigo]
 	3886  ISL3886 [Prism Javelin/Prism Xbow]
-		17cf 0037  XG-901 and clones Wireless Adapter
 	3890  ISL3890 [Prism GT/Prism Duette]/ISL3886 [Prism Javelin/Prism Xbow]
-		10b8 2802  SMC2802W V1 Wireless PCI Adapter [ISL3890]
-		10b8 2835  SMC2835W Wireless Cardbus Adapter
-		10b8 a835  SMC2835W V2 Wireless Cardbus Adapter
-		1113 4203  WN4201B
-		1113 8201  T-Com T-Sinus 154pcicard Wireless PCI Adapter
-		1113 b301  T-Sinus 154card Cardbus
-		1113 ee03  SMC2802W V2 Wireless PCI Adapter [ISL3886]
-		1113 ee08  SMC2835W V3 EU Wireless Cardbus Adapter
-		1186 3202  DWL-G650 A1 Wireless Adapter
-		1259 c104  CG-WLCB54GT Wireless Adapter
-		1260 0000  WG511 v1 54 Mbps Wireless PC Card
-		1385 4800  WG511 v2/v3 54 Mbps Wireless PC Card
-		16a5 1605  ALLNET ALL0271 Wireless PCI Adapter
-		17cf 0014  XG-600 and clones Wireless Adapter
-		17cf 0020  XG-900 and clones Wireless Adapter
-		187e 3403  G-110 802.11g Wireless Cardbus Adapter
 	8130  HMP8130 NTSC/PAL Video Decoder
 	8131  HMP8131 NTSC/PAL Video Decoder
-# This is probably more likely a HW fault, but I am keeping it for now --mj
 	ffff  ISL3886IK
-		1260 0000  Senao 3054MP+ (J) mini-PCI WLAN 802.11g adapter
 1261  Matsushita-Kotobuki Electronics Industries, Ltd.
 1262  ES Computer Company, Ltd.
 1263  Sonic Solutions
@@ -14475,7 +7308,6 @@ var pciids = []byte(`#
 1266  Microdyne Corporation
 	0001  NE10/100 Adapter (i82557B)
 	1910  NE2000Plus (RT8029) Ethernet Adapter
-		1266 1910  NE2000Plus Ethernet Adapter
 1267  S. A. Telecommunications
 	5352  PCR2101
 	5a4b  Telsat Turbo
@@ -14509,72 +7341,8 @@ var pciids = []byte(`#
 1274  Ensoniq
 	1171  ES1373 / Creative Labs CT5803 [AudioPCI]
 	1371  ES1371/ES1373 / Creative Labs CT2518
-		0e11 0024  AudioPCI on Motherboard Compaq Deskpro
-		0e11 b1a7  ES1371, ES1373 AudioPCI
-		1033 80ac  ES1371, ES1373 AudioPCI
-		1042 1854  Tazer
-		107b 8054  Tabor2
-		1274 1371  Audio PCI 64V/128/5200 / Creative CT4810/CT5803/CT5806 [Sound Blaster PCI]
-		1274 8001  CT4751 board
-		1462 6470  ES1371, ES1373 AudioPCI On Motherboard MS-6147 1.1A
-		1462 6560  ES1371, ES1373 AudioPCI On Motherboard MS-6156 1.10
-		1462 6630  ES1371, ES1373 AudioPCI On Motherboard MS-6163BX 1.0A
-		1462 6631  ES1371, ES1373 AudioPCI On Motherboard MS-6163VIA 1.0A
-		1462 6632  ES1371, ES1373 AudioPCI On Motherboard MS-6163BX 2.0A
-		1462 6633  ES1371, ES1373 AudioPCI On Motherboard MS-6163VIA 2.0A
-		1462 6820  ES1371, ES1373 AudioPCI On Motherboard MS-6182 1.00
-		1462 6822  ES1371, ES1373 AudioPCI On Motherboard MS-6182 1.00A
-		1462 6830  ES1371, ES1373 AudioPCI On Motherboard MS-6183 1.00
-		1462 6880  ES1371, ES1373 AudioPCI On Motherboard MS-6188 1.00
-		1462 6900  ES1371, ES1373 AudioPCI On Motherboard MS-6190 1.00
-		1462 6910  ES1371, ES1373 AudioPCI On Motherboard MS-6191
-		1462 6930  ES1371, ES1373 AudioPCI On Motherboard MS-6193
-		1462 6990  ES1371, ES1373 AudioPCI On Motherboard MS-6199BX 2.0A
-		1462 6991  ES1371, ES1373 AudioPCI On Motherboard MS-6199VIA 2.0A
-		14a4 2077  ES1371, ES1373 AudioPCI On Motherboard KR639
-		14a4 2105  ES1371, ES1373 AudioPCI On Motherboard MR800
-		14a4 2107  ES1371, ES1373 AudioPCI On Motherboard MR801
-		14a4 2172  ES1371, ES1373 AudioPCI On Motherboard DR739
-		1509 9902  ES1371, ES1373 AudioPCI On Motherboard KW11
-		1509 9903  ES1371, ES1373 AudioPCI On Motherboard KW31
-		1509 9904  ES1371, ES1373 AudioPCI On Motherboard KA11
-		1509 9905  ES1371, ES1373 AudioPCI On Motherboard KC13
-		152d 8801  ES1371, ES1373 AudioPCI On Motherboard CP810E
-		152d 8802  ES1371, ES1373 AudioPCI On Motherboard CP810
-		152d 8803  ES1371, ES1373 AudioPCI On Motherboard P3810E
-		152d 8804  ES1371, ES1373 AudioPCI On Motherboard P3810-S
-		152d 8805  ES1371, ES1373 AudioPCI On Motherboard P3820-S
-		270f 2001  ES1371, ES1373 AudioPCI On Motherboard 6CTR
-		270f 2200  ES1371, ES1373 AudioPCI On Motherboard 6WTX
-		270f 3000  ES1371, ES1373 AudioPCI On Motherboard 6WSV
-		270f 3100  ES1371, ES1373 AudioPCI On Motherboard 6WIV2
-		270f 3102  ES1371, ES1373 AudioPCI On Motherboard 6WIV
-		270f 7060  ES1371, ES1373 AudioPCI On Motherboard 6ASA2
-		8086 4249  ES1371, ES1373 AudioPCI On Motherboard BI440ZX
-		8086 424c  ES1371, ES1373 AudioPCI On Motherboard BL440ZX
-		8086 425a  ES1371, ES1373 AudioPCI On Motherboard BZ440ZX
-		8086 4341  ES1371, ES1373 AudioPCI On Motherboard Cayman
-		8086 4343  ES1371, ES1373 AudioPCI On Motherboard Cape Cod
-		8086 4541  D815EEA Motherboard
-		8086 4649  ES1371, ES1373 AudioPCI On Motherboard Fire Island
-		8086 464a  ES1371, ES1373 AudioPCI On Motherboard FJ440ZX
-		8086 4d4f  ES1371, ES1373 AudioPCI On Motherboard Montreal
-		8086 4f43  ES1371, ES1373 AudioPCI On Motherboard OC440LX
-		8086 5243  ES1371, ES1373 AudioPCI On Motherboard RC440BX
-		8086 5352  ES1371, ES1373 AudioPCI On Motherboard SunRiver
-		8086 5643  ES1371, ES1373 AudioPCI On Motherboard Vancouver
-		8086 5753  ES1371, ES1373 AudioPCI On Motherboard WS440BX
 	5000  ES1370 [AudioPCI]
 	5880  5880B / Creative Labs CT5880
-		1274 2000  Creative CT4810 [Sound Blaster AudioPCI 128]
-		1274 2003  Creative SoundBlaster AudioPCI 128
-		1274 5880  Creative CT4750 [Sound Blaster PCI 128]
-		1274 8001  Sound Blaster 16PCI 4.1ch
-		1458 a000  5880 AudioPCI On Motherboard 6OXET
-		1462 6880  5880 AudioPCI On Motherboard MS-6188 1.00
-		270f 2001  5880 AudioPCI On Motherboard 6CTR
-		270f 2200  5880 AudioPCI On Motherboard 6WTX
-		270f 7040  5880 AudioPCI On Motherboard 6ATA4
 	8001  CT5880 [AudioPCI]
 	8002  5880A [AudioPCI]
 1275  Network Appliance Corporation
@@ -14594,72 +7362,13 @@ var pciids = []byte(`#
 	0397  BIOS scratchpad
 127a  Rockwell International
 	1002  HCF 56k Data/Fax Modem
-		1092 094c  SupraExpress 56i PRO [Diamond SUP2380]
-		122d 4002  HPG / MDP3858-U
-		122d 4005  MDP3858-E
-		122d 4007  MDP3858-A/-NZ
-		122d 4012  MDP3858-SA
-		122d 4017  MDP3858-W
-		122d 4018  MDP3858-W
-		127a 1002  Rockwell 56K D/F HCF Modem
 	1003  HCF 56k Data/Fax Modem
-		0e11 b0bc  229-DF Zephyr
-		0e11 b114  229-DF Cheetah
-		1033 802b  229-DF
-		13df 1003  PCI56RX Modem
-		13e0 0117  IBM
-		13e0 0147  IBM F-1156IV+/R3 Spain V.90 Modem
-		13e0 0197  IBM
-		13e0 01c7  IBM F-1156IV+/R3 WW V.90 Modem
-		13e0 01f7  IBM
-		1436 1003  IBM
-		1436 1103  IBM 5614PM3G V.90 Modem
-		1436 1602  Compaq 229-DF Ducati
 	1004  HCF 56k Data/Fax/Voice Modem
-		1048 1500  MicroLink 56k Modem
-		10cf 1059  Fujitsu 229-DFRT
 	1005  HCF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
-		1005 127a  AOpen FM56-P
-		1033 8029  229-DFSV
-		1033 8054  Modem
-		10cf 103c  Fujitsu
-		10cf 1055  Fujitsu 229-DFSV
-		10cf 1056  Fujitsu 229-DFSV
-		122d 4003  MDP3858SP-U
-		122d 4006  Packard Bell MDP3858V-E
-		122d 4008  MDP3858SP-A/SP-NZ
-		122d 4009  MDP3858SP-E
-		122d 4010  MDP3858V-U
-		122d 4011  MDP3858SP-SA
-		122d 4013  MDP3858V-A/V-NZ
-		122d 4015  MDP3858SP-W
-		122d 4016  MDP3858V-W
-		122d 4019  MDP3858V-SA
-		13df 1005  PCI56RVP Modem
-		13e0 0187  IBM
-		13e0 01a7  IBM
-		13e0 01b7  IBM DF-1156IV+/R3 Spain V.90 Modem
-		13e0 01d7  IBM DF-1156IV+/R3 WW V.90 Modem
-		1436 1005  IBM
-		1436 1105  IBM
-		1437 1105  IBM 5614PS3G V.90 Modem
 	1022  HCF 56k Modem
-		1436 1303  M3-5614PM3G V.90 Modem
 	1023  HCF 56k Data/Fax Modem
-		122d 4020  Packard Bell MDP3858-WE
-		122d 4023  MDP3858-UE
-		13e0 0247  IBM F-1156IV+/R6 Spain V.90 Modem
-		13e0 0297  IBM
-		13e0 02c7  IBM F-1156IV+/R6 WW V.90 Modem
-		1436 1203  IBM
-		1436 1303  IBM
 	1024  HCF 56k Data/Fax/Voice Modem
 	1025  HCF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
-		10cf 106a  Fujitsu 235-DFSV
-		122d 4021  Packard Bell MDP3858V-WE
-		122d 4022  MDP3858SP-WE
-		122d 4024  MDP3858V-UE
-		122d 4025  MDP3858SP-UE
 	1026  HCF 56k PCI Speakerphone Modem
 	1032  HCF 56k Modem
 	1033  HCF 56k Modem
@@ -14669,45 +7378,15 @@ var pciids = []byte(`#
 	1085  HCF 56k Volcano PCI Modem
 	2004  HSF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
 	2005  HCF 56k Data/Fax Modem
-		104d 8044  229-DFSV
-		104d 8045  229-DFSV
-		104d 8055  PBE/Aztech 235W-DFSV
-		104d 8056  235-DFSV
-		104d 805a  Modem
-		104d 805f  Modem
-		104d 8074  Modem
 	2013  HSF 56k Data/Fax Modem
-		1179 0001  Modem
-		1179 ff00  Modem
 	2014  HSF 56k Data/Fax/Voice Modem
-		10cf 1057  Fujitsu Citicorp III
-		122d 4050  MSP3880-U
-		122d 4055  MSP3880-W
 	2015  HSF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
-		10cf 1063  Fujitsu
-		10cf 1064  Fujitsu
-		1468 2015  Fujitsu
 	2016  HSF 56k Data/Fax/Voice/Spkp Modem
-		122d 4051  MSP3880V-W
-		122d 4052  MSP3880SP-W
-		122d 4054  MSP3880V-U
-		122d 4056  MSP3880SP-U
-		122d 4057  MSP3880SP-A
 	4311  Riptide HSF 56k PCI Modem
-		127a 4311  Ring Modular? Riptide HSF RT HP Dom
-		13e0 0210  HP-GVC
 	4320  Riptide PCI Audio Controller
-		1235 4320  Riptide PCI Audio Controller
 	4321  Riptide HCF 56k PCI Modem
-		1235 4321  Hewlett Packard DF
-		1235 4324  Hewlett Packard DF
-		13e0 0210  Hewlett Packard DF
-		144d 2321  Riptide
 	4322  Riptide PCI Game Controller
-		1235 4322  Riptide PCI Game Controller
 	8234  RapidFire 616X ATM155 Adapter
-		108d 0022  RapidFire 616X ATM155 Adapter
-		108d 0027  RapidFire 616X ATM155 Adapter
 127b  Pixera Corporation
 127c  Crosspoint Solutions, Inc.
 127d  Vela Research
@@ -14721,18 +7400,13 @@ var pciids = []byte(`#
 	9009  Ethernet 100/10 MBit
 	9100  21x4x DEC-Tulip compatible 10/100 Ethernet
 	9102  21x4x DEC-Tulip compatible 10/100 Ethernet
-# Subsystem ID is main ID reveresed.
-		0291 8212  DM9102A (DM9102AE, SM9102AF) Ethernet 100/10 MBit
 	9132  Ethernet 100/10 MBit
 1283  Integrated Technology Express, Inc.
 	673a  IT8330G
 	8152  IT8152F/G Advanced RISC-to-PCI Companion Chip
 	8211  ITE 8211F Single Channel UDMA 133
-		1043 8138  P5GD1-VW Mainboard
 	8212  IT8212 Dual channel ATA RAID controller
-		1283 0001  IT/ITE8212 Dual channel ATA RAID controller
 	8213  IT8213 IDE Controller
-		1458 b000  GA-EG45M-DS2H Mainboard
 	8330  IT8330G
 	8872  IT887xF PCI to ISA I/O chip with SMB, GPIO, Serial or Parallel Port
 	8888  IT8888F/G PCI to ISA Bridge with SMB [Golden Gate]
@@ -14810,11 +7484,7 @@ var pciids = []byte(`#
 12ad  Multidata GmbH
 12ae  Alteon Networks Inc.
 	0001  AceNIC Gigabit Ethernet
-		1014 0104  Gigabit Ethernet-SX PCI Adapter
-		12ae 0001  Gigabit Ethernet-SX (Universal)
 	0002  AceNIC Gigabit Ethernet (Copper)
-		10a9 8002  Acenic Gigabit Ethernet
-		12ae 0002  Gigabit Ethernet-T (3C986-T)
 	00fa  Farallon PN9100-T Gigabit Ethernet
 12af  TDK USA Corp
 12b0  Jorge Scientific Corp
@@ -14826,29 +7496,10 @@ var pciids = []byte(`#
 12b6  Natural Microsystems
 12b7  Cognex Modular Vision Systems Div. - Acumen Inc.
 12b8  Korg
-# Nee US Robotics
 12b9  3Com Corp, Modem Division
 	1006  WinModem
-		12b9 005c  USR 56k Internal Voice WinModem (Model 3472)
-		12b9 005e  USR 56k Internal WinModem (Models 662975)
-		12b9 0062  USR 56k Internal Voice WinModem (Model 662978)
-		12b9 0068  USR 56k Internal Voice WinModem (Model 5690)
-		12b9 007a  USR 56k Internal Voice WinModem (Model 662974)
-		12b9 007f  USR 56k Internal WinModem (Models 5698, 5699)
-		12b9 0080  USR 56k Internal WinModem (Models 2975, 3528)
-		12b9 0081  USR 56k Internal Voice WinModem (Models 2974, 3529)
-		12b9 0091  USR 56k Internal Voice WinModem (Model 2978)
 	1007  USR 56k Internal WinModem
-		12b9 00a3  USR 56k Internal WinModem (Model 3595)
-		12b9 00c4  U.S. Robotics V.92 Voice Faxmodem (2884A/B/C)
 	1008  56K FaxModem Model 5610
-		12b9 00a2  USR 56k Internal FAX Modem (Model 2977)
-		12b9 00aa  USR 56k Internal Voice Modem (Model 2976)
-		12b9 00ab  USR 56k Internal Voice Modem (Model 5609)
-		12b9 00ac  USR 56k Internal Voice Modem (Model 3298)
-		12b9 00ad  USR 56k Internal FAX Modem (Model 5610)
-		12b9 00d3  USR 56K Internal V92 FAX Modem (Model 5610)
-		12b9 baba  USR 56K Internal Voice Modem 3CP3298-DEL (Model 5601) [Hawk]
 12ba  BittWare, Inc.
 12bb  Nippon Unisoft Corporation
 12bc  Array Microsystems
@@ -14856,7 +7507,6 @@ var pciids = []byte(`#
 12be  Anchor Chips Inc.
 	3041  AN3041Q CO-MEM
 	3042  AN3042Q CO-MEM Lite
-		12be 3042  Anchor Chips Lite Evaluation Board
 12bf  Fujifilm Microdevices
 12c0  Infimed
 12c1  GMM Research Corp
@@ -14901,13 +7551,9 @@ var pciids = []byte(`#
 	0086  THR2 Multi-scale Thresholder
 12c6  Mitani Corporation
 12c7  Dialogic Corp
-# 12 Line, 6 port, CT-BUS/SC-BUS, loopstart FXO adaptor.
 	0546  Springware D/120JCT-LS
-# 24 Channel, 1 Port, CT-BUS/SC-BUS, T1/PRI adaptor.
 	0647  Springware D/240JCT-T1
-# 4 Line, 4 port, CT-BUS/SC-BUS, loopstart FXO adaptor. Revision 01
 	0676  Springware D/41JCT-LS
-# 48 Channel, 2 Port, CT-BUS/SC-BUS, T1/PRI adaptor.
 	0685  Springware D/480JCT-2T1
 12c8  G Force Co, Ltd
 12c9  Gigi Operations
@@ -14925,24 +7571,6 @@ var pciids = []byte(`#
 	0008  NV1
 	0009  DAC64
 	0018  Riva128
-		1048 0c10  VICTORY Erazor
-		107b 8030  STB Velocity 128
-		1092 0350  Viper V330
-		1092 1092  Viper V330
-		10b4 1b1b  STB Velocity 128
-		10b4 1b1d  STB Velocity 128
-		10b4 1b1e  STB Velocity 128, PAL TV-Out
-		10b4 1b20  STB Velocity 128 Sapphire
-		10b4 1b21  STB Velocity 128
-		10b4 1b22  STB Velocity 128 AGP, NTSC TV-Out
-		10b4 1b23  STB Velocity 128 AGP, PAL TV-Out
-		10b4 1b27  STB Velocity 128 DVD
-		10b4 1b88  MVP Pro 128
-		10b4 222a  STB Velocity 128 AGP
-		10b4 2230  STB Velocity 128
-		10b4 2232  STB Velocity 128
-		10b4 2235  STB Velocity 128 AGP
-		2a15 54a3  3DVision-SAGP / 3DexPlorer 3000
 	0019  Riva128ZX
 	0020  TNT
 	0028  TNT2
@@ -14971,7 +7599,6 @@ var pciids = []byte(`#
 	8152  PI7C8152A/PI7C8152B/PI7C8152BI PCI-to-PCI Bridge
 	8154  PI7C8154A/PI7C8154B/PI7C8154BI PCI-to-PCI Bridge
 	e110  PI7C9X110 PCI Express to PCI bridge
-		1775 11cc  CC11/CL11 CompactPCI Bridge
 	e111  PI7C9X111SL PCIe-to-PCI Reversible Bridge
 	e130  PCI Express to PCI-XPI7C9X130 PCI-X Bridge
 12d9  Aculab PLC
@@ -14979,8 +7606,6 @@ var pciids = []byte(`#
 	0004  cPCI Prosody
 	0005  Aculab E1/T1 PCI card
 	1078  Prosody X class e1000 device
-		12d9 000d  Prosody X PCI
-		12d9 000e  Prosody X cPCI
 12da  True Time Inc.
 12db  Annapolis Micro Systems, Inc
 12dc  Symicron Computer Communication Ltd.
@@ -15004,39 +7629,9 @@ var pciids = []byte(`#
 12ea  Zuken
 12eb  Aureal Semiconductor
 	0001  Vortex 1
-		104d 8036  AU8820 Vortex Digital Audio Processor
-		1092 2000  Sonic Impact A3D
-		1092 2100  Sonic Impact A3D
-		1092 2110  Sonic Impact A3D
-		1092 2200  Sonic Impact A3D
-		122d 1002  AU8820 Vortex Digital Audio Processor
-		12eb 0001  AU8820 Vortex Digital Audio Processor
-		5053 3355  Montego
-		50b2 1111  XLerate
 	0002  Vortex 2
-		104d 8049  AU8830 Vortex 3D Digital Audio Processor
-		104d 807b  AU8830 Vortex 3D Digital Audio Processor
-		1092 3000  Monster Sound II
-		1092 3001  Monster Sound II
-		1092 3002  Monster Sound II
-		1092 3003  Monster Sound II
-		1092 3004  Monster Sound II
-		12eb 0002  AU8830 Vortex 3D Digital Audio Processor
-		12eb 0088  AU8830 Vortex 3D Digital Audio Processor
-		144d 3510  AU8830 Vortex 3D Digital Audio Processor
-		5053 3356  Montego II
 	0003  AU8810 Vortex Digital Audio Processor
-		104d 8049  AU8810 Vortex Digital Audio Processor
-		104d 8077  AU8810 Vortex Digital Audio Processor
-		109f 1000  AU8810 Vortex Digital Audio Processor
-		12eb 0003  AU8810 Vortex Digital Audio Processor
-		1462 6780  AU8810 Vortex Digital Audio Processor
-		14a4 2073  AU8810 Vortex Digital Audio Processor
-		14a4 2091  AU8810 Vortex Digital Audio Processor
-		14a4 2104  AU8810 Vortex Digital Audio Processor
-		14a4 2106  AU8810 Vortex Digital Audio Processor
 	8803  Vortex 56k Software Modem
-		12eb 8803  Vortex 56k Software Modem
 12ec  3A International, Inc.
 12ed  Optivision Inc.
 12ee  Orange Micro
@@ -15078,7 +7673,6 @@ var pciids = []byte(`#
 1304  Juniper Networks
 1305  Netphone, Inc
 1306  Duet Technologies
-# Nee ComputerBoards
 1307  Measurement Computing
 	0001  PCI-DAS1602/16
 	000b  PCI-DIO48H
@@ -15138,7 +7732,6 @@ var pciids = []byte(`#
 	0115  PCIe-DAS1602/16
 1308  Jato Technologies Inc.
 	0001  NetCelerator Adapter
-		1308 0001  NetCelerator Adapter
 1309  AB Semiconductor Ltd
 130a  Mitsubishi Electric Microcomputer
 130b  Colorgraphic Communications Corp
@@ -15155,24 +7748,17 @@ var pciids = []byte(`#
 1317  ADMtek
 	0981  21x4x DEC-Tulip compatible 10/100 Ethernet
 	0985  NC100 Network Everywhere Fast Ethernet 10/100
-		1734 100c  Scenic N300 ADMtek AN983 10/100 Mbps PCI Adapter
 	1985  21x4x DEC-Tulip compatible 10/100 Ethernet
-		1385 511a  FA511
-		1395 2103  CB100-EZ (4-LED version)
 	2850  HSP MicroModem 56
 	5120  ADM5120 OpenGate System-on-Chip
 	8201  ADM8211 802.11b Wireless Interface
-		10b8 2635  SMC2635W v1 802.11b Wireless Cardbus Adapter
-		1317 8201  SMC2635W v2 802.11b Wireless Cardbus Adapter
 	8211  ADM8211 802.11b Wireless Interface
 	9511  21x4x DEC-Tulip compatible 10/100 Ethernet
 1318  Packet Engines Inc.
 	0911  GNIC-II PCI Gigabit Ethernet [Hamachi]
 1319  Fortemedia, Inc
 	0801  Xwave QS3000A [FM801]
-		1319 1319  FM801 PCI Audio
 	0802  Xwave QS3000A [FM801 game port]
-		1319 1319  FM801 PCI Joystick
 	1000  FM801 PCI Audio
 	1001  FM801 PCI Joystick
 131a  Finisar Corp.
@@ -15206,7 +7792,6 @@ var pciids = []byte(`#
 	2020  CyberParallel (1-port)
 	2021  CyberParallel (2-port)
 	2030  CyberSerial (2-port) 16550
-		131f 2030  PCI Serial Card
 	2031  CyberSerial (2-port) 16650
 	2032  CyberSerial (2-port) 16850
 	2040  Trio 1S(16550)+2P
@@ -15258,7 +7843,6 @@ var pciids = []byte(`#
 1341  Kyoto Microcomputer Co
 1342  Promax Systems Inc
 1343  Phylon Communications Inc
-# nee Crucial Technology
 1344  Micron Technology Inc
 	5150  RealSSD P320h
 	5151  RealSSD P320m
@@ -15281,9 +7865,7 @@ var pciids = []byte(`#
 	2189  HSP56 MicroModem
 	2486  2304WT V.92 MDC Modem
 	7890  HSP MicroModem 56
-		134d 0001  PCT789 adapter
 	7891  HSP MicroModem 56
-		134d 0001  HSP MicroModem 56
 	7892  HSP MicroModem 56
 	7893  HSP MicroModem 56
 	7894  HSP MicroModem 56
@@ -15294,7 +7876,6 @@ var pciids = []byte(`#
 134f  Algo System Co Ltd
 1350  Systec Co. Ltd
 1351  Sonix Inc
-# nee Thales Idatys
 1353  Vierling Communication SAS
 	0002  Proserver
 	0003  PCI-FUT
@@ -15380,7 +7961,6 @@ var pciids = []byte(`#
 1370  ATL Products
 1371  CNet Technology Inc
 	434e  GigaCard Network Adapter
-		1371 434e  N-Way PCI-Bus Giga-Card 1000/100/10Mbps(L)
 1373  Silicon Vision Inc
 1374  Silicom Ltd.
 	0024  Silicom Dual port Giga Ethernet BGE Bypass Server Adapter
@@ -15512,58 +8092,13 @@ var pciids = []byte(`#
 	3200  Intellio C320 Turbo PCI
 1394  Level One Communications
 	0001  LXT1001 Gigabit Ethernet
-		1186 4800  DGE-500SX
-		1394 0001  NetCelerator Adapter
 1395  Ambicom Inc
 1396  Cipher Systems Inc
 1397  Cologne Chip Designs GmbH
 	08b4  ISDN network Controller [HFC-4S]
-		1397 08b4  HFC-4S [Cologne Chip HFC-4S Eval. Board]
-		1397 b51a  HFC-4S [Allo.com BRI card]
-		1397 b520  HFC-4S [IOB4ST]
-		1397 b540  HFC-4S [Swyx SX2 QuadBri]
-		1397 b550  HFC-4S [Junghanns.NET quadBRI]
-		1397 b556  HFC-4S [Junghanns.NET duoBRI]
-		1397 b559  HFC-4S [Junghanns.NET duoBRI miniPCI]
-		1397 b560  HFC-4S [BeroNet BN4S0]
-		1397 b566  HFC-4S [BeroNet BN2S0]
-		1397 b567  HFC-4S [BeroNet BN1S0 miniPCI]
-		1397 b568  HFC-4S [BeroNet BN4S0 miniPCI]
-		1397 b569  HFC-4S [BeroNet BN2S0 miniPCI]
-		1397 b620  HFC-4S
-		1397 b752  HFC-4S [Junghanns.NET quadBRI PCIe]
-		1397 b761  HFC-4S [BeroNet BN2S0 PCIe]
-		1397 b762  HFC-4S [BeroNet BN4S0 PCIe]
-		1397 e884  HFC-4S [OpenVox B200P]
-		1397 e888  HFC-4S [OpenVox B200P / B400P]
 	16b8  ISDN network Controller [HFC-8S]
-		1397 16b8  HFC-8S [Cologne Chip HFC-8S Eval. Board]
-		1397 b521  HFC-8S [IOB4ST Recording]
-		1397 b522  HFC-8S [IOB8ST]
-		1397 b552  HFC-8S [Junghanns.NET octoBRI]
-		1397 b55b  HFC-8S [Junghanns.NET octoBRI]
-		1397 b562  HFC-8S [BeroNet BN8S0]
-		1397 b56b  HFC-8S [BeroNet BN8S0+]
-		1397 b622  HFC-8S
-		1397 e998  HFC-8S [OpenVox B800P]
 	2bd0  ISDN network controller [HFC-PCI]
-		0675 1704  ISDN Adapter (PCI Bus, D, C)
-		0675 1708  ISDN Adapter (PCI Bus, D, C, ACPI)
-		1397 2bd0  ISDN Board
-		e4bf 1000  CI1-1-Harp
 	30b1  ISDN network Controller [HFC-E1]
-		1397 30b1  HFC-E1 [Cologne Chip HFC-E1 Eval. Board]
-		1397 b523  HFC-E1 [IOB1E1]
-		1397 b543  HFC-E1 [Swyx SX2 SinglePRI V2]
-		1397 b544  HFC-E1 [Swyx SX2 DualPRI V2]
-		1397 b553  HFC-E1 [Junghanns.NET singleE1]
-		1397 b554  HFC-E1 [Junghanns.NET doubleE1]
-		1397 b555  HFC-E1 [Junghanns.NET doubleE1 2.0]
-		1397 b55a  HFC-E1 [Junghanns.NET singleE1 miniPCI]
-		1397 b563  HFC-E1 [beroNet BN1E1]
-		1397 b564  HFC-E1 [beroNet BN2E1]
-		1397 b565  HFC-E1 [beroNet BN2E1+]
-		1397 b56a  HFC-E1 [beroNet BN1E1 miniPCI]
 	b700  ISDN network controller PrimuX S0 [HFC-PCI]
 	f001  GSM Network Controller [HFC-4GSM]
 1398  Clarion co. Ltd
@@ -15595,20 +8130,10 @@ var pciids = []byte(`#
 	0026  8155 Security Processor
 	002e  9630 Compression Processor
 	002f  9725 Compression and Security Processor
-		13a3 1600  DR1600 Acceleration Card
-		13a3 1605  DR1605 Acceleration Card
-		13a3 1610  DR1610 Acceleration Card
-		13a3 1615  DR1615 Acceleration Card
-		13a3 1620  DR1620 Acceleration Card
-		13a3 1625  DR1625 Acceleration Card
 	0033  8201 Acceleration Processor
-		13a3 0036  DX1710 Acceleration Card
 	0034  8202 Acceleration Processor
-		13a3 0036  DX1720 Acceleration Card
 	0035  8203 Acceleration Processor
-		13a3 0036  DX1730 Acceleration Card
 	0037  8204 Acceleration Processor
-		13a3 0036  DX1740 Acceleration Card
 13a4  Rascom Inc
 13a5  Audio Digital Imaging Inc
 13a6  Videonics Inc
@@ -15654,7 +8179,6 @@ var pciids = []byte(`#
 13c1  3ware Inc
 	1000  5xxx/6xxx-series PATA-RAID
 	1001  7xxx/8xxx-series PATA/SATA-RAID
-		13c1 1001  7xxx/8xxx-series PATA/SATA-RAID
 	1002  9xxx-series SATA-RAID
 	1003  9550SX SATA-II RAID PCI-X
 	1004  9650SE SATA-II RAID PCIe
@@ -15709,7 +8233,6 @@ var pciids = []byte(`#
 13de  ABB Robotics Products AB
 13df  E-Tech Inc
 	0001  PCI56RVP Modem
-		13df 0001  PCI56RVP Modem
 13e0  GVC Corporation
 13e1  Silicom Multimedia Systems Inc
 13e2  Dynamics Research Corporation
@@ -15729,11 +8252,9 @@ var pciids = []byte(`#
 13ef  Coppercom Inc
 13f0  Sundance Technology Inc / IC Plus Corp
 	0200  IC Plus IP100A Integrated 10/100 Ethernet MAC + PHY
-		1043 8213  NX1001
 	0201  ST201 Sundance Ethernet
 	1021  TC902x Gigabit Ethernet
 	1023  IP1000 Family Gigabit Ethernet
-		1043 8180  NX1101
 13f1  Oce' - Technologies B.V.
 13f2  Ford Microelectronics Inc
 13f3  Mcdata Corporation
@@ -15743,61 +8264,11 @@ var pciids = []byte(`#
 13f6  C-Media Electronics Inc
 	0011  CMI8738
 	0100  CM8338A
-		13f6 ffff  CMI8338/C3DX PCI Audio Device
 	0101  CM8338B
-		13f6 0101  CMI8338-031 PCI Audio Device
 	0111  CMI8738/CMI8768 PCI Audio
-		1019 0970  P6STP-FL motherboard
-		1043 8035  CUSI-FX motherboard
-		1043 8077  CMI8738 6-channel audio controller
-		1043 80e2  CMI8738 6ch-MX
-		13f6 0111  CMI8738/C3DX PCI Audio Device
-		13f6 9761  Theatron Agrippa
-		153b 1144  Aureon 5.1
-		153b 1170  Aureon 7.1
-		1681 a000  Gamesurround MUSE XL
-		17ab 0604  PSC604 Dynamic Edge
-		17ab 0605  PSC605 Sonic Edge
-		17ab 7777  PSC605 Sonic Edge
-		270f 1103  CT-7NJS Ultra motherboard
-		270f f462  7NJL1 motherboard
-		584d 3731  Digital X-Mystique
-		584d 3741  X-Plosion 7.1
-		584d 3751  X-Raider 7.1
-		584d 3761  X-Mystique 7.1 LP
-		584d 3771  X-Mystique 7.1 LP Value
-		7284 8384  Striker 7.1
 	0211  CM8738
 	5011  CM8888 [Oxygen Express]
-		13f6 5011  HDA Controller
 	8788  CMI8788 [Oxygen HD Audio]
-		1043 8269  Virtuoso 200 (Xonar D2)
-		1043 8275  Virtuoso 100 (Xonar DX)
-		1043 82b7  Virtuoso 200 (Xonar D2X)
-		1043 8314  Virtuoso 200 (Xonar HDAV1.3)
-		1043 8327  Virtuoso 100 (Xonar DX)
-		1043 834f  Virtuoso 100 (Xonar D1)
-		1043 835c  Virtuoso 100 (Xonar Essence STX)
-		1043 835d  Virtuoso 100 (Xonar ST)
-		1043 835e  Virtuoso 200 (Xonar HDAV1.3 Slim)
-		1043 838e  Virtuoso 66 (Xonar DS)
-		1043 8428  Virtuoso 100 (Xonar Xense)
-		1043 8467  CMI8786 (Xonar DG)
-		1043 8521  CMI8786 (Xonar DGX)
-		1043 85f4  Virtuoso 100 (Xonar Essence STX II)
-		13f6 8782  PCI 2.0 HD Audio
-		13f6 ffff  CMI8787-HG2PCI
-		14c3 1710  HiFier Fantasia
-		14c3 1711  HiFier Serenade
-		14c3 1713  HiFier Serenade III
-		1a58 0910  Barracuda AC-1
-		415a 5431  X-Meridian 7.1
-		5431 017a  X-Meridian 7.1 2G
-		584d 3781  HDA X-Purity 7.1 Platinum
-		7284 9761  CLARO
-		7284 9781  CLARO halo
-		7284 9783  eCLARO
-		7284 9787  CLARO II
 13f7  Wildfire Communications
 13f8  Ad Lib Multimedia Inc
 13f9  NTT Advanced Technology Corp.
@@ -15808,23 +8279,14 @@ var pciids = []byte(`#
 13fe  Advantech Co. Ltd
 	1240  PCI-1240 4-channel stepper motor controller card
 	1600  PCI-16xx series PCI multiport serial board (function 0)
-# This board has two PCI functions, appears as two PCI devices
-		1601 0002  PCI-1601 2-port unisolated RS-422/485
-# This board has two PCI functions, appears as two PCI devices
-		1602 0002  PCI-1602 2-port isolated RS-422/485
-		1612 0004  PCI-1612 4-port RS-232/422/485
 	1603  PCI-1603 2-port isolated RS-232/current loop
 	1604  PCI-1604 2-port RS-232
 	16ff  PCI-16xx series PCI multiport serial board (function 1: RX/TX steering CPLD)
-		1601 0000  PCI-1601 2-port unisolated RS-422/485 PCI communications card
-		1602 0000  PCI-1602 2-port isolated RS-422/485
-		1612 0000  PCI-1612 4-port RS-232/422/485
 	1711  PCI-1711 16-channel data acquisition card 12-bit, 100kS/s
 	1733  PCI-1733 32-channel isolated digital input card
 	1752  PCI-1752
 	1754  PCI-1754
 	1756  PCI-1756
-# FPGA bridge to two SJA1000
 	c302  MIOe-3680 2-Port CAN-Bus MIOe Module with Isolation Protection
 13ff  Silicon Spice Inc
 1400  Artx Inc
@@ -15938,22 +8400,8 @@ var pciids = []byte(`#
 1408  Aloka Co. Ltd
 1409  Timedia Technology Co Ltd
 	7168  PCI2S550 (Dual 16550 UART)
-		1409 0002  SER4036A3V (2x RS232 port)
-		1409 4027  SER4027A (1x RS232 port)
-		1409 4037  SER4037A(L) [SUNIX SUN1889] (2x RS232 port)
-# Single DC-37 connector
-		1409 4056  SER4056A (4x RS232)
-		1409 5027  SER4027D
-		1409 5037  SER4037D (2x RS232 port)
-# Single DC-62 connector
-		1409 5066  SER4066R (8x RS232)
-# 4x 8p8c connectors
-		1409 6056  SER4056D (4x RS232 port)
 	7268  SUN1888 (Dual IEEE1284 parallel port)
-		1409 0103  PAR4008A
-		1409 0104  PAR4018A
 140a  DSP Research Inc
-# Formerly RAMiX, GE Fanuc, GE Intelligent Platforms
 140b  Abaco Systems, Inc.
 140c  Elmic Systems Inc
 140d  Matsushita Electric Works Ltd
@@ -15961,43 +8409,9 @@ var pciids = []byte(`#
 140f  Salient Systems Corp
 1410  Midas lab Inc
 1411  Ikos Systems Inc
-# Nee IC Ensemble Inc.
 1412  VIA Technologies Inc.
 	1712  ICE1712 [Envy24] PCI Multi-Channel I/O Controller
-		1412 1712  Hoontech ST Audio DSP 24
-		1412 d630  M-Audio Delta 1010
-		1412 d631  M-Audio Delta DiO
-		1412 d632  M-Audio Delta 66
-		1412 d633  M-Audio Delta 44
-		1412 d634  M-Audio Delta Audiophile 2496
-		1412 d635  M-Audio Delta TDIF
-		1412 d637  M-Audio Delta RBUS
-		1412 d638  M-Audio Delta 410
-		1412 d63b  M-Audio Delta 1010LT
-		1412 d63c  Digigram VX442
-		1416 1712  Hoontech ST Audio DSP 24 Media 7.1
-		153b 1115  EWS88 MT
-		153b 1125  EWS88 MT (Master)
-		153b 112b  EWS88 D
-		153b 112c  EWS88 D (Master)
-		153b 1130  EWX 24/96
-		153b 1138  DMX 6fire 24/96
-		153b 1151  PHASE88
-		16ce 1040  Edirol DA-2496
 	1724  VT1720/24 [Envy24PT/HT] PCI Multi-Channel Audio Controller
-		10b0 0200  Hollywood@Home 7.1
-		1412 1724  Albatron PX865PE 7.1
-		1412 3630  M-Audio Revolution 7.1
-		1412 3631  M-Audio Revolution 5.1
-		1412 3632  M-Audio Audiophile 192
-		153b 1145  Aureon 7.1 Space
-		153b 1147  Aureon 5.1 Sky
-		153b 1150  PHASE 22
-		153b 1153  Aureon 7.1 Universe
-		17ab 1906  PSC 724 [Ultimate Edge]
-		270f f641  ZNF3-150
-		270f f645  ZNF3-250
-		3130 4154  MAYA 44 MKII
 1413  Addonics
 1414  Microsoft Corporation
 	0001  MN-120 (ADMtek Centaur-C based)
@@ -16019,31 +8433,16 @@ var pciids = []byte(`#
 	8403  OX9162 Mode 0 (parallel port)
 	9500  OX16PCI954 (Quad 16950 UART) function 0 (Disabled)
 	9501  OX16PCI954 (Quad 16950 UART) function 0 (Uart)
-		12c4 0201  Titan/cPCI (2 port)
-		12c4 0202  Titan/cPCI (4 port)
-		12c4 0203  Titan/cPCI (8 port)
-		12c4 0210  Titan/104-Plus (8 port, p1-4)
-		131f 2050  CyberPro (4-port)
-# Model IO1085, Part No: JJ-P46012
-		131f 2051  CyberSerial 4S Plus
-		15ed 2000  MCCR Serial p0-3 of 8
-		15ed 2001  MCCR Serial p0-3 of 16
 	9505  OXuPCI952 (Dual 16C950 UART)
 	950a  EXSYS EX-41092 Dual 16950 Serial adapter
 	950b  OXCB950 Cardbus 16950 UART
 	9510  OX16PCI954 (Quad 16950 UART) function 1 (Disabled)
-		12c4 0200  Titan/cPCI (Unused)
 	9511  OX16PCI954 (Quad 16950 UART) function 1 (8bit bus)
-		12c4 0211  Titan/104-Plus (8 port, p5-8)
-		15ed 2000  MCCR Serial p4-7 of 8
-		15ed 2001  MCCR Serial p4-15 of 16
 	9512  OX16PCI954 (Quad 16950 UART) function 1 (32bit bus)
 	9513  OX16PCI954 (Quad 16950 UART) function 1 (parallel port)
 	9521  OX16PCI952 (Dual 16950 UART)
 	9523  OX16PCI952 Integrated Parallel Port
 	c158  OXPCIe952 Dual 16C950 UART
-		e4bf c504  CP4-SCAT Wireless Technologies Carrier Board
-		e4bf d551  DU1-MUSTANG Dual-Port RS-485 Interface
 	c308  EX-44016 16-port serial
 1416  Multiwave Innovation pte Ltd
 1417  Convergenet Technologies Inc
@@ -16066,7 +8465,6 @@ var pciids = []byte(`#
 	000c  T204 Protocol Engine
 	0022  10GbE Ethernet Adapter
 	0030  T310 10GbE Single Port Adapter
-		103c 705e  PCIe 10GBase-SR [AD386A]
 	0031  T320 10GbE Dual Port Adapter
 	0032  T302 1GbE Dual Port Adapter
 	0033  T304 1GbE Quad Port Adapter
@@ -16278,6 +8676,8 @@ var pciids = []byte(`#
 	50a7  T580-50A7 Unified Wire Ethernet Controller
 	50a8  T580-50A8 Unified Wire Ethernet Controller
 	50a9  T580-50A9 Unified Wire Ethernet Controller
+	50aa  T580-50AA Unified Wire Ethernet Controller
+	50ab  T520-50AB Unified Wire Ethernet Controller
 	5401  T520-CR Unified Wire Ethernet Controller
 	5402  T522-CR Unified Wire Ethernet Controller
 	5403  T540-CR Unified Wire Ethernet Controller
@@ -16338,6 +8738,8 @@ var pciids = []byte(`#
 	54a7  T580-50A7 Unified Wire Ethernet Controller
 	54a8  T580-50A8 Unified Wire Ethernet Controller
 	54a9  T580-50A9 Unified Wire Ethernet Controller
+	54aa  T580-50AA Unified Wire Ethernet Controller
+	54ab  T520-50AB Unified Wire Ethernet Controller
 	5501  T520-CR Unified Wire Storage Controller
 	5502  T522-CR Unified Wire Storage Controller
 	5503  T540-CR Unified Wire Storage Controller
@@ -16458,6 +8860,8 @@ var pciids = []byte(`#
 	56a7  T580-50A7 Unified Wire Storage Controller
 	56a8  T580-50A8 Unified Wire Storage Controller
 	56a9  T580-50A9 Unified Wire Storage Controller
+	56aa  T580-50AA Unified Wire Storage Controller
+	56ab  T520-50AB Unified Wire Storage Controller
 	5701  T520-CR Unified Wire Ethernet Controller
 	5702  T522-CR Unified Wire Ethernet Controller
 	5703  T540-CR Unified Wire Ethernet Controller
@@ -16557,6 +8961,8 @@ var pciids = []byte(`#
 	58a7  T580-50A7 Unified Wire Ethernet Controller [VF]
 	58a8  T580-50A8 Unified Wire Ethernet Controller [VF]
 	58a9  T580-50A9 Unified Wire Ethernet Controller [VF]
+	58aa  T580-50AA Unified Wire Ethernet Controller [VF]
+	58ab  T520-50AB Unified Wire Ethernet Controller [VF]
 	6001  T6225-CR Unified Wire Ethernet Controller
 	6002  T6225-SO-CR Unified Wire Ethernet Controller
 	6003  T6425-CR Unified Wire Ethernet Controller
@@ -16670,7 +9076,6 @@ var pciids = []byte(`#
 1432  Edimax Computer Co.
 	9130  RTL81xx Fast Ethernet
 1433  Eltec Elektronik GmbH
-# Nee Real Time Devices US Inc.
 1435  RTD Embedded Technologies, Inc.
 	4520  PCI4520
 	6020  SPM6020
@@ -16715,9 +9120,7 @@ var pciids = []byte(`#
 	9111  PCI-9111
 	9113  PCI-9113
 	9114  PCI-9114
-# 2-16 MB SRAM, 4x UART, I2C, misc I/O
 	a001  ADi-BSEC
-# nee Loronix Information Systems Inc.
 144b  Verint Systems Inc.
 144c  Catalina Research Inc
 144d  Samsung Electronics Co Ltd
@@ -16726,32 +9129,8 @@ var pciids = []byte(`#
 	a802  NVMe SSD Controller SM951/PM951
 	a804  NVMe SSD Controller SM961/PM961
 	a820  NVMe SSD Controller 171X
-		1028 1f95  Express Flash NVMe XS1715 SSD 400GB
-		1028 1f96  Express Flash NVMe XS1715 SSD 800GB
-		1028 1f97  Express Flash NVMe XS1715 SSD 1600GB
-		1028 1fa4  Express Flash NVMe SM1715 3.2TB SFF
-		1028 1fa6  Express Flash NVMe SM1715 3.2TB AIC
-		1028 1fba  Express Flash NVMe SM1715 800GB SFF
-		1028 1fbb  Express Flash NVMe SM1715 1.6TB SFF
-		1028 1fbc  Express Flash NVMe SM1715 1.6TB AIC
 	a821  NVMe SSD Controller 172X
-		1028 1fb7  Express Flash NVMe PM1725 3.2TB SFF
-		1028 1fb8  Express Flash NVMe PM1725 3.2TB AIC
-		1028 1fb9  Express Flash NVMe PM1725 6.4TB AIC
-		1028 1fc1  Express Flash NVMe PM1725 800GB SFF
-		1028 1fc2  Express Flash NVMe PM1725 1.6TB SFF
-		1028 1fc4  Express Flash NVMe PM1725 1.6TB AIC
 	a822  NVMe SSD Controller 172Xa
-		1014 0621  PCIe3 1.6TB NVMe Flash Adapter II x8
-		1014 0622  PCIe3 3.2TB NVMe Flash Adapter II x8
-		1014 0629  PCIe3 6.4TB NVMe Flash Adapter II x8
-		1028 1fd9  Express Flash PM1725a 800GB SFF
-		1028 1fda  Express Flash PM1725a 1.6TB SFF
-		1028 1fdb  Express Flash PM1725a 3.2TB SFF
-		1028 1fdc  Express Flash PM1725a 6.4TB SFF
-		1028 1fdd  Express Flash PM1725a 1.6TB AIC
-		1028 1fde  Express Flash PM1725a 3.2TB AIC
-		1028 1fdf  Express Flash PM1725a 6.4TB AIC
 144e  OLITEC
 144f  Askey Computer Corp.
 1450  Octave Communications Ind.
@@ -16786,9 +9165,7 @@ var pciids = []byte(`#
 1467  DIGICOM SPA
 1468  AMBIT Microsystem Corp.
 1469  Cleveland Motion Controls
-# formerly IFR.
 146a  Aeroflex
-# 1.5 GHz to 3.0 GHz x 1Hz
 	3010  3010 RF Synthesizer
 	3a11  3011A PXI RF Synthesizer
 146b  Parascan Technologies Ltd
@@ -16864,7 +9241,6 @@ var pciids = []byte(`#
 14a3  Maverick Networks
 14a4  Lite-On Technology Corporation
 	22f1  M8Pe Series NVMe SSD
-# Wrong vendor ID used
 	4318  Broadcom BCM4318 [AirForce One 54g] 802.11g WLAN Controller
 14a5  XIONICS Document Technologies Inc
 14a6  INOVA Computers GmBH & Co KG
@@ -16907,7 +9283,6 @@ var pciids = []byte(`#
 	a505  Cisco Aironet CB20a 802.11a Wireless LAN Adapter
 	a506  Cisco Aironet Mini PCI b/g
 14ba  INTERNIX Inc.
-# ARCNET interface card based on SMSC COM20022 chip and manufactured for SMSC Japan
 	0600  ARC-PCI/22
 14bb  SEMTECH Corporation
 14bc  Globespan Semiconductor Inc.
@@ -16917,18 +9292,12 @@ var pciids = []byte(`#
 14be  L3 Communications
 14bf  SPIDER Communications Inc.
 14c0  COMPAL Electronics Inc
-# now owned by CSP, Inc.
 14c1  MYRICOM Inc.
 	0008  Myri-10G Dual-Protocol NIC
-		14c1 0008  10G-PCIE-8A
-		14c1 0009  10G-PCIE-8A (MSI-X firmware)
-		14c1 000a  10G-PCIE-8B
 	8043  Myrinet 2000 Scalable Cluster Interconnect
-		103c 1240  Myrinet M2L-PCI64/2-3.0 LANai 7.4 (HP OEM)
 14c2  DTK Computer
 14c3  MEDIATEK Corp.
 	7630  MT7630e 802.11bgn Wireless Network Adapter
-# MT7612E too?
 	7662  MT7662E 802.11ac PCI Express Wireless Network Adapter
 14c4  IWASAKI Information Systems Co Ltd
 14c5  Automation Products AB
@@ -16979,7 +9348,6 @@ var pciids = []byte(`#
 	6201  ACS-62xxx, External PCIe to SAS/SATA RAID controller
 14d7  Hirakawa Hewtech Corp
 14d8  HOPF Elektronik GmBH
-# Formerly SiPackets, Inc., formerly API NetWorks, Inc., formerly Alpha Processor, Inc.
 14d9  Alliance Semiconductor Corporation
 	0010  AP1011/SP1011 HyperTransport-PCI Bridge [Sturgeon]
 	9000  AS90L10204/10208 HyperTransport to PCI-X Bridge
@@ -17006,7 +9374,6 @@ var pciids = []byte(`#
 14e1  INVERTEX
 14e2  INFOLIBRIA
 14e3  AMTELCO
-# Formerly Broadcom Corporation
 14e4  Broadcom Limited
 	0576  BCM43224 802.11a/b/g/n
 	0800  Sentry5 Chipcommon I/O Controller
@@ -17019,186 +9386,49 @@ var pciids = []byte(`#
 	0816  BCM3302 Sentry5 MIPS32 CPU
 	1570  720p FaceTime HD Camera
 	1600  NetXtreme BCM5752 Gigabit Ethernet PCI Express
-		1028 01c1  Precision 490
-		1028 01c2  Latitude D620
-		103c 3015  PCIe LAN on Motherboard
-		107b 5048  E4500 Onboard
-		1259 2705  AT-2711FX
 	1601  NetXtreme BCM5752M Gigabit Ethernet PCI Express
 	1612  BCM70012 Video Decoder [Crystal HD]
 	1615  BCM70015 Video Decoder [Crystal HD]
 	1639  NetXtreme II BCM5709 Gigabit Ethernet
-		1028 0235  PowerEdge R710 BCM5709 Gigabit Ethernet
-		1028 0236  PowerEdge R610 BCM5709 Gigabit Ethernet
-		1028 0237  PowerEdge T610 BCM5709 Gigabit Ethernet
-		103c 7055  NC382i Integrated Multi-port PCI Express Gigabit Server Adapter
-		103c 7059  NC382T PCIe Dual Port Multifunction Gigabit Server Adapter
-		10a9 8027  Quad port Gigabit Ethernet Controller
 	163a  NetXtreme II BCM5709S Gigabit Ethernet
-		1028 027b  PowerEdge M805 Broadcom NetXtreme II BCM5709S
-		1028 029c  PowerEdge M710 BCM5709S Gigabit Ethernet
-		103c 171d  NC382m Dual Port 1GbE Multifunction BL-c Adapter
-		103c 7056  NC382i Integrated Quad Port PCI Express Gigabit Server Adapter
-		1259 2984  AT-2973SX
 	163b  NetXtreme II BCM5716 Gigabit Ethernet
-		1028 028c  PowerEdge R410 BCM5716 Gigabit Ethernet
-		1028 028d  PowerEdge T410 BCM5716 Gigabit Ethernet
-		1028 02f1  PowerEdge R510 BCM5716 Gigabit Ethernet
 	163c  NetXtreme II BCM5716S Gigabit Ethernet
 	163d  NetXtreme II BCM57811 10-Gigabit Ethernet
-		1043 858a  PEB-10G/57811-1S
 	163e  NetXtreme II BCM57811 10 Gigabit Ethernet Multi Function
 	163f  NetXtreme II BCM57811 10-Gigabit Ethernet Virtual Function
 	1641  NetXtreme BCM57787 Gigabit Ethernet PCIe
 	1642  NetXtreme BCM57764 Gigabit Ethernet PCIe
 	1643  NetXtreme BCM5725 Gigabit Ethernet PCIe
 	1644  NetXtreme BCM5700 Gigabit Ethernet
-		1014 0277  Broadcom Vigil B5700 1000Base-T
-		1028 00d1  Broadcom BCM5700
-		1028 0106  Broadcom BCM5700
-		1028 0109  Broadcom BCM5700 1000Base-T
-		1028 010a  Broadcom BCM5700 1000BaseTX
-		10b7 1000  3C996-T 1000Base-T
-		10b7 1001  3C996B-T 1000Base-T
-		10b7 1002  3C996C-T 1000Base-T
-		10b7 1003  3C997-T 1000Base-T Dual Port
-		10b7 1004  3C996-SX 1000Base-SX
-		10b7 1005  3C997-SX 1000Base-SX Dual Port
-		10b7 1008  3C942 Gigabit LOM (31X31)
-		14e4 0002  NetXtreme 1000Base-SX
-		14e4 0003  NetXtreme 1000Base-SX
-		14e4 0004  NetXtreme 1000Base-T
-		14e4 1028  NetXtreme 1000BaseTX
-		14e4 1644  BCM5700 1000Base-T
 	1645  NetXtreme BCM5701 Gigabit Ethernet
-		0e11 007c  NC7770 Gigabit Server Adapter (PCI-X, 10/100/1000-T)
-		0e11 007d  NC6770 Gigabit Server Adapter (PCI-X, 1000-SX)
-		0e11 0085  NC7780 Gigabit Server Adapter (embedded, WOL)
-		0e11 0099  NC7780 Gigabit Server Adapter (embedded, WOL)
-		0e11 009a  NC7770 Gigabit Server Adapter (PCI-X, 10/100/1000-T)
-		0e11 00c1  NC6770 Gigabit Server Adapter (PCI-X, 1000-SX)
-		1028 0121  Broadcom BCM5701 1000Base-T
-		103c 128a  BCM5701 1000Base-T (HP, OEM 3COM)
-		103c 128b  1000Base-SX (PCI) [A7073A]
-		103c 12a4  Core Lan 1000Base-T
-		103c 12c1  IOX Core Lan 1000Base-T [A7109AX]
-		103c 1300  Core LAN/SCSI Combo [A6794A]
-		10a9 8010  IO9/IO10 Gigabit Ethernet (Copper)
-		10a9 8011  Gigabit Ethernet (Copper)
-		10a9 8012  Gigabit Ethernet (Fiber)
-		10b7 1004  3C996-SX 1000Base-SX
-		10b7 1006  3C996B-T 1000Base-T
-		10b7 1007  3C1000-T 1000Base-T
-		10b7 1008  3C940-BR01 1000Base-T
-		14e4 0001  BCM5701 1000Base-T
-		14e4 0005  BCM5701 1000Base-T
-		14e4 0006  BCM5701 1000Base-T
-		14e4 0007  BCM5701 1000Base-SX
-		14e4 0008  BCM5701 1000Base-T
-		14e4 1645  NetXtreme BCM5701 Gigabit Ethernet
-		14e4 8008  BCM5701 1000Base-T
 	1646  NetXtreme BCM5702 Gigabit Ethernet
-		0e11 00bb  NC7760 1000BaseTX
-		1028 0126  Broadcom BCM5702 1000BaseTX
-		14e4 8009  BCM5702 1000BaseTX
 	1647  NetXtreme BCM5703 Gigabit Ethernet
-		0e11 0099  NC7780 1000BaseTX
-		0e11 009a  NC7770 1000BaseTX
-		10a9 8010  IO9 Gigabit Ethernet (Copper)
-		14e4 0009  BCM5703 1000BaseTX
-		14e4 000a  BCM5703 1000BaseSX
-		14e4 000b  BCM5703 1000BaseTX
-		14e4 8009  BCM5703 1000BaseTX
-		14e4 800a  BCM5703 1000BaseTX
 	1648  NetXtreme BCM5704 Gigabit Ethernet
-		0e11 00cf  NC7772 Gigabit Server Adapter (PCI-X, 10,100,1000-T)
-		0e11 00d0  NC7782 Gigabit Server Adapter (PCI-X, 10,100,1000-T)
-		0e11 00d1  NC7783 Gigabit Server Adapter (PCI-X, 10,100,1000-T)
-		1028 014a  PowerEdge 1750
-		1028 0170  PowerEdge 6850 Broadcom NetXtreme BCM5704
-		103c 310f  NC7782 Gigabit Server Adapter (PCI-X, 10,100,1000-T)
-		10a9 8013  Dual Port Gigabit Ethernet (PCI-X,Copper)
-		10a9 8018  Dual Port Gigabit Ethernet (A330)
-		10a9 801a  Dual Port Gigabit Ethernet (IA-blade)
-		10a9 801b  Quad Port Gigabit Ethernet (PCI-E,Copper)
-		10b7 2000  3C998-T Dual Port 10/100/1000 PCI-X
-		10b7 3000  3C999-T Quad Port 10/100/1000 PCI-X
-		1166 1648  NetXtreme CIOB-E 1000Base-T
-		1734 100b  PRIMERGY RX/TX series onboard LAN
 	1649  NetXtreme BCM5704S_2 Gigabit Ethernet
 	164a  NetXtreme II BCM5706 Gigabit Ethernet
-		103c 1709  NC371i Integrated PCI-X Multifunction Gigabit Server Adapter
-		103c 3070  NC380T PCI Express Dual Port Multifunction Gigabit Server Adapter
-		103c 3101  NC370T MultifuNCtion Gigabit Server Adapter
-		103c 3106  NC370i Multifunction Gigabit Server Adapter
 	164c  NetXtreme II BCM5708 Gigabit Ethernet
-		1028 01f0  PowerEdge R900 Broadcom NetXtreme II BCM5708
-		1028 0205  PowerEdge 2970 Broadcom NetXtreme II BCM5708
-		1028 020b  PowerEdge T605 Broadcom NetXtreme II BCM5708
-		1028 0221  PowerEdge R805 Broadcom NetXtreme II BCM5708
-		1028 0223  PowerEdge R905 Broadcom NetXtreme II BCM5708
-		1028 1f12  PowerEdge R805/R905 Broadcom NetXtreme II BCM5708
-		103c 7037  NC373T PCI Express Multifunction Gigabit Server Adapter
-		103c 7038  NC373i Integrated Multifunction Gigabit Server Adapter
-		103c 7045  NC374m PCI Express Dual Port Multifunction Gigabit Server Adapter
 	164d  NetXtreme BCM5702FE Gigabit Ethernet
 	164e  NetXtreme II BCM57710 10-Gigabit PCIe [Everest]
-		103c 171c  NC532m Dual Port 10GbE Multifunction BL-C Adapter
-		103c 7058  NC532i Dual Port 10GbE Multifunction BL-C Adapter
 	164f  NetXtreme II BCM57711 10-Gigabit PCIe
 	1650  NetXtreme II BCM57711E 10-Gigabit PCIe
-		103c 171c  NC532m Dual Port 10GbE Multifunction BL-C Adapter
-		103c 7058  NC532i Dual Port 10GbE Multifunction BL-C Adapter
 	1653  NetXtreme BCM5705 Gigabit Ethernet
-		0e11 00e3  NC7761 Gigabit Server Adapter
-		1734 1073  Primergy Econel 200 D2020 mainboard
 	1654  NetXtreme BCM5705_2 Gigabit Ethernet
-		0e11 00e3  NC7761 Gigabit Server Adapter
-		103c 3100  NC1020 ProLiant Gigabit Server Adapter 32 PCI
-		103c 3226  NC150T 4-port Gigabit Combo Switch & Adapter
 	1655  NetXtreme BCM5717 Gigabit Ethernet PCIe
 	1656  NetXtreme BCM5718 Gigabit Ethernet PCIe
 	1657  NetXtreme BCM5719 Gigabit Ethernet PCIe
-		1014 0420  FC 5260/5899 4-port 1 GbE Adapter for Power
-		103c 169d  Ethernet 1Gb 4-port 331FLR Adapter
-		103c 22be  Ethernet 1Gb 4-port 331i Adapter
-		103c 3383  Ethernet 1Gb 4-port 331T Adapter
 	1659  NetXtreme BCM5721 Gigabit Ethernet PCI Express
-		1014 02c6  eServer xSeries server mainboard
-		1028 01e6  PowerEdge 860
-		1028 023c  PowerEdge R200 Broadcom NetXtreme BCM5721
-		103c 170b  NC320m PCI Express Dual Port Gigabit Server Adapter
-		103c 7031  NC320T PCIe Gigabit Server Adapter
-		103c 7032  NC320i PCIe Gigabit Server Adapter
-		1734 1061  PRIMERGY RX/TX S2 series onboard LAN
 	165a  NetXtreme BCM5722 Gigabit Ethernet PCI Express
-# Dual NIC server
-		1014 0378  System x3350 (Machine type 4192)
-		1028 020f  PowerEdge R300 Broadcom NetXtreme 5722
-		1028 0210  PowerEdge T300 Broadcom NetXtreme 5722
-		1028 0225  PowerEdge T105 Broadcom NetXtreme 5722
-		103c 7051  NC105i PCIe Gigabit Server Adapter
-		103c 7052  NC105T PCIe Gigabit Server Adapter
 	165b  NetXtreme BCM5723 Gigabit Ethernet PCIe
-		103c 705d  NC107i Integrated PCI Express Gigabit Server Adapter
 	165c  NetXtreme BCM5724 Gigabit Ethernet PCIe
 	165d  NetXtreme BCM5705M Gigabit Ethernet
-		1028 865d  Latitude D400
-		14e4 165d  Dell Latitude D600
 	165e  NetXtreme BCM5705M_2 Gigabit Ethernet
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 099c  NX6110/NC6120
-		10cf 1279  LifeBook E8010D
 	165f  NetXtreme BCM5720 Gigabit Ethernet PCIe
 	1662  NetXtreme II BCM57712 10 Gigabit Ethernet
 	1663  NetXtreme II BCM57712 10 Gigabit Ethernet Multi Function
 	1665  NetXtreme BCM5717 Gigabit Ethernet PCIe
 	1668  NetXtreme BCM5714 Gigabit Ethernet
-		103c 7039  NC324i PCIe Dual Port Gigabit Server Adapter
 	1669  NetXtreme 5714S Gigabit Ethernet
 	166a  NetXtreme BCM5780 Gigabit Ethernet
-		103c 7035  NC325i Integrated Dual port PCIe Express Gigabit Server Adapter
 	166b  NetXtreme BCM5780S Gigabit Ethernet
 	166e  570x 10/100 Integrated Controller
 	166f  NetXtreme II BCM57712 10 Gigabit Ethernet Virtual Function
@@ -17206,35 +9436,11 @@ var pciids = []byte(`#
 	1673  NetXtreme BCM5755M Gigabit Ethernet PCI Express
 	1674  NetXtreme BCM5756ME Gigabit Ethernet PCI Express
 	1677  NetXtreme BCM5751 Gigabit Ethernet PCI Express
-		1028 0176  Dimension XPS Gen 4
-		1028 0177  Dimension 8400
-		1028 0179  Optiplex GX280
-		1028 0182  Latitude D610
-		1028 0187  Precision M70
-		1028 01a8  Precision 380
-		1028 01ad  OptiPlex GX620
-		103c 3006  DC7100 SFF(DX878AV)
-		1462 028c  915P/G Neo2
-		1734 105d  Scenic W620
 	1678  NetXtreme BCM5715 Gigabit Ethernet
-		103c 703e  NC326i PCIe Dual Port Gigabit Server Adapter
 	1679  NetXtreme BCM5715S Gigabit Ethernet
-		103c 1707  NC326m PCIe Dual Port Adapter
-		103c 170c  NC325m PCIe Quad Port Adapter
-		103c 703c  NC326i PCIe Dual Port Gigabit Server Adapter
 	167a  NetXtreme BCM5754 Gigabit Ethernet PCI Express
-		1028 01da  OptiPlex 745
-		1028 01de  Precision 390
-		1028 01df  PowerEdge SC440
-		1028 0214  Precision T3400
-		1028 021e  Precision T5400
 	167b  NetXtreme BCM5755 Gigabit Ethernet PCI Express
-		103c 280a  DC5750 Microtower
 	167d  NetXtreme BCM5751M Gigabit Ethernet PCI Express
-		1014 0577  ThinkPad X41 / Z60t
-		103c 0934  nx8220
-		103c 0940  Compaq nw8240 Mobile Workstation
-		17aa 2081  ThinkPad R60e
 	167e  NetXtreme BCM5751F Fast Ethernet PCI Express
 	167f  NetLink BCM5787F Fast Ethernet PCI Express
 	1680  NetXtreme BCM5761e Gigabit Ethernet PCIe
@@ -17246,134 +9452,39 @@ var pciids = []byte(`#
 	1686  NetXtreme BCM57766 Gigabit Ethernet PCIe
 	1687  NetXtreme BCM5762 Gigabit Ethernet PCIe
 	1688  NetXtreme BCM5761 10/100/1000BASE-T Ethernet
-		1259 2708  AT-2712 FX
-# The Broadcom 57800 device has two 1Gig ports and two 10Gig ports. The subsystem information can be used to differentiate.
 	168a  NetXtreme II BCM57800 1/10 Gigabit Ethernet
-		1028 1f5c  BCM57800 10-Gigabit Ethernet
-		1028 1f5d  BCM57800 10-Gigabit Ethernet
-		1028 1f67  BCM57800 1-Gigabit Ethernet
-		1028 1f68  BCM57800 1-Gigabit Ethernet
 	168d  NetXtreme II BCM57840 10/20 Gigabit Ethernet
 	168e  NetXtreme II BCM57810 10 Gigabit Ethernet
-		1014 0492  PCIe2 2-port 10 GbE BaseT RJ45 Adapter (FC EN0W; CCIN 2CC4)
-		103c 1798  Flex-10 10Gb 2-port 530FLB Adapter [Meru]
-		103c 17a5  Flex-10 10Gb 2-port 530M Adapter
-		103c 18d3  Ethernet 10Gb 2-port 530T Adapter
-		103c 1930  FlexFabric 10Gb 2-port 534FLR-SFP+ Adapter
-		103c 1931  StoreFabric CN1100R Dual Port Converged Network Adapter
-		103c 1932  FlexFabric 10Gb 2-port 534FLB Adapter
-		103c 1933  FlexFabric 10Gb 2-port 534M Adapter
-		103c 193a  FlexFabric 10Gb 2-port 533FLR-T Adapter
-		103c 3382  Ethernet 10Gb 2-port 530FLR-SFP+ Adapter
-		103c 339d  Ethernet 10Gb 2-port 530SFP+ Adapter
 	1690  NetXtreme BCM57760 Gigabit Ethernet PCIe
 	1691  NetLink BCM57788 Gigabit Ethernet PCIe
-		1028 04aa  XPS 8300
 	1692  NetLink BCM57780 Gigabit Ethernet PCIe
-		1025 033d  Aspire 7740G
 	1693  NetLink BCM5787M Gigabit Ethernet PCI Express
-		1025 0121  Aspire 5920G
-		103c 30c0  6710b
-		17aa 20d5  ThinkPad R61
 	1694  NetLink BCM57790 Gigabit Ethernet PCIe
 	1696  NetXtreme BCM5782 Gigabit Ethernet
-		103c 12bc  d530 CMT (DG746A)
-		14e4 000d  NetXtreme BCM5782 1000Base-T
 	1698  NetLink BCM5784M Gigabit Ethernet PCIe
 	1699  NetLink BCM5785 Gigabit Ethernet
 	169a  NetLink BCM5786 Gigabit Ethernet PCI Express
 	169b  NetLink BCM5787 Gigabit Ethernet PCI Express
 	169c  NetXtreme BCM5788 Gigabit Ethernet
-		103c 308b  MX6125
-		103c 30a1  NC2400
-		144d c018  X20
-		1462 590c  KT6 Delta-FIS2R (MS-6590)
 	169d  NetLink BCM5789 Gigabit Ethernet PCI Express
 	16a0  NetLink BCM5785 Fast Ethernet
 	16a1  BCM57840 NetXtreme II 10 Gigabit Ethernet
 	16a2  BCM57840 NetXtreme II 10/20-Gigabit Ethernet
-		103c 1916  FlexFabric 20Gb 2-port 630FLB Adapter
-		103c 1917  FlexFabric 20Gb 2-port 630M Adapter
-		103c 2231  3820C 10/20Gb Converged Network Adapter
-		103c 22fa  FlexFabric 10Gb 2-port 536FLB Adapter
 	16a3  NetXtreme BCM57786 Gigabit Ethernet PCIe
 	16a4  BCM57840 NetXtreme II Ethernet Multi Function
-		103c 1916  NPAR 20Gb 2-port 630FLB Adapter
-		103c 1917  NPAR 20Gb 2-port 630M Adapter
-		103c 2231  3820C 10/20Gb Converged Network Adapter (NPAR 1.5)
-		103c 22fa  FlexFabric 10Gb 2-port 536FLB Adapter (NPAR 1.5)
-# The Broadcom 57800 device has two 1Gig ports and two 10Gig ports. The subsystem information can be used to differentiate.
 	16a5  NetXtreme II BCM57800 1/10 Gigabit Ethernet Multi Function
-		1028 1f5c  NetXtreme II BCM57800 10-Gigabit Ethernet Multi Function
-		1028 1f5d  NetXtreme II BCM57800 10-Gigabit Ethernet Multi Function
-		1028 1f67  NetXtreme II BCM57800 1-Gigabit Ethernet Multi Function
-		1028 1f68  NetXtreme II BCM57800 1-Gigabit Ethernet Multi Function
 	16a6  NetXtreme BCM5702X Gigabit Ethernet
-		0e11 00bb  NC7760 Gigabit Server Adapter (PCI-X, 10/100/1000-T)
-		1028 0126  BCM5702 1000Base-T
-		14e4 000c  BCM5702 1000Base-T
-		14e4 8009  BCM5702 1000Base-T
 	16a7  NetXtreme BCM5703X Gigabit Ethernet
-		0e11 00ca  NC7771 Gigabit Server Adapter (PCI-X, 10,100,1000-T)
-		0e11 00cb  NC7781 Gigabit Server Adapter (PCI-X, 10,100,1000-T)
-		1014 026f  eServer xSeries server mainboard
-		14e4 0009  NetXtreme BCM5703 1000Base-T
-		14e4 000a  NetXtreme BCM5703 1000Base-SX
-		14e4 000b  NetXtreme BCM5703 1000Base-T
-		14e4 800a  NetXtreme BCM5703 1000Base-T
 	16a8  NetXtreme BCM5704S Gigabit Ethernet
-		103c 132b  PCI-X 1000Mbps Dual-port Built-in
-		10a9 8014  Dual Port Gigabit Ethernet (PCI-X,Fiber)
-		10a9 801c  Quad Port Gigabit Ethernet (PCI-E,Fiber)
-		10b7 2001  3C998-SX Dual Port 1000-SX PCI-X
-# The Broadcom 57800 device has two 1Gig ports and two 10Gig ports. The subsystem information can be used to differentiate.
 	16a9  NetXtreme II BCM57800 1/10 Gigabit Ethernet Virtual Function
-		1028 1f5c  NetXtreme II BCM57800 10-Gigabit Ethernet Virtual Function
-		1028 1f5d  NetXtreme II BCM57800 10-Gigabit Ethernet Virtual Function
-		1028 1f67  NetXtreme II BCM57800 1-Gigabit Ethernet Virtual Function
-		1028 1f68  NetXtreme II BCM57800 1-Gigabit Ethernet Virtual Function
 	16aa  NetXtreme II BCM5706S Gigabit Ethernet
-		103c 3102  NC370F MultifuNCtion Gigabit Server Adapter
-		103c 310c  NC370i Multifunction Gigabit Server Adapter
 	16ab  NetXtreme II BCM57840 10/20 Gigabit Ethernet Multi Function
 	16ac  NetXtreme II BCM5708S Gigabit Ethernet
-		1014 0304  NetXtreme II BCM5708S Gigabit Ethernet
-		1028 01bb  PowerEdge 1955 Broadcom NetXtreme II BCM5708S
-		1028 020c  PowerEdge M605 Broadcom NetXtreme II BCM5708S
-		103c 1706  NC373m Multifunction Gigabit Server Adapter
-		103c 7038  NC373i PCI Express Multifunction Gigabit Server Adapter
-		103c 703b  NC373i Integrated Multifunction Gigabit Server Adapter
-		103c 703d  NC373F PCI Express Multifunction Gigabit Server Adapter
 	16ad  NetXtreme II BCM57840 10/20 Gigabit Ethernet Virtual Function
-		103c 1916  FlexFabric 20Gb 2-port 630FLB Adapter
-		103c 1917  FlexFabric 20Gb 2-port 630M Adapter
-		103c 2231  3820C 10/20Gb Converged Network Adapter (SR-IOV VF)
-		103c 22fa  FlexFabric 10Gb 2-port 536FLB Adapter (SR-IOV VF)
 	16ae  NetXtreme II BCM57810 10 Gigabit Ethernet Multi Function
-		103c 1798  NPAR 10Gb 2-port 530FLB Adapter
-		103c 17a5  NPAR 10Gb 2-port 530M Adapter
-		103c 18d3  NPAR 10Gb 2-port 530T Adapter
-		103c 1930  NPAR 10Gb 2-port 534FLR-SFP+ Adapter
-		103c 1931  NPAR CN1100R Dual Port Converged Network Adapter
-		103c 1932  NPAR 10Gb 2-port 534FLB Adapter
-		103c 1933  NPAR 10Gb 2-port 534M Adapter
-		103c 193a  NPAR 10Gb 2-port 533FLR-T Adapter
-		103c 3382  NPAR 10Gb 2-port 530FLR-SFP+ Adapter
-		103c 339d  NPAR 10Gb 2-port 530SFP+ Adapter
 	16af  NetXtreme II BCM57810 10 Gigabit Ethernet Virtual Function
-		103c 1798  Flex-10 10Gb 2-port 530FLB Adapter
-		103c 17a5  Flex-10 10Gb 2-port 530M Adapter
-		103c 18d3  Ethernet 10Gb 2-port 530T Adapter
-		103c 1930  FlexFabric 10Gb 2-port 534FLR-SFP+ Adapter
-		103c 1931  StoreFabric CN1100R Dual Port Converged Network Adapter
-		103c 1932  FlexFabric 10Gb 2-port 534FLB Adapter
-		103c 1933  FlexFabric 10Gb 2-port 534M Adapter
-		103c 193a  FlexFabric 10Gb 2-port 533FLR-T Adapter
-		103c 3382  Ethernet 10Gb 2-port 530FLR-SFP+ Adapter
-		103c 339d  Ethernet 10Gb 2-port 530SFP+ Adapter
 	16b0  NetXtreme BCM57761 Gigabit Ethernet PCIe
 	16b1  NetLink BCM57781 Gigabit Ethernet PCIe
-		1849 96b1  Z77 Extreme4 motherboard
 	16b2  NetLink BCM57791 Gigabit Ethernet PCIe
 	16b3  NetXtreme BCM57786 Gigabit Ethernet PCIe
 	16b4  NetXtreme BCM57765 Gigabit Ethernet PCIe
@@ -17385,17 +9496,7 @@ var pciids = []byte(`#
 	16bf  BCM57765/57785 xD-Picture Card Reader
 	16c1  NetXtreme-E RDMA Virtual Function
 	16c6  NetXtreme BCM5702A3 Gigabit Ethernet
-		10b7 1100  3C1000B-T 10/100/1000 PCI
-		14e4 000c  BCM5702 1000Base-T
-		14e4 8009  BCM5702 1000Base-T
 	16c7  NetXtreme BCM5703 Gigabit Ethernet
-		0e11 00ca  NC7771 Gigabit Server Adapter (PCI-X, 10,100,1000-T)
-		0e11 00cb  NC7781 Gigabit Server Adapter (PCI-X, 10,100,1000-T)
-		103c 12c3  Combo FC/GigE-SX [A9782A]
-		103c 12ca  Combo FC/GigE-T [A9784A]
-		103c 1321  Core I/O LAN/SCSI Combo [AB314A]
-		14e4 0009  NetXtreme BCM5703 1000Base-T
-		14e4 000a  NetXtreme BCM5703 1000Base-SX
 	16c8  BCM57301 NetXtreme-C 10Gb Ethernet Controller
 	16c9  BCM57302 NetXtreme-C 10Gb/25Gb Ethernet Controller
 	16ca  BCM57304 NetXtreme-C 10Gb/25Gb/40Gb/50Gb Ethernet Controller
@@ -17411,22 +9512,14 @@ var pciids = []byte(`#
 	16d5  BCM57407 NetXtreme-E 10GBase-T Ethernet Controller
 	16d6  BCM57412 NetXtreme-E 10Gb RDMA Ethernet Controller
 	16d7  BCM57414 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller
-		14e4 1202  BCM957412M4122 OCP 1x25G Type1 wRoCE
-		14e4 1404  BCM957414M4142 OCP 2x25G Type1 wRoCE
-		1590 020e  Ethernet 25Gb 2-port 631SFP28 Adapter
-		1590 0211  Ethernet 25Gb 2-port 631FLR-SFP28 Adapter
 	16d8  BCM57416 NetXtreme-E 10GBase-T RDMA Ethernet Controller
-		1590 020c  Ethernet 10Gb 2-port 535T Adapter
-		1590 0212  Ethernet 10Gb 2-port 535FLR-T Adapter
 	16d9  BCM57417 NetXtreme-E 10GBASE-T RDMA Ethernet Controller
-		108e 4866  Dual Port 10GBase-T Ethernet Controller
 	16dc  NetXtreme-E Ethernet Virtual Function
 	16dd  NetLink BCM5781 Gigabit Ethernet PCI Express
 	16de  BCM57412 NetXtreme-E Ethernet Partition
 	16df  BCM57314 NetXtreme-C 10Gb/25Gb/40Gb/50Gb RDMA Ethernet Controller
 	16e1  NetXtreme-C Ethernet Virtual Function
 	16e2  BCM57417 NetXtreme-E 10Gb/25Gb RDMA Ethernet Controller
-		108e 4866  Dual Port 10Gb/25Gb SFP28 Ethernet Controller
 	16e3  BCM57416 NetXtreme-E 10Gb RDMA Ethernet Controller
 	16e5  NetXtreme-C RDMA Virtual Function
 	16e7  BCM57404 NetXtreme-E Ethernet Partition
@@ -17439,29 +9532,12 @@ var pciids = []byte(`#
 	16f3  NetXtreme BCM5727 Gigabit Ethernet PCIe
 	16f7  NetXtreme BCM5753 Gigabit Ethernet PCI Express
 	16fd  NetXtreme BCM5753M Gigabit Ethernet PCI Express
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a3  Compaq nw8440
 	16fe  NetXtreme BCM5753F Fast Ethernet PCI Express
 	170c  BCM4401-B0 100Base-TX
-		1028 0188  Inspiron 6000 laptop
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		1028 01af  Inspiron 6400
-		1028 01cd  Inspiron 9400 Laptop
-		1028 01d7  XPS M1210
-		1028 01d8  Inspiron E1405
-		103c 099c  NX6110/NC6120
-		103c 30a2  NX7300 laptop
-		14e4 170c  HP Compaq 6720t Mobile Thin Client
 	170d  NetXtreme BCM5901 100Base-TX
-		1014 0545  ThinkPad R40e
 	170e  NetXtreme BCM5901 100Base-TX
 	1712  NetLink BCM5906 Fast Ethernet PCI Express
 	1713  NetLink BCM5906M Fast Ethernet PCI Express
-		1028 01f3  Inspiron 1420
-		1028 0209  XPS M1330
-		103c 30c0  Compaq 6710b
-		17aa 3a23  IdeaPad S10e
 	3352  BCM3352
 	3360  BCM3360
 	4210  BCM4210 iLine10 HomePNA 2.0
@@ -17470,169 +9546,39 @@ var pciids = []byte(`#
 	4220  802-11b/g Wireless PCI controller, packaged as a Linksys WPC54G ver 1.2 PCMCIA card
 	4222  NetXtreme BCM5753M Gigabit Ethernet PCI Express
 	4301  BCM4301 802.11b Wireless LAN Controller
-		1028 0407  TrueMobile 1180 Onboard WLAN
-		1043 0120  WL-103b Wireless LAN PC Card
-		16a5 1602  B-300 802.11b Wireless CardBus Adapter
-		1737 4301  WMP11 v2.7 802.11b Wireless-B PCI Adapter
 	4305  BCM4307 V.90 56k Modem
 	4306  BCM4306 802.11bg Wireless LAN controller
 	4307  BCM4306 802.11bg Wireless LAN Controller
 	4310  BCM4310 Chipcommon I/OController
 	4311  BCM4311 802.11b/g WLAN
-		1028 0007  Wireless 1390 WLAN Mini-Card
-		1028 0008  Wireless 1390 WLAN ExpressCard
-		103c 1363  BCM4311 802.11b/g Wireless LAN Controller
-		103c 1364  BCM4311 802.11b/g Wireless LAN Controller
-		103c 1365  BCM4311 802.11b/g Wireless LAN Controller
-		103c 1374  BCM4311 802.11b/g Wireless LAN Controller
-		103c 1375  BCM4311 802.11b/g Wireless LAN Controller
-		103c 1376  BCM4311 802.11b/g Wireless LAN Controller
-		103c 1377  BCM4311 802.11b/g Wireless LAN Controller
-		103c 137f  BCM4322 802.11a/b/g/n Wireless LAN Controller
-		103c 1380  BCM4322 802.11a/b/g/n Wireless LAN Controller
-		14e4 4311  BCM94311MCG
 	4312  BCM4311 802.11a/b/g
-		1028 0007  Wireless 1490 Dual Band WLAN Mini-Card
-		1028 0008  Wireless 1490 Dual Band WLAN ExpressCard
-		103c 135a  Broadcom 802.11a/b/g WLAN
-		103c 135f  Broadcom 802.11a/b/g WLAN
-		103c 1360  Broadcom 802.11a/b/g WLAN
-		103c 1361  Broadcom 802.11a/b/g WLAN
-		103c 1362  Broadcom 802.11a/b/g WLAN
-		103c 1370  Broadcom 802.11a/b/g WLAN
-		103c 1371  Broadcom 802.11a/b/g WLAN
-		103c 1372  Broadcom 802.11a/b/g WLAN
-		103c 1373  Broadcom 802.11a/b/g WLAN
-		103c 30b5  Presario V3242AU
-		106b 0089  AirPort Extreme
-		1371 103c  Broadcom 802.11 Multiband-netwerkadapter(6715s)
 	4313  BCM4311 802.11a
 	4315  BCM4312 802.11b/g LP-PHY
-		1028 000b  Wireless 1395 WLAN Mini-Card
-		1028 000c  Wireless 1397 WLAN Mini-Card
-		103c 137c  BCM4312 802.11b/g Wireless LAN Controller
-		103c 137d  BCM4312 802.11b/g Wireless LAN Controller
-		103c 1507  U98Z049.00 Wireless Mini PCIe Card
-		105b e003  T77H030.00 Wireless Mini PCIe Card
-		105b e01b  T77H106.00 Wireless Half-size Mini PCIe Card
 	4318  BCM4318 [AirForce One 54g] 802.11g Wireless LAN Controller
-		1028 0005  Wireless 1370 WLAN Mini-PCI Card
-		1028 0006  Wireless 1370 WLAN PC Card
-		103c 1355  Broadcom 802.11b/g WLAN
-		103c 1356  Broadcom 802.11b/g WLAN
-		103c 1357  Broadcom 802.11b/g WLAN
-		1043 100f  WL-138G v2 / WL-138gE / WL-100gE
-		1043 120f  A6U notebook embedded card
-		1154 0355  Buffalo WLI2-PCI-G54S High Speed Mode Wireless Adapter
-		1468 0311  Aspire 3022WLMi, 5024WLMi, 5020
-		1468 0312  TravelMate 2410
-		14e4 0449  Gateway 7510GX
-		16ec 0119  U.S.Robotics Wireless MAXg PC Card
-		1737 0042  WMP54GS v1.1 802.11g Wireless-G PCI Adapter with SpeedBooster
-		1737 0048  WPC54G v3 802.11g Wireless-G Notebook Adapter
-		1737 0049  WPC54GS v2 802.11g Wireless-G Notebook Adapter with SpeedBooster
-		1799 7000  F5D7000 v4000 Wireless G Desktop Card
-		1799 7001  F5D7001 v2000 Wireless G Plus Desktop Card
-		1799 7010  F5D7010 v4000 Wireless G Notebook Card
-		1799 7011  F5D7011 v2000 High-Speed Mode Wireless G Notebook Card
 	4319  BCM4318 [AirForce 54g] 802.11a/b/g PCI Express Transceiver
-		1028 0005  Wireless 1470 Dual Band WLAN Mini-PCI Card
-		1028 0006  Wireless 1470 Dual Band WLAN PC Card
-		103c 1358  Broadcom 802.11a/b/g WLAN
-		103c 1359  Broadcom 802.11a/b/g WLAN
-		103c 135a  Broadcom 802.11a/b/g WLAN
 	4320  BCM4306 802.11b/g Wireless LAN Controller
-		1028 0001  TrueMobile 1300 WLAN Mini-PCI Card
-		1028 0002  TrueMobile 1300 WLAN PC Card
-		1028 0003  Wireless 1350 WLAN Mini-PCI Card
-		1028 0004  Wireless 1350 WLAN PC Card
-		103c 12f4  Broadcom 802.11b/g WLAN
-		103c 12f8  Broadcom 802.11b/g WLAN
-		103c 12fa  Broadcom 802.11b/g WLAN
-		103c 12fb  Broadcom 802.11b/g WLAN
-		1043 100f  WL-100G
-		1057 7025  WN825G
-		106b 004e  AirPort Extreme
-		1154 0330  Buffalo WLI2-PCI-G54S High Speed Mode Wireless Desktop Adapter
-		144f 7050  eMachines M6805 802.11g Built-in Wireless
-		144f 7051  Sonnet Aria Extreme PCI
-		1737 0013  WMP54G v1 802.11g PCI Adapter
-		1737 0014  WMP54G v2 802.11g PCI Adapter
-		1737 0015  WMP54GS v1.0 802.11g Wireless-G PCI Adapter with SpeedBooster
-		1737 4320  WPC54G v1 / WPC54GS v1 802.11g Wireless-G Notebook Adapter
-		1799 7000  F5D7000 v1000 Wireless G Desktop Card
-		1799 7001  F5D7001 v1000 Wireless G Plus Desktop Card
-		1799 7010  F5D7010 v1000 Wireless G Notebook Card
-		1799 7011  F5D7011 v1000 High-Speed Mode Wireless G Notebook Card
-		185f 1220  TravelMate 290E WLAN Mini-PCI Card
 	4321  BCM4321 802.11a Wireless Network Controller
 	4322  BCM4322 802.11bgn Wireless Network Controller
 	4324  BCM4309 802.11abg Wireless Network Controller
-		1028 0001  Truemobile 1400
-		1028 0002  TrueMobile 1400 Dual Band WLAN PC Card
-		1028 0003  Truemobile 1450 MiniPCI
-		1028 0004  Wireless 1450 Dual Band WLAN PC Card
-		103c 12f9  Broadcom 802.11a/b/g WLAN
-		103c 12fc  Broadcom 802.11a/b/g WLAN
 	4325  BCM4306 802.11bg Wireless Network Controller
-		1414 0003  Wireless Notebook Adapter MN-720
-		1414 0004  Wireless PCI Adapter MN-730
 	4326  BCM4307 Chipcommon I/O Controller?
 	4328  BCM4321 802.11a/b/g/n
-		1028 0009  Wireless 1500 Draft 802.11n WLAN Mini-Card
-		1028 000a  Wireless 1500 Draft 802.11n WLAN Mini-card
-		103c 1366  BCM4321 802.11a/b/g/n Wireless LAN Controller
-		103c 1367  BCM4321 802.11a/b/g/n Wireless LAN Controller
-		103c 1368  BCM4321 802.11a/b/g/n Wireless LAN Controller
-		103c 1369  BCM4321 802.11a/b/g/n Wireless LAN Controller
-		106b 0087  AirPort Extreme
-		106b 0088  AirPort Extreme
-		106b 008b  AirPort Extreme
-		106b 008c  AirPort Extreme
-		106b 0090  AirPort Extreme
-		14e4 4328  BCM4328 802.11a/b/g/n
-		1737 0066  WPC600N v1 802.11a/b/g/n Wireless-N CardBus Adapter
-		1737 0068  WEC600N v1 802.11a/b/g/n Wireless-N ExpressCard
 	4329  BCM4321 802.11b/g/n
-		1385 7b00  WN511B RangeMax NEXT Wireless Notebook Adapter
-		1385 7d00  WN311B RangeMax Next 270 Mbps Wireless PCI Adapter
-		1737 0058  WPC300N v1 Wireless-N Notebook Adapter
 	432a  BCM4321 802.11an Wireless Network Controller
 	432b  BCM4322 802.11a/b/g/n Wireless LAN Controller
-		1028 000d  Wireless 1510 Wireless-N WLAN Mini-Card
-		106b 008d  AirPort Extreme
-		106b 008e  AirPort Extreme
 	432c  BCM4322 802.11b/g/n
-		1799 d311  Dynex DX-NNBX 802.11n WLAN Cardbus Card
 	432d  BCM4322 802.11an Wireless Network Controller
 	4331  BCM4331 802.11a/b/g/n
-		106b 00d6  AirPort Extreme
-		106b 00e4  AirPort Extreme
-		106b 00ef  AirPort Extreme
-		106b 00f4  AirPort Extreme
-		106b 00f5  AirPort Extreme
-		106b 010e  AirPort Extreme
-		106b 010f  AirPort Extreme
 	4333  Serial (EDGE/GPRS modem part of Option GT Combo Edge)
 	4344  EDGE/GPRS data and 802.11b/g combo cardbus [GC89]
 	4350  BCM43222 Wireless Network Adapter
 	4351  BCM43222 802.11abgn Wireless Network Adapter
 	4353  BCM43224 802.11a/b/g/n
-		1028 000e  Wireless 1520 Half-size Mini PCIe Card
-		103c 1509  WMIB-275N Half-size Mini PCIe Card
-		106b 0093  AirPort Extreme
-		106b 00d1  AirPort Extreme
-		106b 00e9  AirPort Extreme
-		14e4 04d8  Pegatron UPWL6024
 	4357  BCM43225 802.11b/g/n
-		105b e021  T77H103.00 Wireless Half-size Mini PCIe Card
 	4358  BCM43227 802.11b/g/n
 	4359  BCM43228 802.11a/b/g/n
-		1028 0011  Wireless 1530 Half-size Mini PCIe Card
-		103c 182c  BCM943228HM4L 802.11a/b/g/n 2x2 Wi-Fi Adapter
 	4360  BCM4360 802.11ac Wireless Network Adapter
 	4365  BCM43142 802.11b/g/n
-		1028 0016  Wireless 1704 802.11n + BT 4.0
 	43a0  BCM4360 802.11ac Wireless Network Adapter
 	43a1  BCM4360 802.11ac Wireless Network Adapter
 	43a2  BCM4360 802.11ac Wireless Network Adapter
@@ -17650,11 +9596,6 @@ var pciids = []byte(`#
 	43e9  BCM4358 802.11ac Wireless LAN SoC
 	43ec  BCM4356 802.11ac Wireless Network Adapter
 	4401  BCM4401 100Base-T
-		1025 0035  TravelMate 660
-		1025 0064  Extensa 3000 series laptop
-		1028 8127  Dimension 2400
-		103c 08b0  tc1100 tablet
-		1043 80a8  A7V8X motherboard
 	4402  BCM4402 Integrated 10/100BaseT
 	4403  BCM4402 V.90 56k Modem
 	4410  BCM4413 iLine32 HomePNA 2.0
@@ -17685,7 +9626,6 @@ var pciids = []byte(`#
 	4719  BCM47xx/53xx RoboSwitch Core
 	4720  BCM4712 MIPS CPU
 	4727  BCM4313 802.11bgn Wireless Network Adapter
-		1028 0010  Inspiron M5010 / XPS 8300
 	5365  BCM5365P Sentry5 Host Bridge
 	5600  BCM5600 StrataSwitch 24+2 Ethernet Switch Controller
 	5605  BCM5605 StrataSwitch 24+2 Ethernet Switch Controller
@@ -17714,9 +9654,7 @@ var pciids = []byte(`#
 	b334  BCM56334 StrataXGS 24x1GE 4x10GE Switch Controller
 	b800  BCM56800 StrataXGS 10GE Switch Controller
 	b842  BCM56842 Trident 10GE Switch Controller
-# Trident2
 	b850  Broadcom BCM56850 Switch ASIC
-# Tomahawk
 	b960  Broadcom BCM56960 Switch ASIC
 14e5  Pixelfusion Ltd
 14e6  SHINING Technology Inc
@@ -17728,7 +9666,6 @@ var pciids = []byte(`#
 	ab07  RTL81xx RealTek Ethernet
 	ab08  FNW-3602-TX CardBus Fast Ethernet
 14eb  SEIKO EPSON Corp
-# nee ACQIRIS
 14ec  Agilent Technologies
 	0000  Aciris Digitizer (malformed ID)
 14ed  DATAKINETICS Ltd
@@ -17748,47 +9685,20 @@ var pciids = []byte(`#
 	1026  HCF 56k Modem
 	1032  HCF 56k Modem
 	1033  HCF 56k Data/Fax Modem
-		1033 8077  NEC
-		122d 4027  Dell Zeus - MDP3880-W(B) Data Fax Modem
-		122d 4030  Dell Mercury - MDP3880-U(B) Data Fax Modem
-		122d 4034  Dell Thor - MDP3880-W(U) Data Fax Modem
-		13e0 020d  Dell Copper
-		13e0 020e  Dell Silver
-		13e0 0261  IBM
-		13e0 0290  Compaq Goldwing
-		13e0 02a0  IBM
-		13e0 02b0  IBM
-		13e0 02c0  Compaq Scooter
-		13e0 02d0  IBM
-		144f 1500  IBM P85-DF (1)
-		144f 1501  IBM P85-DF (2)
-		144f 150a  IBM P85-DF (3)
-		144f 150b  IBM P85-DF Low Profile (1)
-		144f 1510  IBM P85-DF Low Profile (2)
 	1034  HCF 56k Data/Fax/Voice Modem
 	1035  HCF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
-		10cf 1098  Fujitsu P85-DFSV
 	1036  HCF 56k Data/Fax/Voice/Spkp Modem
-		104d 8067  HCF 56k Modem
-		122d 4029  MDP3880SP-W
-		122d 4031  MDP3880SP-U
-		13e0 0209  Dell Titanium
-		13e0 020a  Dell Graphite
-		13e0 0260  Gateway Red Owl
-		13e0 0270  Gateway White Horse
 	1052  HCF 56k Data/Fax Modem (Worldwide)
 	1053  HCF 56k Data/Fax Modem (Worldwide)
 	1054  HCF 56k Data/Fax/Voice Modem (Worldwide)
 	1055  HCF 56k Data/Fax/Voice/Spkp (w/Handset) Modem (Worldwide)
 	1056  HCF 56k Data/Fax/Voice/Spkp Modem (Worldwide)
-		122d 4035  MDP3900V-W
 	1057  HCF 56k Data/Fax/Voice/Spkp Modem (Worldwide)
 	1059  HCF 56k Data/Fax/Voice Modem (Worldwide)
 	1063  HCF 56k Data/Fax Modem
 	1064  HCF 56k Data/Fax/Voice Modem
 	1065  HCF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
 	1066  HCF 56k Data/Fax/Voice/Spkp Modem
-		122d 4033  Dell Athena - MDP3900V-U
 	1085  HCF V90 56k Data/Fax/Voice/Spkp PCI Modem
 	10b6  CX06834-11 HCF V.92 56k Data/Fax/Voice/Spkp Modem
 	1433  HCF 56k Data/Fax Modem
@@ -17796,56 +9706,35 @@ var pciids = []byte(`#
 	1435  HCF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
 	1436  HCF 56k Data/Fax Modem
 	1453  HCF 56k Data/Fax Modem
-		13e0 0240  IBM
-		13e0 0250  IBM
-		144f 1502  IBM P95-DF (1)
-		144f 1503  IBM P95-DF (2)
 	1454  HCF 56k Data/Fax/Voice Modem
 	1455  HCF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
 	1456  HCF 56k Data/Fax/Voice/Spkp Modem
-		122d 4035  Dell Europa - MDP3900V-W
-		122d 4302  Dell MP3930V-W(C) MiniPCI
 	1610  ADSL AccessRunner PCI Arbitration Device
 	1611  AccessRunner PCI ADSL Interface Device
 	1620  AccessRunner V2 PCI ADSL Arbitration Device
 	1621  AccessRunner V2 PCI ADSL Interface Device
 	1622  AccessRunner V2 PCI ADSL Yukon WAN Adapter
 	1803  HCF 56k Modem
-		0e11 0023  623-LAN Grizzly
-		0e11 0043  623-LAN Yogi
 	1811  MiniPCI Network Adapter
 	1815  HCF 56k Modem
-		0e11 0022  Grizzly
-		0e11 0042  Yogi
-# Integrated in CX86111/CX86113 processors
 	1830  CX861xx Integrated Host Bridge
 	2003  HSF 56k Data/Fax Modem
 	2004  HSF 56k Data/Fax/Voice Modem
 	2005  HSF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
 	2006  HSF 56k Data/Fax/Voice/Spkp Modem
 	2013  HSF 56k Data/Fax Modem
-		0e11 b195  Bear
-		0e11 b196  Seminole 1
-		0e11 b1be  Seminole 2
-		1025 8013  Acer
-		1033 809d  NEC
-		1033 80bc  NEC
-		155d 6793  HP
-		155d 8850  E Machines
 	2014  HSF 56k Data/Fax/Voice Modem
 	2015  HSF 56k Data/Fax/Voice/Spkp (w/Handset) Modem
 	2016  HSF 56k Data/Fax/Voice/Spkp Modem
 	2043  HSF 56k Data/Fax Modem (WorldW SmartDAA)
 	2044  HSF 56k Data/Fax/Voice Modem (WorldW SmartDAA)
 	2045  HSF 56k Data/Fax/Voice/Spkp (w/Handset) Modem (WorldW SmartDAA)
-		14f1 2045  Generic SoftK56
 	2046  HSF 56k Data/Fax/Voice/Spkp Modem (WorldW SmartDAA)
 	2063  HSF 56k Data/Fax Modem (SmartDAA)
 	2064  HSF 56k Data/Fax/Voice Modem (SmartDAA)
 	2065  HSF 56k Data/Fax/Voice/Spkp (w/Handset) Modem (SmartDAA)
 	2066  HSF 56k Data/Fax/Voice/Spkp Modem (SmartDAA)
 	2093  HSF 56k Modem
-		155d 2f07  Legend
 	2143  HSF 56k Data/Fax/Cell Modem (Mob WorldW SmartDAA)
 	2144  HSF 56k Data/Fax/Voice/Cell Modem (Mob WorldW SmartDAA)
 	2145  HSF 56k Data/Fax/Voice/Spkp (w/HS)/Cell Modem (Mob WorldW SmartDAA)
@@ -17863,9 +9752,6 @@ var pciids = []byte(`#
 	2365  HSF 56k Data/Fax/Voice/Spkp (w/HS) CardBus Modem (Mob SmartDAA)
 	2366  HSF 56k Data/Fax/Voice/Spkp CardBus Modem (Mob SmartDAA)
 	2443  HSF 56k Data/Fax Modem (Mob WorldW SmartDAA)
-		104d 8075  Modem
-		104d 8083  Modem
-		104d 8097  Modem
 	2444  HSF 56k Data/Fax/Voice Modem (Mob WorldW SmartDAA)
 	2445  HSF 56k Data/Fax/Voice/Spkp (w/HS) Modem (Mob WorldW SmartDAA)
 	2446  HSF 56k Data/Fax/Voice/Spkp Modem (Mob WorldW SmartDAA)
@@ -17874,137 +9760,22 @@ var pciids = []byte(`#
 	2465  HSF 56k Data/Fax/Voice/Spkp (w/HS) Modem (Mob SmartDAA)
 	2466  HSF 56k Data/Fax/Voice/Spkp Modem (Mob SmartDAA)
 	2702  HSFi modem RD01-D270
-		1028 8d88  SmartHSFi V92 56K PCI Modem
 	2f00  HSF 56k HSFi Modem
-		13e0 8d84  IBM HSFi V.90
-		13e0 8d85  Compaq Stinger
-		14f1 2004  Dynalink 56PMi
 	2f02  HSF 56k HSFi Data/Fax
 	2f11  HSF 56k HSFi Modem
 	2f20  HSF 56k Data/Fax Modem
-		14f1 200c  Soft Data Fax Modem with SmartCP
-		14f1 200f  Dimension 3000
 	2f30  SoftV92 SpeakerPhone SoftRing Modem with SmartSP
-		14f1 2014  Devolo MikroLink 56K Modem PCI
 	2f50  Conexant SoftK56 Data/Fax Modem
 	5b7a  CX23418 Single-Chip MPEG-2 Encoder with Integrated Analog Video/Broadcast Audio Decoder
-		0070 7444  WinTV HVR-1600
-		107d 6f34  WinFast DVR3100 H
-		5854 3343  GoTView PCI DVD3 Hybrid
 	8200  CX25850
 	8234  RS8234 ATM SAR Controller [ServiceSAR Plus]
 	8800  CX23880/1/2/3 PCI Video and Audio Decoder
-		0070 2801  Hauppauge WinTV 28xxx (Roslyn) models
-		0070 3400  WinTV 34604
-		0070 3401  Hauppauge WinTV 34xxx models
-		0070 6902  WinTV HVR-4000-HD
-		0070 7801  WinTV HVR-1800 MCE
-		0070 9001  Nova-T DVB-T
-		0070 9200  Nova-SE2 DVB-S
-		0070 9202  Nova-S-Plus DVB-S
-		0070 9402  WinTV-HVR1100 DVB-T/Hybrid
-		0070 9600  WinTV 88x Video
-		0070 9802  WinTV-HVR1100 DVB-T/Hybrid (Low Profile)
-		1002 00f8  ATI TV Wonder Pro
-		1002 00f9  ATI TV Wonder
-		1002 a101  HDTV Wonder
-		1043 4823  PVR-416
-		107d 6611  Winfast TV 2000XP Expert
-		107d 6613  Leadtek Winfast 2000XP Expert
-		107d 6620  Leadtek Winfast DV2000
-		107d 663c  Leadtek PVR 2000
-		107d 665f  WinFast DTV1000-T
-		10fc d003  IODATA GV-VCP3/PCI
-		10fc d035  IODATA GV/BCTV7E
-		1421 0334  Instant TV DVB-T PCI
-		1461 000a  AVerTV 303 (M126)
-		1461 000b  AverTV Studio 303 (M126)
-		1461 8011  UltraTV Media Center PCI 550
-		1462 8606  MSI TV-@nywhere Master
-		14c7 0107  GDI Black Gold
-		14f1 0187  Conexant DVB-T reference design
-		14f1 0342  Digital-Logic MICROSPACE Entertainment Center (MEC)
-		153b 1166  Cinergy 1400 DVB-T
-		1540 2580  Provideo PV259
-		1554 4811  PixelView
-		1554 4813  Club 3D  ZAP1000 MCE Edition
-		17de 08a1  KWorld/VStream XPert DVB-T with cx22702
-		17de 08a6  KWorld/VStream XPert DVB-T
-		17de 08b2  KWorld DVB-S 100
-		17de a8a6  digitalnow DNTV Live! DVB-T
-		1822 0025  digitalnow DNTV Live! DVB-T Pro
-		185b e000  VideoMate X500
-		18ac d500  FusionHDTV 5 Gold
-		18ac d810  FusionHDTV 3 Gold-Q
-		18ac d820  FusionHDTV 3 Gold-T
-		18ac db00  FusionHDTV DVB-T1
-		18ac db11  FusionHDTV DVB-T Plus
-		18ac db50  FusionHDTV DVB-T Dual Digital
-		5654 2388  GoTView PCI Hybrid TV Tuner Card
-		7063 3000  pcHDTV HD3000 HDTV
-		7063 5500  pcHDTV HD-5500
 	8801  CX23880/1/2/3 PCI Video and Audio Decoder [Audio Port]
-		0070 2801  Hauppauge WinTV 28xxx (Roslyn) models
-		185b e000  VideoMate X500
-		5654 2388  GoTView PCI Hybrid Audio AVStream Device
-		7063 5500  pcHDTV HD-5500
 	8802  CX23880/1/2/3 PCI Video and Audio Decoder [MPEG Port]
-		0070 2801  Hauppauge WinTV 28xxx (Roslyn) models
-		0070 6902  WinTV HVR-4000-HD
-		0070 9002  Nova-T DVB-T Model 909
-		0070 9402  WinTV-HVR1100 DVB-T/Hybrid
-		0070 9600  WinTV 88x MPEG Encoder
-		1043 4823  PVR-416
-		107d 663c  Leadtek PVR 2000
-		107d 665f  WinFast DTV1000-T
-		14f1 0187  Conexant DVB-T reference design
-		17de 08a1  XPert DVB-T PCI BDA DVBT 23880 Transport Stream Capture
-		17de 08a6  KWorld/VStream XPert DVB-T
-		18ac d500  DViCO FusionHDTV5 Gold
-		18ac d810  DViCO FusionHDTV3 Gold-Q
-		18ac d820  DViCO FusionHDTV3 Gold-T
-		18ac db00  DVICO FusionHDTV DVB-T1
-		18ac db10  DVICO FusionHDTV DVB-T Plus
-		5654 2388  GoTView PCI Hybrid TS Capture Device
-		7063 3000  pcHDTV HD3000 HDTV
-		7063 5500  pcHDTV HD-5500
 	8804  CX23880/1/2/3 PCI Video and Audio Decoder [IR Port]
-		0070 6902  WinTV HVR-4000-HD
-		0070 9002  Nova-T DVB-T Model 909
-		0070 9402  WinTV-HVR1100 DVB-T/Hybrid
-		7063 5500  pcHDTV HD-5500
 	8811  CX23880/1/2/3 PCI Video and Audio Decoder [Audio Port]
-		0070 3400  WinTV 34604
-		0070 3401  Hauppauge WinTV 34xxx models
-		0070 6902  WinTV HVR-4000-HD
-		0070 9402  WinTV-HVR1100 DVB-T/Hybrid
-		0070 9600  WinTV 88x Audio
-		1462 8606  MSI TV-@nywhere Master
-		18ac d500  DViCO FusionHDTV5 Gold
-		18ac d810  DViCO FusionHDTV3 Gold-Q
-		18ac d820  DViCO FusionHDTV3 Gold-T
-		18ac db00  DVICO FusionHDTV DVB-T1
-		5654 2388  GoTView PCI Hybrid Audio Capture Device
 	8852  CX23885 PCI Video and Audio Decoder
-		0070 8010  WinTV HVR-1400 ExpressCard
-		0070 f038  WinTV HVR-5525
-		107d 6f22  WinFast PxTV1200
-		12ab d585  PE988J Hybrid ATSC/QAM PCI-E AVS Video Capture (SoftEncoder)
-		13c2 3013  TT-budget CT2-4500 CI
-		1461 c039  AVerTV Hybrid Express (A577)
-		153b 117e  Cinergy T PCIe Dual
-		18ac db78  FusionHDTV DVB-T Dual Express
-		4254 0950  S950
-		4254 0952  S952
-		4254 0982  T982
-		4254 9580  T9580
-		4254 980c  T980C
 	8880  CX23887/8 PCIe Broadcast Audio and Video Decoder with 3D Comb
-		0070 2259  WinTV HVR-1250
-		0070 6a18  WinTV-quadHD
-		0070 c108  WinTV-HVR-4400-HD model 1278
-		5654 2389  GoTView X5 DVD Hybrid PCI-E
-		5654 2390  GoTView X5 3D HYBRID PCI-E
 14f2  MOBILITY Electronics
 	0120  EV1000 bridge
 	0121  EV1000 Parallel port
@@ -18040,7 +9811,6 @@ var pciids = []byte(`#
 1504  KAISER Electronics
 1505  ITA INGENIEURBURO FUR TESTAUFGABEN GmbH
 1506  CHAMELEON Systems Inc
-# Should be HTEC Ltd, but there are no known HTEC chips and 1507 is already used by mistake by Motorola (see vendor ID 1057).
 1507  Motorola ?? / HTEC
 	0001  MPC105 [Eagle]
 	0002  MPC106 [Grackle]
@@ -18068,10 +9838,8 @@ var pciids = []byte(`#
 1516  MYSON Technology Inc
 	0800  MTD-8xx 100/10M Ethernet PCI Adapter
 	0803  SURECOM EP-320X-S 100/10M Ethernet PCI Adapter
-		1320 10bd  SURECOM EP-320X-S 100/10M Ethernet PCI Adapter
 	0891  MTD-8xx 100/10M Ethernet PCI Adapter
 1517  ECHOTEK Corp
-# old ID, now 1059
 1518  Kontron
 1519  TELEFON AKTIEBOLAGET LM Ericsson
 151a  Globetek
@@ -18090,42 +9858,10 @@ var pciids = []byte(`#
 1521  BELL Corp
 1522  MainPine Ltd
 	0100  PCI <-> IOBus Bridge
-		1522 0200  RockForceDUO 2 Port V.92/V.44 Data/Fax/Voice Modem
-		1522 0300  RockForceQUATRO 4 Port V.92/V.44 Data/Fax/Voice Modem
-		1522 0400  RockForceDUO+ 2 Port V.92/V.44 Data/Fax/Voice Modem
-		1522 0500  RockForceQUATRO+ 4 Port V.92/V.44 Data/Fax/Voice Modem
-		1522 0600  RockForce+ 2 Port V.90 Data/Fax/Voice Modem
-		1522 0700  RockForce+ 4 Port V.90 Data/Fax/Voice Modem
-		1522 0800  RockForceOCTO+ 8 Port V.92/V.44 Data/Fax/Voice Modem
-		1522 0c00  RockForceDUO+ 2 Port V.92/V.44 Data, V.34 Super-G3 Fax, Voice Modem
-		1522 0d00  RockForceQUATRO+ 4 Port V.92/V.44 Data, V.34 Super-G3 Fax, Voice Modem
-		1522 1d00  RockForceOCTO+ 8 Port V.92/V.44 Data, V.34 Super-G3 Fax, Voice Modem
-		1522 2000  RockForceD1 1 Port V.90 Data Modem
-		1522 2100  RockForceF1 1 Port V.34 Super-G3 Fax Modem
-		1522 2200  RockForceD2 2 Port V.90 Data Modem
-		1522 2300  RockForceF2 2 Port V.34 Super-G3 Fax Modem
-		1522 2400  RockForceD4 4 Port V.90 Data Modem
-		1522 2500  RockForceF4 4 Port V.34 Super-G3 Fax Modem
-		1522 2600  RockForceD8 8 Port V.90 Data Modem
-		1522 2700  RockForceF8 8 Port V.34 Super-G3 Fax Modem
-		1522 3000  IQ Express D1 - 1 Port V.92 Data Modem
-		1522 3100  IQ Express F1 - 1 Port V.34 Super-G3 Fax Modem
-		1522 3200  IQ Express D2 - 2 Port V.92 Data Modem
-		1522 3300  IQ Express F2 - 2 Port V.34 Super-G3 Fax Modem
-		1522 3400  IQ Express D4 - 4 Port V.92 Data Modem
-		1522 3500  IQ Express F4 - 4 Port V.34 Super-G3 Fax Modem
-		1522 3c00  IQ Express D8 - 8 Port V.92 Data Modem
-		1522 3d00  IQ Express F8 - 8 Port V.34 Super-G3 Fax Modem
 	4000  PCI Express UART
-		1522 4001  IQ Express 1-port V.34 Super-G3 Fax
-		1522 4002  IQ Express 2-port V.34 Super-G3 Fax
-		1522 4004  IQ Express 4-port V.34 Super-G3 Fax
-		1522 4008  IQ Express 8-port V.34 Super-G3 Fax
-		1522 4100  IQ Express SideBand
 1523  MUSIC Semiconductors
 1524  ENE Technology Inc
 	0510  CB710 Memory Card Reader Controller
-		103c 006a  NX9500
 	0520  FLASH memory: ENE Technology Inc:
 	0530  ENE PCI Memory Stick Card Reader Controller
 	0550  ENE PCI Secure Digital Card Reader Controller
@@ -18138,11 +9874,7 @@ var pciids = []byte(`#
 	1211  CB1211 Cardbus Controller
 	1225  CB1225 Cardbus Controller
 	1410  CB1410 Cardbus Controller
-		1025 003c  CL50 motherboard
-		1025 005a  TravelMate 290
-		103c 30d5  530 Laptop
 	1411  CB-710/2/4 Cardbus Controller
-		103c 006a  NX9500
 	1412  CB-712/4 Cardbus Controller
 	1420  CB1420 Cardbus Controller
 	1421  CB-720/2/4 Cardbus Controller
@@ -18173,7 +9905,6 @@ var pciids = []byte(`#
 153a  ONO SOKKI
 153b  TERRATEC Electronic GmbH
 	1144  Aureon 5.1
-# Terratec seems to use several IDs for the same card.
 	1147  Aureon 5.1 Sky
 	1158  Philips Semiconductors SAA7134 (rev 01) [Terratec Cinergy 600 TV]
 153c  ANTAL Electronic
@@ -18183,7 +9914,6 @@ var pciids = []byte(`#
 	0001  SOC-it 101 System Controller
 1540  PROVIDEO MULTIMEDIA Co Ltd
 1541  MACHONE Communications
-# nee VIVID Technology Inc.
 1542  Concurrent Real-Time
 	9260  RCIM-II Real-Time Clock & Interrupt Module
 	9271  RCIM-III Real-Time Clock & Interrupt Module (PCIe)
@@ -18296,7 +10026,6 @@ var pciids = []byte(`#
 158d  Point Multimedia Systems
 158e  Lara Technology Inc
 158f  Ditect Coop
-# formerly 3PAR Inc.
 1590  Hewlett Packard Enterprise
 	0001  Eagle Cluster Manager
 	0002  Osprey Cluster Manager
@@ -18355,7 +10084,6 @@ var pciids = []byte(`#
 	07c0  PVSCSI SCSI Controller
 	07e0  SATA AHCI controller
 	0801  Virtual Machine Interface
-		15ad 0800  Hypervisor ROM Interface
 	0820  Paravirtual RDMA controller
 	1977  HD Audio Controller
 15ae  Amersham Pharmacia Biotech
@@ -18372,49 +10100,17 @@ var pciids = []byte(`#
 	020d  MT28800 Family [ConnectX-5 Flash Recovery]
 	020f  MT28908A0 Family [ConnectX-6 Flash Recovery]
 	0211  MT416842 Family [BlueField SoC Flash Recovery]
-# reserved for RM#105916
 	024e  MT53100 [Spectrum-2, Flash recovery mode]
-# Actual value to be used
 	024f  MT53100 [Spectrum-2, Flash recovery mode]
 	0262  MT27710 [ConnectX-4 Lx Programmable] EN
 	0263  MT27710 [ConnectX-4 Lx Programmable Virtual Function] EN
 	0281  NPS-600 Flash Recovery
 	1002  MT25400 Family [ConnectX-2 Virtual Function]
 	1003  MT27500 Family [ConnectX-3]
-		103c 1777  InfiniBand FDR/EN 10/40Gb Dual Port 544FLR-QSFP Adapter (Rev Cx)
-		103c 17c9  Infiniband QDR/Ethernet 10Gb 2-port 544i Adapter
-		103c 18ce  InfiniBand QDR/EN 10Gb Dual Port 544M Adapter
-		103c 18cf  InfiniBand FDR/EN 10/40Gb Dual Port 544M Adapter
-		103c 18d6  InfiniBand FDR/EN 10/40Gb Dual Port 544QSFP Adapter
-		15b3 0025  ConnectX-3 IB QDR Dual Port Mezzanine Card
-		15b3 0026  ConnectX-3 IB FDR Dual Port Mezzanine Card
-		15b3 0028  ConnectX-3 VPI Dual QSFP+ Port QDR Infiniband 40Gb/s or 10Gb Ethernet
-		15b3 0059  ConnectX-3 VPI IB FDR/40 GbE Single Port QSFP+ Mezzanine Card
-		15b3 0065  ConnectX-3 VPI IB FDR/40 GbE Dual Port QSFP+ Adapter
-		15b3 0066  ConnectX-3 IB FDR10 Dual Port Mezzanine Card
-		15b3 0067  ConnectX-3 VPI IB FDR/40 GbE Single Port QSFP+ Adapter
-		15b3 0071  ConnectX-3 VPI IB FDR/40 GbE Dual Port QSFP+ Mezzanine Card
-# SVID = 15B3 SSID = 0078
-		15b3 0078  ConnectX-3 10 GbE Dual Port KR Mezzanine Card
-		15b3 0079  ConnectX-3 40 GbE Dual Port QSFP+ Adapter
-# SVID = 15B3 SSID = 0080
-		15b3 0080  ConnectX-3 10 GbE Dual Port SFP+ Adapter
 	1004  MT27500/MT27520 Family [ConnectX-3/ConnectX-3 Pro Virtual Function]
 	1005  MT27510 Family
 	1006  MT27511 Family
 	1007  MT27520 Family [ConnectX-3 Pro]
-		1014 04eb  2-Port 10GbE NIC and RoCE SR PCIe3
-		103c 22f3  InfiniBand FDR/Ethernet 10Gb/40Gb 2-port 544+QSFP Adapter
-		103c 22f4  InfiniBand FDR/Ethernet 10Gb/40Gb 2-port 544+FLR-QSFP Adapter
-		103c 801f  Ethernet 10G 2-port 546SFP+ Adapter
-		117c 0090  FastFrame NQ41
-		117c 0091  FastFrame NQ42
-		117c 0092  FastFrame NQ11
-		117c 0093  FastFrame NQ12
-		15b3 0006  Mellanox Technologies ConnectX-3 Pro Stand-up dual-port 40GbE MCX314A-BCCT
-		15b3 0078  ConnectX-3 Pro 10 GbE Dual Port KR Mezzanine Card
-		15b3 0079  ConnectX-3 Pro 40 GbE Dual Port QSFP+ Adapter
-		15b3 0080  ConnectX-3 Pro 10 GbE Dual Port SFP+ Adapter
 	1009  MT27530 Family
 	100a  MT27531 Family
 	100b  MT27540 Family
@@ -18426,20 +10122,8 @@ var pciids = []byte(`#
 	1011  MT27600 [Connect-IB]
 	1012  MT27600 Family [Connect-IB Virtual Function]
 	1013  MT27700 Family [ConnectX-4]
-		15b3 0003  Mellanox Technologies ConnectX-4 Stand-up single-port 40GbE MCX413A-BCAT
-		15b3 0005  Mellanox Technologies ConnectX-4 Stand-up single-port 40GbE MCX415A-BCAT
-		15b3 0006  MCX416A-BCAT, ConnectX-4 EN, 40/56GbE 2P, PCIe3.0 x16
-		15b3 0008  ConnectX-4 Stand-up dual-port 100GbE MCX416A-CCAT
-		15b3 0033  ConnectX-4 VPI IB EDR/100 GbE Single Port QSFP28 Adapter
-		15b3 0034  ConnectX-4 VPI IB EDR/100 GbE Dual Port QSFP28 Adapter
-		15b3 0050  ConnectX-4 100 GbE Dual Port QSFP28 Adapter
 	1014  MT27700 Family [ConnectX-4 Virtual Function]
 	1015  MT27710 Family [ConnectX-4 Lx]
-		15b3 0005  Mellanox Technologies ConnectX-4 Lx Stand-up single-port 40GbE MCX4131A-BCAT
-		15b3 0016  ConnectX-4 Lx 25 GbE Dual Port SFP28 Adapter
-		15b3 0020  MCX4411A-ACQN, ConnectX-4 Lx EN OCP, 1x25Gb
-		15b3 0021  MCX4421A-ACQN ConnectX-4 Lx EN OCP,2x25G
-		15b3 0025  ConnectX-4 Lx 25 GbE Dual Port SFP28 rNDC
 	1016  MT27710 Family [ConnectX-4 Lx Virtual Function]
 	1017  MT27800 Family [ConnectX-5]
 	1018  MT27800 Family [ConnectX-5 Virtual Function]
@@ -18470,20 +10154,10 @@ var pciids = []byte(`#
 	6372  MT25408 [ConnectX EN 10GigE 10GBaseT, PCIe 2.0 2.5GT/s]
 	6732  MT26418 [ConnectX VPI PCIe 2.0 5GT/s - IB DDR / 10GigE]
 	673c  MT26428 [ConnectX VPI PCIe 2.0 5GT/s - IB QDR / 10GigE]
-		1014 0487  GX++ 1-port 4X IB QDR Adapter for Power 795
-		103c 1782  4X QDR InfiniBand Mezzanine HCA for c-Class BladeSystem
-		15b3 0021  HP InfiniBand 4X QDR CX-2 PCI-e G2 Dual Port HCA
 	6746  MT26438 [ConnectX VPI PCIe 2.0 5GT/s - IB QDR / 10GigE Virtualization+]
-		103c 1781  NC543i 1-port 4x QDR IB/Flex-10 10Gb Adapter
-		103c 3349  NC543i 2-port 4xQDR IB/10Gb Adapter
 	6750  MT26448 [ConnectX EN 10GigE, PCIe 2.0 5GT/s]
-		1014 0461  2-Port 10 GbE RoCE SR LP PCIe2 (rev b0)
-		15b3 0018  HP 10 GbE PCI-e G2 Dual-Port NIC (rev C1)
-# FC EC26
-		15b3 6572  IBM Flex System EN4132 2-port 10Gb RoCE Adapter
 	675a  MT25408 [ConnectX EN 10GigE 10GBaseT, PCIe Gen2 5GT/s]
 	6764  MT26468 [ConnectX EN 10GigE, PCIe 2.0 5GT/s Virtualization+]
-		103c 3313  NC542m Dual Port Flex-10 10GbE BLc Adapter
 	676e  MT26478 [ConnectX EN 40GigE, PCIe 2.0 5GT/s]
 	6778  MT26488 [ConnectX VPI PCIe 2.0 5GT/s - IB DDR / 10GigE Virtualization+]
 	7101  NPS-400 configuration and management interface
@@ -18496,13 +10170,11 @@ var pciids = []byte(`#
 	a2d1  MT416842 BlueField SoC Crypto disabled
 	a2d2  MT416842 BlueField integrated ConnectX-5 network controller
 	a2d3  MT416842 BlueField multicore SoC family VF
-# SwitchX-2, 40GbE switch
 	c738  MT51136
 	c739  MT51136 GW
 	c838  MT52236
 	c839  MT52236 router
 	caf1  ConnectX-4 CAPI Function
-# Spectrum, 100GbE Switch
 	cb84  MT52100
 	cf08  MT53236
 	cf6c  MT53100 [Spectrum-2, 64 x 100GbE switch]
@@ -18546,9 +10218,6 @@ var pciids = []byte(`#
 	0100  HPFC-5600 Tachyon DX2+ FC
 	0103  QX4 PCI Express quad 4-gigabit Fibre Channel controller
 	0105  Celerity FC-44XS/FC-42XS/FC-41XS/FC-44ES/FC-42ES/FC-41ES
-		117c 0022  Celerity FC-42XS Fibre Channel Adapter
-		117c 0025  Celerity FC-44ES Fibre Channel Adapter
-		117c 0026  Celerity FC-42ES Fibre Channel Adapter
 	1100  E8001-66442 PCI Express CIC
 	2922  64 Bit, 133MHz PCI-X Exerciser & Protocol Checker
 	2928  64 Bit, 66MHz PCI Exerciser & Analyzer
@@ -18686,32 +10355,17 @@ var pciids = []byte(`#
 1642  Bitland(ShenZhen) Information Technology Co., Ltd.
 1657  Brocade Communications Systems, Inc.
 	0013  425/825/42B/82B 4Gbps/8Gbps PCIe dual port FC HBA
-		103c 1742  82B 8Gbps dual port FC HBA
-		103c 1744  42B 4Gbps dual port FC HBA
-		1657 0014  425/825 4Gbps/8Gbps PCIe dual port FC HBA
 	0014  1010/1020/1007/1741 10Gbps CNA
-		1657 0014  1010/1020/1007/1741 10Gbps CNA - FCOE
-		1657 0015  1010/1020/1007/1741 10Gbps CNA - LL
 	0017  415/815/41B/81B 4Gbps/8Gbps PCIe single port FC HBA
-		103c 1741  41B 4Gbps single port FC HBA
-		103c 1743  81B 8Gbps single port FC HBA
-		1657 0014  415/815 4Gbps/8Gbps single port PCIe FC HBA
 	0021  804 8Gbps FC HBA for HP Bladesystem c-class
-# AnyIO Adapter
 	0022  1860 16Gbps/10Gbps Fabric Adapter
-		1657 0022  10Gbps CNA - FCOE
-		1657 0023  10Gbps CNA - LL
-		1657 0024  16Gbps FC HBA
-# Mezz card for IBM
 	0023  1867/1869 16Gbps FC HBA
-# Same Device_ID used for 410 (1port) and 420 (2 port) HBAs.
 	0646  400 4Gbps PCIe FC HBA
 165a  Epix Inc
 	c100  PIXCI(R) CL1 Camera Link Video Capture Board [custom QL5232]
 	d200  PIXCI(R) D2X Digital Video Capture Board [custom QL5232]
 	d300  PIXCI(R) D3X Digital Video Capture Board [custom QL5232]
 	eb01  PIXCI(R) EB1 PCI Camera Link Video Capture Board
-# Gidel Reconfigurable Computing
 165c  Gidel Ltd.
 	5361  PROCStarII60-1
 	5362  PROCStarII60-2
@@ -18786,7 +10440,6 @@ var pciids = []byte(`#
 1661  Worldspace Corp.
 1668  Actiontec Electronics Inc
 	0100  Mini-PCI bridge
-# Formerly SiByte, Inc.
 166d  Broadcom Corporation
 	0001  SiByte BCM1125/1125H/1250 System-on-a-Chip PCI
 	0002  SiByte BCM1125H/1250 System-on-a-Chip HyperTransport
@@ -18802,8 +10455,6 @@ var pciids = []byte(`#
 	3000  SD Standard host controller [Ellen]
 167b  ZyDAS Technology Corp.
 	2102  ZyDAS ZD1202
-		187e 3406  ZyAIR B-122 CardBus 11Mbs Wireless LAN Card
-		187e 3407  ZyAIR B-320 802.11b Wireless PCI Adapter
 	2116  ZD1212B Wireless Adapter
 167d  Samsung Electro-Mechanics Co., Ltd.
 	a000  MagicLAN SWL-2210P 802.11b [Intersil ISL3874]
@@ -18812,253 +10463,47 @@ var pciids = []byte(`#
 1682  XFX Pine Group Inc.
 1688  CastleNet Technology Inc.
 	1170  WLAN 802.11b card
-# nee Atheros Communications, Inc.
 168c  Qualcomm Atheros
 	0007  AR5210 Wireless Network Adapter [AR5000 802.11a]
-		1737 0007  WPC54A Wireless PC Card
-		1b47 0100  Harmony 8450CN Wireless CardBus Module
-		1b47 0110  Skyline 4030 / Harmony 8450 802.11a Wireless CardBus Adapter
-		8086 2501  PRO/Wireless 5000 LAN PCI Adapter Module
 	0011  AR5211 Wireless Network Adapter [AR5001A 802.11a]
 	0012  AR5211 Wireless Network Adapter [AR5001X 802.11ab]
-		1186 3a03  AirPro DWL-A650 Wireless Cardbus Adapter (rev.B)
-		1186 3a04  AirPro DWL-AB650 Multimode Wireless Cardbus Adapter
-		1186 3a05  AirPro DWL-AB520 Multimode Wireless PCI Adapter
-		126c 8031  2201 Mobile Adapter
-		1385 4400  WAB501 802.11ab Wireless CardBus Card
-		1b47 aa00  8460 802.11ab Wireless CardBus Adapter
 	0013  AR5212/5213/2414 Wireless Network Adapter
-		0308 3402  AG-100 802.11ag Wireless Cardbus Adapter
-		0308 3405  G-102 v2 802.11g Wireless Cardbus Adapter
-		0308 3408  G-170S 802.11g Wireless CardBus Adapter
-		0e11 00e5  NC6000/NC8000 laptop
-		10b7 6002  3CRWE154A72 802.11abg Cardbus Adapter
-		1113 d301  Philips CPWNA100 Wireless CardBus adapter
-		1113 ee23  SMCWPCIT-G 108Mbps Wireless PCI adapter
-		1154 033b  Buffalo WLI-CB-AMG54
-		1154 034e  Buffalo WLI-CB-AG108HP 802.11abg Cardbus Adapter
-		1186 3202  DWL-G650 (Rev B3,B5) Wireless cardbus adapter
-		1186 3203  AirPlus DWL-G520 Wireless PCI Adapter (rev. A)
-		1186 3a07  AirXpert DWL-AG650 Wireless Cardbus Adapter
-		1186 3a08  AirXpert DWL-AG520 Wireless PCI Adapter
-		1186 3a12  D-Link AirPlus DWL-G650 Wireless Cardbus Adapter(rev.C)
-		1186 3a13  AirPlus DWL-G520 Wireless PCI Adapter (rev. B)
-		1186 3a14  AirPremier AG DWL-AG530 Wireless PCI Adapter (rev.A)
-		1186 3a17  D-Link AirPremier DWL-G680 Wireless Cardbus Adapter
-		1186 3a18  D-Link AirPremier DWL-G550 Wireless PCI Adapter
-		1186 3a1a  WNA-2330 802.11bg Wireless CardBus Adapter
-		1186 3a63  D-Link AirPremier DWL-AG660 Wireless Cardbus Adapter
-		1186 3a93  Conceptronic C54I Wireless 801.11g PCI card
-		1186 3a94  Conceptronic C54C 802.11g Wireless Cardbus Adapter
-		1186 3ab0  Allnet ALL0281 Wireless PCI Card
-		1385 4600  WAG511 802.11a/b/g Dual Band Wireless PC Card
-		1385 4610  WAG511 802.11a/b/g Dual Band Wireless PC Card
-		1385 4900  WG311v1 802.11g Wireless PCI Adapter
-		1385 4a00  WAG311 802.11a/g Wireless PCI Adapter
-		1385 4b00  WG511T 108 Mbps Wireless PC Card (rev.A/B)
-		1385 4d00  WG311T 108 Mbps Wireless PCI Adapter (rev.A2)
-		1385 4f00  WG511U Double 108 Mbps Wireless PC Card
-		1385 5a00  WG311T (rev.A3 v1h3/v1h4) 108 Mbps Wireless PCI Adapter [AR2412]
-		1385 5b00  WG511T 108 Mbps Wireless PC Card (rev.C)
-		1385 5d00  WPN511 RangeMax Wireless PC Card
-		1458 e911  GN-WIAG02
-		1468 0403  U10H014 802.11g Cardbus Adapter
-		1468 0408  ThinkPad 11b/g Wireless LAN Mini PCI Adapter
-		14b7 0a10  8480-WD 802.11abg Cardbus Adapter
-		14b7 0a60  8482-WD ORiNOCO 11a/b/g Wireless PCI Adapter
-		14b7 aa30  8800-FC 802.11bg Cardbus Adapter
-		14b7 aa40  8470-WD 802.11bg Cardbus Adapter
-		14b9 cb21  CB21 802.11a/b/g Cardbus Adapter
-		1668 1026  IBM HighRate 11 a/b/g Wireless CardBus Adapter
-		168c 0013  AirPlus XtremeG DWL-G650 Wireless PCMCIA Adapter
-		168c 1025  DWL-G650B2 Wireless CardBus Adapter
-		168c 1027  Engenius NL-3054CB ARIES b/g CardBus Adapter
-		168c 1042  Ubiquiti Networks SuperRange a/b/g Cardbus Adapter
-		168c 1051  EZ Connect g 802.11g 108Mbps Wireless PCI Adapter
-		168c 2026  Netgate 5354MP ARIES a(108Mb turbo)/b/g MiniPCI Adapter
-		168c 2027  D-Link AirPlus DWL-G520 Wireless PCI Adapter (rev. A)
-		168c 2041  Engenius 5354MP Plus ARIES2 b/g MiniPCI Adapter
-		168c 2042  Engenius 5354MP Plus ARIES2 a/b/g MiniPCI Adapter
-		168c 2051  TRENDnet TEW-443PI Wireless PCI Adapter
-		16a5 160a  BWP712 802.11bg Wireless CardBus Adapter
-		16ab 7302  Trust Speedshare Turbo Pro Wireless PCI Adapter
-		1737 0017  WPC55AG
-		1737 0026  WMP55AG v1.1
-		1737 0035  WPC55AG v1.2 802.11abg Cardbus Adapter
-		1737 0036  WMP55AG v1.2 802.11abg PCI Adapter
-		1799 3000  F6D3000 Dual-Band Wireless A+G Desktop Card
-		1799 3010  F6D3010 Dual-Band Wireless A+G Notebook Card
-		17cf 0042  Z-COMAX Highpower XG-622H (400mw) 802.11b/g mini-PCI Adapter
-		185f 1012  CM9 Wireless a/b/g MiniPCI Adapter
-		185f 2012  Wistron NeWeb WLAN a+b+g model CB9
-		a727 6801  3CRXJK10075 OfficeConnect Wireless 108Mbps 11g XJACK PC Card
 	001a  AR2413/AR2414 Wireless Network Adapter [AR5005G(S) 802.11bg]
-		1052 168c  Sweex Wireless Lan PC Card 54Mbps
-		1113 ee20  SMC Wireless CardBus Adapter 802.11g (SMCWCB-G EU)
-		1113 ee24  SMC Wireless PCI Card WPCI-G
-		1186 3a15  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.D1)
-		1186 3a16  AirPlus G DWL-G510 Wireless PCI Adapter(rev.B)
-		1186 3a1c  WNA-1330 Notebook Adapter
-		1186 3a1d  WDA-1320 Desktop Adapter
-		1186 3a23  AirPlus G DWL-G520+A Wireless PCI Adapter
-		1186 3a24  AirPlus G DWL-G650+A Wireless Cardbus Adapter
-		1186 3b08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.C1)
-		168c 001a  Belkin FD7000
-		168c 1052  TP-Link TL-WN510G Wireless CardBus Adapter
-		168c 2052  Compex Wireless 802.11 b/g  MiniPCI Adapter, Rev A1 [WLM54G]
-		16ec 0122  Wireless PCI Adapter Model 5418
-		1737 0053  WPC54G v7 802.11g Wireless-G Notebook Adapter
-		1799 700c  F5D7000 v5000 Wireless G Desktop Card
-		1799 701d  F5D7010 v5000 Wireless G Notebook Card
-		17f9 0008  DX-WGNBC 802.11bg Wireless CardBus Adapter
-		17f9 0018  DX-WGDTC 802.11bg Wireless PCI Adapter
 	001b  AR5413/AR5414 Wireless Network Adapter [AR5006X(S) 802.11abg]
-# Atheros AR5414 32-bit mini-PCI type IIIB
-		0777 1107  UB5 802.11a Wireless Mini PCI Adapter
-		0777 3002  XR2 802.11g Wireless Mini PCI Adapter
-		0777 3005  XR5 802.11a Wireless Mini PCI Adapter
-		0777 3009  XR9 900MHz Wireless Mini PCI Adapter
-		1154 034e  WLI-CB-AG108HP 802.11abg Wireless CardBus Adapter
-		1186 3a19  D-Link AirPremier AG DWL-AG660 Wireless Cardbus Adapter
-		1186 3a22  AirPremier AG DWL-AG530 Wireless PCI Adapter (rev.B)
-		11ad 5001  WN5301A 802.11bg Wireless PCI Adapter
-		1458 e901  GN-WI01HT Wireless a/b/g MiniPCI Adapter
-		168c 001b  Wireless LAN PCI LiteOn
-		168c 1062  IPN-W100CB 802.11abg Wireless CardBus Adapter
-		168c 2062  EnGenius EMP-8602 (400mw) or Compex WLM54AG (SuperAG)
-		168c 2063  EnGenius EMP-8602 (400mw) or Compex WLM54AG
-		17f9 000b  WL-711A 802.11abg Wireless CardBus Adapter
-		17f9 000c  WPIA-112AG 802.11abg Wireless PCI Adapter
-		17f9 000d  PC-686X 802.11abg Wireless Mini PCI Adapter
-		185f 1600  DCMA-82 High Power WLAN 802.11a/b/g mini-PCI Module (Super A/G, eXtended Range, 400mW)
-		1948 3aba  RBTBJ-AW 802.11abg Wireless Cardbus Adapter
-		a727 6804  Wireless 11a/b/g PC Card with XJACK(r) Antenna
 	001c  AR242x / AR542x Wireless Network Adapter (PCI-Express)
-		0777 3006  SRX 802.11abg Wireless ExpressCard Adapter
-		103c 137a  AR5BXB63 (Foxconn) 802.11bg Mini PCIe NIC
-		106b 0086  AirPort Extreme
-		144f 7106  WLL3140 (Toshiba PA3501U-1MPC) 802.11bg Wireless Mini PCIe Card
-		144f 7128  WLL3141 (Toshiba PA3613U-1MPC) 802.11bg Wireless Mini PCIe Card
-		1468 0428  AR5BXB63 802.11bg NIC
-		1468 042a  AR5007EG 802.11bg NIC
-		147b 1033  AirPace Wi-Fi
-		168c 001c  AR242x 802.11abg NIC (PCI Express)
-		168c 3061  AR5006EGS 802.11bg NIC (2.4GHz, PCI Express)
-		168c 3062  AR5006EXS 802.11abg NIC (2.4/5.0GHz, PCI Express)
-		168c 3063  AR5006EX 802.11abg NIC (2.4/5.0GHz, PCI Express)
-		168c 3065  AR5006EG 802.11bg NIC (2.4GHz, PCI Express)
-		168c 3067  AR242x 802.11abg Wireless PCI Express Adapter (rev 01)
-		1a3b 1026  AW-GE780 802.11bg Wireless Mini PCIe Card
 	001d  AR2417 Wireless Network Adapter [AR5007G 802.11bg]
-		1799 720b  F5D7000 v8000 Wireless G Desktop Card
-		1799 721b  F5D7010 v8000 Wireless G Notebook Card
-# the name AR5005VL is used for some AR5513 based designs
 	0020  AR5513 802.11abg Wireless NIC
-		0308 3407  M-102 802.11g Wireless Cardbus Adapter
-		1186 3a67  DWL-G650M Super G MIMO Wireless Notebook Adapter
-		1186 3a68  DWL-G520M Wireless 108G MIMO Desktop Adapter
-		187e 340e  M-302 802.11g Wireless PCI Adapter
-		1976 2003  TEW-601PC 802.11g Wireless CardBus Adapter
 	0023  AR5416 Wireless Network Adapter [AR5008 802.11(a)bgn]
-		0308 340b  NWD-170N 802.11bgn Wireless CardBus Adapter
-		1154 0365  Buffalo WLP-CB-AG300 802.11abgn Cardbus Adapter
-		1154 0367  WLI-CB-AG301N 802.11abgn Wireless CardBus Adapter
-		1186 3a6a  DWA-642 802.11n RangeBooster N CardBus Adapter
-		1186 3a6b  DWA-547 802.11n RangeBooster N 650 DeskTop Adapter
-		1186 3a6d  DWA-552 802.11n Xtreme N Desktop Adapter (rev A1)
-		1186 3a76  DWA-645 802.11n RangeBooster N 650 Notebook Adapter (rev A1)
-		1737 0059  WPC300N v2 Wireless-N Notebook Adapter
-		1737 0069  WPC100 v1 802.11n RangePlus Wireless Notebook Adapter
-		1737 0072  WMP110 v1 802.11n RangePlus Wireless PCI Adapter
-		1799 8011  F5D8011 v1 802.11n N1 Wireless Notebook Card
-		187e 3411  NWD-370N 802.11n Wireless PCI Adapter
-		1976 2008  TEW-621PC 802.11bgn Wireless CardBus Adapter
 	0024  AR5418 Wireless Network Adapter [AR5008E 802.11(a)bgn] (PCI-Express)
-		106b 0087  AirPort Extreme
-		1186 3a70  DWA-556 Xtreme N PCI Express Desktop Adapter
 	0027  AR9160 Wireless Network Adapter [AR9001 802.11(a)bgn]
-		0777 4082  SR71-A 802.11abgn Wireless Mini PCI Adapter
 	0029  AR922X Wireless Network Adapter
-		0777 4005  SR71-15 802.11an Mini PCI Adapter
-		1186 3a7a  DWA-552 802.11n Xtreme N Desktop Adapter (rev A2)
-		1186 3a7d  DWA-552 802.11n Xtreme N Desktop Adapter (rev A3)
-		168c 2096  Compex WLM200NX / Wistron DNMA-92
 	002a  AR928X Wireless Network Adapter (PCI-Express)
-		0777 4f05  SR71-X 802.11abgn Wireless ExpressCard Adapter [AR9280]
-		103c 3041  AR5BHB92-H 802.11abgn Wireless Half-size Mini PCIe Card [AR9280]
-		103c 3042  AzureWave AW-NE773 802.11abgn Wireless Half-size Mini PCIe Card [AR9280]
-		105b e006  T77H053.00 802.11bgn Wireless Mini PCIe Card [AR9281]
-		105b e01f  T77H047.31 802.11bgn Wireless Half-size Mini PCIe Card [AR9283]
-		106b 008f  AirPort Extreme
-		11ad 6600  WN6600A 802.11bgn Wireless Mini PCIe Card [AR9281]
-		144f 7141  WLL6080 802.11bgn Wireless Mini PCIe Card [AR9281]
-		168c 0203  DW1525 802.11abgn WLAN PCIe Card [AR9280]
-		1a32 0303  EM303 802.11bgn Wireless Mini PCIe Card [AR9281]
-		1a32 0306  EM306 802.11bgn Wireless Half-size Mini PCIe Card [AR9283]
-		1a3b 1067  AW-NE771 802.11bgn Wireless Mini PCIe Card [AR9281]
-		1a3b 1081  AW-NE773 802.11abgn Wireless Half-size Mini PCIe Card [AR9280]
 	002b  AR9285 Wireless Network Adapter (PCI-Express)
-		1028 0204  Wireless 1502 802.11bgn Half-size Mini PCIe Card
-		1028 0205  Wireless 1702 802.11bgn Half-size Mini PCIe Card [AR9002WB-1NGCD]
-		103c 303f  U98Z062.10 802.11bgn Wireless Half-size Mini PCIe Card
-		103c 3040  U98Z062.12 802.11bgn Wireless Half-size Mini PCIe Card
-		105b e017  T77H126.00 802.11bgn Wireless Half-size Mini PCIe Card
-		105b e023  T77H121.04 802.11bgn Wireless Half-size Mini PCIe Card
-		105b e025  T77H121.05 802.11bgn Wireless Half-size Mini PCIe Card
-		1113 e811  WN7811A (Toshiba PA3722U-1MPC) 802.11bgn Wireless Half-size Mini PCIe Card
-		185f 30af  DNXA-95 802.11bgn Wireless Half-size Mini PCIe Card
-		1931 0023  Option GTM67x PCIe WiFi Adapter
-		1a3b 1089  AW-NE785 / AW-NE785H 802.11bgn Wireless Full or Half-size Mini PCIe Card
-		1a3b 2c37  AW-NB037H 802.11bgn Wireless Half-size Mini PCIe Card [AR9002WB-1NGCD]
-		1b9a 0401  XW204E 802.11bgn Wireless Half-size Mini PCIe Card
-		1b9a 0c03  WB214E 802.11bgn Wireless Half-size Mini PCIe Card [AR9002WB-1NGCD]
 	002c  AR2427 802.11bg Wireless Network Adapter (PCI-Express)
 	002d  AR9227 Wireless Network Adapter
 	002e  AR9287 Wireless Network Adapter (PCI-Express)
-		105b e034  T77H167.00
 	0030  AR93xx Wireless Network Adapter
-		103c 1627  AR9380/HB112 802.11abgn 3×3 Wi-Fi Adapter
-		106b 009a  AirPort Extreme
-		1186 3a7e  DWA-566 Wireless N 300 Dual Band PCIe Desktop Adapter
-		1a56 2000  Killer Wireless-N 1102 Half-size Mini PCIe Card [AR9382]
-		1a56 2001  Killer Wireless-N 1103 Half-size Mini PCIe Card [AR9380]
 	0032  AR9485 Wireless Network Adapter
-		1028 0208  Wireless 1506 WLAN Half Mini-Card
-		103c 1838  AR9485/HB125 802.11bgn 1×1 Wi-Fi Adapter
-		105b e044  Unex DHXA-225
-		144d 410e  AR9485WB-EG 802.11b/g/n mini-PCIe card on a series 3 laptop
-		1a3b 1186  AW-NE186H
 	0033  AR958x 802.11abgn Wireless Network Adapter
-		168c a120  AR9582 802.11a/n WLAN Mini-PCIe Adapter
 	0034  AR9462 Wireless Network Adapter
-		1028 020b  Wireless 1601 802.11abgn Adapter
-		1028 0300  Wireless 1802 802.11abgn Adapter
-		1a56 2003  Killer Wireless-N 1202 Half-size Mini PCIe Card
 	0036  QCA9565 / AR9565 Wireless Network Adapter
 	0037  AR9485 Wireless Network Adapter
-# Also used as Gigabyte GC-WB150 on a PCIe-to-mini-PCIe converter
-		1a3b 2100  AW-NB100H 802.11n Wireless Mini PCIe Card
 	003c  QCA986x/988x 802.11ac Wireless Network Adapter
 	003e  QCA6174 802.11ac Wireless Network Adapter
-		1a56 1525  Killer N1525 Wireless-AC
 	0040  QCA9980/9990 802.11ac Wireless Network Adapter
 	0041  QCA6164 802.11ac Wireless Network Adapter
 	0042  QCA9377 802.11ac Wireless Network Adapter
 	0050  QCA9887 802.11ac Wireless Network Adapter
 	0207  AR5210 Wireless Network Adapter [AR5000 802.11a]
 	1014  AR5212 802.11abg NIC
-		1014 058a  ThinkPad 11a/b/g Wireless LAN Mini Express Adapter (AR5BXB6)
 	9013  AR5002X Wireless Network Adapter
 	ff19  AR5006X Wireless Network Adapter
 	ff1b  AR2425 Wireless Network Adapter [AR5007EG 802.11bg]
 	ff1c  AR5008 Wireless Network Adapter
 	ff1d  AR922x Wireless Network Adapter
-# Found in "AVM Fritz!Box FON WLAN 7270v3"
-		168c ee1c  AR9220-AC1A [AVM Fritz!Box FON WLAN 7270 v3]
 1695  EPoX Computer Co., Ltd.
 169c  Netcell Corporation
 	0044  Revolution Storage Processing Card
-# The right ID is 196d, but they got it nibble-swapped in 2202.
 169d  Club-3D VB (Wrong ID)
 16a5  Tekram Technology Co.,Ltd.
 16ab  Global Sun Technology Inc
@@ -19070,8 +10515,6 @@ var pciids = []byte(`#
 	0001  SafeXcel 1140
 	000a  SafeXcel 1841
 	1141  SafeXcel 1141
-# misused vendor ID 0001
-		0001 0001  SafeXcel 1141 v. 1.1
 	1841  SafeXcel 1842
 16af  SparkLAN Communications, Inc.
 16b4  Aspex Semiconductor Ltd
@@ -19085,7 +10528,6 @@ var pciids = []byte(`#
 16c9  EONIC B.V. The Netherlands
 16ca  CENATEK Inc
 	0001  Rocket Drive DL
-# nee Innocore Gaming Ltd., nee Densitron Gaming Ltd., a division of Densitron Technologies
 16cd  Advantech Co. Ltd
 	0101  DirectPCI SRAM for DPX-11x series
 	0102  DirectPCI SRAM for DPX-S/C/E-series
@@ -19169,12 +10611,14 @@ var pciids = []byte(`#
 	7016  AP470 48-Channel TTL Level Digital Input/Output Module
 	7017  AP323 16-bit, 20 or 40 Channel Analog Input Module
 	7018  AP408: 32-Channel Digital I/O Module
+	7019  AP341 14-bit, 16-Channel Simultaneous Conversion Analog Input Module
 	701a  AP220-16 12-Bit, 16-Channel Analog Output Module
 	701b  AP231-16 16-Bit, 16-Channel Analog Output Module
 	7021  APA7-201 Reconfigurable Artix-7 FPGA module 48 TTL channels
 	7022  APA7-202 Reconfigurable Artix-7 FPGA module 24 RS485 channels
 	7023  APA7-203 Reconfigurable Artix-7 FPGA module 24 TTL & 12 RS485 channels
 	7024  APA7-204 Reconfigurable Artix-7 FPGA module 24 LVDS channels
+	7027  AP418 16-Channel High Voltage Digital Input/Output Module
 	7042  AP482 Counter Timer Module with TTL Level Input/Output
 	7043  AP483 Counter Timer Module with TTL Level and RS422 Input/Output
 	7044  AP484 Counter Timer Module with RS422 Input/Output
@@ -19198,7 +10642,6 @@ var pciids = []byte(`#
 	1001  UMIO communication card
 16f2  ETAS GmbH
 	0200  I/O board
-		16f2 0010  ES53xx I/O board
 16f3  Jetway Information Co., Ltd.
 16f4  Vweb Corp
 	8000  VW2010
@@ -19210,28 +10653,22 @@ var pciids = []byte(`#
 170c  YottaYotta Inc.
 1719  EZChip Technologies
 	1000  NPA Access Network Processor Family
-# Seems to be a 2nd ID for Vitesse Semiconductor
 1725  Vitesse Semiconductor
 	7174  VSC7174 PCI/PCI-X Serial ATA Host Bus Controller
 172a  Accelerated Encryption
 	13c8  AEP SureWare Runner 1000V3
-# nee Fujitsu Siemens Computers GmbH
 1734  Fujitsu Technology Solutions
 1735  Aten International Co. Ltd.
 1737  Linksys
 	0029  WPG54G ver. 4 PCI Card
 	1032  Gigabit Network Adapter
-		1737 0015  EG1032 v2 Instant Gigabit Network Adapter
-		1737 0024  EG1032 v3 Instant Gigabit Network Adapter
 	1064  Gigabit Network Adapter
-		1737 0016  EG1064 v2 Instant Gigabit Network Adapter
 	ab08  21x4x DEC-Tulip compatible 10/100 Ethernet
 	ab09  21x4x DEC-Tulip compatible 10/100 Ethernet
 173b  Altima (nee Broadcom)
 	03e8  AC1000 Gigabit Ethernet
 	03e9  AC1001 Gigabit Ethernet
 	03ea  AC9100 Gigabit Ethernet
-		173b 0001  AC1002
 	03eb  AC1003 Gigabit Ethernet
 1743  Peppercon AG
 	8139  ROL/F-100 Fast Ethernet Adapter with ROL
@@ -19248,7 +10685,6 @@ var pciids = []byte(`#
 	0102  PCD-7104 Digital Input & Output PCI Card
 	0303  PCD-7006C Digital Input & Output PCI Card
 1771  InnoVISION Multimedia Ltd.
-# nee SBS Technologies
 1775  GE Intelligent Platforms
 177d  Cavium, Inc.
 	0001  Nitrox XL N1
@@ -19272,30 +10708,13 @@ var pciids = []byte(`#
 	0096  Octeon III CN70XX Network Processor
 	9700  Octeon III CN73XX Network Processor
 	9702  CN23XX [LiquidIO II] Intelligent Adapter
-		177d 0003  CN2350 [LiquidIO II] 2-port 10GbE Intelligent adapter
-# This was changed during the production phase to 10GbE adapter.
-		177d 0004  CN2350 [LiquidIO II] 2-port 10GbE Intelligent adapter
-		177d 0005  CN2360 [LiquidIO II] 2-port 10GbE Intelligent adapter
-		177d 0006  CN2360 [LiquidIO II] 2-port 25GbE Intelligent adapter
-		177d 0007  CN2350 [LiquidIO II] 2-port 25GbE Intelligent adapter
-		177d 0008  CN2350 [LiquidIO II] 2-port 10GbE SFP+ Intelligent adapter
-		177d 0009  CN2360 [LiquidIO II] 2-port 10GbE SFP+ Intelligent adapter
-		177d 000a  CN2350 [LiquidIO II] 2-port 10GBASE-T Intelligent adapter
-		177d 000b  CN2360 [LiquidIO II] 2-port 10GBASE-T Intelligent adapter
 	9703  CN23XX [LiquidIO II] NVMe Controller
 	9712  CN23XX [LiquidIO II] SRIOV Virtual Function
-		177d 0003  CN2350 [LiquidIO II] 2-port 10GbE SRIOV Virtual Function
-		177d 0004  CN2350 [LiquidIO II] 2-port 10GbE SRIOV Virtual Function
-		177d 0005  CN2360 [LiquidIO II] 2-port 10GbE SRIOV Virtual Function
-		177d 0006  CN2360 [LiquidIO II] 2-port 25GbE SRIOV Virtual Function
-		177d 0007  CN2350 [LiquidIO II] 2-port 25GbE SRIOV Virtual Function
 	9713  CN23XX [LiquidIO II] NVMe SRIOV Virtual Function
 	9800  Octeon Fusion CNF75XX Processor
 	a001  ThunderX MRML(Master RML Bridge to RSL devices)
 	a002  THUNDERX PCC Bridge
-		177d a102  CN88XX PCC Bridge
 	a008  THUNDERX SMMU
-		177d a108  CN88XX SMMU
 	a009  THUNDERX Generic Interrupt Controller
 	a00a  THUNDERX GPIO Controller
 	a00b  THUNDERX MPI / SPI Controller
@@ -19316,7 +10735,6 @@ var pciids = []byte(`#
 	a01a  THUNDERX Zip Coprocessor
 	a01b  THUNDERX xHCI USB Controller
 	a01c  THUNDERX AHCI SATA Controller
-		177d a11c  CN88XX AHCI SATA Controller
 	a01d  THUNDERX RAID Coprocessor
 	a01e  THUNDERX Network Interface Controller
 	a01f  THUNDERX Traffic Network Switch
@@ -19349,7 +10767,6 @@ var pciids = []byte(`#
 	a300  OCTEON TX CN83XX
 1787  Hightech Information System Ltd.
 1789  Ennyah Technologies Corp.
-# also used by Struck Innovative Systeme for joint developments
 1796  Research Centre Juelich
 	0001  SIS1100 [Gigabit link]
 	0002  HOTlink
@@ -19364,7 +10781,6 @@ var pciids = []byte(`#
 	0011  SIS1100-e single link
 	0012  SIS1100-e quad link
 	0015  SIS8100 [Gigabit link, MicroTCA]
-# nee Techwell, Inc.
 1797  Intersil Techwell
 	5864  TW5864 multimedia video controller
 	6801  TW6802 multimedia video card
@@ -19373,15 +10789,10 @@ var pciids = []byte(`#
 	6811  TW6816 multimedia video controller
 	6812  TW6816 multimedia video controller
 	6813  TW6816 multimedia video controller
-# port 5 of 8
 	6814  TW6816 multimedia video controller
-# port 6 of 8
 	6815  TW6816 multimedia video controller
-# port 7 of 8
 	6816  TW6816 multimedia video controller
-# channel 8 of 8
 	6817  TW6816 multimedia video controller
-# Example MuniPCI-E card: http://www.commell.com.tw/product/surveillance/MPX-6864.htm
 	6864  TW6864 multimedia video controller
 1799  Belkin
 	6001  F5D6001 Wireless PCI Card [Realtek RTL8180]
@@ -19396,7 +10807,6 @@ var pciids = []byte(`#
 	0566  DP-PCI-566 [Intelligent PCI 1553B]
 	1152  DP-cPCI-1152 (8-channel Isolated ADC Module)
 	5031  DP-CPCI-5031-Synchro Module
-# cPCI Carrier for Mezzanine Modules
 	5112  DP-cPCI-5112 [MM-Carrier]
 	5121  DP-CPCI-5121-IP Carrier
 	5211  DP-CPCI-5211-IP Carrier
@@ -19419,14 +10829,9 @@ var pciids = []byte(`#
 	0017  StorSecure 300 GZIP Compression and AES Encryption Card
 17c0  Wistron Corp.
 17c2  Newisys, Inc.
-# nee Airgo Networks, Inc.
 17cb  Qualcomm
 	0001  AGN100 802.11 a/b/g True MIMO Wireless Card
-		1385 5c00  WGM511 Pre-N 802.11g Wireless CardBus Adapter
-		1737 0045  WMP54GX v1 802.11g Wireless-G PCI Adapter with SRX
 	0002  AGN300 802.11 a/b/g True MIMO Wireless Card
-		1385 6d00  WPNT511 RangeMax 240 Mbps Wireless CardBus Adapter
-		1737 0054  WPC54GX4 v1 802.11g Wireless-G Notebook Adapter with SRX400
 	0400  Datacenter Technologies QDF2432 PCI Express Root Port
 	0401  Datacenter Technologies QDF2400 PCI Express Root Port
 17cc  NetChip Technology, Inc
@@ -19443,65 +10848,23 @@ var pciids = []byte(`#
 	1203  ARC-1203 2/4/8 Port PCIe 2.0 to SATA 6Gb RAID Controller
 	1210  ARC-1210 4-Port PCI-Express to SATA RAID Controller
 	1214  ARC-12x4 PCIe 2.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1214  ARC-1214 4-Port PCIe 2.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1224  ARC-1224 8-Port PCIe 2.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1264  ARC-1264 12/16 Port PCIe 2.0 to SATA 6Gb RAID Controller
-		17d3 1284  ARC-1284 24 Port PCIe 2.0 to SATA 6Gb RAID Controller
 	1220  ARC-1220 8-Port PCI-Express to SATA RAID Controller
 	1222  ARC-1222 8-Port PCI-Express to SAS/SATA II RAID Controller
 	1230  ARC-1230 12-Port PCI-Express to SATA RAID Controller
 	1260  ARC-1260 16-Port PCI-Express to SATA RAID Controller
 	1280  ARC-1280/1280ML 24-Port PCI-Express to SATA II RAID Controller
-		17d3 1221  ARC-1221 8-Port PCI-Express to SATA RAID Controller
 	1300  ARC-1300ix-16 16-Port PCI-Express to SAS Non-RAID Host Adapter
 	1320  ARC-1320 8/16 Port PCIe 2.0 to SAS/SATA 6Gb Non-RAID Host Adapter
 	1330  ARC-1330 16 Port PCIe 3.0 to SAS/SATA 12Gb Non-RAID Host Adapter
 	1680  ARC-1680 series PCIe to SAS/SATA 3Gb RAID Controller
-		17d3 1212  ARC-1212 4-Port PCIe to SAS/SATA II RAID Controller
-		17d3 1222  ARC-1222 8-Port PCIe to SAS/SATA 3Gb RAID Controller
-		17d3 1680  ARC-1680 8/12/16/24 Port PCIe to SAS/SATA 3Gb RAID Controller
 	1880  ARC-188x series PCIe 2.0/3.0 to SAS/SATA 6/12Gb RAID Controller
-		17d3 1213  ARC-1213 4-Port PCIe 2.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1215  ARC-1215 4-Port PCIe 3.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1216  ARC-1216 4-Port PCIe 3.0 to SAS/SATA 12Gb RAID Controller
-		17d3 1223  ARC-1223 8-Port PCIe 2.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1225  ARC-1225 8-Port PCIe 3.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1226  ARC-1226 8-Port PCIe 3.0 to SAS/SATA 12Gb RAID Controller
-		17d3 1880  ARC-1880 8/12/16/24 Port PCIe 2.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1882  ARC-1882 8/12/16/24 Port PCIe 3.0 to SAS/SATA 6Gb RAID Controller
-		17d3 1883  ARC-1883 8/12/16/24 Port PCIe 3.0 to SAS/SATA 12Gb RAID Controller
 	1884  ARC-1884 series PCIe 3.0 to SAS/SATA 12/6Gb RAID Controller
-# nee Neterion Inc., previously S2io Inc.
 17d5  Exar Corp.
 	5731  Xframe 10-Gigabit Ethernet PCI-X
 	5732  Xframe II 10-Gigabit Ethernet PCI-X 2.0
 	5831  Xframe 10-Gigabit Ethernet PCI-X
-		103c 12d5  PCI-X 133MHz 10GbE SR Fiber
-		10a9 8020  Single Port 10-Gigabit Ethernet (PCI-X, Fiber)
-		10a9 8024  Single Port 10-Gigabit Ethernet (PCI-X, Fiber)
 	5832  Xframe II 10-Gigabit Ethernet PCI-X 2.0
-		103c 1337  PCI-X 266MHz 10GigE SR [AD385A]
-		10a9 8021  Single Port 10-Gigabit Ethernet II (PCI-X, Fiber)
-		17d5 6020  Xframe II SR
-		17d5 6021  Xframe II SR, Low Profile
-		17d5 6022  Xframe E SR
-		17d5 6420  Xframe II LR
-		17d5 6421  Xframe II LR, Low Profile
-		17d5 6422  Xframe E LR
-		17d5 6c20  Xframe II CX4
-		17d5 6c21  Xframe II CX4, Low Profile
-		17d5 6c22  Xframe E CX4
 	5833  X3100 Series 10 Gigabit Ethernet PCIe
-		17d5 6030  X3110 Single Port SR
-		17d5 6031  X3120 Dual Port SR
-		17d5 6430  X3110 Single Port LR
-		17d5 6431  X3120 Dual Port LR
-		17d5 7030  X3110 Single Port LRM
-		17d5 7031  X3120 Dual Port LRM
-		17d5 7430  X3110 Single Port 10GBase-T
-		17d5 7431  X3120 Dual Port 10GBase-T
-		17d5 7830  X3110 Single Port 10GBase-CR
-		17d5 7831  X3120 Dual Port 10GBase-CR
 17db  Cray Inc
 	0101  XT Series [Seastar] 3D Toroidal Router
 17de  KWorld Computer Co. Ltd.
@@ -19547,7 +10910,6 @@ var pciids = []byte(`#
 17e4  Sectra AB
 	0001  KK671 Cardbus encryption board
 	0002  KK672 Cardbus encryption board
-# nee Entropic Communications Inc.
 17e6  MaxLinear
 	0010  EN2010 [c.Link] MoCA Network Controller (Coax, PCI interface)
 	0011  EN2010 [c.Link] MoCA Network Controller (Coax, MPEG interface)
@@ -19573,102 +10935,44 @@ var pciids = []byte(`#
 17fc  IOGEAR, Inc.
 17fe  InProComm Inc.
 	2120  IPN 2120 802.11b
-		1737 0020  WMP11 v4 802.11b Wireless-B PCI Adapter
 	2220  IPN 2220 802.11g
-		1468 0305  T60N871 802.11g Mini PCI Wireless Adapter
-		1737 0029  WPC54G v4 802.11g Wireless-G Notebook Adapter
 17ff  Benq Corporation
 1800  Qualcore Logic Inc.
 	1100  Nanospeed Trading Gateway
 1803  ProdaSafe GmbH
 1805  Euresys S.A.
 1809  Lumanate, Inc.
+180c  IEI Integration Corp
 1813  Ambient Technologies Inc
 	4000  HaM controllerless modem
-		16be 0001  V9x HAM Data Fax Modem
 	4100  HaM plus Data Fax Modem
-		16be 0002  V9x HAM 1394
 1814  Ralink corp.
 	0101  Wireless PCI Adapter RT2400 / RT2460
-		1043 0127  WiFi-b add-on Card
-		1371 0010  Minitar MNW2BPCI Wireless PCI Card
-		1462 6828  PC11B2 (MS-6828) Wireless 11b PCI Card
 	0200  RT2500 802.11g PCI [PC54G2]
 	0201  RT2500 Wireless 802.11bg
-		1043 130f  WL-130g
-		1186 3c00  DWL-G650X Wireless 11g CardBus Adapter
-		1371 001e  CWC-854 Wireless-G CardBus Adapter
-		1371 001f  CWM-854 Wireless-G Mini PCI Adapter
-		1371 0020  CWP-854 Wireless-G PCI Adapter
-		1458 e381  GN-WMKG 802.11b/g Wireless CardBus Adapter
-		1458 e931  GN-WIKG 802.11b/g mini-PCI Adapter
-		1462 6833  Unknown 802.11g mini-PCI Adapter
-		1462 6835  Wireless 11G CardBus CB54G2
-		1737 0032  WMP54G v4.0 PCI Adapter
-		1799 700a  F5D7000 v2000/v3000 Wireless G Desktop Card
-		1799 701a  F5D7010 v2000/v3000 Wireless G Notebook Card
-		1814 2560  RT2500 Wireless 802.11bg
-		182d 9073  WL-115 Wireless Network PCI Adapter
-		185f 22a0  CN-WF513 Wireless Cardbus Adapter
-		18eb 5312  WL531P IEEE 802.11g PCI Card-EU
-		1948 3c00  C54RC v1 Wireless 11g CardBus Adapter
-		1948 3c01  C54Ri v1 Wireless 11g PCI Adapter
 	0300  Wireless Adapter Canyon CN-WF511
 	0301  RT2561/RT61 802.11g PCI
-		1186 3c08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.E1)
-		1186 3c09  DWL-G510 Rev C
-		13d1 abe3  miniPCI Pluscom 802.11 a/b/g
-		1458 e933  GN-WI01GS
-		1458 e934  GN-WP01GS
-		1462 b833  MP54G5 (MS-6833B)
-		1737 0055  WMP54G v4.1
-		1799 700e  F5D7000 v6000 Wireless G Desktop Card
-		1799 701e  F5D7010 v6000 Wireless G Notebook Card
-		17f9 0012  AWLC3026T 802.11g Wireless CardBus Adapter
-		1814 2561  EW-7108PCg/EW-7128g
 	0302  RT2561/RT61 rev B 802.11g
-		1186 3a71  DWA-510 Wireless G Desktop Adapter
-		1186 3c08  AirPlus G DWL-G630 Wireless Cardbus Adapter (rev.E2)
-		1186 3c09  AirPlus G DWL-G510 Wireless Network Adapter (Rev.C)
-		1462 b834  PC54G3 Wireless 11g PCI Card
-		1948 3c23  C54RC v2 Wireless 11g CardBus Adapter
-		1948 3c24  C54Ri v2 Wireless 11g PCI Adapter
 	0401  RT2600 802.11 MIMO
-		1737 0052  WPC54GR v1 802.11g Wireless-G Notebook Adapter with RangeBooster
-		17f9 0011  WPCR-137G 802.11bg Wireless CardBus Adapter
-		17f9 0016  WPIR-119GH 802.11bg Wireless Desktop Adapter
 	0601  RT2800 802.11n PCI
-		1799 801c  F5D8011 v3 802.11n N1 Wireless Notebook Card
-		187e 3412  NWD-310N 802.11n Wireless PCI Adapter
 	0681  RT2890 Wireless 802.11n PCIe
-		1458 e939  GN-WS30N-RH 802.11bgn Mini PCIe Card
 	0701  RT2760 Wireless 802.11n 1T/2R
-		1737 0074  WMP110 v2 802.11n RangePlus Wireless PCI Adapter
 	0781  RT2790 Wireless 802.11n 1T/2R PCIe
-		1814 2790  RT2790 Wireless 802.11n 1T/2R PCIe
 	3060  RT3060 Wireless 802.11n 1T/1R
-		1186 3c04  DWA-525 Wireless N 150 Desktop Adapter (rev.A1)
 	3062  RT3062 Wireless 802.11n 2T/2R
 	3090  RT3090 Wireless 802.11n 1T/1R PCIe
-		13bd 1057  GN-WS32L-RH Half-size Mini PCIe Card
 	3091  RT3091 Wireless 802.11n 1T/2R PCIe
 	3092  RT3092 Wireless 802.11n 2T/2R PCIe
 	3290  RT3290 Wireless 802.11n 1T/1R PCIe
-		103c 18ec  Ralink RT3290LE 802.11bgn 1x1 Wi-Fi and Bluetooth 4.0 Combo Adapter
 	3298  RT3290 Bluetooth
-		103c 18ec  Ralink RT3290LE 802.11bgn 1x1 Wi-Fi and Bluetooth 4.0 Combo Adapter
 	3592  RT3592 Wireless 802.11abgn 2T/2R PCIe
 	359f  RT3592 PCIe Wireless Network Adapter
 	5360  RT5360 Wireless 802.11n 1T/1R
-		1186 3c05  DWA-525 Wireless N 150 Desktop Adapter (rev.A2)
-		20f4 703a  TEW-703PI N150 Wireless PCI Adapter
 	5362  RT5362 PCI 802.11n Wireless Network Adapter
 	5390  RT5390 Wireless 802.11n 1T/1R PCIe
-		103c 1636  U98Z077.00 Half-size Mini PCIe Card
 	5392  RT5392 PCIe Wireless Network Adapter
 	539b  RT5390R 802.11bgn PCIe Wireless Network Adapter
 	539f  RT5390 [802.11 b/g/n 1T1R G-band PCI Express Single Chip]
-		103c 1637  Pavilion DM1Z-3000 PCIe wireless card
 	5592  RT5592 PCIe Wireless Network Adapter
 	e932  RT2560F 802.11 b/g PCI
 1815  Devolo AG
@@ -19676,14 +10980,11 @@ var pciids = []byte(`#
 1822  Twinhan Technology Co. Ltd
 	4e35  Mantis DTV PCI Bridge Controller [Ver 1.0]
 182d  SiteCom Europe BV
-# HFC-based ISDN card
 	3069  ISDN PCI DC-105V2
 	9790  WL-121 Wireless Network Adapter 100g+ [Ver.3]
 182e  Raza Microelectronics, Inc.
 	0008  XLR516 Processor
-# Strange vendor ID used by BCM5785 when in RAID mode
 182f  Broadcom
-# HT1000 uses 3 IDs 1166:024a (Native SATA Mode), 1166:024b (PATA/IDE Mode), 182f:000b (RAID Mode) depends on SATA BIOS setting
 	000b  BCM5785 [HT1000] SATA (RAID Mode)
 1830  Credence Systems Corporation
 183b  MikroM GmbH
@@ -19760,12 +11061,9 @@ var pciids = []byte(`#
 	db78  FusionHDTV DVB-T Dual Express
 18b8  Ammasso
 	b001  AMSO 1100 iWARP/RDMA Gigabit Ethernet Coprocessor
-# formally Info-Tek Corp.
 18bc  GeCube Technologies, Inc.
 18c3  Micronas Semiconductor Holding AG
 	0720  nGene PCI-Express Multimedia Controller
-		1461 032e  Hybrid M779 PCI-E
-# Nee Octigabay System
 18c8  Cray Inc
 18c9  ARVOO Engineering BV
 18ca  XGI Technology Inc. (eXtreme Graphics Innovation)
@@ -19774,9 +11072,7 @@ var pciids = []byte(`#
 	0027  Z11/Z11M
 	0040  Volari V3XT/V5/V8
 	0047  Volari 8300 (chip: XP10, codename: XG47)
-# should be 182d
 18d2  Sitecom Europe BV (Wrong ID)
-# Sitecom HFC-S based ISDN controller card DC-105v2
 	3069  DC-105v2 ISDN controller
 18d4  Celestica
 18d8  Dialogue Technology Corp.
@@ -19788,53 +11084,13 @@ var pciids = []byte(`#
 18eb  Advance Multimedia Internet Technology, Inc.
 18ec  Cesnet, z.s.p.o.
 	6d05  ML555
-		18ec 0100  NIC (ethernet interfaces)
-		18ec 0200  NIC (szedata2) 4x1G
-		18ec 0201  NIC (szedata2) 2x10G
-		18ec 0300  NIFIC (szedata2) 4x1G
-		18ec 0302  NIFIC (szedata2) 2x10G
-		18ec 4200  Flexible FlowMon (szedata2) 1x10G
-		18ec ff00  Testing design
-		18ec ff01  Boot design
 	c006  COMBO6
-		18ec d001  COMBO-4MTX
-		18ec d002  COMBO-4SFP
-		18ec d003  COMBO-4SFPRO
-		18ec d004  COMBO-2XFP
 	c032  COMBO-LXT110
-		18ec 0100  NIC (ethernet interfaces)
-		18ec 0200  NIC (szedata2) 4x1G
-		18ec 0201  NIC (szedata2) 2x10G
-		18ec 0300  NIFIC (szedata2) 4x1G
-		18ec 0302  NIFIC (szedata2) 2x10G
-		18ec 4200  Flexible FlowMon (szedata2) 1x10G
-		18ec ff00  Testing design
-		18ec ff01  Boot design
 	c045  COMBO6E
 	c050  COMBO-PTM
 	c058  COMBO6X
-		18ec d001  COMBO-4MTX
-		18ec d002  COMBO-4SFP
-		18ec d003  COMBO-4SFPRO
-		18ec d004  COMBO-2XFP
 	c132  COMBO-LXT155
-		18ec 0100  NIC (ethernet interfaces)
-		18ec 0200  NIC (szedata2) 4x1G
-		18ec 0201  NIC (szedata2) 2x10G
-		18ec 0300  NIFIC (szedata2) 4x1G
-		18ec 0302  NIFIC (szedata2) 2x10G
-		18ec 4200  Flexible FlowMon (szedata2) 1x10G
-		18ec ff00  Testing design
-		18ec ff01  Boot design
 	c232  COMBO-FXT100
-		18ec 0100  NIC (ethernet interfaces)
-		18ec 0200  NIC (szedata2) 4x1G
-		18ec 0201  NIC (szedata2) 2x10G
-		18ec 0300  NIFIC (szedata2) 4x1G
-		18ec 0302  NIFIC (szedata2) 2x10G
-		18ec 4200  Flexible FlowMon (szedata2) 1x10G
-		18ec ff00  Testing design
-		18ec ff01  Boot design
 18ee  Chenming Mold Ind. Corp.
 18f1  Spectrum GmbH
 18f4  Napatech A/S
@@ -19848,12 +11104,10 @@ var pciids = []byte(`#
 	0091  NT20X Capture Card [New Rev]
 	00a1  NT4E-STD Capture Card
 	00a4  NT4E-STD Inline Card
-# 8 x 1 Gbps / 10 Gbps PCIe Optical Bypass Adapter
 	00b1  NTBPE Optical Bypass Adapter
 	00c5  NT20E2 Network Adapter 2x10Gb
 	00d5  NT40E2-4 Network Adapter 4x10Gb
 	00e5  NT40E2-1 Network Adapter 1x40Gb
-# 4-Port Adapter for 1 GbE In-Line Bypass Applications
 	00f5  NT4E2-4T-BP Network Adapter 4x1Gb with Electrical Bypass
 	0105  NT4E2-4-PTP Network Adapter 4x1Gb
 	0115  NT20E2-PTP Network Adapter 2x10Gb
@@ -19886,32 +11140,21 @@ var pciids = []byte(`#
 	0014  SuperFSCC Serial PCI Adapter [Fastcom]
 	0015  SuperFSCC-104-LVDS Serial PC/104+ Adapter [Fastcom]
 	0016  FSCC-232 RS-232 Serial PCI Adapter [Fastcom]
-# Software UARTs
 	0017  SuperFSCC-104 Serial PC/104+ Adapter [Fastcom]
-# Software UARTs
 	0018  SuperFSCC/4 Serial PCI Adapter [Fastcom]
-# Software UARTs
 	0019  SuperFSCC Serial PCI Adapter [Fastcom]
 	001a  SuperFSCC-LVDS Serial PCI Adapter [Fastcom]
-# Software UARTs
 	001b  FSCC/4 Serial PCI Adapter [Fastcom]
-# RS-644 Only
 	001c  SuperFSCC/4-LVDS Serial PCI Adapter [Fastcom]
-# Software UARTs
 	001d  FSCC Serial PCI Adapter [Fastcom]
 	001e  SuperFSCC/4 Serial PCIe Adapter [Fastcom]
 	001f  SuperFSCC/4 Serial cPCI Adapter [Fastcom]
 	0020  422/4-PCIe Serial PCIe Adapter [Fastcom]
 	0021  422/8-PCIe Serial PCIe Adapter [Fastcom]
-# RS-644 Only
 	0022  SuperFSCC/4-LVDS Serial PCIe Adapter [Fastcom]
-# Software UARTs
 	0023  SuperFSCC/4 Serial cPCI Adapter [Fastcom]
-# RS-644 Only, Software UARTs
 	0025  SuperFSCC/4-LVDS Serial PCI Adapter [Fastcom]
-# RS-644 Only, Software UARTs
 	0026  SuperFSCC-LVDS Serial PCI Adapter [Fastcom]
-# Software UARTs
 	0027  FSCC/4 Serial PCIe Adapter [Fastcom]
 18fb  Resilience Corporation
 1904  Hangzhou Silan Microelectronics Co., Ltd.
@@ -19936,118 +11179,18 @@ var pciids = []byte(`#
 	0400  A104u Quad T1/E1 AFT
 1924  Solarflare Communications
 	0703  SFC4000 rev A net [Solarstorm]
-		10b8 0102  SMC10GPCIe-10BT (A2) [TigerCard]
-		10b8 0103  SMC10GPCIe-10BT (A3) [TigerCard]
-		10b8 0201  SMC10GPCIe-XFP (A1) [TigerCard]
-		1924 0101  SFE4001-A1
-		1924 0102  SFE4001-A2
-		1924 0103  SFE4001-A3
-		1924 0201  SFE4002-A1
-		1924 0301  SFE4003-A1
-		1924 0302  SFE4003-A2
-		1924 0303  SFE4003-A3
-		1924 0304  SFE4003-A4
-		1924 0500  SFE4005-A0
 	0710  SFC4000 rev B [Solarstorm]
-		10b8 0103  SMC10GPCIe-10BT (A3) [TigerCard]
-		10b8 0201  SMC10GPCIe-XFP (A1) [TigerCard]
-		1924 0102  SFE4001-A2
-		1924 0103  SFE4001-A3
-		1924 0201  SFE4002-A1
-		1924 0302  SFE4003-A2
-		1924 0303  SFE4003-A3
-		1924 0304  SFE4003-A4
-		1924 0500  SFE4005-A0
-		1924 5102  SFN4111T-A2
-		1924 5103  SFN4111T-R3
-		1924 5104  SFN4111T-R4
-		1924 5105  SFN4111T-R5
-		1924 5201  SFN4112F-R1
-		1924 5202  SFN4112F-R2
 	0803  SFC9020 10G Ethernet Controller
-		1014 0478  2-port 10GbE Low-Latency (R7)
-		1014 0479  2-port 10GbE OpenOnload (R7)
-		1014 04a7  Solarflare 10Gb Low-latency Dual-port HBA (R7)
-		1014 04a8  Solarflare 10Gb Dual-port HBA (R7)
-		103c 2132  Ethernet 10Gb 2-port 570FLR-SFP+ Adapter (R1)
-		103c 2136  Ethernet 10Gb 2-port 570SFP+ Adapter (R7)
-		1924 1201  SFA6902F-R1 SFP+ AOE Adapter
-		1924 6200  SFN5122F-R0 SFP+ Server Adapter
-		1924 6201  SFN5122F-R1 SFP+ Server Adapter
-		1924 6202  SFN5122F-R2 SFP+ Server Adapter
-		1924 6204  SFN5122F-R4 SFP+ Server Adapter
-		1924 6205  SFN5122F-R5 SFP+ Server Adapter
-		1924 6206  SFN5122F-R6 SFP+ Server Adapter
-		1924 6207  SFN5122F-R7 SFP+ Server Adapter
-		1924 6210  SFN5322F-R0 SFP+ Precision Time Synchronization Server Adapter
-		1924 6211  SFN5322F-R1 SFP+ Precision Time Synchronization Server Adapter
-		1924 6217  SFN5322F-R7 SFP+ Precision Time Synchronization Server Adapter
-		1924 6227  SFN6122F-R7 SFP+ Server Adapter
-		1924 6237  SFN6322F-R7 SFP+ Precision Time Synchronization Server Adapter
-		1924 6501  SFN5802K-R1 Mezzanine Adapter
-		1924 6511  SFN5814H-R1 Mezzanine Adapter
-		1924 6521  SFN5812H-R1 Mezzanine Adapter
-		1924 6562  SFN6832F-R2 SFP+ Mezzanine Adapter
-		1924 6a05  SFN5112F-R5 SFP+ Server Adapter
-		1924 6a06  SFN5112F-R6 SFP+ Server Adapter
-		1924 7206  SFN5162F-R6 SFP+ Server Adapter
-		1924 7207  SFN5162F-R7 SFP+ Server Adapter
-		1924 7a06  SFN5152F-R6 SFP+ Server Adapter
-		1924 7a07  SFN5152F-R7 SFP+ Server Adapter
 	0813  SFL9021 10GBASE-T Ethernet Controller
-		1924 6100  SFN5121T-R0 10GBASE-T Server Adapter
-		1924 6102  SFN5121T-R2 10GBASE-T Server Adapter
-		1924 6103  SFN5121T-R3 10GBASE-T Server Adapter
-		1924 6104  SFN5121T-R4 10GBASE-T Server Adapter
-		1924 6902  SFN5111T-R2 10GBASE-T Server Adapter
-		1924 6904  SFN5111T-R4 10GBASE-T Server Adapter
-		1924 7104  SFN5161T-R4 10GBASE-T Server Adapter
-		1924 7904  SFN5151T-R4 10GBASE-T Server Adapter
 	0903  SFC9120 10G Ethernet Controller
-		1014 04cc  SFN7122F-R2 2x10GbE SFP+ Flareon Ultra
-		1924 8002  SFN7122F-R1 SFP+ Server Adapter
-		1924 8003  SFN7x41Q-R1 Flareon Ultra 7000 Series 10/40G Adapter
-		1924 8006  SFN7022F-R1 SFP+ Server Adapter
-		1924 8007  SFN7322F-R2 Precision Time SFP+ Server Adapter
-		1924 8009  SFN7x22F-R2 Flareon Ultra 7000 Series 10G Adapter
-		1924 800a  SFN7x02F-R2 Flareon 7000 Series 10G Adapter
-		1924 800c  SFN7x22F-R3 Flareon Ultra 7000 Series 10G Adapter
-		1924 800d  SFN7x02F-R3 Flareon 7000 Series 10G Adapter
-		1924 8010  SFA7942Q-R1 QSFP+ AOE Adapter
-		1924 8015  SFA7942Q-A5-0-R1 QSFP+ AOE Adapter
 	0923  SFC9140 10/40G Ethernet Controller
-		1924 800b  SFN7x42Q-R1 Flareon Ultra 7000 Series 10/40G Adapter
-		1924 800e  SFN7x42Q-R2 Flareon Ultra 7000 Series 10/40G Adapter
-		1924 800f  SFN7xx4F-R1 Flareon Ultra 7000 Series 10G Adapter
 	0a03  SFC9220 10/40G Ethernet Controller
-		1924 8011  SFN8022-R1 8000 Series 10G Adapter
-		1924 8012  SFN8522-R1 8000 Series 10G Adapter
-		1924 8013  SFN8042-R1 8000 Series 10/40G Adapter
-		1924 8014  SFN8542-R1 8000 Series 10/40G Adapter
-		1924 8016  SFN8022-R2 8000 Series 10G Adapter
-		1924 8017  SFN8522-R2 8000 Series 10G Adapter
-		1924 8018  SFN8042-R2 8000 Series 10/40G Adapter
-		1924 8019  SFN8542-R2 8000 Series 10/40G Adapter
-		1924 801a  SFN8722-R1 8000 Series OCP 10G Adapter
-		1924 801b  SFN8522-R3 8000 Series 10G Adapter
 	1803  SFC9020 10G Ethernet Controller (Virtual Function)
 	1813  SFL9021 10GBASE-T Ethernet Controller (Virtual Function)
 	1903  SFC9120 10G Ethernet Controller (Virtual Function)
 	1923  SFC9140 10/40G Ethernet Controller (Virtual Function)
 	1a03  SFC9220 10/40G Ethernet Controller (Virtual Function)
 	6703  SFC4000 rev A iSCSI/Onload [Solarstorm]
-		10b8 0102  SMC10GPCIe-10BT (A2) [TigerCard]
-		10b8 0103  SMC10GPCIe-10BT (A3) [TigerCard]
-		10b8 0201  SMC10GPCIe-XFP (A1) [TigerCard]
-		1924 0101  SFE4001-A1
-		1924 0102  SFE4001-A2
-		1924 0103  SFE4001-A3
-		1924 0201  SFE4002-A1
-		1924 0301  SFE4003-A1
-		1924 0302  SFE4003-A2
-		1924 0303  SFE4003-A3
-		1924 0304  SFE4003-A4
-		1924 0500  SFE4005-A0
 	c101  EF1-21022T [EtherFabric]
 192a  BiTMICRO Networks Inc.
 192e  TransDimension
@@ -20084,7 +11227,6 @@ var pciids = []byte(`#
 	1201  FireTrac 3460bT (fallback firmware)
 	1202  FireTrac 3460bT
 	1203  FireTrac 3460bT (fallback firmware)
-# nee Curtis, Inc.
 1954  One Stop Systems, Inc.
 1957  Freescale Semiconductor Inc
 	0012  MPC8548E
@@ -20119,14 +11261,11 @@ var pciids = []byte(`#
 	0082  MPC8347E TBGA
 	0083  MPC8347 TBGA
 	0084  MPC8347E PBGA
-		110a 4074  SIMATIC NET CP 1628
 	0085  MPC8347 PBGA
-		110a 4046  SIMATIC NET CP 1623
 	0086  MPC8343E
 	0087  MPC8343
 	00b4  MPC8315E
 	00b6  MPC8314E
-		1a56 1101  Killer Xeno Pro Gigabit Ethernet Controller
 	00c2  MPC8379E
 	00c3  MPC8379
 	00c4  MPC8378E
@@ -20143,7 +11282,6 @@ var pciids = []byte(`#
 	010b  P1012
 	0110  P1022E
 	0111  P1022
-		1c7f 5200  EB5200
 	0118  P1013E
 	0119  P1013
 	0128  P1010
@@ -20165,10 +11303,7 @@ var pciids = []byte(`#
 	7011  MPC8641D PCI Host Bridge
 	7018  MPC8610
 	c006  MPC8308
-		1a56 1201  Killer E2100 Gigabit Ethernet Controller
-# PCIe interface for emulator
 	fc02  RedStone
-# CFI device over PCIe
 	fc03  CFI
 1958  Faster Technology, LLC.
 1959  PA Semi, Inc
@@ -20189,30 +11324,22 @@ var pciids = []byte(`#
 1966  Orad Hi-Tec Systems
 	1975  DVG64 family
 	1977  DVG128 family
-# nee Atheros Communications, Inc. nee Attansic Technology Corp.
 1969  Qualcomm Atheros
 	1026  AR8121/AR8113/AR8114 Gigabit or Fast Ethernet
-		1043 8304  P5KPL-CM Motherboard
 	1048  Attansic L1 Gigabit Ethernet
-		1043 8226  P5KPL-VM Motherboard
 	1062  AR8132 Fast Ethernet
 	1063  AR8131 Gigabit Ethernet
-		1458 e000  GA-G31M-ES2L Motherboard
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	1066  Attansic L2c Gigabit Ethernet
 	1067  Attansic L1c Gigabit Ethernet
 	1073  AR8151 v1.0 Gigabit Ethernet
 	1083  AR8151 v2.0 Gigabit Ethernet
 	1090  AR8162 Fast Ethernet
-		1043 108d  VivoBook X202E, X202EV
 	1091  AR8161 Gigabit Ethernet
-		1043 1477  N56VZ
 	10a0  QCA8172 Fast Ethernet
 	10a1  QCA8171 Gigabit Ethernet
 	2048  Attansic L2 Fast Ethernet
 	2060  AR8152 v1.1 Fast Ethernet
 	2062  AR8152 v2.0 Fast Ethernet
-# E2200, E2201, E2205
 	e091  Killer E220x Gigabit Ethernet Controller
 	e0a1  Killer E2400 Gigabit Ethernet Controller
 	e0b1  Killer E2500 Gigabit Ethernet Controller
@@ -20223,7 +11350,6 @@ var pciids = []byte(`#
 196d  Club-3D BV
 1971  AGEIA Technologies, Inc.
 	1011  Physics Processing Unit [PhysX]
-		1043 0001  PhysX P1
 1974  Eberspaecher Electronics
 1976  TRENDnet
 1977  Parsec
@@ -20233,13 +11359,8 @@ var pciids = []byte(`#
 	0368  JMB368 IDE controller
 	2360  JMB360 AHCI Controller
 	2361  JMB361 AHCI/IDE
-		1462 7235  P965 Neo MS-7235 mainboard
 	2362  JMB362 SATA Controller
-		1043 8460  P8P67 Deluxe Motherboard
 	2363  JMB363 SATA/IDE Controller
-		1043 81e4  P5B [JMB363]
-		1458 b000  Motherboard
-		1849 2363  Motherboard (one of many)
 	2364  JMB364 AHCI Controller
 	2365  JMB365 AHCI/IDE
 	2366  JMB366 AHCI/IDE
@@ -20275,7 +11396,6 @@ var pciids = []byte(`#
 199f  Auvitek
 	8501  AU85X1 PCI REV1.1
 	8521  AU8521 TV card
-# nee ServerEngines Corp.
 19a2  Emulex Corporation
 	0120  x1 PCIe Gen2 Bridge[Pilot4]
 	0200  BladeEngine 10Gb PCI-E iSCSI adapter
@@ -20285,32 +11405,11 @@ var pciids = []byte(`#
 	0221  BladeEngine3 10Gb Gen2 PCIe Network Adapter
 	0222  BladeEngine3 10Gb Gen2 PCIe iSCSI Adapter
 	0700  OneConnect OCe10100/OCe10102 Series 10 GbE
-		103c 1747  NC550SFP DualPort 10GbE Server Adapter
-		103c 1749  NC550SFP Dual Port Server Adapter
-		103c 174a  NC551m Dual Port FlexFabric 10Gb Adapter
-		103c 174b  StorageWorks NC550 DualPort Converged Network Adapter
-		103c 3314  NC551i Dual Port FlexFabric 10Gb Adapter
 	0702  OneConnect 10Gb iSCSI Initiator
 	0704  OneConnect OCe10100/OCe10102 Series 10 GbE CNA
-		10df e602  OneConnect OCe10100 10Gb CNA
-		10df e630  OneConnect OCe10102-FM-E / OCe10102-FX-E for EMC VNX Symmetrix
 	0710  OneConnect 10Gb NIC (be3)
-# FC 5287 / FC 5284; CCIN 5287
-		1014 03d0  PCIe2 2-port 10GbE SR Adapter for POWER
-# FC 5288 / FC 5286; CCIN 5288
-		1014 03d1  PCIe2 2-port 10GbE SFP+ Copper Adapter for POWER
-		1014 0409  Integrated Multifunction Card with Dual 10GbE SR Optical + Dual 1GbE for Power 750/760
-		1014 040a  Integrated Multifunction Card with Dual 10GbE SR Copper + Dual 1GbE for Power 750/760
-		103c 3315  NC553i 10Gb 2-port FlexFabric Converged Network Adapter
-		103c 3340  NC552SFP 2-port 10Gb Server Adapter
-		103c 3341  NC552m 10Gb 2-port FlexFabric Converged Network Adapter
-		103c 3345  NC553m 10Gb 2-port FlexFabric Converged Network Adapter
-		103c 337b  NC554FLB 10Gb 2-port FlexFabric Converged Network Adapter
-		10df e733  Flex System EN4054 4-port 10Gb Ethernet Mezzanine Adapter
 	0712  OneConnect 10Gb iSCSI Initiator (be3)
 	0714  OneConnect 10Gb FCoE Initiator (be3)
-		103c 3315  NC553i 10Gb 2-port FlexFabric Converged Network Adapter
-		103c 337b  NC554FLB 10Gb 2-port FlexFabric Converged Network Adapter
 	0800  ServerView iRMC HTI
 19a8  DAQDATA GmbH
 19ac  Kasten Chase Applied Research
@@ -20321,7 +11420,6 @@ var pciids = []byte(`#
 19ba  ZyXEL Communications Corp.
 	2330  ZyWALL Turbo Card
 19c1  Exegy Inc.
-# nee NextNet Wireless
 19d1  Motorola Expedience
 19d4  Quixant Limited
 19da  ZOTAC International (MCO) Ltd.
@@ -20370,7 +11468,6 @@ var pciids = []byte(`#
 	0005  ETP v1.4
 	000a  ETP-104 v1.1
 	000e  DSLP-104 v1.1
-# nee Metalink Ltd.
 1a30  Lantiq
 	0680  MtW8171 [Hyperion II]
 	0700  Wave300 PSB8224 [Hyperion III]
@@ -20422,10 +11519,6 @@ var pciids = []byte(`#
 1a77  Lightfleet Corporation
 1a78  Virident Systems Inc.
 	0031  FlashMAX Drive
-		1a78 0034  FlashMAX PCIe SSD [rev 3]
-		1a78 0037  FlashMAX PCIe SSD [rev 3D]
-		1a78 0038  FlashMAX PCIe SSD [rev 4]
-		1a78 0039  FlashMAX PCIe SSD [rev 4D]
 	0040  FlashMAX II
 	0041  FlashMAX II
 	0042  FlashMAX II
@@ -20445,7 +11538,6 @@ var pciids = []byte(`#
 1aae  Global Velocity, Inc.
 1ab6  CalDigit, Inc.
 	6201  RAID Card
-# Parallels VM virtual devices
 1ab8  Parallels, Inc.
 	4000  Virtual Machine Communication Interface
 	4005  Accelerated Virtual Video Adapter
@@ -20459,8 +11551,6 @@ var pciids = []byte(`#
 1ade  Spin Master Ltd.
 	1501  Swipetech barcode scanner
 	3038  PCIe Video Bridge
-		13c2 3016  TT-budget S2-4200 Twin
-		4254 0552  S952 v3
 1ae0  Google, Inc.
 1ae7  First Wise Media GmbH
 	0520  HFC-S PCI A [X-TENSIONS XC-520]
@@ -20479,17 +11569,9 @@ var pciids = []byte(`#
 1aea  Alcor Micro
 	6601  AU6601 PCI-E Flash card reader controller
 1aec  Wolfson Microelectronics
-# nee Fusion-io
 1aed  SanDisk
 	1003  ioDimm3 (v1.2)
 	1005  ioDimm3
-		1014 03c3  High IOPS SSD PCIe Adapter
-		103c 176f  1.28TB MLC PCIe ioDrive Duo
-		103c 1770  5.2TB MLC PCIe ioDrive Octal
-		103c 178b  160GB SLC PCIe ioDrive
-		103c 178c  320GB MLC PCIe ioDrive
-		103c 178d  320GB SLC PCIe ioDrive Duo
-		103c 178e  640GB MLC PCIe ioDrive Duo
 	1006  ioXtreme
 	1007  ioXtreme Pro
 	1008  ioXtreme-2
@@ -20498,7 +11580,6 @@ var pciids = []byte(`#
 	3002  ioMemory HHHL
 	3003  ioMemory Mezzanine
 1aee  Caustic Graphics Inc.
-# nee Qumranet, Inc.
 1af4  Red Hat, Inc.
 	1000  Virtio network device
 	1001  Virtio block device
@@ -20507,26 +11588,16 @@ var pciids = []byte(`#
 	1004  Virtio SCSI
 	1005  Virtio RNG
 	1009  Virtio filesystem
-# virtio 1.0
 	1041  Virtio network device
-# virtio 1.0
 	1042  Virtio block device
-# virtio 1.0
 	1043  Virtio console
-# virtio 1.0
 	1044  Virtio RNG
-# virtio 1.0
 	1045  Virtio memory balloon
-# virtio 1.0
 	1048  Virtio SCSI
-# virtio 1.0
 	1049  Virtio filesystem
-# virtio 1.0
 	1050  Virtio GPU
-# virtio 1.0
 	1052  Virtio input
 	1110  Inter-VM shared memory
-		1af4 1100  QEMU Virtual Machine
 1af5  Netezza Corp.
 1afa  J & W Electronics Co., Ltd.
 1b03  Magnum Semiconductor, Inc,
@@ -20540,25 +11611,17 @@ var pciids = []byte(`#
 1b21  ASMedia Technology Inc.
 	0611  ASM1061 SATA IDE Controller
 	0612  ASM1062 Serial ATA Controller
-		1849 0612  Motherboard
 	1042  ASM1042 SuperSpeed USB Host Controller
-		1043 8488  P8B WS Motherboard
-		1849 1042  Motherboard
 	1080  ASM1083/1085 PCIe to PCI Bridge
-		1849 1080  Motherboard
 	1142  ASM1042A USB 3.0 Host Controller
 	1242  ASM1142 USB 3.1 Host Controller
 1b2c  Opal-RT Technologies Inc.
 1b36  Red Hat, Inc.
 	0001  QEMU PCI-PCI bridge
 	0002  QEMU PCI 16550A Adapter
-		1af4 1100  QEMU Virtual Machine
 	0003  QEMU PCI Dual-port 16550A Adapter
-		1af4 1100  QEMU Virtual Machine
 	0004  QEMU PCI Quad-port 16550A Adapter
-		1af4 1100  QEMU Virtual Machine
 	0005  QEMU PCI Test Device
-		1af4 1100  QEMU Virtual Machine
 	0006  PCI Rocker Ethernet switch device
 	0007  PCI SD Card Host Controller Interface
 	0008  QEMU PCIe Host bridge
@@ -20568,7 +11631,6 @@ var pciids = []byte(`#
 	000c  QEMU PCIe Root port
 	000d  QEMU XHCI Host Controller
 	0100  QXL paravirtual graphic card
-		1af4 1100  QEMU Virtual Machine
 1b37  Signal Processing Devices Sweden AB
 	0001  ADQ214
 	0003  ADQ114
@@ -20585,17 +11647,13 @@ var pciids = []byte(`#
 	0023  ADQ7
 	2014  TX320
 	2019  S6000
-# now owned by HGST (a Western Digital subsidiary)
 1b39  sTec, Inc.
 	0001  S1120 PCIe Accelerator SSD
 1b3a  Westar Display Technologies
 	7589  HRED J2000 - JPEG 2000 Video Codec Device
 1b3e  Teradata Corp.
 	1fa8  BYNET BIC2SE/X
-		1b3e 00a3  BYNET BIC2SX
-		1b3e 00c3  BYNET BIC2SE
 1b40  Schooner Information Technology, Inc.
-# also used by some PROXIM (14b7) devices erroneously
 1b47  Numascale AS
 	0601  NumaChip N601
 	0602  NumaChip N602
@@ -20603,11 +11661,9 @@ var pciids = []byte(`#
 	0640  88SE9128 SATA III 6Gb/s RAID Controller
 	9120  88SE9120 SATA 6Gb/s Controller
 	9123  88SE9123 PCIe SATA 6.0 Gb/s controller
-		dc93 600e  DC-6xxe series SATA 6G controller
 	9125  88SE9125 PCIe SATA 6.0 Gb/s controller
 	9128  88SE9128 PCIe SATA 6 Gb/s RAID controller
 	9130  88SE9128 PCIe SATA 6 Gb/s RAID controller with HyperDuo
-		1043 8438  P8P67 Deluxe Motherboard
 	9172  88SE9172 SATA 6Gb/s Controller
 	9178  88SE9170 PCIe SATA 6Gb/s Controller
 	917a  88SE9172 SATA III 6Gb/s RAID Controller
@@ -20617,7 +11673,6 @@ var pciids = []byte(`#
 	91a4  88SE912x IDE Controller
 	9220  88SE9220 PCIe 2.0 x2 2-port SATA 6 Gb/s RAID Controller
 	9230  88SE9230 PCIe SATA 6Gb/s Controller
-		1d49 0300  ThinkSystem M.2 with Mirroring Enablement Kit
 	9235  88SE9235 PCIe 2.0 x2 4-port SATA 6 Gb/s Controller
 	9445  88SE9445 PCIe 2.0 x4 4-Port SAS/SATA 6 Gbps RAID Controller
 	9480  88SE9480 SAS/SATA 6Gb/s RAID controller
@@ -20627,7 +11682,6 @@ var pciids = []byte(`#
 	18f7  Dual DVB Universal CI card rev 1.4
 	2a2c  Dual DVB-S2-CI card
 	e2e4  Dual DVB-T/C-CI RF card
-# 2xHDMI and 2xHD-SDI inputs
 	e5f4  MPEG2 and H264 Encoder-Transcoder
 	f1c4  Dual ASI-RX/TX-CI card
 1b66  Deltacast
@@ -20637,7 +11691,6 @@ var pciids = []byte(`#
 	7052  EJ188/EJ198 USB 3.0 Host Controller
 1b73  Fresco Logic
 	1000  FL1000G USB 3.0 Host Controller
-		1d5c 1000  Anker USB 3.0 Express Card
 	1009  FL1009 USB 3.0 Host Controller
 	1100  FL1100 USB 3.0 Host Controller
 1b74  OpenVox Communication Co. Ltd.
@@ -20662,27 +11715,7 @@ var pciids = []byte(`#
 	0010  OmniCube Accelerator OA-3000-2
 1bb1  Seagate Technology PLC
 	005d  Nytro PCIe Flash Storage
-		1bb1 6501  Nytro XP6500-8A1536 1.5TB
-# 2TB Nytro PCIe controller
-		1bb1 6502  Nytro XP6500-8A2048
-# 4TB Nytro PCIe controller
-		1bb1 6503  Nytro XP6500-8A4096
-# 2GB DRAM variant of Nytro card
-		1bb1 6511  Nytro XH6550-2GB DRAM
-# 8GB variant of Nytro PCIe controller
-		1bb1 6512  Nytro XH6550-8GB DRAM
-# 1.5 TB Nytro PCIe controller
-		1bb1 6521  Nytro XP6500-8A1536 1.5TB
-# 2TB Nytro PCIe controller
-		1bb1 6522  Nytro XP6500-8A2048
-# 4TB Nytro PCIe controller
-		1bb1 6523  Nytro XP6500-8A4096
 	0100  Nytro Flash Storage
-		1bb1 0101  Nytro XF1440
-		1bb1 0103  Nytro 5000
-		1bb1 0121  Nytro XM1440
-		1bb1 0123  Nytro 5000
-		1bb1 01a1  Nytro XP7102
 1bb3  Bluecherry
 	4304  BC-04120A MPEG4 4 port video encoder / decoder
 	4309  BC-08240A MPEG4 4 port video encoder / decoder
@@ -20742,26 +11775,19 @@ var pciids = []byte(`#
 	00ad  FBC2CGG3HL Capture 2x200Gb
 	00af  Capture slave device
 	a001  FBC2CGG3 Capture 2x200Gb
-# Used on V120 VME Crate Controller
 1c32  Highland Technology, Inc.
 1c33  Daktronics, Inc
 1c3b  Accensus, LLC
 	0200  Telas2
-# http://www.accensusllc.com/accensustelas2.html
 	0300  Telas 2.V
 1c44  Enmotus Inc
 	8000  8000 Storage IO Controller
-# A Western Digital Subsidiary
 1c58  HGST, Inc.
 	0003  Ultrastar SN100 Series NVMe SSD
-		1014 04f5  PCIe3 1.6TB NVMe Flash Adapter
-		1014 04f6  PCIe3 3.2TB NVMe Flash Adapter
 	0023  Ultrastar SN200 Series NVMe SSD
 1c5f  Beijing Memblaze Technology Co. Ltd.
 	0540  PBlaze4 NVMe SSD
-# http://www.nicevt.ru/ (in Russian)
 1c63  Science and Research Centre of Computer Technology (JSC "NICEVT")
-# http://www.radiotec.ru/catalog.php?cat=jr8&art=14109
 	0008  K1927BB1Ya [EC8430] Angara Interconnection Network Adapter
 1c7e  TTTech Computertechnik AG
 	0200  zFAS Debug Port
@@ -20862,7 +11888,6 @@ var pciids = []byte(`#
 1d1d  CNEX Labs
 	1f1f  QEMU NVM Express LightNVM Controller
 	2807  8800 series NVMe SSD
-# CEM Solutions Pvt. Ltd.
 1d21  Allo
 1d26  Kalray Inc.
 	0040  Turbocard2 Accelerator
@@ -20895,9 +11920,7 @@ var pciids = []byte(`#
 	100b  K35-2SFP
 	100c  K35-4SFP
 	100d  AR-ARKA-FX0 [Arkville 32B DPDK Data Mover]
-		1d6c 2001  DPDK-Aware Virtual Function [Arkville VF]
 	100e  AR-ARKA-FX1 [Arkville 64B DPDK Data Mover]
-		1d6c 2001  DPDK-Aware Virtual Function [Arkville VF]
 	4200  A5PL-E1-10GETI [10 GbE Ethernet Traffic Instrument]
 1d78  DERA
 1d7c  Aerotech, Inc.
@@ -20914,57 +11937,27 @@ var pciids = []byte(`#
 1de5  Eideticom, Inc
 	1000  IO Memory Controller
 	2000  NoLoad Hardware Development Kit
-# nee Tumsan Oy
 1fc0  Ascom (Finland) Oy
 	0300  E2200 Dual E1/Rawpipe Card
 	0301  C5400 SHDSL/E1 Card
-# nee PathScale, Inc
 1fc1  QLogic, Corp.
 	000d  IBA6110 InfiniBand HCA
 	0010  IBA6120 InfiniBand HCA
 1fc9  Tehuti Networks Ltd.
 	3009  10-Giga TOE SmartNIC
 	3010  10-Giga TOE SmartNIC
-		0000 3002  10-Giga TOE Single Port XFP SmartNIC
-		0000 3004  10-Giga TOE Single Port SFP+ SmartNIC
-		0000 3008  10-Giga TOE Single Port CX4 SmartNIC
 	3014  10-Giga TOE SmartNIC 2-Port
-		0000 3003  10-Giga TOE Dual Port XFP Low Profile SmartNIC
-		0000 3005  10-Giga TOE Dual Port SFP+ Low Profile SmartNIC
-		0000 3014  10-Giga TOE Dual Port CX4 Low Profile SmartNIC
 	3110  10-Giga TOE Single Port SmartNIC
-		0000 3004  10-Giga TOE Single Port SFP+ SmartNIC
 	3114  10-Giga TOE Dual Port Low Profile SmartNIC
-		0000 3005  10-Giga TOE Dual Port SFP+ Low Profile SmartNIC
-		0000 3011  10-Giga TOE Dual Port SFP+/CX4 Low Profile SmartNIC
-		0000 3012  10-Giga TOE Dual Port CX4/SFP+ Low Profile SmartNIC
-		0000 3014  10-Giga TOE Dual Port CX4 Low Profile SmartNIC
 	3310  10-Giga TOE SFP+ Single Port SmartNIC
-		0000 3004  10-Giga TOE Single Port SFP+ SmartNIC
 	3314  10-Giga TOE Dual Port Low Profile SmartNIC
-		0000 3005  10-Giga TOE Dual Port SFP+ Low Profile SmartNIC
-		0000 3011  10-Giga TOE Dual Port SFP+/CX4 Low Profile SmartNIC
-		0000 3012  10-Giga TOE Dual Port CX4/SFP+ Low Profile SmartNIC
-		0000 3014  10-Giga TOE Dual Port CX4 Low Profile SmartNIC
 	4010  TN4010 Clean SROM
 	4020  TN9030 10GbE CX4 Ethernet Adapter
-		180c 2040  Mustang-200 10GbE Ethernet Adapter
 	4022  TN9310 10GbE SFP+ Ethernet Adapter
-		1043 8709  XG-C100F 10GbE SFP+ Ethernet Adapter
-		1186 4d00  DXE-810S 10GbE SFP+ Ethernet Adapter
-		1432 8103  10 Gigabit Ethernet SFP+ PCI Express Adapter
-		1fc9 3015  Ethernet Adapter
 	4024  TN9210 10GBase-T Ethernet Adapter
 	4025  TN9510 10GBase-T/NBASE-T Ethernet Adapter
-		105a 7203  SANLink3 NBase-T1
-		1186 2900  DXE-810T 10GBase-T Ethernet Adapter
-		1432 8102  10 Gigabit Ethernet PCI Express Adapter
-		1fc9 3015  Ethernet Adapter
 	4026  TN9610 10GbE SFP+ Ethernet Adapter
 	4027  TN9710P 10GBase-T/NBASE-T Ethernet Adapter
-		1154 0368  LGY-PCIE-MG
-		1432 8104  10 Gigabit Ethernet PCI Express Adapter
-		1fc9 3015  Ethernet Adapter
 	4527  TN9710Q 5GBase-T/NBASE-T Ethernet Adapter
 1fcc  StreamLabs
 	f416  MS416
@@ -21005,15 +11998,6 @@ var pciids = []byte(`#
 	0014  HiNT HC4 PCI to ISDN bridge, Network controller
 	0020  HB6 Universal PCI-PCI bridge (transparent mode)
 	0021  HB6 Universal PCI-PCI bridge (non-transparent mode)
-		1775 c200  C2K CompactPCI interface bridge
-		1775 ce90  CE9
-		4c53 1050  CT7 mainboard
-		4c53 1080  CT8 mainboard
-		4c53 1090  Cx9 mainboard
-		4c53 10a0  CA3/CR3 mainboard
-		4c53 3010  PPCI mezzanine (32-bit PMC)
-		4c53 3011  PPCI mezzanine (64-bit PMC)
-		4c53 4000  PMCCARR1 carrier board
 	0022  HiNT HB4 PCI-PCI Bridge (PCI6150)
 	0026  HB2 PCI-PCI Bridge
 	1014  AudioTrak Maya
@@ -21022,11 +12006,8 @@ var pciids = []byte(`#
 	101a  E.Band [AudioTrak Inca88]
 	101b  E.Band [AudioTrak Inca88]
 	8011  VXPro II Chipset
-		3388 8011  VXPro II Chipset CPU to PCI Bridge
 	8012  VXPro II Chipset
-		3388 8012  VXPro II Chipset PCI to ISA Bridge
 	8013  VXPro II IDE
-		3388 8013  VXPro II Chipset EIDE Controller
 	a103  Blackmagic Design DeckLink HD Pro
 3411  Quantum Designs (H.K.) Inc
 3442  Bihl+Wiedemann GmbH
@@ -21036,9 +12017,7 @@ var pciids = []byte(`#
 3513  ARCOM Control Systems Ltd
 37d9  ITD Firm ltd.
 	1138  SCHD-PH-8 Phase detector
-# 12-ch Relay Actuator Card
 	1140  VR-12-PCI
-# multiport serial board
 	1141  PCI-485(422)
 	1142  PCI-CAN2
 3842  eVga.com. Corp.
@@ -21046,33 +12025,15 @@ var pciids = []byte(`#
 3d3d  3DLabs
 	0001  GLINT 300SX
 	0002  GLINT 500TX
-		0000 0000  GLoria L
 	0003  GLINT Delta
-		0000 0000  GLoria XL
 	0004  Permedia
 	0005  Permedia
 	0006  GLINT MX
-		0000 0000  GLoria XL
-		1048 0a42  GLoria XXL
 	0007  3D Extreme
 	0008  GLINT Gamma G1
-		1048 0a42  GLoria XXL
 	0009  Permedia II 2D+3D
-		1040 0011  AccelStar II
-		1048 0a42  GLoria XXL
-		13e9 1000  6221L-4U
-		3d3d 0100  AccelStar II 3D Accelerator
-		3d3d 0111  Permedia 3:16
-		3d3d 0114  Santa Ana
-		3d3d 0116  Oxygen GVX1
-		3d3d 0119  Scirocco
-		3d3d 0120  Santa Ana PCL
-		3d3d 0125  Oxygen VX1
-		3d3d 0127  Permedia3 Create!
 	000a  GLINT R3
-		3d3d 0121  Oxygen VX1
 	000c  GLINT R3 [Oxygen VX1]
-		3d3d 0144  Oxygen VX1-4X AGP [Permedia 4]
 	000d  GLint R4 rev A
 	000e  GLINT Gamma G2
 	0011  GLint R4 rev B
@@ -21105,30 +12066,18 @@ var pciids = []byte(`#
 	2464  ALG-2464
 	2501  ALG-2564A/25128A
 	4000  ALS4000 Audio Chipset
-		4005 4000  ALS4000 Audio Chipset
 	4710  ALC200/200P
 4033  Addtron Technology Co, Inc.
 	1360  RTL8139 Ethernet
 4040  NetXen Incorporated
 	0001  NXB-10GXSR 10-Gigabit Ethernet PCIe Adapter with SR-XFP optical interface
-		103c 7047  NC510F PCIe 10-Gigabit Server Adapter
 	0002  NXB-10GCX4 10-Gigabit Ethernet PCIe Adapter with CX4 copper interface
-		103c 7048  NC510c PCIe 10-Gigabit Server Adapter
 	0003  NXB-4GCU Quad Gigabit Ethernet PCIe Adapter with 1000-BASE-T interface
 	0004  BladeCenter-H 10-Gigabit Ethernet High Speed Daughter Card
 	0005  NetXen Dual Port 10GbE Multifunction Adapter for c-Class
-		103c 170e  NC512m Dual Port 10GbE Multifunction BL-C Adapter
 	0024  XG Mgmt
 	0025  XG Mgmt
 	0100  NX3031 Multifunction 1/10-Gigabit Server Adapter
-		103c 171b  NC522m Dual Port 10GbE Multifunction BL-c Adapter
-		103c 1740  NC375T PCI Express Quad Port Gigabit Server Adapter
-		103c 3251  NC375i 1G w/NC524SFP 10G Module
-		103c 705a  NC375i Integrated Quad Port Multifunction Gigabit Server Adapter
-		103c 705b  NC522SFP Dual Port 10GbE Server Adapter
-		152d 896b  TG20 Dual Port 10GbE Server/Storage Adapter
-		4040 0124  NX3031 Quad Port Gigabit Server Adapter
-		4040 0126  Dual Port SFP+ 10GbE Server Adapter
 4143  Digital Equipment Corp
 4144  Alpha Data
 	0044  ADM-XRCIIPro
@@ -21153,68 +12102,7 @@ var pciids = []byte(`#
 434e  CAST Navigation LLC
 4444  Internext Compression Inc
 	0016  iTVC16 (CX23416) Video Decoder
-		0070 0003  WinTV PVR 250
-		0070 0009  WinTV PVR 150
-		0070 0801  WinTV PVR 150
-		0070 0807  WinTV PVR 150
-		0070 4001  WinTV PVR 250
-		0070 4009  WinTV PVR 250
-		0070 4801  WinTV PVR 250
-		0070 4803  WinTV PVR 250
-		0070 8003  WinTV PVR 150
-		0070 8801  WinTV PVR 150
-		0070 c801  WinTV PVR 150
-		0070 e807  WinTV PVR 500 (1st unit)
-		0070 e817  WinTV PVR 500 (2nd unit)
-		0070 ff92  WiNTV PVR-550
-		0270 0801  WinTV PVR 150
-		104d 013d  ENX-26 TV Encoder
-		10fc d038  GV-MVP/RX2W (1st unit)
-		10fc d039  GV-MVP/RX2W (2nd unit)
-		12ab fff3  MPG600
-		12ab ffff  MPG600
-		1461 c00a  M113 PCI Analog TV (PAL/SECAM, Philips FQ1216MK3 tuner)
-		1461 c00b  M113 PCI Analog TV (PAL/SECAM+FM, Philips FM1216MK3 tuner)
-		1461 c00c  M113 PCI Analog TV (NTSC, JAPAN version, Philips FI1286MK2 tuner)
-		1461 c010  M113 PCI Analog TV (NTSC, Philips FI1236MK3 tuner)
-		1461 c011  M113 PCI Analog TV (NTSC+FM, Philips FM1236MK3 tuner)
-		1461 c018  M113 PCI Analog TV (NTSC, Philips FQ1236MK5 tuner)
-		1461 c019  UltraTV 1500 MCE, a.k.a. M113 PCI Analog TV (NTSC+FM, Philips FQ1236MK5 tuner)
-		1461 c01a  M113 PCI Analog TV (PAL/SECAM, Philips FQ1216MK5 tuner)
-		1461 c01b  M113 PCI Analog TV (PAL/SECAM+FM, Philips FM1216MK5 tuner)
-		1461 c030  M113 PCI Analog TV (NTSC-J, Partsnic tuner)
-		1461 c031  M113 PCI Analog TV (NTSC-J+FM, Partsnic tuner)
-		1461 c032  M113 PCI Analog TV (PAL/SECAM, Partsnic tuner)
-		1461 c033  M113 PCI Analog TV (PAL/SECAM+FM, Partsnic tuner)
-		1461 c034  M113 PCI Analog TV (NTSC, Partsnic tuner)
-		1461 c035  M113 PCI Analog TV (NTSC+FM, Partsnic tuner)
-		1461 c03f  C115 PCI video capture card (no tuner)
-		1461 c136  M104 mini-PCI Analog TV
-		1461 c20a  M755 AVerTV Video Capture (PAL/SECAM, Philips FQ1216MK3 tuner)
-		1461 c218  M755 AVerTV Video Capture (NTSC, Philips FQ1236MK5 tuner)
-		1461 c219  M755 AVerTV Video Capture (NTSC+FM, Philips FQ1236MK5 tuner)
-		1461 c21a  M755 AVerTV Video Capture (PAL/SECAM, Philips FQ1216MK5 tuner)
-		1461 c21b  M755 AVerTV Video Capture (PAL/SECAM+FM, Philips FM1216MK5 tuner)
-		1461 c230  M755 AVerTV Video Capture (NTSC-J, Partsnic tuner)
-		1461 c231  M755 AVerTV Video Capture (NTSC-J+FM, Partsnic tuner)
-		1461 c232  M755 AVerTV Video Capture (PAL/SECAM, Partsnic tuner)
-		1461 c233  M755 AVerTV Video Capture (PAL/SECAM+FM, Partsnic tuner)
-		1461 c234  M755 AVerTV Video Capture (NTSC, Partsnic tuner)
-		1461 c235  M755 AVerTV Video Capture (NTSC+FM, Partsnic tuner)
-		1461 c337  E106 AVerMedia AVerTV Video Capture
-		1461 c439  M116 AVerMedia AVerTV MCE 116 Plus (NTSC/PAL/SECAM+FM+REMOTE, Xceive 2028 tuner)
-		1461 c5ff  C755 AVerTV Video Capture card (no tuner)
-		1461 c6ff  C115 PCI video capture card (no tuner)
-		1461 c739  M785 AVerMedia PCI Analog TV (NTSC/PAL/SECAM+FM, Xceive 2028 tuner)
-		9005 0092  VideOh! AVC-2010
-		9005 0093  VideOh! AVC-2410
 	0803  iTVC15 (CX23415) Video Decoder
-		0070 4000  WinTV PVR-350
-		0070 4001  WinTV PVR-250
-		0070 4800  WinTV PVR-350 (V1)
-		12ab 0000  MPG160
-		1461 a3ce  M179
-		1461 a3cf  M179
 4468  Bridgeport machines
 4594  Cogetec Informatique Inc
 45fb  Baldor Electric Company
@@ -21222,7 +12110,6 @@ var pciids = []byte(`#
 	adc1  ADC200ME High speed ADC
 	de01  DL200ME High resolution delay line PCI based card
 	de02  DL200ME Middle resolution delay line PCI based card
-# Can't find any information on this company
 4651  TXIC
 4680  Umax Computer Corp
 4843  Hercules Computer Technology Inc
@@ -21355,15 +12242,11 @@ var pciids = []byte(`#
 4978  Axil Computer Inc
 4a14  NetVin
 	5000  NV5000SC
-		4a14 5000  RT8029-Based Ethernet Adapter
 4b10  Buslogic Inc.
 4c48  LUNG HWA Electronics
 4c53  SBS Technologies
 	0000  PLUSTEST device
-		4c53 3000  PLUSTEST card (PC104+)
-		4c53 3001  PLUSTEST card (PMC)
 	0001  PLUSTEST-MM device
-		4c53 3002  PLUSTEST-MM card (PMC)
 4ca1  Seanix Technology Inc
 4d51  MediaQ Inc.
 	0200  MQ-200
@@ -21442,15 +12325,10 @@ var pciids = []byte(`#
 	88f2  86c968 [Vision 968 VRAM] rev 2
 	88f3  86c968 [Vision 968 VRAM] rev 3
 	8900  86c755 [Trio 64V2/DX]
-		5333 8900  86C775 Trio64V2/DX
 	8901  86c775/86c785 [Trio 64V2/DX or /GX]
-		5333 8901  86C775 Trio64V2/DX, 86C785 Trio64V2/GX
 	8902  Plato/PX
 	8903  Trio 3D business multimedia
 	8904  86c365, 86c366 [Trio 3D]
-		1014 00db  Integrated Trio3D
-		4843 314a  Terminator 128/3D GLH
-		5333 8904  86C365 Trio3D AGP
 	8905  Trio 64V+ family
 	8906  Trio 64V+ family
 	8907  Trio 64V+ family
@@ -21463,64 +12341,22 @@ var pciids = []byte(`#
 	890e  Trio 64V+ family
 	890f  Trio 64V+ family
 	8a01  86c375 [ViRGE/DX] or 86c385 [ViRGE/GX]
-		0e11 b032  ViRGE/GX
-		10b4 1617  Nitro 3D
-		10b4 1717  Nitro 3D
-		5333 8a01  ViRGE/DX
 	8a10  ViRGE/GX2
-		1092 8a10  Stealth 3D 4000
 	8a13  86c360 [Trio 3D/1X], 86c362, 86c368 [Trio 3D/2X]
-		5333 8a13  Trio3D/2X
 	8a20  86c794 [Savage 3D]
-		5333 8a20  86C391 Savage3D
 	8a21  86c390 [Savage 3D/MV]
-		5333 8a21  86C390 Savage3D/MV
 	8a22  Savage 4
-		1033 8068  Savage 4
-		1033 8069  Savage 4
-		1033 8110  Savage 4 LT
-		105d 0018  SR9 8Mb SDRAM
-		105d 002a  SR9 Pro 16Mb SDRAM
-		105d 003a  SR9 Pro 32Mb SDRAM
-		105d 092f  SR9 Pro+ 16Mb SGRAM
-		1092 4207  Stealth III S540
-		1092 4800  Stealth III S540
-		1092 4807  SpeedStar A90
-		1092 4808  Stealth III S540
-		1092 4809  Stealth III S540
-		1092 480e  Stealth III S540
-		1092 4904  Stealth III S520
-		1092 4905  SpeedStar A200
-		1092 4a09  Stealth III S540
-		1092 4a0b  Stealth III S540 Xtreme
-		1092 4a0f  Stealth III S540
-		1092 4e01  Stealth III S540
-		1102 101d  3d Blaster Savage 4
-		1102 101e  3d Blaster Savage 4
-		5333 8100  86C394-397 Savage4 SDRAM 100
-		5333 8110  86C394-397 Savage4 SDRAM 110
-		5333 8125  86C394-397 Savage4 SDRAM 125
-		5333 8143  86C394-397 Savage4 SDRAM 143
-		5333 8a22  86C394-397 Savage4
-		5333 8a2e  86C394-397 Savage4 32bit
-		5333 9125  86C394-397 Savage4 SGRAM 125
-		5333 9143  86C394-397 Savage4 SGRAM 143
 	8a23  Savage 4
 	8a25  ProSavage PM133
-		0303 0303  D9840-60001 [Brio BA410 Motherboard]
 	8a26  ProSavage KM133
 	8c00  ViRGE/M3
 	8c01  ViRGE/MX
-		1179 0001  ViRGE/MX
 	8c02  ViRGE/MX+
 	8c03  ViRGE/MX+MV
 	8c10  86C270-294 [SavageMX-MV]
 	8c11  82C270-294 [SavageMX]
 	8c12  86C270-294 [SavageIX-MV]
-		1014 017f  ThinkPad T20/T22
-		1179 0001  86C584 SuperSavage/IXC Toshiba
 	8c13  86C270-294 [SavageIX]
-		1179 0001  Magnia Z310
 	8c22  SuperSavage MX/128
 	8c24  SuperSavage MX/64
 	8c26  SuperSavage MX/64C
@@ -21529,7 +12365,6 @@ var pciids = []byte(`#
 	8c2c  SuperSavage IX/64 SDR
 	8c2d  SuperSavage IX/64 DDR
 	8c2e  SuperSavage IX/C SDR
-		1014 01fc  ThinkPad T23
 	8c2f  SuperSavage IX/C DDR
 	8d01  86C380 [ProSavageDDR K4M266]
 	8d02  VT8636A [ProSavage KN133] AGP4X VGA Controller (TwisterK)
@@ -21539,29 +12374,16 @@ var pciids = []byte(`#
 	8e26  ProSavage
 	8e40  2300E Graphics Processor
 	8e48  Matrix [Chrome S25 / S27]
-		5333 0130  Chrome S27 256M DDR2
 	9043  Chrome 430 GT
 	9045  Chrome 430 ULP / 435 ULP / 440 GTX
 	9060  Chrome 530 GT
 	9102  86C410 [Savage 2000]
-		1092 5932  Viper II Z200
-		1092 5934  Viper II Z200
-		1092 5952  Viper II Z200
-		1092 5954  Viper II Z200
-		1092 5a35  Viper II Z200
-		1092 5a37  Viper II Z200
-		1092 5a55  Viper II Z200
-		1092 5a57  Viper II Z200
 	ca00  SonicVibes
 5431  AuzenTech, Inc.
 544c  Teralogic Inc
 	0350  TL880-based HDTV/ATSC tuner
 544d  TBS Technologies
 	6178  DVB-S2 4 Tuner PCIe Card
-		544d 6904  TBS6904 DVB-S2 Quad Tuner PCIe Card
-		544d 6905  TBS6905 DVB-S2 Quad Tuner PCIe Card
-		6205 0001  TBS6205 DVB-T2/T/C Quad TV Tuner PCIe Card
-		6209 0001  TBS6209 DVB-T2/C2/T/C/ISDB-T OctaTV Tuner
 5452  SCANLAB AG
 	3443  RTC4
 5455  Technische University Berlin
@@ -21577,7 +12399,6 @@ var pciids = []byte(`#
 5654  VoiceTronix Pty Ltd
 5678  Dawicontrol Computersysteme GmbH
 5700  Netpower
-# alternately Extreme Engineering Solutions, Inc.
 5845  X-ES, Inc.
 584d  AuzenTech Co., Ltd.
 5851  Exacq Technologies
@@ -21587,9 +12408,7 @@ var pciids = []byte(`#
 5853  XenSource, Inc.
 	0001  Xen Platform Device
 	c000  Citrix XenServer PCI Device for Windows Update
-# Virtual device surfaced in guests to provide HID events.
 	c110  Virtualized HID
-# Device surfaced in guests to provide 2d graphics capabilities
 	c147  Virtualized Graphics Device
 5854  GoTView
 5ace  Beholder International Ltd.
@@ -21621,7 +12440,6 @@ var pciids = []byte(`#
 	1400  CooVOX TDM GSM Module
 	1600  CooVOX TDM E1/T1 Module
 	1800  CooVOX TDM BRI Module
-# nee Qumranet
 6900  Red Hat, Inc.
 7063  pcHDTV
 	2000  HD-2000
@@ -21638,7 +12456,6 @@ var pciids = []byte(`#
 	0010  WDOG1 [PCI-Watchdog 1]
 	0011  PWDOG2 [PCI-Watchdog 2]
 	0015  Clock77/PCI & Clock77/PCIe (DCF-77 receiver)
-# Wrong ID used in subsystem ID of AsusTek PCI-USB2 PCI card.
 807d  Asustek Computer, Inc.
 8086  Intel Corporation
 	0007  82379AB
@@ -21649,19 +12466,8 @@ var pciids = []byte(`#
 	0042  Core Processor Integrated Graphics Controller
 	0043  Core Processor Secondary PCI Express Root Port
 	0044  Core Processor DRAM Controller
-		1025 0347  Aspire 7740G
-		1025 0487  TravelMate 5742
-		1028 040a  Latitude E6410
-		144d c06a  R730 Laptop
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
-		e4bf 50c1  PC1-GROOVE
 	0045  Core Processor PCI Express x16 Root Port
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	0046  Core Processor Integrated Graphics Controller
-		1028 040a  Latitude E6410
-		144d c06a  R730 Laptop
-		17c0 10d9  Medion Akoya E7214 Notebook PC [MD98410]
-		e4bf 50c1  PC1-GROOVE
 	0047  Core Processor Secondary PCI Express Root Port
 	0048  Core Processor DRAM Controller
 	0049  Core Processor PCI Express x16 Root Port
@@ -21670,75 +12476,20 @@ var pciids = []byte(`#
 	0050  Core Processor Thermal Management Controller
 	0069  Core Processor DRAM Controller
 	0082  Centrino Advanced-N 6205 [Taylor Peak]
-		8086 1301  Centrino Advanced-N 6205 AGN
-		8086 1306  Centrino Advanced-N 6205 ABG
-		8086 1307  Centrino Advanced-N 6205 BG
-		8086 1321  Centrino Advanced-N 6205 AGN
-		8086 1326  Centrino Advanced-N 6205 ABG
 	0083  Centrino Wireless-N 1000 [Condor Peak]
-		8086 1205  Centrino Wireless-N 1000 BGN
-		8086 1206  Centrino Wireless-N 1000 BG
-		8086 1225  Centrino Wireless-N 1000 BGN
-		8086 1226  Centrino Wireless-N 1000 BG
-		8086 1305  Centrino Wireless-N 1000 BGN
-		8086 1306  Centrino Wireless-N 1000 BG
-		8086 1325  Centrino Wireless-N 1000 BGN
-		8086 1326  Centrino Wireless-N 1000 BG
 	0084  Centrino Wireless-N 1000 [Condor Peak]
-		8086 1215  Centrino Wireless-N 1000 BGN
-		8086 1216  Centrino Wireless-N 1000 BG
-		8086 1315  Centrino Wireless-N 1000 BGN
-		8086 1316  Centrino Wireless-N 1000 BG
 	0085  Centrino Advanced-N 6205 [Taylor Peak]
-		8086 1311  Centrino Advanced-N 6205 (802.11a/b/g/n)
-		8086 1316  Centrino Advanced-N 6205 ABG
 	0087  Centrino Advanced-N + WiMAX 6250 [Kilmer Peak]
-		8086 1301  Centrino Advanced-N + WiMAX 6250 2x2 AGN
-		8086 1306  Centrino Advanced-N + WiMAX 6250 2x2 ABG
-		8086 1321  Centrino Advanced-N + WiMAX 6250 2x2 AGN
-		8086 1326  Centrino Advanced-N + WiMAX 6250 2x2 ABG
 	0089  Centrino Advanced-N + WiMAX 6250 [Kilmer Peak]
-		8086 1311  Centrino Advanced-N + WiMAX 6250 2x2 AGN
-		8086 1316  Centrino Advanced-N + WiMAX 6250 2x2 ABG
 	008a  Centrino Wireless-N 1030 [Rainbow Peak]
-		8086 5305  Centrino Wireless-N 1030 BGN
-		8086 5307  Centrino Wireless-N 1030 BG
-		8086 5325  Centrino Wireless-N 1030 BGN
-		8086 5327  Centrino Wireless-N 1030 BG
 	008b  Centrino Wireless-N 1030 [Rainbow Peak]
-		8086 5315  Centrino Wireless-N 1030 BGN
-		8086 5317  Centrino Wireless-N 1030 BG
 	0090  Centrino Advanced-N 6230 [Rainbow Peak]
-		8086 5211  Centrino Advanced-N 6230 AGN
-		8086 5215  Centrino Advanced-N 6230 BGN
-		8086 5216  Centrino Advanced-N 6230 ABG
 	0091  Centrino Advanced-N 6230 [Rainbow Peak]
-		8086 5201  Centrino Advanced-N 6230 AGN
-		8086 5205  Centrino Advanced-N 6230 BGN
-		8086 5206  Centrino Advanced-N 6230 ABG
-		8086 5207  Centrino Advanced-N 6230 BG
-		8086 5221  Centrino Advanced-N 6230 AGN
-		8086 5225  Centrino Advanced-N 6230 BGN
-		8086 5226  Centrino Advanced-N 6230 ABG
 	0100  2nd Generation Core Processor Family DRAM Controller
-		1028 04aa  XPS 8300
-		1043 844d  P8P67/P8H67 Series Motherboard
 	0101  Xeon E3-1200/2nd Generation Core Processor Family PCI Express Root Port
-		1028 04b2  Vostro 3350
-		106b 00dc  MacBookPro8,2 [Core i7, 15", 2011]
-		144d c652  NP300E5C series laptop
 	0102  2nd Generation Core Processor Family Integrated Graphics Controller
-		1028 04aa  XPS 8300
-		1043 0102  P8H67 Series Motherboard
 	0104  2nd Generation Core Processor Family DRAM Controller
-		1028 04a3  Precision M4600
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		106b 00dc  MacBookPro8,2 [Core i7, 15", 2011]
-		144d c652  NP300E5C series laptop
-		17aa 21cf  ThinkPad T520
 	0105  Xeon E3-1200/2nd Generation Core Processor Family PCI Express Root Port
-		106b 00dc  MacBookPro8,2 [Core i7, 15", 2011]
 	0106  2nd Generation Core Processor Family Integrated Graphics Controller
 	0108  Xeon E3-1200 Processor Family DRAM Controller
 	0109  Xeon E3-1200/2nd Generation Core Processor Family PCI Express Root Port
@@ -21749,64 +12500,30 @@ var pciids = []byte(`#
 	010e  Xeon E3-1200/2nd Generation Core Processor Family Integrated Graphics Controller
 	0112  2nd Generation Core Processor Family Integrated Graphics Controller
 	0116  2nd Generation Core Processor Family Integrated Graphics Controller
-		1028 04da  Vostro 3750
-		144d c652  integrated HD 3000 graphics controller on NP300E5C series laptop
 	0122  2nd Generation Core Processor Family Integrated Graphics Controller
 	0126  2nd Generation Core Processor Family Integrated Graphics Controller
-		1028 04cc  Vostro 3350
-		17aa 21cf  ThinkPad T520
 	0150  Xeon E3-1200 v2/3rd Gen Core processor DRAM Controller
-		1043 84ca  P8 series motherboard
-		1458 d000  Ivy Bridge GT1 [HD Graphics]
-		15d9 0624  X9SCM-F Motherboard
-		1849 0150  Motherboard
 	0151  Xeon E3-1200 v2/3rd Gen Core processor PCI Express Root Port
-		1043 1477  N56VZ
-		1043 844d  P8 series motherboard
-		1043 84ca  P8H77-I Motherboard
-		8086 2010  Server Board S1200BTS
 	0152  Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller
-		1043 84ca  P8H77-I Motherboard
 	0153  3rd Gen Core Processor Thermal Subsystem
-		1043 1517  Zenbook Prime UX31A
 	0154  3rd Gen Core processor DRAM Controller
-		1025 0806  Aspire E1-470G
-		1025 0813  Aspire R7-571
-		103c 17f6  ProBook 4540s
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
 	0155  Xeon E3-1200 v2/3rd Gen Core processor PCI Express Root Port
-		8086 2010  Server Board S1200BTS
 	0156  3rd Gen Core processor Graphics Controller
-		1043 108d  VivoBook X202EV
 	0158  Xeon E3-1200 v2/Ivy Bridge DRAM Controller
-		1043 844d  P8 series motherboard
-		8086 2010  Server Board S1200BTS
 	0159  Xeon E3-1200 v2/3rd Gen Core processor PCI Express Root Port
 	015a  Xeon E3-1200 v2/Ivy Bridge Graphics Controller
 	015c  Xeon E3-1200 v2/3rd Gen Core processor DRAM Controller
 	015d  Xeon E3-1200 v2/3rd Gen Core processor PCI Express Root Port
-		1043 844d  P8 series motherboard
 	015e  Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller
 	0162  Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller
-		1043 84ca  P8 series motherboard
-		1849 0162  Motherboard
 	0166  3rd Gen Core processor Graphics Controller
-		1043 1517  Zenbook Prime UX31A
-		1043 2103  N56VZ
 	016a  Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller
-		1043 844d  P8B WS Motherboard
 	0172  Xeon E3-1200 v2/3rd Gen Core processor Graphics Controller
 	0176  3rd Gen Core processor Graphics Controller
 	0309  80303 I/O Processor PCI-to-PCI Bridge
 	030d  80312 I/O Companion Chip PCI-to-PCI Bridge
 	0326  6700/6702PXH I/OxAPIC Interrupt Controller A
-		103c 3208  ProLiant DL140 G2
-		1775 1100  CR11/VR11 Single Board Computer
 	0327  6700PXH I/OxAPIC Interrupt Controller B
-		103c 3208  ProLiant DL140 G2
-		1775 1100  CR11/VR11 Single Board Computer
 	0329  6700PXH PCI Express-to-PCI Bridge A
 	032a  6700PXH PCI Express-to-PCI Bridge B
 	032c  6702PXH PCI Express-to-PCI Bridge A
@@ -21829,7 +12546,6 @@ var pciids = []byte(`#
 	040a  Xeon E3-1200 v3 Processor Integrated Graphics Controller
 	0412  Xeon E3-1200 v3/4th Gen Core Processor Integrated Graphics Controller
 	0416  4th Gen Core Processor Integrated Graphics Controller
-		17aa 220e  ThinkPad T440p
 	041a  Xeon E3-1200 v3 Processor Integrated Graphics Controller
 	041e  4th Generation Core Processor Family Integrated Graphics Controller
 	0434  DH89XXCC Series QAT
@@ -21849,9 +12565,7 @@ var pciids = []byte(`#
 	04d0  82437FX [Triton FX]
 	0500  E8870 Processor bus control
 	0501  E8870 Memory controller
-# and registers common to both SPs
 	0502  E8870 Scalability Port 0
-# and global performance monitoring
 	0503  E8870 Scalability Port 1
 	0510  E8870IO Hub Interface Port 0 registers (8-bit compatibility port)
 	0511  E8870IO Hub Interface Port 1 registers
@@ -21866,16 +12580,9 @@ var pciids = []byte(`#
 	0533  E8870SP Scalability Port 3 registers
 	0534  E8870SP Scalability Port 4 registers
 	0535  E8870SP Scalability Port 5 registers
-# (bi-interleave 0) and global registers that are neither per-port nor per-interleave
 	0536  E8870SP Interleave registers 0 and 1
-# (bi-interleave 1)
 	0537  E8870SP Interleave registers 2 and 3
 	0600  RAID Controller
-		8086 0136  SRCU31L
-		8086 01af  SRCZCR
-		8086 01c1  ICP Vortex GDT8546RZ
-		8086 01f7  SCRU32
-# uninitialized SRCU32 RAID Controller
 	061f  80303 I/O Processor
 	0700  CE Media Processor A/V Bridge
 	0701  CE Media Processor NAND Flash Controller
@@ -21927,370 +12634,46 @@ var pciids = []byte(`#
 	082d  Medfield Serial IO I2C Controller #1
 	082e  Medfield Serial IO I2C Controller #2
 	0885  Centrino Wireless-N + WiMAX 6150
-		8086 1305  Centrino Wireless-N + WiMAX 6150 BGN
-		8086 1307  Centrino Wireless-N + WiMAX 6150 BG
-		8086 1325  Centrino Wireless-N + WiMAX 6150 BGN
-		8086 1327  Centrino Wireless-N + WiMAX 6150 BG
 	0886  Centrino Wireless-N + WiMAX 6150
-		8086 1315  Centrino Wireless-N + WiMAX 6150 BGN
-		8086 1317  Centrino Wireless-N + WiMAX 6150 BG
 	0887  Centrino Wireless-N 2230
-		8086 4062  Centrino Wireless-N 2230 BGN
-		8086 4462  Centrino Wireless-N 2230 BGN
 	0888  Centrino Wireless-N 2230
-		8086 4262  Centrino Wireless-N 2230 BGN
 	088e  Centrino Advanced-N 6235
-		8086 4060  Centrino Advanced-N 6235 AGN
-		8086 4460  Centrino Advanced-N 6235 AGN
 	088f  Centrino Advanced-N 6235
-		8086 4260  Centrino Advanced-N 6235 AGN
 	0890  Centrino Wireless-N 2200
-		8086 4022  Centrino Wireless-N 2200 BGN
-		8086 4422  Centrino Wireless-N 2200 BGN
-		8086 4822  Centrino Wireless-N 2200 BGN
 	0891  Centrino Wireless-N 2200
-		8086 4222  Centrino Wireless-N 2200 BGN
 	0892  Centrino Wireless-N 135
-		8086 0062  Centrino Wireless-N 135 BGN
-		8086 0462  Centrino Wireless-N 135 BGN
 	0893  Centrino Wireless-N 135
-		8086 0262  Centrino Wireless-N 135 BGN
 	0894  Centrino Wireless-N 105
-		8086 0022  Centrino Wireless-N 105 BGN
-		8086 0422  Centrino Wireless-N 105 BGN
-		8086 0822  Centrino Wireless-N 105 BGN
 	0895  Centrino Wireless-N 105
-		8086 0222  Centrino Wireless-N 105 BGN
 	0896  Centrino Wireless-N 130
-		8086 5005  Centrino Wireless-N 130 BGN
-		8086 5007  Centrino Wireless-N 130 BG
-		8086 5025  Centrino Wireless-N 130 BGN
-		8086 5027  Centrino Wireless-N 130 BG
 	0897  Centrino Wireless-N 130
-		8086 5015  Centrino Wireless-N 130 BGN
-		8086 5017  Centrino Wireless-N 130 BG
 	08ae  Centrino Wireless-N 100
-		8086 1005  Centrino Wireless-N 100 BGN
-		8086 1007  Centrino Wireless-N 100 BG
-		8086 1025  Centrino Wireless-N 100 BGN
-		8086 1027  Centrino Wireless-N 100 BG
 	08af  Centrino Wireless-N 100
-		8086 1015  Centrino Wireless-N 100 BGN
-		8086 1017  Centrino Wireless-N 100 BG
 	08b1  Wireless 7260
-# Wilkins Peak 2
-		8086 4020  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 402a  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4060  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4062  Wireless-N 7260
-# Wilkins Peak 2
-		8086 406a  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4070  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4072  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4160  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4162  Wireless-N 7260
-# Wilkins Peak 2
-		8086 4170  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4420  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4460  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4462  Wireless-N 7260
-# Wilkins Peak 2
-		8086 446a  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4470  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4472  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4560  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4570  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 486e  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4870  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4a6c  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4a6e  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4a70  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4c60  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4c70  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 5070  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 5072  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 5170  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 5770  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c020  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c02a  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c060  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c062  Wireless-N 7260
-# Wilkins Peak 2
-		8086 c06a  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c070  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c072  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c160  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c162  Wireless-N 7260
-# Wilkins Peak 2
-		8086 c170  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c360  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c420  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c460  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c462  Wireless-N 7260
-# Wilkins Peak 2
-		8086 c470  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c472  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c560  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c570  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c760  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c770  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 cc60  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 cc70  Dual Band Wireless-AC 7260
 	08b2  Wireless 7260
-# Wilkins Peak 2
-		8086 4220  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4260  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4262  Wireless-N 7260
-# Wilkins Peak 2
-		8086 426a  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4270  Wireless-N 7260
-# Wilkins Peak 2
-		8086 4272  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 4360  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 4370  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c220  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c260  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c262  Wireless-N 7260
-# Wilkins Peak 2
-		8086 c26a  Dual Band Wireless-N 7260
-# Wilkins Peak 2
-		8086 c270  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c272  Dual Band Wireless-AC 7260
-# Wilkins Peak 2
-		8086 c370  Dual Band Wireless-AC 7260
 	08b3  Wireless 3160
-# Wilkins Peak 1
-		8086 0060  Dual Band Wireless-N 3160
-# Wilkins Peak 1
-		8086 0062  Wireless-N 3160
-# Wilkins Peak 1
-		8086 0070  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 0072  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 0170  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 0172  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 0260  Dual Band Wireless-N 3160
-# Wilkins Peak 1
-		8086 0470  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 0472  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 1070  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 1170  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 8060  Dual Band Wireless N-3160
-# Wilkins Peak 1
-		8086 8062  Wireless N-3160
-# Wilkins Peak 1
-		8086 8070  Dual Band Wireless AC 3160
-# Wilkins Peak 1
-		8086 8072  Dual Band Wireless AC 3160
-# Wilkins Peak 1
-		8086 8170  Dual Band Wireless AC 3160
-# Wilkins Peak 1
-		8086 8172  Dual Band Wireless AC 3160
-# Wilkins Peak 1
-		8086 8470  Dual Band Wireless AC 3160
-# Wilkins Peak 1
-		8086 8570  Dual Band Wireless AC 3160
 	08b4  Wireless 3160
-# Wilkins Peak 1
-		8086 0270  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 0272  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 0370  Dual Band Wireless-AC 3160
-# Wilkins Peak 1
-		8086 8260  Dual Band Wireless AC 3160
-# Wilkins Peak 1
-		8086 8270  Dual Band Wireless AC 3160
-# Wilkins Peak 1
-		8086 8272  Dual Band Wireless AC 3160
-# Wilkins Peak 1
-		8086 8370  Dual Band Wireless AC 3160
-# PowerVR SGX 545
 	08cf  Atom Processor Z2760 Integrated Graphics Controller
 	0953  PCIe Data Center SSD
-		8086 3702  DC P3700 SSD
-		8086 3703  DC P3700 SSD [2.5" SFF]
-		8086 3704  DC P3500 SSD [Add-in Card]
-		8086 3705  DC P3500 SSD [2.5" SFF]
-		8086 3709  DC P3600 SSD [Add-in Card]
-		8086 370a  DC P3600 SSD [2.5" SFF]
-		8086 370d  SSD 750 Series [Add-in Card]
-		8086 370e  SSD 750 Series [2.5" SFF]
 	095a  Wireless 7265
-# Stone Peak 2 AC
-		8086 1010  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 5000  Dual Band Wireless-N 7265
-# Stone Peak 2 BGN
-		8086 5002  Wireless-N 7265
-# Stone Peak 2 AGN
-		8086 500a  Dual Band Wireless-N 7265
-# Stone Peak 2 AC
-		8086 5010  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 5012  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 5020  Dual Band Wireless-N 7265
-# Stone Peak 2 AGN
-		8086 502a  Dual Band Wireless-N 7265
-# Maple Peak AC
-		8086 5090  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 5100  Dual Band Wireless-AC 7265
-# Stone Peak 2 BGN
-		8086 5102  Wireless-N 7265
-# Stone Peak 2 AGN
-		8086 510a  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 5110  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 5112  Dual Band Wireless-AC 7265
-# Maple Peak AC
-		8086 5190  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 5400  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 5410  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 5412  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 5420  Dual Band Wireless-N 7265
-# Maple Peak AC
-		8086 5490  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 5510  Dual Band Wireless-AC 7265
-# Maple Peak AC
-		8086 5590  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 9000  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 900a  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 9010  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 9012  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 9110  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 9112  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 9210  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 9310  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 9400  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 9410  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 9510  Dual Band Wireless-AC 7265
 	095b  Wireless 7265
-# Stone Peak 2 AGN
-		8086 5200  Dual Band Wireless-N 7265
-# Stone Peak 2 BGN
-		8086 5202  Wireless-N 7265
-# Stone Peak 2 AGN
-		8086 520a  Dual Band Wireless-N 7265
-# Stone Peak 2 AC
-		8086 5210  Dual Band Wireless-AC 7265
-# Stone Peak 2 AC
-		8086 5212  Dual Band Wireless-AC 7265
-# Maple Peak AC
-		8086 5290  Dual Band Wireless-AC 7265
-# Stone Peak 2 BGN
-		8086 5302  Wireless-N 7265
-# Stone Peak 2 AC
-		8086 5310  Dual Band Wireless-AC 7265
-# Stone Peak 2 AGN
-		8086 9200  Dual Band Wireless-AC 7265
 	0960  80960RP (i960RP) Microprocessor/Bridge
 	0962  80960RM (i960RM) Bridge
 	0964  80960RP (i960RP) Microprocessor/Bridge
+	0a03  Haswell-ULT Thermal Subsystem
 	0a04  Haswell-ULT DRAM Controller
-		17aa 2214  ThinkPad X240
 	0a06  Haswell-ULT Integrated Graphics Controller
 	0a0c  Haswell-ULT HD Audio Controller
-		17aa 2214  ThinkPad X240
 	0a16  Haswell-ULT Integrated Graphics Controller
-		17aa 2214  ThinkPad X240
 	0a22  Haswell-ULT Integrated Graphics Controller
 	0a26  Haswell-ULT Integrated Graphics Controller
 	0a2a  Haswell-ULT Integrated Graphics Controller
 	0a2e  Haswell-ULT Integrated Graphics Controller
 	0a53  DC P3520 SSD
 	0a54  Express Flash NVMe P4500
-		1028 1fe1  Express Flash NVMe 1TB 2.5" U.2 (P4500)
-		1028 1fe2  Express Flash NVMe 2TB 2.5" U.2 (P4500)
-		1028 1fe3  Express Flash NVMe 4TB 2.5" U.2 (P4500)
-		1028 1fe4  Express Flash NVMe 4TB HHHL AIC (P4500)
 	0a55  Express Flash NVMe P4600
-		1028 1fe5  Express Flash NVMe 1.6TB 2.5" U.2 (P4600)
-		1028 1fe6  Express Flash NVMe 2TB 2.5" U.2 (P4600)
-		1028 1fe7  Express Flash NVMe 3.2TB 2.5" U.2 (P4600)
-		1028 1fe8  Express Flash NVMe 2.0TB HHHL AIC (P4600)
-		1028 1fe9  Express Flash NVMe 4.0TB HHHL AIC (P4600)
 	0be0  Atom Processor D2xxx/N2xxx Integrated Graphics Controller
 	0be1  Atom Processor D2xxx/N2xxx Integrated Graphics Controller
-		105b 0d7c  D270S/D250S Motherboard
 	0be2  Atom Processor D2xxx/N2xxx Integrated Graphics Controller
 	0be3  Atom Processor D2xxx/N2xxx Integrated Graphics Controller
 	0be4  Atom Processor D2xxx/N2xxx Integrated Graphics Controller
@@ -22311,19 +12694,15 @@ var pciids = []byte(`#
 	0bf3  Atom Processor D2xxx/N2xxx DRAM Controller
 	0bf4  Atom Processor D2xxx/N2xxx DRAM Controller
 	0bf5  Atom Processor D2xxx/N2xxx DRAM Controller
-		105b 0d7c  D270S/D250S Motherboard
 	0bf6  Atom Processor D2xxx/N2xxx DRAM Controller
 	0bf7  Atom Processor D2xxx/N2xxx DRAM Controller
 	0c00  4th Gen Core Processor DRAM Controller
 	0c01  Xeon E3-1200 v3/4th Gen Core Processor PCI Express x16 Controller
 	0c04  Xeon E3-1200 v3/4th Gen Core Processor DRAM Controller
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	0c05  Xeon E3-1200 v3/4th Gen Core Processor PCI Express x8 Controller
 	0c08  Xeon E3-1200 v3 Processor DRAM Controller
 	0c09  Xeon E3-1200 v3/4th Gen Core Processor PCI Express x4 Controller
 	0c0c  Xeon E3-1200 v3/4th Gen Core Processor HD Audio Controller
-		17aa 220e  ThinkPad T440p
 	0c46  Atom Processor S1200 PCI Express Root Port 1
 	0c47  Atom Processor S1200 PCI Express Root Port 2
 	0c48  Atom Processor S1200 PCI Express Root Port 3
@@ -22526,7 +12905,6 @@ var pciids = []byte(`#
 	0f31  Atom Processor Z36xxx/Z37xxx Series Graphics & Display
 	0f34  Atom Processor Z36xxx/Z37xxx Series USB EHCI
 	0f35  Atom Processor Z36xxx/Z37xxx, Celeron N2000 Series USB xHCI
-		1025 0936  Aspire ES1
 	0f37  Atom Processor Z36xxx/Z37xxx Series OTG USB Device
 	0f38  Atom Processor Z36xxx/Z37xxx Series Camera ISP
 	0f40  Atom Processor Z36xxx/Z37xxx Series LPIO2 DMA Controller
@@ -22543,146 +12921,35 @@ var pciids = []byte(`#
 	0f4e  Atom Processor E3800 Series PCI Express Root Port 4
 	0f50  Atom Processor E3800 Series eMMC 4.5 Controller
 	1000  82542 Gigabit Ethernet Controller (Fiber)
-		0e11 b0df  NC6132 Gigabit Ethernet Adapter (1000-SX)
-		0e11 b0e0  NC6133 Gigabit Ethernet Adapter (1000-LX)
-		0e11 b123  NC6134 Gigabit Ethernet Adapter (1000-LX)
-		1014 0119  Netfinity Gigabit Ethernet SX Adapter
-		8086 1000  PRO/1000 Gigabit Server Adapter
 	1001  82543GC Gigabit Ethernet Controller (Fiber)
-		0e11 004a  NC6136 Gigabit Server Adapter
-		1014 01ea  Netfinity Gigabit Ethernet SX Adapter
-		8086 1002  PRO/1000 F Server Adapter
-		8086 1003  PRO/1000 F Server Adapter
 	1002  Pro 100 LAN+Modem 56 Cardbus II
-		8086 200e  Pro 100 LAN+Modem 56 Cardbus II
-		8086 2013  Pro 100 SR Mobile Combo Adapter
-		8086 2017  Pro 100 S Combo Mobile Adapter
 	1004  82543GC Gigabit Ethernet Controller (Copper)
-		0e11 0049  NC7132 Gigabit Upgrade Module
-		0e11 b1a4  NC7131 Gigabit Server Adapter
-		1014 10f2  Gigabit Ethernet Server Adapter
-		8086 1004  PRO/1000 T Server Adapter
-		8086 2004  PRO/1000 T Server Adapter
 	1008  82544EI Gigabit Ethernet Controller (Copper)
-		1014 0269  iSeries 1000/100/10 Ethernet Adapter
-		1028 011b  PowerEdge 1650/2550
-		1028 011c  PRO/1000 XT Network Connection
-		8086 1107  PRO/1000 XT Server Adapter
-		8086 2107  PRO/1000 XT Server Adapter
-		8086 2110  PRO/1000 XT Desktop Adapter
-		8086 3108  PRO/1000 XT Network Connection
 	1009  82544EI Gigabit Ethernet Controller (Fiber)
-		1014 0268  iSeries Gigabit Ethernet Adapter
-		8086 1109  PRO/1000 XF Server Adapter
-		8086 2109  PRO/1000 XF Server Adapter
 	100a  82540EM Gigabit Ethernet Controller
 	100c  82544GC Gigabit Ethernet Controller (Copper)
-		8086 1112  PRO/1000 T Desktop Adapter
-		8086 2112  PRO/1000 T Desktop Adapter
 	100d  82544GC Gigabit Ethernet Controller (LOM)
-		1028 0123  PRO/1000 XT Network Connection
-		1079 891f  82544GC Based Network Connection
-		4c53 1080  CT8 mainboard
-		8086 110d  82544GC Based Network Connection
 	100e  82540EM Gigabit Ethernet Controller
-		1014 0265  PRO/1000 MT Network Connection
-		1014 0267  PRO/1000 MT Network Connection
-		1014 026a  PRO/1000 MT Network Connection
-		1028 002e  Optiplex GX260
-		1028 0134  PowerEdge 600SC
-		1028 0151  Optiplex GX270
-		107b 8920  PRO/1000 MT Desktop Adapter
-		1af4 1100  QEMU Virtual Machine
-		8086 001e  PRO/1000 MT Desktop Adapter
-		8086 002e  PRO/1000 MT Desktop Adapter
-		8086 1376  PRO/1000 GT Desktop Adapter
-		8086 1476  PRO/1000 GT Desktop Adapter
 	100f  82545EM Gigabit Ethernet Controller (Copper)
-		1014 0269  iSeries 1000/100/10 Ethernet Adapter
-		1014 028e  PRO/1000 MT Network Connection
-		15ad 0750  PRO/1000 MT Single Port Adapter
-		8086 1000  PRO/1000 MT Network Connection
-		8086 1001  PRO/1000 MT Server Adapter
 	1010  82546EB Gigabit Ethernet Controller (Copper)
-		0e11 00db  NC7170 Gigabit Server Adapter
-		1014 027c  PRO/1000 MT Dual Port Network Adapter
-		15ad 0760  PRO/1000 MT Dual Port Adapter
-		18fb 7872  RESlink-X
-		1fc1 0026  Niagara 2260 Bypass Card
-		4c53 1080  CT8 mainboard
-		4c53 10a0  CA3/CR3 mainboard
-		8086 1011  PRO/1000 MT Dual Port Server Adapter
-		8086 1012  PRO/1000 MT Dual Port Server Adapter
-		8086 101a  PRO/1000 MT Dual Port Network Connection
-		8086 3424  SE7501HG2 Mainboard
 	1011  82545EM Gigabit Ethernet Controller (Fiber)
-		1014 0268  iSeries Gigabit Ethernet Adapter
-		8086 1002  PRO/1000 MF Server Adapter
-		8086 1003  PRO/1000 MF Server Adapter (LX)
 	1012  82546EB Gigabit Ethernet Controller (Fiber)
-		0e11 00dc  NC6170 Gigabit Server Adapter
-		8086 1012  PRO/1000 MF Dual Port Server Adapter
 	1013  82541EI Gigabit Ethernet Controller
-		8086 0013  PRO/1000 MT Network Connection
-		8086 1013  PRO/1000 MT Network Connection
-		8086 1113  PRO/1000 MT Desktop Adapter
 	1014  82541ER Gigabit Ethernet Controller
-		8086 0014  PRO/1000 MT Desktop Connection
-		8086 1014  PRO/1000 MT Network Connection
 	1015  82540EM Gigabit Ethernet Controller (LOM)
-		8086 1015  PRO/1000 MT Mobile Connection
 	1016  82540EP Gigabit Ethernet Controller (Mobile)
-		1014 052c  PRO/1000 MT Mobile Connection
-		1179 0001  PRO/1000 MT Mobile Connection
-		8086 1016  PRO/1000 MT Mobile Connection
 	1017  82540EP Gigabit Ethernet Controller
-		8086 1017  PR0/1000 MT Desktop Connection
 	1018  82541EI Gigabit Ethernet Controller
-		8086 1018  PRO/1000 MT Mobile Connection
 	1019  82547EI Gigabit Ethernet Controller
-		1458 1019  GA-8IPE1000 Pro2 motherboard (865PE)
-		1458 e000  Intel Gigabit Ethernet (Kenai II)
-		8086 1019  PRO/1000 CT Desktop Connection
-		8086 301f  D865PERL mainboard
-		8086 3025  D875PBZ motherboard
-		8086 302c  D865GBF Mainboard
-		8086 3427  S875WP1-E mainboard
 	101a  82547EI Gigabit Ethernet Controller (Mobile)
-		8086 101a  PRO/1000 CT Mobile Connection
 	101d  82546EB Gigabit Ethernet Controller
-		8086 1000  PRO/1000 MT Quad Port Server Adapter
 	101e  82540EP Gigabit Ethernet Controller (Mobile)
-		1014 0549  Thinkpad
-		1179 0001  PRO/1000 MT Mobile Connection
-		8086 101e  PRO/1000 MT Mobile Connection
 	1026  82545GM Gigabit Ethernet Controller
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		8086 1000  PRO/1000 MT Server Connection
-		8086 1001  PRO/1000 MT Server Adapter
-		8086 1002  PRO/1000 MT Server Adapter
-		8086 1003  PRO/1000 GT Server Adapter
-		8086 1026  PRO/1000 MT Server Connection
 	1027  82545GM Gigabit Ethernet Controller
-		103c 3103  NC310F PCI-X Gigabit Server Adapter
-		8086 1001  PRO/1000 MF Server Adapter(LX)
-		8086 1002  PRO/1000 MF Server Adapter(LX)
-		8086 1003  PRO/1000 MF Server Adapter(LX)
-		8086 1027  PRO/1000 MF Server Adapter
 	1028  82545GM Gigabit Ethernet Controller
-		8086 1028  PRO/1000 MB Server Connection
 	1029  82559 Ethernet Controller
 	1030  82559 InBusiness 10/100
 	1031  82801CAM (ICH3) PRO/100 VE (LOM) Ethernet Controller
-		1014 0209  ThinkPad A/T/X Series
-		104d 80e7  Vaio PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		104d 813c  Vaio PCG-GRV616G
-		107b 5350  EtherExpress PRO/100 VE
-		1179 0001  EtherExpress PRO/100 VE
-		144d c000  EtherExpress PRO/100 VE
-		144d c001  EtherExpress PRO/100 VE
-		144d c003  EtherExpress PRO/100 VE
-		144d c006  vpr Matrix 170B4
 	1032  82801CAM (ICH3) PRO/100 VE Ethernet Controller
 	1033  82801CAM (ICH3) PRO/100 VM (LOM) Ethernet Controller
 	1034  82801CAM (ICH3) PRO/100 VM Ethernet Controller
@@ -22690,43 +12957,21 @@ var pciids = []byte(`#
 	1036  82801CAM (ICH3) 82562EH Ethernet Controller
 	1037  82801CAM (ICH3) Chipset Ethernet Controller
 	1038  82801CAM (ICH3) PRO/100 VM (KM) Ethernet Controller
-		0e11 0098  Evo N600c
 	1039  82801DB PRO/100 VE (LOM) Ethernet Controller
-		1014 0267  NetVista A30p
-		114a 0582  PC8 onboard ethernet ETH1
 	103a  82801DB PRO/100 VE (CNR) Ethernet Controller
 	103b  82801DB PRO/100 VM (LOM) Ethernet Controller
 	103c  82801DB PRO/100 VM (CNR) Ethernet Controller
 	103d  82801DB PRO/100 VE (MOB) Ethernet Controller
-		1014 0522  ThinkPad R40
-		1028 2002  Latitude D500
-		8086 103d  82562EZ 10/100 Ethernet Controller
 	103e  82801DB PRO/100 VM (MOB) Ethernet Controller
 	1040  536EP Data Fax Modem
-		16be 1040  V.9X DSP Data Fax Modem
 	1043  PRO/Wireless LAN 2100 3B Mini PCI Adapter
-		103c 08b0  tc1100 tablet
-		8086 2522  Samsung X10/P30 integrated WLAN
-		8086 2527  MIM2000/Centrino
-		8086 2561  Dell Latitude D800
-		8086 2581  Toshiba Satellite M10
 	1048  82597EX 10GbE Ethernet Controller
-		8086 a01f  PRO/10GbE LR Server Adapter
-		8086 a11f  PRO/10GbE LR Server Adapter
 	1049  82566MM Gigabit Network Connection
-		103c 30c1  Compaq 6910p
-		17aa 20b9  ThinkPad T61/R61
 	104a  82566DM Gigabit Network Connection
 	104b  82566DC Gigabit Network Connection
 	104c  82562V 10/100 Network Connection
 	104d  82566MC Gigabit Network Connection
 	1050  82562EZ 10/100 Ethernet Controller
-		1028 019d  Dimension 3000
-		1462 728c  865PE Neo2 (MS-6728)
-		1462 758c  MS-6758 (875P Neo)
-		8086 3020  D865PERL mainboard
-		8086 302f  Desktop Board D865GBF
-		8086 3427  S875WP1-E mainboard
 	1051  82801EB/ER (ICH5/ICH5R) integrated LAN Controller
 	1052  PRO/100 VM Network Connection
 	1053  PRO/100 VM Network Connection
@@ -22737,85 +12982,26 @@ var pciids = []byte(`#
 	1059  82551QM Ethernet Controller
 	105b  82546GB Gigabit Ethernet Controller (Copper)
 	105e  82571EB Gigabit Ethernet Controller
-		103c 7044  NC360T PCI Express Dual Port Gigabit Server Adapter
-		103c 704e  Dual Port 1000Base-T (PCIe) [AD337A]
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 6003  Telum GE-QT
-		18df 1214  2x 1GbE, PCIe x1, dual Intel 82571EB chips
-		8086 005e  PRO/1000 PT Dual Port Server Connection
-		8086 105e  PRO/1000 PT Dual Port Network Connection
-		8086 10d5  82571PT Gigabit PT Quad Port Server ExpressModule
-		8086 115e  PRO/1000 PT Dual Port Server Adapter
-		8086 125e  PRO/1000 PT Dual Port Server Adapter
-		8086 135e  PRO/1000 PT Dual Port Server Adapter
 	105f  82571EB Gigabit Ethernet Controller
-		103c 704f  Dual Port 1000Base-SX (PCIe) [AD338A]
-		8086 005a  PRO/1000 PF Dual Port Server Adapter
-		8086 115f  PRO/1000 PF Dual Port Server Adapter
-		8086 125f  PRO/1000 PF Dual Port Server Adapter
-		8086 135f  PRO/1000 PF Dual Port Server Adapter
 	1060  82571EB Gigabit Ethernet Controller
-		8086 0060  PRO/1000 PB Dual Port Server Connection
-		8086 1060  PRO/1000 PB Dual Port Server Connection
 	1064  82562ET/EZ/GT/GZ - PRO/100 VE (LOM) Ethernet Controller
-		1043 80f8  P5GD1-VW Mainboard
 	1065  82562ET/EZ/GT/GZ - PRO/100 VE Ethernet Controller
 	1066  82562 EM/EX/GX - PRO/100 VM (LOM) Ethernet Controller
 	1067  82562 EM/EX/GX - PRO/100 VM Ethernet Controller
 	1068  82562ET/EZ/GT/GZ - PRO/100 VE (LOM) Ethernet Controller Mobile
-		103c 30d5  530 Laptop
 	1069  82562EM/EX/GX - PRO/100 VM (LOM) Ethernet Controller Mobile
 	106a  82562G - PRO/100 VE (LOM) Ethernet Controller
 	106b  82562G - PRO/100 VE Ethernet Controller Mobile
 	1075  82547GI Gigabit Ethernet Controller
-		1028 0165  PowerEdge 750
-		8086 0075  PRO/1000 CT Network Connection
-		8086 1075  PRO/1000 CT Network Connection
 	1076  82541GI Gigabit Ethernet Controller
-		1028 0165  PRO/1000 MT Network Connection
-		1028 016d  PRO/1000 MT Network Connection
-		1028 019a  PRO/1000 MT Network Connection
-		1028 106d  PRO/1000 MT Network Connection
-		8086 0076  PRO/1000 MT Network Connection
-		8086 1076  PRO/1000 MT Network Connection
-		8086 1176  PRO/1000 MT Desktop Adapter
-		8086 1276  PRO/1000 MT Network Adapter
 	1077  82541GI Gigabit Ethernet Controller
-		1179 0001  PRO/1000 MT Mobile Connection
-		8086 0077  PRO/1000 MT Mobile Connection
-		8086 1077  PRO/1000 MT Mobile Connection
 	1078  82541ER Gigabit Ethernet Controller
-		8086 1078  82541ER-based Network Connection
 	1079  82546GB Gigabit Ethernet Controller
-		103c 12a6  Dual Port 1000Base-T [A9900A]
-		103c 12cf  Core Dual Port 1000Base-T [AB352A]
-		1775 10d0  V5D Single Board Computer Gigabit Ethernet
-		1775 ce90  CE9
-		1fc1 0027  Niagara 2261 Failover NIC
-		4c53 1090  Cx9 / Vx9 mainboard
-		4c53 10b0  CL9 mainboard
-		8086 0079  PRO/1000 MT Dual Port Network Connection
-		8086 1079  PRO/1000 MT Dual Port Network Connection
-		8086 1179  PRO/1000 MT Dual Port Server Adapter
-		8086 117a  PRO/1000 MT Dual Port Server Adapter
 	107a  82546GB Gigabit Ethernet Controller
-		103c 12a8  Dual Port 1000base-SX [A9899A]
-		8086 107a  PRO/1000 MF Dual Port Server Adapter
-		8086 127a  PRO/1000 MF Dual Port Server Adapter
 	107b  82546GB Gigabit Ethernet Controller
-		8086 007b  PRO/1000 MB Dual Port Server Connection
-		8086 107b  PRO/1000 MB Dual Port Server Connection
 	107c  82541PI Gigabit Ethernet Controller
-		8086 1376  PRO/1000 GT Desktop Adapter
-		8086 1476  PRO/1000 GT Desktop Adapter
 	107d  82572EI Gigabit Ethernet Controller (Copper)
-		8086 1082  PRO/1000 PT Server Adapter
-		8086 1084  PRO/1000 PT Server Adapter
-		8086 1092  PRO/1000 PT Server Adapter
 	107e  82572EI Gigabit Ethernet Controller (Fiber)
-		8086 1084  PRO/1000 PF Server Adapter
-		8086 1085  PRO/1000 PF Server Adapter
-		8086 1094  PRO/1000 PF Server Adapter
 	107f  82572EI Gigabit Ethernet Controller
 	1080  FA82537EP 56K V.92 Data/Fax Modem PCI
 	1081  631xESB/632xESB LAN Controller Copper
@@ -22827,227 +13013,93 @@ var pciids = []byte(`#
 	1087  631xESB/632xESB UHCI Redirection
 	1089  631xESB/632xESB BT
 	108a  82546GB Gigabit Ethernet Controller
-		8086 108a  PRO/1000 P Dual Port Server Adapter
-		8086 118a  PRO/1000 P Dual Port Server Adapter
 	108b  82573V Gigabit Ethernet Controller (Copper)
-		1462 176c  on board on MSI 945P - NEO (MS-7176)
 	108c  82573E Gigabit Ethernet Controller (Copper)
 	108e  82573E KCS (Active Management)
 	108f  Active Management Technology - SOL
 	1091  PRO/100 VM Network Connection
 	1092  PRO/100 VE Network Connection
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
 	1093  PRO/100 VM Network Connection
 	1094  PRO/100 VE Network Connection
 	1095  PRO/100 VE Network Connection
 	1096  80003ES2LAN Gigabit Ethernet Controller (Copper)
-		15d9 1096  Motherboard
-		15d9 8680  X7DVL-E-O motherboard
-		8086 3476  S5000PSLSATA Server Board
 	1097  631xESB/632xESB DPT LAN Controller (Fiber)
 	1098  80003ES2LAN Gigabit Ethernet Controller (Serdes)
 	1099  82546GB Gigabit Ethernet Controller (Copper)
-		8086 1099  PRO/1000 GT Quad Port Server Adapter
 	109a  82573L Gigabit Ethernet Controller
-		1179 ff10  PRO/1000 PL
-		17aa 2001  ThinkPad T60
-		17aa 207e  ThinkPad X60/X60s
-		8086 109a  PRO/1000 PL Network Connection
-		8086 309c  Desktop Board D945GTP
-		8086 30a5  Desktop Board D975XBX
 	109b  82546GB PRO/1000 GF Quad Port Server Adapter
 	109e  82597EX 10GbE Ethernet Controller
-		8086 a01f  PRO/10GbE CX4 Server Adapter
-		8086 a11f  PRO/10GbE CX4 Server Adapter
 	10a0  82571EB PRO/1000 AT Quad Port Bypass Adapter
 	10a1  82571EB PRO/1000 AF Quad Port Bypass Adapter
 	10a4  82571EB Gigabit Ethernet Controller
-		8086 10a4  PRO/1000 PT Quad Port Server Adapter
-		8086 11a4  PRO/1000 PT Quad Port Server Adapter
 	10a5  82571EB Gigabit Ethernet Controller (Fiber)
-		8086 10a5  PRO/1000 PF Quad Port Server Adapter
-		8086 10a6  PRO/1000 PF Quad Port Server Adapter
 	10a6  82599EB 10-Gigabit Dummy Function
 	10a7  82575EB Gigabit Network Connection
-		8086 10a8  82575EB Gigabit Riser Card
 	10a9  82575EB Gigabit Backplane Connection
 	10b0  82573L PRO/1000 PL Network Connection
 	10b2  82573V PRO/1000 PM Network Connection
 	10b3  82573E PRO/1000 PM Network Connection
 	10b4  82573L PRO/1000 PL Network Connection
 	10b5  82546GB Gigabit Ethernet Controller (Copper)
-		103c 3109  NC340T PCI-X Quad-port Gigabit Server Adapter
-		8086 1099  PRO/1000 GT Quad Port Server Adapter
-		8086 1199  PRO/1000 GT Quad Port Server Adapter
 	10b6  82598 10GbE PCI-Express Ethernet Controller
 	10b9  82572EI Gigabit Ethernet Controller (Copper)
-		103c 704a  110T PCIe Gigabit Server Adapter
-		8086 1083  PRO/1000 PT Desktop Adapter
-		8086 1093  PRO/1000 PT Desktop Adapter
 	10ba  80003ES2LAN Gigabit Ethernet Controller (Copper)
 	10bb  80003ES2LAN Gigabit Ethernet Controller (Serdes)
 	10bc  82571EB Gigabit Ethernet Controller (Copper)
-		1014 0368  4-Port 10/100/1000 Base-TX PCI Express Adapter for POWER
-		103c 704b  NC364T PCI Express Quad Port Gigabit Server Adapter
-		108e 11bc  x4 PCI-Express Quad Gigabit Ethernet UTP Low Profile Adapter
-		8086 10bc  PRO/1000 PT Quad Port LP Server Adapter
-		8086 11bc  PRO/1000 PT Quad Port LP Server Adapter
 	10bd  82566DM-2 Gigabit Network Connection
-		1028 0211  OptiPlex 755
 	10bf  82567LF Gigabit Network Connection
 	10c0  82562V-2 10/100 Network Connection
-		1028 020d  Inspiron 530
 	10c2  82562G-2 10/100 Network Connection
 	10c3  82562GT-2 10/100 Network Connection
 	10c4  82562GT 10/100 Network Connection
 	10c5  82562G 10/100 Network Connection
 	10c6  82598EB 10-Gigabit AF Dual Port Network Connection
-		8086 a05f  10-Gigabit XF SR Dual Port Server Adapter
-		8086 a15f  10-Gigabit XF SR Dual Port Server Adapter
 	10c7  82598EB 10-Gigabit AF Network Connection
-		1014 037f  10-Gigabit XF SR Server Adapter
-		1014 0380  10-Gigabit XF LR Server Adapter
-		8086 a05f  10-Gigabit XF SR Server Adapter
-		8086 a15f  10-Gigabit XF SR Server Adapter
-		8086 a16f  10-Gigabit XF SR Server Adapter
 	10c8  82598EB 10-Gigabit AT Network Connection
-		8086 a10c  10-Gigabit AT Server Adapter
-		8086 a11c  10-Gigabit AT Server Adapter
-		8086 a12c  10-Gigabit AT Server Adapter
 	10c9  82576 Gigabit Network Connection
-		103c 31ef  NC362i Integrated Dual port Gigabit Server Adapter
-		103c 323f  NC362i Integrated Dual port Gigabit Server Adapter
-		10a9 8028  UV-BaseIO dual-port GbE
-		13a3 0037  DS4100 Secure Multi-Gigabit Server Adapter with Compression
-		15d9 a811  H8DGU
-		8086 a01c  Gigabit ET Dual Port Server Adapter
-		8086 a03c  Gigabit ET Dual Port Server Adapter
-		8086 a04c  Gigabit ET Dual Port Server Adapter
 	10ca  82576 Virtual Function
 	10cb  82567V Gigabit Network Connection
 	10cc  82567LM-2 Gigabit Network Connection
 	10cd  82567LF-2 Gigabit Network Connection
 	10ce  82567V-2 Gigabit Network Connection
 	10d3  82574L Gigabit Network Connection
-		103c 1785  NC112i 1-port Ethernet Server Adapter
-		103c 3250  NC112T PCI Express single Port Gigabit Server Adapter
-		1043 8369  Motherboard
-		1093 76e9  PCIe-8233 Ethernet Adapter
-		10a9 8029  Prism XL Single Port Gigabit Ethernet
-		15d9 060a  X7SPA-H/X7SPA-HF Motherboard
-		15d9 060d  C7SIM-Q Motherboard
-		8086 0001  Gigabit CT2 Desktop Adapter
-		8086 357a  Server Board S1200BTS
-		8086 a01f  Gigabit CT Desktop Adapter
-		e4bf 50c1  PC1-GROOVE
-		e4bf 50c2  PC2-LIMBO
 	10d4  Matrox Concord GE (customized Intel 82574)
 	10d5  82571PT Gigabit PT Quad Port Server ExpressModule
 	10d6  82575GB Gigabit Network Connection
-		8086 10d6  Gigabit VT Quad Port Server Adapter
-		8086 145a  Gigabit VT Quad Port Server Adapter
-		8086 147a  Gigabit VT Quad Port Server Adapter
 	10d8  82599EB 10 Gigabit Unprogrammed
 	10d9  82571EB Dual Port Gigabit Mezzanine Adapter
-		103c 1716  NC360m Dual Port 1GbE BL-c Adapter
 	10da  82571EB Quad Port Gigabit Mezzanine Adapter
-		103c 1717  NC364m Quad Port 1GbE BL-c Adapter
 	10db  82598EB 10-Gigabit Dual Port Network Connection
 	10dd  82598EB 10-Gigabit AT CX4 Network Connection
 	10de  82567LM-3 Gigabit Network Connection
 	10df  82567LF-3 Gigabit Network Connection
 	10e1  82598EB 10-Gigabit AF Dual Port Network Connection
-		8086 a15f  10-Gigabit SR Dual Port Express Module
 	10e2  82575GB Gigabit Network Connection
-		8086 10e2  Gigabit VT Quad Port Server Adapter
 	10e5  82567LM-4 Gigabit Network Connection
 	10e6  82576 Gigabit Network Connection
-		8086 a01f  Gigabit EF Dual Port Server Adapter
-		8086 a02f  Gigabit EF Dual Port Server Adapter
 	10e7  82576 Gigabit Network Connection
-		103c 31ff  NC362i Integrated Dual Port BL-c Gigabit Server Adapter
 	10e8  82576 Gigabit Network Connection
-		8086 a02b  Gigabit ET Quad Port Server Adapter
-		8086 a02c  Gigabit ET Quad Port Server Adapter
 	10ea  82577LM Gigabit Network Connection
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		e4bf 50c1  PC1-GROOVE
 	10eb  82577LC Gigabit Network Connection
 	10ec  82598EB 10-Gigabit AT CX4 Network Connection
-		8086 a01f  10-Gigabit CX4 Dual Port Server Adapter
-		8086 a11f  10-Gigabit CX4 Dual Port Server Adapter
 	10ed  82599 Ethernet Controller Virtual Function
 	10ef  82578DM Gigabit Network Connection
-		1028 02da  OptiPlex 980
-		15d9 060d  C7SIM-Q Motherboard
 	10f0  82578DC Gigabit Network Connection
 	10f1  82598EB 10-Gigabit AF Dual Port Network Connection
-		8086 a20f  10-Gigabit AF DA Dual Port Server Adapter
-		8086 a21f  10-Gigabit AF DA Dual Port Server Adapter
 	10f4  82598EB 10-Gigabit AF Network Connection
-		8086 106f  10-Gigabit XF LR Server Adapter
-		8086 a06f  10-Gigabit XF LR Server Adapter
 	10f5  82567LM Gigabit Network Connection
 	10f6  82574L Gigabit Network Connection
 	10f7  10 Gigabit BR KX4 Dual Port Network Connection
-		108e 7b12  Sun Dual 10GbE PCIe 2.0 FEM
-		8086 000d  Ethernet Mezzanine Adapter X520-KX4-2
 	10f8  82599 10 Gigabit Dual Port Backplane Connection
-		1028 1f63  10GbE 2P X520k bNDC
-		103c 17d2  Ethernet 10Gb 2-port 560M Adapter
-		103c 18d0  Ethernet 10Gb 2-port 560FLB Adapter
-		1059 0111  T4007 10GbE interface
-		1059 0130  T4009 10GbE interface
-		8086 000c  Ethernet X520 10GbE Dual Port KX4-KR Mezz
 	10f9  82599 10 Gigabit Dual Port Network Connection
 	10fb  82599ES 10-Gigabit SFI/SFP+ Network Connection
-		1028 1f72  Ethernet 10G 4P X520/I350 rNDC
-		103c 17d0  Ethernet 10Gb 2-port 560FLR-SFP+ Adapter
-		103c 17d2  Ethernet 10Gb 2-port 560M Adapter
-		103c 17d3  Ethernet 10Gb 2-port 560SFP+ Adapter
-		103c 211b  Ethernet 10Gb 1-port P560FLR-SFP+ Adapter
-		103c 2147  Ethernet 10Gb 1-port 561i Adapter
-		103c 2159  Ethernet 10Gb 2-port 562i Adapter
-		108e 7b11  Ethernet Server Adapter X520-2
-		1170 004c  82599 DP 10G Mezzanine Adapter
-		1734 11a9  10 Gigabit Dual Port Network Connection
-		17aa 1071  ThinkServer X520-2 AnyFabric
-		17aa 4007  82599ES 10-Gigabit SFI/SFP+ Network Connection
-		17aa 402b  82599ES 10Gb 2-port Server Adapter X520-DA2
-		17aa 402f  FPGA Card XC7VX690T-3FFG1157E
-		18d4 0c09  82599ES 10Gb 2-port SFP+ OCP Mezz Card MOP81-I-10GS2
-		1bd4 001b  10G SFP+ DP ER102Fi4 Rack Adapter
-		1bd4 002f  10G SFP+ DP EP102Fi4A Adapter
-		1bd4 0032  10G SFP+ DP EP102Fi4 Adapter
-		8086 0002  Ethernet Server Adapter X520-DA2
-		8086 0003  Ethernet Server Adapter X520-2
-		8086 0006  Ethernet Server Adapter X520-1
-		8086 0008  Ethernet OCP Server Adapter X520-2
-		8086 000a  Ethernet Server Adapter X520-1
-		8086 000c  Ethernet Server Adapter X520-2
-		8086 10a6  82599ES 10Gb 2 port Server Adapter X520-DA2
-		8086 7a11  Ethernet Server Adapter X520-2
-		8086 7a12  Ethernet Server Adapter X520-2
 	10fc  82599 10 Gigabit Dual Port Network Connection
 	10fe  82552 10/100 Network Connection
 	1107  PRO/1000 MF Server Adapter (LX)
 	1130  82815 815 Chipset Host Bridge and Memory Controller Hub
-		1025 1016  Travelmate 612 TX
-		1043 8027  TUSL2-C Mainboard
-		104d 80df  Vaio PCG-FX403
-		8086 4532  Desktop Board D815EEA2/D815EFV
-		8086 4557  D815EGEW Mainboard
 	1131  82815 815 Chipset AGP Bridge
 	1132  82815 Chipset Graphics Controller (CGC)
-		1025 1016  Travelmate 612 TX
-		103c 2001  e-pc 40
-		104d 80df  Vaio PCG-FX403
-		8086 4532  Desktop Board D815EEA2/D815EFV
-		8086 4541  D815EEA Motherboard
-		8086 4557  D815EGEW Mainboard
 	1161  82806AA PCI64 Hub Advanced Programmable Interrupt Controller
-		8086 1161  82806AA PCI64 Hub APIC
 	1162  Xscale 80200 Big Endian Companion Chip
 	1190  Merrifield SD/SDIO/eMMC Controller
 	1191  Merrifield Serial IO HSUART Controller
@@ -23062,13 +13114,7 @@ var pciids = []byte(`#
 	11a2  Merrifield Serial IO DMA Controller
 	11a5  Merrifield Serial IO PWM Controller
 	1200  IXP1200 Network Processor
-		172a 0000  AEP SSL Accelerator
 	1209  8255xER/82551IT Fast Ethernet Controller
-		140b 0610  PMC610 quad Ethernet board
-		1af4 1100  QEMU Virtual Machine
-		4c53 1050  CT7 mainboard
-		4c53 1051  CE7 mainboard
-		4c53 1070  PC6 mainboard
 	1221  82092AA PCI to PCMCIA Bridge
 	1222  82092AA IDE Controller
 	1223  SAA7116
@@ -23077,167 +13123,6 @@ var pciids = []byte(`#
 	1227  82865 EtherExpress PRO/100A
 	1228  82556 EtherExpress PRO/100 Smart
 	1229  82557/8/9/0/1 Ethernet Pro 100
-		0e11 3001  82559 Fast Ethernet LOM with Alert on LAN*
-		0e11 3002  82559 Fast Ethernet LOM with Alert on LAN*
-		0e11 3003  82559 Fast Ethernet LOM with Alert on LAN*
-		0e11 3004  82559 Fast Ethernet LOM with Alert on LAN*
-		0e11 3005  82559 Fast Ethernet LOM with Alert on LAN*
-		0e11 3006  82559 Fast Ethernet LOM with Alert on LAN*
-		0e11 3007  82559 Fast Ethernet LOM with Alert on LAN*
-		0e11 b01e  NC3120 Fast Ethernet NIC
-		0e11 b01f  NC3122 Fast Ethernet NIC (dual port)
-		0e11 b02f  NC1120 Ethernet NIC
-		0e11 b04a  Netelligent 10/100TX NIC with Wake on LAN
-		0e11 b0c6  NC3161 Fast Ethernet NIC (embedded, WOL)
-		0e11 b0c7  NC3160 Fast Ethernet NIC (embedded)
-		0e11 b0d7  NC3121 Fast Ethernet NIC (WOL)
-		0e11 b0dd  NC3131 Fast Ethernet NIC (dual port)
-		0e11 b0de  NC3132 Fast Ethernet Module (dual port)
-		0e11 b0e1  NC3133 Fast Ethernet Module (100-FX)
-		0e11 b134  NC3163 Fast Ethernet NIC (embedded, WOL)
-		0e11 b13c  NC3162 Fast Ethernet NIC (embedded)
-		0e11 b144  NC3123 Fast Ethernet NIC (WOL)
-		0e11 b163  NC3134 Fast Ethernet NIC (dual port)
-		0e11 b164  NC3135 Fast Ethernet Upgrade Module (dual port)
-		0e11 b1a4  NC7131 Gigabit Server Adapter
-		1014 005c  82558B Ethernet Pro 10/100
-		1014 01bc  82559 Fast Ethernet LAN On Motherboard
-		1014 01f1  10/100 Ethernet Server Adapter
-		1014 01f2  10/100 Ethernet Server Adapter
-		1014 0207  Ethernet Pro/100 S
-		1014 0232  10/100 Dual Port Server Adapter
-		1014 023a  ThinkPad R30
-		1014 105c  Netfinity 10/100
-		1014 2205  ThinkPad A22p
-		1014 305c  10/100 EtherJet Management Adapter
-		1014 405c  10/100 EtherJet Adapter with Alert on LAN
-		1014 505c  10/100 EtherJet Secure Management Adapter
-		1014 605c  10/100 EtherJet Secure Management Adapter
-		1014 705c  10/100 Netfinity 10/100 Ethernet Security Adapter
-		1014 805c  10/100 Netfinity 10/100 Ethernet Security Adapter
-		1028 009b  10/100 Ethernet Server Adapter
-		1028 00ce  10/100 Ethernet Server Adapter
-		1033 8000  PC-9821X-B06
-		1033 8016  PK-UG-X006
-		1033 801f  PK-UG-X006
-		1033 8026  PK-UG-X006
-		1033 8063  82559-based Fast Ethernet Adapter
-		1033 8064  82559-based Fast Ethernet Adapter
-		103c 10c0  NetServer 10/100TX
-		103c 10c3  NetServer 10/100TX
-		103c 10ca  NetServer 10/100TX
-		103c 10cb  NetServer 10/100TX
-		103c 10e3  NetServer 10/100TX
-		103c 10e4  NetServer 10/100TX
-		103c 1200  NetServer 10/100TX
-		108e 10cf  EtherExpress PRO/100(B)
-		10c3 1100  SmartEther100 SC1100
-		10cf 1115  8255x-based Ethernet Adapter (10/100)
-		10cf 1143  8255x-based Ethernet Adapter (10/100)
-		110a 008b  82551QM Fast Ethernet Multifuction PCI/CardBus Controller
-		114a 0582  PC8 onboard ethernet ETH2
-		1179 0001  8255x-based Ethernet Adapter (10/100)
-		1179 0002  PCI FastEther LAN on Docker
-		1179 0003  8255x-based Fast Ethernet
-		1259 2560  AT-2560 100
-		1259 2561  AT-2560 100 FX Ethernet Adapter
-		1266 0001  NE10/100 Adapter
-		13e9 1000  6221L-4U
-		144d 2501  SEM-2000 MiniPCI LAN Adapter
-		144d 2502  SEM-2100IL MiniPCI LAN Adapter
-		1668 1100  EtherExpress PRO/100B (TX) (MiniPCI Ethernet+Modem)
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		1af4 1100  QEMU Virtual Machine
-		4c53 1080  CT8 mainboard
-		4c53 10e0  PSL09 PrPMC
-		8086 0001  EtherExpress PRO/100B (TX)
-		8086 0002  EtherExpress PRO/100B (T4)
-		8086 0003  EtherExpress PRO/10+
-		8086 0004  EtherExpress PRO/100 WfM
-		8086 0005  82557 10/100
-		8086 0006  82557 10/100 with Wake on LAN
-		8086 0007  82558 10/100 Adapter
-		8086 0008  82558 10/100 with Wake on LAN
-		8086 0009  82558B PRO/100+ PCI (TP)
-		8086 000a  EtherExpress PRO/100+ Management Adapter
-		8086 000b  EtherExpress PRO/100+
-		8086 000c  EtherExpress PRO/100+ Management Adapter
-		8086 000d  EtherExpress PRO/100+ Alert On LAN II* Adapter
-		8086 000e  EtherExpress PRO/100+ Management Adapter with Alert On LAN*
-		8086 000f  EtherExpress PRO/100 Desktop Adapter
-		8086 0010  EtherExpress PRO/100 S Management Adapter
-		8086 0011  EtherExpress PRO/100 S Management Adapter
-		8086 0012  EtherExpress PRO/100 S Advanced Management Adapter (D)
-		8086 0013  EtherExpress PRO/100 S Advanced Management Adapter (E)
-		8086 0030  EtherExpress PRO/100  Management Adapter with Alert On LAN* GC
-		8086 0031  EtherExpress PRO/100 Desktop Adapter
-		8086 0040  EtherExpress PRO/100 S Desktop Adapter
-		8086 0041  EtherExpress PRO/100 S Desktop Adapter
-		8086 0042  EtherExpress PRO/100 Desktop Adapter
-		8086 0050  EtherExpress PRO/100 S Desktop Adapter
-		8086 1009  EtherExpress PRO/100+ Server Adapter
-		8086 100c  EtherExpress PRO/100+ Server Adapter (PILA8470B)
-		8086 1012  EtherExpress PRO/100 S Server Adapter (D)
-		8086 1013  EtherExpress PRO/100 S Server Adapter (E)
-		8086 1015  EtherExpress PRO/100 S Dual Port Server Adapter
-		8086 1017  EtherExpress PRO/100+ Dual Port Server Adapter
-		8086 1030  EtherExpress PRO/100+ Management Adapter with Alert On LAN* G Server
-		8086 1040  EtherExpress PRO/100 S Server Adapter
-		8086 1041  EtherExpress PRO/100 S Server Adapter
-		8086 1042  EtherExpress PRO/100 Server Adapter
-		8086 1050  EtherExpress PRO/100 S Server Adapter
-		8086 1051  EtherExpress PRO/100 Server Adapter
-		8086 1052  EtherExpress PRO/100 Server Adapter
-		8086 10f0  EtherExpress PRO/100+ Dual Port Adapter
-		8086 1229  82557/8/9 [Ethernet Pro 100]
-		8086 2009  EtherExpress PRO/100 S Mobile Adapter
-		8086 200d  EtherExpress PRO/100 Cardbus
-		8086 200e  EtherExpress PRO/100 LAN+V90 Cardbus Modem
-		8086 200f  EtherExpress PRO/100 SR Mobile Adapter
-		8086 2010  EtherExpress PRO/100 S Mobile Combo Adapter
-		8086 2013  EtherExpress PRO/100 SR Mobile Combo Adapter
-		8086 2016  EtherExpress PRO/100 S Mobile Adapter
-		8086 2017  EtherExpress PRO/100 S Combo Mobile Adapter
-		8086 2018  EtherExpress PRO/100 SR Mobile Adapter
-		8086 2019  EtherExpress PRO/100 SR Combo Mobile Adapter
-		8086 2101  EtherExpress PRO/100 P Mobile Adapter
-		8086 2102  EtherExpress PRO/100 SP Mobile Adapter
-		8086 2103  EtherExpress PRO/100 SP Mobile Adapter
-		8086 2104  EtherExpress PRO/100 SP Mobile Adapter
-		8086 2105  EtherExpress PRO/100 SP Mobile Adapter
-		8086 2106  EtherExpress PRO/100 P Mobile Adapter
-		8086 2107  EtherExpress PRO/100 Network Connection
-		8086 2108  EtherExpress PRO/100 Network Connection
-		8086 2200  EtherExpress PRO/100 P Mobile Combo Adapter
-		8086 2201  EtherExpress PRO/100 P Mobile Combo Adapter
-		8086 2202  EtherExpress PRO/100 SP Mobile Combo Adapter
-		8086 2203  EtherExpress PRO/100+ MiniPCI
-		8086 2204  EtherExpress PRO/100+ MiniPCI
-		8086 2205  EtherExpress PRO/100 SP Mobile Combo Adapter
-		8086 2206  EtherExpress PRO/100 SP Mobile Combo Adapter
-		8086 2207  EtherExpress PRO/100 SP Mobile Combo Adapter
-		8086 2208  EtherExpress PRO/100 P Mobile Combo Adapter
-		8086 2402  EtherExpress PRO/100+ MiniPCI
-		8086 2407  EtherExpress PRO/100+ MiniPCI
-		8086 2408  EtherExpress PRO/100+ MiniPCI
-		8086 2409  EtherExpress PRO/100+ MiniPCI
-		8086 240f  EtherExpress PRO/100+ MiniPCI
-		8086 2410  EtherExpress PRO/100+ MiniPCI
-		8086 2411  EtherExpress PRO/100+ MiniPCI
-		8086 2412  EtherExpress PRO/100+ MiniPCI
-		8086 2413  EtherExpress PRO/100+ MiniPCI
-		8086 3000  82559 Fast Ethernet LAN on Motherboard
-		8086 3001  82559 Fast Ethernet LOM with Basic Alert on LAN*
-		8086 3002  82559 Fast Ethernet LOM with Alert on LAN II*
-		8086 3006  EtherExpress PRO/100 S Network Connection
-		8086 3007  EtherExpress PRO/100 S Network Connection
-		8086 3008  EtherExpress PRO/100 Network Connection
-		8086 3010  EtherExpress PRO/100 S Network Connection
-		8086 3011  EtherExpress PRO/100 S Network Connection
-		8086 3012  EtherExpress PRO/100 Network Connection
-		8086 301a  S845WD1-E mainboard
-		8086 3411  SDS2 Mainboard
 	122d  430FX - 82437FX TSC [Triton I]
 	122e  82371FB PIIX ISA [Triton I]
 	1230  82371FB PIIX IDE [Triton I]
@@ -23245,7 +13130,6 @@ var pciids = []byte(`#
 	1234  430MX - 82371MX Mobile PCI I/O IDE Xcelerator (MPIIX)
 	1235  430MX - 82437MX Mob. System Ctrlr (MTSC) & 82438MX Data Path (MTDP)
 	1237  440FX - 82441FX PMC [Natoma]
-		1af4 1100  Qemu virtual machine
 	1239  82371FB PIIX IDE Interface
 	123b  82380PB PCI to PCI Docking Bridge
 	123c  82380AB (MISA) Mobile PCI-to-ISA Bridge
@@ -23257,202 +13141,66 @@ var pciids = []byte(`#
 	1250  430HX - 82439HX TXC [Triton II]
 	1360  82806AA PCI64 Hub PCI Bridge
 	1361  82806AA PCI64 Hub Controller (HRes)
-		8086 1361  82806AA PCI64 Hub Controller (HRes)
-		8086 8000  82806AA PCI64 Hub Controller (HRes)
 	1460  82870P2 P64H2 Hub PCI Bridge
 	1461  82870P2 P64H2 I/OxAPIC
-		15d9 3480  P4DP6
-		4c53 1090  Cx9/Vx9 mainboard
 	1462  82870P2 P64H2 Hot Plug Controller
 	1501  82567V-3 Gigabit Network Connection
 	1502  82579LM Gigabit Network Connection (Lewisville)
-		1028 04a3  Precision M4600
-		17aa 21ce  ThinkPad T520
-		8086 357a  Server Board S1200BTS
 	1503  82579V Gigabit Network Connection
-		1043 849c  P8P67 Deluxe Motherboard
 	1507  Ethernet Express Module X520-P2
 	1508  82598EB Gigabit BX Network Connection
 	150a  82576NS Gigabit Network Connection
 	150b  82598EB 10-Gigabit AT2 Server Adapter
-		8086 a10c  82598EB 10-Gigabit AT2 Server Adapter
-		8086 a11c  82598EB 10-Gigabit AT2 Server Adapter
-		8086 a12c  82598EB 10-Gigabit AT2 Server Adapter
 	150c  82583V Gigabit Network Connection
 	150d  82576 Gigabit Backplane Connection
-		8086 a10c  Gigabit ET Quad Port Mezzanine Card
 	150e  82580 Gigabit Network Connection
-		103c 1780  NC365T 4-port Ethernet Server Adapter
-		8086 12a1  Ethernet Server Adapter I340-T4
-		8086 12a2  Ethernet Server Adapter I340-T4
 	150f  82580 Gigabit Fiber Network Connection
 	1510  82580 Gigabit Backplane Connection
 	1511  82580 Gigabit SFP Connection
 	1513  CV82524 Thunderbolt Controller [Light Ridge 4C 2010]
 	1514  Ethernet X520 10GbE Dual Port KX4 Mezz
-		8086 000b  Ethernet X520 10GbE Dual Port KX4 Mezz
 	1515  X540 Ethernet Controller Virtual Function
 	1516  82580 Gigabit Network Connection
-		8086 12b1  Ethernet Server Adapter I340-T2
-		8086 12b2  Ethernet Server Adapter I340-T2
 	1517  82599ES 10 Gigabit Network Connection
-		1137 006a  UCS CNA M61KR-I Intel Converged Network Adapter
 	1518  82576NS SerDes Gigabit Network Connection
 	151a  DSL2310 Thunderbolt Controller [Eagle Ridge 2C 2011]
 	151b  CVL2510 Thunderbolt Controller [Light Peak 2C 2010]
 	151c  82599 10 Gigabit TN Network Connection
-		108e 7b13  Dual 10GBASE-T LP
 	1520  I350 Ethernet Controller Virtual Function
 	1521  I350 Gigabit Network Connection
-		1028 0602  Gigabit 2P I350-t LOM
-		1028 0693  Gigabit 2P I350-t LOM
-		1028 06e2  Gigabit 2P I350-t LOM
-		1028 0757  Gigabit I350-t LOM
-		1028 075a  Gigabit I350-t LOM
-		1028 1f60  Gigabit 4P I350-t rNDC
-		1028 1f62  Gigabit 4P X540/I350 rNDC
-		1028 1fa8  Ethernet 10G 4P X550/I350 rNDC
-		1028 1fa9  Ethernet 10G 4P X550 rNDC
-		1028 1faa  Gigabit 4P X550/I350 rNDC
-		1028 ff9a  Gigabit 4P X710/I350 rNDC
-		103c 17d1  Ethernet 1Gb 4-port 366FLR Adapter
-		103c 2003  Ethernet 1Gb 2-port 367i Adapter
-		103c 2226  Ethernet 1Gb 1-port 364i Adapter
-		103c 337f  Ethernet 1Gb 2-port 361i Adapter
-		103c 3380  Ethernet 1Gb 4-port 366i Adapter
-		103c 339e  Ethernet 1Gb 2-port 361T Adapter
-		103c 8157  Ethernet 1Gb 4-port 366T Adapter
-		108e 7b16  Quad Port GbE PCIe 2.0 ExpressModule, UTP
-		108e 7b18  Quad Port GbE PCIe 2.0 Low Profile Adapter, UTP
-		1093 7648  PCIe-8237R Ethernet Adapter
-		1093 7649  PCIe-8236 Ethernet Adapter
-		1093 76b1  PCIe-8237R-S Ethernet Adapter
-		1093 775b  PCIe-8237 Ethernet Adapter
-		10a9 802a  UV2-BaseIO dual-port GbE
-		15d9 0652  Dual Port i350 GbE MicroLP [AOC-CGP-i2]
-		17aa 1074  ThinkServer I350-T4 AnyFabric
-		17aa 4005  I350 Gigabit Network Connection
-		18d4 0c07  I350 1Gb 2-port RJ45 OCP Mezz Card MOP41-I-1GT2
-		1bd4 001d  1G base-T QP EP014Ti1 Adapter
-		1bd4 0035  1G base-T QP EP014Ti1 Adapter
-		8086 0001  Ethernet Server Adapter I350-T4
-		8086 0002  Ethernet Server Adapter I350-T2
-		8086 00a1  Ethernet Server Adapter I350-T4
-		8086 00a2  Ethernet Server Adapter I350-T2
-		8086 5001  Ethernet Server Adapter I350-T4
-		8086 5002  Ethernet Server Adapter I350-T2
 	1522  I350 Gigabit Fiber Network Connection
-		108e 7b17  Quad Port GbE PCIe 2.0 ExpressModule, MMF
-		108e 7b19  Dual Port GbE PCIe 2.0 Low Profile Adapter, MMF
-		8086 0002  Ethernet Server Adapter I350-T2
-		8086 0003  Ethernet Server Adapter I350-F4
-		8086 0004  Ethernet Server Adapter I350-F2
-		8086 0005  Ethernet Server Adapter I350-F1
-		8086 00a2  Ethernet Server Adapter I350-T2
-		8086 00a3  Ethernet Server Adapter I350-F4
-		8086 00a4  Ethernet Server Adapter I350-F2
 	1523  I350 Gigabit Backplane Connection
-		1028 0060  Gigabit 2P I350 LOM
-		1028 1f9b  Gigabit 4P I350-t bNDC
-		103c 1784  Ethernet 1Gb 2-port 361FLB Adapter
-		103c 18d1  Ethernet 1Gb 2-port 361FLB Adapter
-		103c 1989  Ethernet 1Gb 2-port 363i Adapter
-		103c 339f  Ethernet 1Gb 4-port 366M Adapter
-		8086 1f52  1GbE 4P I350 Mezz
 	1524  I350 Gigabit Connection
 	1525  82567V-4 Gigabit Network Connection
 	1526  82576 Gigabit Network Connection
-		8086 a05c  Gigabit ET2 Quad Port Server Adapter
-		8086 a06c  Gigabit ET2 Quad Port Server Adapter
 	1527  82580 Gigabit Fiber Network Connection
-		8086 0001  Ethernet Server Adapter I340-F4
-		8086 0002  Ethernet Server Adapter I340-F4
 	1528  Ethernet Controller 10-Gigabit X540-AT2
-		1028 1f61  Ethernet 10G 4P X540/I350 rNDC
-		103c 192d  561FLR-T 2-port 10Gb Ethernet Adapter
-		103c 2004  Ethernet 10Gb 2-port 561i Adapter
-		103c 211a  Ethernet 10Gb 2-port 561T Adapter
-		108e 4853  Ethernet Controller 10-Gigabit X540-AT2
-		108e 7b14  Sun Dual Port 10 GbE PCIe 2.0 ExpressModule, Base-T
-		108e 7b15  Sun Dual Port 10 GbE PCIe 2.0 Low Profile Adapter, Base-T
-		1137 00bf  Ethernet Converged Network Adapter X540-T2
-		17aa 1073  ThinkServer X540-T2 AnyFabric
-		17aa 4006  Ethernet Controller 10-Gigabit X540-AT2
-		1bd4 001a  10G base-T DP ER102Ti3 Rack Adapter
-		1bd4 0033  10G base-T DP EP102Ti3 Adapter
-		1bd4 0034  10G base-T DP EP102Ti3A Adapter
-		8086 0001  Ethernet Converged Network Adapter X540-T2
-		8086 0002  Ethernet Converged Network Adapter X540-T1
-		8086 001a  Ethernet Converged Network Adapter X540-T2
-		8086 00a2  Ethernet Converged Network Adapter X540-T1
-		8086 1f61  Ethernet 10G 4P X540/I350 rNDC
-		8086 5003  Ethernet 10G 2P X540-t Adapter
-		8086 5004  Ethernet 10G 2P X540-t Adapter
 	1529  82599 10 Gigabit Dual Port Network Connection with FCoE
 	152a  82599 10 Gigabit Dual Port Backplane Connection with FCoE
 	152e  82599 Virtual Function
 	152f  I350 Virtual Function
 	1530  X540 Virtual Function
 	1533  I210 Gigabit Network Connection
-		103c 0003  Ethernet I210-T1 GbE NIC
-		1093 7706  Compact Vision System Ethernet Adapter
-		10a9 802c  UV300 BaseIO single-port GbE
-		10a9 802d  UV3000 BaseIO GbE Network
-		17aa 1100  ThinkServer Ethernet Server Adapter
-		8086 0001  Ethernet Server Adapter I210-T1
-		8086 0002  Ethernet Server Adapter I210-T1
 	1536  I210 Gigabit Fiber Network Connection
 	1537  I210 Gigabit Backplane Connection
-		1059 0110  T4005 1GbE interface
-		1059 0111  T4007 1GbE interface
-		1059 0120  T4008 1GbE interface
-		1059 0130  T4009 1GbE interface
-		1059 0140  T2035 1GbE interface
-		1059 0150  RD-01068 1GbE interface
 	1538  I210 Gigabit Network Connection
 	1539  I211 Gigabit Network Connection
 	153a  Ethernet Connection I217-LM
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	153b  Ethernet Connection I217-V
 	1547  DSL3510 Thunderbolt Controller [Cactus Ridge 4C 2012]
 	1548  DSL3310 Thunderbolt Controller [Cactus Ridge 2C 2012]
 	1549  DSL2210 Thunderbolt Controller [Port Ridge 1C 2011]
 	154a  Ethernet Server Adapter X520-4
-		8086 011a  Ethernet Converged Network Adapter X520-4
-		8086 011b  Ethernet Converged Network Adapter X520-4
-		8086 011c  Ethernet Converged Network Adapter X520-4
 	154c  Ethernet Virtual Function 700 Series
 	154d  Ethernet 10G 2P X520 Adapter
-		8086 7b11  10GbE 2P X520 Adapter
 	1557  82599 10 Gigabit Network Connection
-		17aa 4008  82599EN 10 Gigabit Network Connection
-		1bd4 001c  10G SFP+ SP ER101Fi4 Rack Adapter
-		1bd4 0030  10G SFP+ SP EP101Fi4A Adapter
-		8086 0001  Ethernet OCP Server Adapter X520-1
 	1558  Ethernet Converged Network Adapter X520-Q1
-		8086 011a  Ethernet Converged Network Adapter X520-Q1
-		8086 011b  Ethernet Converged Network Adapter X520-Q1
 	1559  Ethernet Connection I218-V
 	155a  Ethernet Connection I218-LM
-		17aa 2214  ThinkPad X240
 	155c  Ethernet Server Bypass Adapter
-		8086 0001  Ethernet Server Bypass Adapter X540-T2
 	155d  Ethernet Server Bypass Adapter
-		8086 0001  Ethernet Server Bypass Adapter X520-SR2
-		8086 0002  Ethernet Server Bypass Adapter X520-LR2
 	1560  Ethernet Controller X540
 	1563  Ethernet Controller 10G X550T
-		1028 1fa8  Ethernet 10G 4P X550/I350 rNDC
-		1028 1fa9  Ethernet 10G 4P X550 rNDC
-		1590 00d1  Ethernet 10Gb 2-port 562T Adapter
-		1590 00d2  Ethernet 10Gb 2-port 562FLR-T Adapter
-		18d4 0c08  X550 10Gb 2-port RJ45 OCP Mezz Card MOP81-I-10GT2
-		8086 0001  Ethernet Converged Network Adapter X550-T2
-		8086 001a  Ethernet Converged Network Adapter X550-T2
-		8086 001b  Ethernet Server Adapter X550-T2 for OCP
-		8086 001d  Ethernet 10G 2P X550-t Adapter
-		8086 0022  Ethernet Converged Network Adapter X550-T2
 	1564  X550 Virtual Function
 	1565  X550 Virtual Function
 	1566  DSL4410 Thunderbolt NHI [Redwood Ridge 2C 2013]
@@ -23467,39 +13215,6 @@ var pciids = []byte(`#
 	1570  Ethernet Connection I219-V
 	1571  Ethernet Virtual Function 700 Series
 	1572  Ethernet Controller X710 for 10GbE SFP+
-		1028 0000  Ethernet 10G X710 rNDC
-		1028 1f99  Ethernet 10G 4P X710/I350 rNDC
-		1028 1f9c  Ethernet 10G 4P X710 SFP+ rNDC
-		103c 0000  Ethernet 10Gb 562SFP+ Adapter
-		103c 22fc  Ethernet 10Gb 2-port 562FLR-SFP+ Adapter
-		103c 22fd  Ethernet 10Gb 2-port 562SFP+ Adapter
-		1137 0000  Ethernet Converged NIC X710-DA
-		1137 013b  Ethernet Converged NIC X710-DA4
-		1137 020a  Ethernet Converged NIC X710-DA2
-		1590 0000  Ethernet Controller X710 for 10GbE SFP+
-		1590 0225  Ethernet 10GbE 4P 563SFP+ Adapter
-		1590 022f  Ethernet 10Gb 2-port 564i Communication Board
-		17aa 0000  ThinkServer X710 AnyFabric for 10GbE SFP+
-		17aa 4001  ThinkServer X710-4 AnyFabric for 10GbE SFP+
-		17aa 4002  ThinkServer X710-2 AnyFabric for 10GbE SFP+
-		19e5 d11c  Ethernet 2-port X710 10Gb SFP+ Adapter SP330
-		8086 0000  Ethernet Converged Network Adapter X710
-		8086 0001  Ethernet Converged Network Adapter X710-4
-		8086 0002  Ethernet Converged Network Adapter X710-4
-		8086 0004  Ethernet Converged Network Adapter X710-4
-		8086 0005  Ethernet 10G 4P X710 Adapter
-		8086 0006  Ethernet 10G 2P X710 Adapter
-		8086 0007  Ethernet Converged Network Adapter X710-2
-		8086 0008  Ethernet Converged Network Adapter X710-2
-		8086 0009  Ethernet Controller X710 for 10GbE SFP+
-		8086 000a  Ethernet Controller X710 for 10GbE SFP+
-		8086 000b  Ethernet Server Adapter X710-DA2 for OCP
-		8086 000d  Ethernet Controller X710 for 10GbE SFP+
-		8086 000e  Ethernet Server Adapter OCP X710-2
-		8086 0010  Ethernet Converged Network Adapter X710
-		8086 4005  Ethernet Controller X710 for 10GbE SFP+
-		8086 4006  Ethernet Controller X710 for 10GbE SFP+
-		8086 4007  Ethernet Controller X710 for 10GbE SFP+
 	1575  DSL6340 Thunderbolt 3 NHI [Alpine Ridge 2C 2015]
 	1576  DSL6340 Thunderbolt 3 Bridge [Alpine Ridge 2C 2015]
 	1577  DSL6540 Thunderbolt 3 NHI [Alpine Ridge 4C 2015]
@@ -23510,65 +13225,15 @@ var pciids = []byte(`#
 	157e  DSL5110 Thunderbolt 2 Bridge (Low Power) [Win Ridge 2C 2014]
 	1580  Ethernet Controller XL710 for 40GbE backplane
 	1581  Ethernet Controller X710 for 10GbE backplane
-		1028 0000  Ethernet 10G X710-k bNDC
-		1028 1f98  Ethernet 10G 4P X710-k bNDC
-		1028 1f9e  Ethernet 10G 2P X710-k bNDC
-		1059 0150  RD-01068 10GbE-KR interface
-		1590 0000  Ethernet 2-port 563i Adapter
-		1590 00f8  Ethernet 2-port 563i Adapter
-		8086 0000  Ethernet Converged Network Adapter XL710-Q2
 	1583  Ethernet Controller XL710 for 40GbE QSFP+
-		1028 0000  Ethernet 40G 2P XL710 QSFP+ rNDC
-		1028 1f9f  Ethernet 40G 2P XL710 QSFP+ rNDC
-		108e 0000  10 Gb/40 Gb Ethernet Adapter
-		108e 7b1b  10 Gb/40 Gb Ethernet Adapter
-		1137 0000  Ethernet Converged NIC XL710-QDA2
-		1137 013c  Ethernet Converged NIC XL710-QDA2
-		8086 0000  Ethernet Converged Network Adapter XL710-Q2
-		8086 0001  Ethernet Converged Network Adapter XL710-Q2
-		8086 0002  Ethernet Converged Network Adapter XL710-Q2
-		8086 0003  Ethernet I/O Module XL710-Q2
-		8086 0004  Ethernet Server Adapter XL710-Q2OCP
-		8086 0006  Ethernet Converged Network Adapter XL710-Q2
 	1584  Ethernet Controller XL710 for 40GbE QSFP+
-		8086 0000  Ethernet Converged Network Adapter XL710-Q1
-		8086 0001  Ethernet Converged Network Adapter XL710-Q1
-		8086 0002  Ethernet Converged Network Adapter XL710-Q1
-		8086 0003  Ethernet I/O Module XL710-Q1
-		8086 0004  Ethernet Server Adapter XL710-Q1OCP
 	1585  Ethernet Controller X710 for 10GbE QSFP+
 	1586  Ethernet Controller X710 for 10GBASE-T
-		108e 0000  Ethernet Controller X710 for 10GBASE-T
-		108e 4857  Ethernet Controller X710 for 10GBASE-T
 	1587  Ethernet Controller XL710 for 20GbE backplane
-		103c 0000  Ethernet 10/20Gb 2-port 660FLB Adapter
-		103c 22fe  Ethernet 10/20Gb 2-port 660FLB Adapter
 	1588  Ethernet Controller XL710 for 20GbE backplane
-		103c 0000  Ethernet 10/20Gb 2-port 660M Adapter
-		103c 22ff  Ethernet 10/20Gb 2-port 660M Adapter
 	1589  Ethernet Controller X710/X557-AT 10GBASE-T
-		108e 0000  Quad Port 10GBase-T Adapter
-		108e 7b1c  Quad Port 10GBase-T Adapter
-		8086 0000  Ethernet Converged Network Adapter X710-T
-		8086 0001  Ethernet Converged Network Adapter X710-T4
-		8086 0002  Ethernet Converged Network Adapter X710-T4
-		8086 0003  Ethernet Converged Network Adapter X710-T
-		8086 00a0  Ethernet Converged Network Adapter X710-T4
-		8086 1003  Ethernet Converged Network Adapter X710-T
 	158a  Ethernet Controller XXV710 for 25GbE backplane
-		8086 000a  Ethernet 25G 2P XXV710 Mezz
 	158b  Ethernet Controller XXV710 for 25GbE SFP28
-		8086 0000  Ethernet Network Adapter XXV710
-		8086 0001  Ethernet Network Adapter XXV710-2
-		8086 0002  Ethernet Network Adapter XXV710-2
-		8086 0003  Ethernet Network Adapter XXV710-1
-		8086 0004  Ethernet Network Adapter XXV710-1
-		8086 0005  Ethernet Network Adapter OCP XXV710-2
-		8086 0006  Ethernet Network Adapter OCP XXV710-2
-		8086 0007  Ethernet Network Adapter OCP XXV710-1
-		8086 0008  Ethernet Network Adapter OCP XXV710-1
-		8086 0009  Ethernet 25G 2P XXV710 Adapter
-		8086 4001  Ethernet Network Adapter XXV710-2
 	15a0  Ethernet Connection (2) I218-LM
 	15a1  Ethernet Connection (2) I218-V
 	15a2  Ethernet Connection (3) I218-LM
@@ -23578,8 +13243,6 @@ var pciids = []byte(`#
 	15a8  Ethernet Connection X552 Virtual Function
 	15a9  X552 Virtual Function
 	15aa  Ethernet Connection X552 10 GbE Backplane
-		1059 0120  T4008 10GbE interface
-		1059 0150  RD-01068 10GbE interface
 	15ab  Ethernet Connection X552 10 GbE Backplane
 	15ac  Ethernet Connection X552 10 GbE SFP+
 	15ad  Ethernet Connection X552/X557-AT 10GBASE-T
@@ -23607,20 +13270,13 @@ var pciids = []byte(`#
 	15ce  Ethernet Connection X553 10 GbE SFP+
 	15d0  Ethernet SDI Adapter FM10420-100GbE-QDA2
 	15d1  Ethernet Controller 10G X550T
-		8086 0002  Ethernet Converged Network Adapter X550-T1
-		8086 001b  Ethernet Server Adapter X550-T1 for OCP
-		8086 0021  Ethernet Converged Network Adapter X550-T1
-		8086 00a2  Ethernet Converged Network Adapter X550-T1
 	15d2  JHL6540 Thunderbolt 3 NHI (C step) [Alpine Ridge 4C 2016]
 	15d3  JHL6540 Thunderbolt 3 Bridge (C step) [Alpine Ridge 4C 2016]
 	15d4  JHL6540 Thunderbolt 3 USB Controller (C step) [Alpine Ridge 4C 2016]
 	15d5  Ethernet SDI Adapter FM10420-25GbE-DA2
-		8086 0001  Intel(R) Ethernet SDI Adapter FM10420-25GbE-DA2
 	15d6  Ethernet Connection (5) I219-V
 	15d7  Ethernet Connection (4) I219-LM
 	15d8  Ethernet Connection (4) I219-V
-		17aa 2247  ThinkPad T570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
 	15d9  JHL6340 Thunderbolt 3 NHI (C step) [Alpine Ridge 2C 2016]
 	15da  JHL6340 Thunderbolt 3 Bridge (C step) [Alpine Ridge 2C 2016]
 	15df  Ethernet Connection (8) I219-LM
@@ -23650,7 +13306,6 @@ var pciids = []byte(`#
 	1612  HD Graphics 5600
 	1614  Broadwell-U Host Bridge - DMI
 	1616  HD Graphics 5500
-		103c 2216  ZBook 15u G2 Mobile Workstation
 	1618  Broadwell-U Host Bridge - DMI
 	161a  Broadwell-U Integrated Graphics
 	161b  Broadwell-U Integrated Graphics
@@ -23674,22 +13329,16 @@ var pciids = []byte(`#
 	1902  HD Graphics 510
 	1903  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Thermal Subsystem
 	1904  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
-		1028 06f3  Latitude 3570
-		17aa 382a  B51-80 Laptop
 	1905  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor PCIe Controller (x8)
 	1906  HD Graphics 510
-		17aa 382a  B51-80 Laptop
 	1908  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 	1909  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor PCIe Controller (x4)
 	190c  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 	190f  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 	1910  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 	1911  Xeon E3-1200 v5/v6 / E3-1500 v5 / 6th/7th Gen Core Processor Gaussian Mixture Model
-		17aa 2247  ThinkPad T570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
 	1912  HD Graphics 530
 	1916  Skylake GT2 [HD Graphics 520]
-		1028 06f3  Latitude 3570
 	1918  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Host Bridge/DRAM Registers
 	1919  Xeon E3-1200 v5/E3-1500 v5/6th Gen Core Processor Imaging Unit
 	191b  HD Graphics 530
@@ -23706,32 +13355,7 @@ var pciids = []byte(`#
 	193b  Iris Pro Graphics 580
 	193d  Iris Pro Graphics P580
 	1960  80960RP (i960RP) Microprocessor
-		101e 0431  MegaRAID 431 RAID Controller
-		101e 0438  MegaRAID 438 Ultra2 LVD RAID Controller
-		101e 0466  MegaRAID 466 Express Plus RAID Controller
-		101e 0467  MegaRAID 467 Enterprise 1500 RAID Controller
-		101e 0490  MegaRAID 490 Express 300 RAID Controller
-		101e 0762  MegaRAID 762 Express RAID Controller
-		101e 09a0  PowerEdge Expandable RAID Controller 2/SC
-		1028 0467  PowerEdge Expandable RAID Controller 2/DC
-		1028 1111  PowerEdge Expandable RAID Controller 2/SC
-		103c 03a2  MegaRAID
-		103c 10c6  MegaRAID 438, NetRAID-3Si
-		103c 10c7  MegaRAID T5, Integrated NetRAID
-		103c 10cc  MegaRAID, Integrated NetRAID
-		103c 10cd  NetRAID-1Si
-		105a 0000  SuperTrak
-		105a 2168  SuperTrak Pro
-		105a 5168  SuperTrak66/100
-		1111 1111  MegaRAID 466, PowerEdge Expandable RAID Controller 2/SC
-		1111 1112  PowerEdge Expandable RAID Controller 2/SC
-		113c 03a2  MegaRAID
-		e4bf 1010  CG1-RADIO
-		e4bf 1020  CU2-QUARTET
-		e4bf 1040  CU1-CHORUS
-		e4bf 3100  CX1-BAND
 	1962  80960RM (i960RM) Microprocessor
-		105a 0000  SuperTrak SX6000 I2O CPU
 	19ac  DNV SMBus Contoller - Host
 	19b0  DNV SATA Controller 0
 	19b1  DNV SATA Controller 0
@@ -23760,115 +13384,38 @@ var pciids = []byte(`#
 	1a23  82840 840 [Carmel] Chipset AGP Bridge
 	1a24  82840 840 [Carmel] Chipset PCI Bridge (Hub B)
 	1a30  82845 845 [Brookdale] Chipset Host Bridge
-		1028 010e  Optiplex GX240
-		147b 0505  BL7 motherboard
-		15d9 3280  Supermicro P4SBE Mainboard
 	1a31  82845 845 [Brookdale] Chipset AGP Bridge
 	1a38  5000 Series Chipset DMA Engine
-		15d9 8680  X7DVL-E-O motherboard
-		8086 3476  S5000PSLSATA Server Board
 	1a48  82597EX 10GbE Ethernet Controller
-		8086 a01f  PRO/10GbE SR Server Adapter
-		8086 a11f  PRO/10GbE SR Server Adapter
 	1b48  82597EX 10GbE Ethernet Controller
-		8086 a01f  PRO/10GbE LR Server Adapter
-		8086 a11f  PRO/10GbE LR Server Adapter
 	1c00  6 Series/C200 Series Chipset Family Desktop SATA Controller (IDE mode, ports 0-3)
 	1c01  6 Series/C200 Series Chipset Family Mobile SATA Controller (IDE mode, ports 0-3)
 	1c02  6 Series/C200 Series Chipset Family 6 port Desktop SATA AHCI Controller
-		1028 04aa  XPS 8300
-		1043 844d  P8 series motherboard
-		8086 7270  Server Board S1200BTS
 	1c03  6 Series/C200 Series Chipset Family 6 port Mobile SATA AHCI Controller
-		1028 04a3  Precision M4600
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		17aa 21cf  ThinkPad T520
-		8086 7270  Apple MacBookPro8,2 [Core i7, 15", 2011]
 	1c04  6 Series/C200 Series Desktop SATA RAID Controller
-		103c 3118  Smart Array B110i SATA RAID Controller
 	1c05  6 Series/C200 Series Mobile SATA RAID Controller
 	1c06  Z68 Express Chipset SATA RAID Controller
 	1c08  6 Series/C200 Series Chipset Family Desktop SATA Controller (IDE mode, ports 4-5)
 	1c09  6 Series/C200 Series Chipset Family Mobile SATA Controller (IDE mode, ports 4-5)
 	1c10  6 Series/C200 Series Chipset Family PCI Express Root Port 1
-		1028 04aa  XPS 8300
-		1028 04da  Vostro 3750
-		1043 844d  P8 series motherboard
-		17aa 21cf  ThinkPad T520
-		8086 7270  Server Board S1200BTS / Apple MacBook Pro 8,1/8,2
 	1c12  6 Series/C200 Series Chipset Family PCI Express Root Port 2
-		1028 04aa  XPS 8300
-		17aa 21cf  ThinkPad T520
-		8086 7270  Apple MacBookPro8,2 [Core i7, 15", 2011]
 	1c14  6 Series/C200 Series Chipset Family PCI Express Root Port 3
-		1028 04da  Vostro 3750
-		8086 7270  Apple MacBookPro8,2 [Core i7, 15", 2011]
 	1c16  6 Series/C200 Series Chipset Family PCI Express Root Port 4
-		1028 04aa  XPS 8300
-		17aa 21cf  ThinkPad T520
 	1c18  6 Series/C200 Series Chipset Family PCI Express Root Port 5
-		1028 04da  Vostro 3750
-		17aa 21cf  ThinkPad T520
-		8086 7270  Server Board S1200BTS
 	1c1a  6 Series/C200 Series Chipset Family PCI Express Root Port 6
-		1028 04da  Vostro 3750
-		1043 844d  P8 series motherboard
 	1c1c  6 Series/C200 Series Chipset Family PCI Express Root Port 7
 	1c1e  6 Series/C200 Series Chipset Family PCI Express Root Port 8
-		1043 844d  P8 series motherboard
 	1c20  6 Series/C200 Series Chipset Family High Definition Audio Controller
-		1028 0490  Alienware M17x R3
-		1028 04a3  Precision M4600
-		1028 04aa  XPS 8300
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		1043 8418  P8P67 Deluxe Motherboard
-		1043 841b  P8H67 Series Motherboard
-		17aa 21cf  ThinkPad T520
-# Realtek ALC888 audio codec
-		8086 2008  DQ67SW board
-		8086 7270  Apple MacBookPro8,2 [Core i7, 15", 2011]
 	1c22  6 Series/C200 Series Chipset Family SMBus Controller
-		1028 04a3  Precision M4600
-		1028 04aa  XPS 8300
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		1043 844d  P8 series motherboard
-		17aa 21cf  ThinkPad T520
-		8086 7270  Server Board S1200BTS / Apple MacBook Pro 8,1/8,2
 	1c24  6 Series/C200 Series Chipset Family Thermal Management Controller
 	1c25  6 Series/C200 Series Chipset Family DMI to PCI Bridge
 	1c26  6 Series/C200 Series Chipset Family USB Enhanced Host Controller #1
-		1028 04a3  Precision M4600
-		1028 04aa  XPS 8300
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		1043 844d  P8 series motherboard
-		17aa 21cf  ThinkPad T520
-		8086 7270  Server Board S1200BTS / Apple MacBook Pro 8,1/8,2
 	1c27  6 Series/C200 Series Chipset Family USB Universal Host Controller #1
-		8086 7270  Apple MacBookPro8,2 [Core i7, 15", 2011]
 	1c2c  6 Series/C200 Series Chipset Family USB Universal Host Controller #5
-		8086 7270  Apple MacBookPro8,2 [Core i7, 15", 2011]
 	1c2d  6 Series/C200 Series Chipset Family USB Enhanced Host Controller #2
-		1028 04a3  Precision M4600
-		1028 04aa  XPS 8300
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		1043 844d  P8 series motherboard
-		17aa 21cf  ThinkPad T520
-		8086 7270  Server Board S1200BTS / Apple MacBook Pro 8,1/8,2
 	1c33  6 Series/C200 Series Chipset Family LAN Controller
 	1c35  6 Series/C200 Series Chipset Family VECI Controller
 	1c3a  6 Series/C200 Series Chipset Family MEI Controller #1
-		1028 04a3  Precision M4600
-		1028 04aa  XPS 8300
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
-		1043 844d  P8 series motherboard
-		17aa 21cf  ThinkPad T520
-		8086 7270  Apple MacBookPro8,2 [Core i7, 15", 2011]
 	1c3b  6 Series/C200 Series Chipset Family MEI Controller #2
 	1c3c  6 Series/C200 Series Chipset Family IDE-r Controller
 	1c3d  6 Series/C200 Series Chipset Family KT Controller
@@ -23879,32 +13426,22 @@ var pciids = []byte(`#
 	1c44  Z68 Express Chipset Family LPC Controller
 	1c45  6 Series/C200 Series Chipset Family LPC Controller
 	1c46  P67 Express Chipset Family LPC Controller
-		1043 844d  P8P67 Deluxe Motherboard
 	1c47  UM67 Express Chipset Family LPC Controller
 	1c48  6 Series/C200 Series Chipset Family LPC Controller
 	1c49  HM65 Express Chipset Family LPC Controller
-		8086 7270  Apple MacBookPro8,2 [Core i7, 15", 2011]
 	1c4a  H67 Express Chipset Family LPC Controller
-		1028 04aa  XPS 8300
-		1043 844d  P8H67 Series Motherboard
 	1c4b  HM67 Express Chipset Family LPC Controller
-		1028 04b2  Vostro 3350
-		1028 04da  Vostro 3750
 	1c4c  Q65 Express Chipset Family LPC Controller
 	1c4d  QS67 Express Chipset Family LPC Controller
 	1c4e  Q67 Express Chipset Family LPC Controller
 	1c4f  QM67 Express Chipset Family LPC Controller
-		1028 04a3  Precision M4600
-		17aa 21cf  ThinkPad T520
 	1c50  B65 Express Chipset Family LPC Controller
 	1c51  6 Series/C200 Series Chipset Family LPC Controller
 	1c52  C202 Chipset Family LPC Controller
-		8086 7270  Server Board S1200BTS
 	1c53  6 Series/C200 Series Chipset Family LPC Controller
 	1c54  C204 Chipset Family LPC Controller
 	1c55  6 Series/C200 Series Chipset Family LPC Controller
 	1c56  C206 Chipset Family LPC Controller
-		1043 844d  P8B WS Motherboard
 	1c57  6 Series/C200 Series Chipset Family LPC Controller
 	1c58  Upgraded B65 Express Chipset Family LPC Controller
 	1c59  Upgraded HM67 Express Chipset Family LPC Controller
@@ -23980,96 +13517,32 @@ var pciids = []byte(`#
 	1d76  C600/X79 series chipset Multi-Function Glue
 	1e00  7 Series/C210 Series Chipset Family 4-port SATA Controller [IDE mode]
 	1e01  7 Series Chipset Family 4-port SATA Controller [IDE mode]
-		144d c652  NP300E5C series laptop
 	1e02  7 Series/C210 Series Chipset Family 6-port SATA Controller [AHCI mode]
-		1043 84ca  P8 series motherboard
-		1849 1e02  Motherboard
 	1e03  7 Series Chipset Family 6-port SATA Controller [AHCI mode]
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
-		144d c652  NP300E5C series laptop
 	1e04  7 Series/C210 Series Chipset Family SATA Controller [RAID mode]
 	1e05  7 Series Chipset SATA Controller [RAID mode]
 	1e06  7 Series/C210 Series Chipset Family SATA Controller [RAID mode]
 	1e07  7 Series Chipset Family SATA Controller [RAID mode]
 	1e08  7 Series/C210 Series Chipset Family 2-port SATA Controller [IDE mode]
 	1e09  7 Series Chipset Family 2-port SATA Controller [IDE mode]
-		144d c652  NP300E5C series laptop
 	1e0e  7 Series/C210 Series Chipset Family SATA Controller [RAID mode]
 	1e10  7 Series/C216 Chipset Family PCI Express Root Port 1
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
-		1043 84ca  P8H77-I Motherboard
-		144d c652  NP300E5C series laptop
-		1849 1e10  Motherboard
 	1e12  7 Series/C210 Series Chipset Family PCI Express Root Port 2
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
 	1e14  7 Series/C210 Series Chipset Family PCI Express Root Port 3
 	1e16  7 Series/C216 Chipset Family PCI Express Root Port 4
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		144d c652  NP300E5C series laptop
-		1849 1618  Z77 Extreme4 motherboard
 	1e18  7 Series/C210 Series Chipset Family PCI Express Root Port 5
-		1043 84ca  P8H77-I Motherboard
-		1849 1e18  Motherboard
 	1e1a  7 Series/C210 Series Chipset Family PCI Express Root Port 6
-		1849 1e1a  Motherboard
 	1e1c  7 Series/C210 Series Chipset Family PCI Express Root Port 7
 	1e1e  7 Series/C210 Series Chipset Family PCI Express Root Port 8
-		1849 1e1e  Motherboard
 	1e20  7 Series/C216 Chipset Family High Definition Audio Controller
-		1028 054b  XPS One 2710
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
-		1043 8415  P8H77-I Motherboard
-		1043 8445  P8Z77-V LX Motherboard
-		144d c652  NP300E5C series laptop
-		1849 1898  Z77 Extreme4 motherboard
 	1e22  7 Series/C216 Chipset Family SMBus Controller
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
-		1043 84ca  P8 series motherboard
-		144d c652  NP300E5C series laptop
-		1849 1e22  Motherboard
 	1e24  7 Series/C210 Series Chipset Family Thermal Management Controller
-		1043 1517  Zenbook Prime UX31A
 	1e25  7 Series/C210 Series Chipset Family DMI to PCI Bridge
 	1e26  7 Series/C216 Chipset Family USB Enhanced Host Controller #1
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
-		1043 84ca  P8 series motherboard
-		144d c652  NP300E5C series laptop
-		1849 1e26  Motherboard
 	1e2d  7 Series/C216 Chipset Family USB Enhanced Host Controller #2
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
-		1043 84ca  P8 series motherboard
-		144d c652  NP300E5C series laptop
-		1849 1e2d  Motherboard
 	1e31  7 Series/C210 Series Chipset Family USB xHCI Host Controller
-		103c 17ab  ProBook 6570b
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
-		1043 84ca  P8 series motherboard
-		1849 1e31  Motherboard
 	1e33  7 Series/C210 Series Chipset Family LAN Controller
 	1e3a  7 Series/C216 Chipset Family MEI Controller #1
-		1043 108d  VivoBook X202EV
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
-		1043 84ca  P8 series motherboard
-		144d c652  NP300E5C series laptop
-		1849 1e3a  Motherboard
 	1e3b  7 Series/C210 Series Chipset Family MEI Controller #2
 	1e3c  7 Series/C210 Series Chipset Family IDE-r Controller
 	1e3d  7 Series/C210 Series Chipset Family KT Controller
@@ -24077,15 +13550,12 @@ var pciids = []byte(`#
 	1e42  7 Series Chipset Family LPC Controller
 	1e43  7 Series Chipset Family LPC Controller
 	1e44  Z77 Express Chipset LPC Controller
-		1043 84ca  P8 series motherboard
-		1849 1e44  Motherboard
 	1e45  7 Series Chipset Family LPC Controller
 	1e46  Z75 Express Chipset LPC Controller
 	1e47  Q77 Express Chipset LPC Controller
 	1e48  Q75 Express Chipset LPC Controller
 	1e49  B75 Express Chipset LPC Controller
 	1e4a  H77 Express Chipset LPC Controller
-		1043 84ca  P8H77-I Motherboard
 	1e4b  7 Series Chipset Family LPC Controller
 	1e4c  7 Series Chipset Family LPC Controller
 	1e4d  7 Series Chipset Family LPC Controller
@@ -24101,15 +13571,11 @@ var pciids = []byte(`#
 	1e57  HM77 Express Chipset LPC Controller
 	1e58  UM77 Express Chipset LPC Controller
 	1e59  HM76 Express Chipset LPC Controller
-		1043 1477  N56VZ
-		1043 1517  Zenbook Prime UX31A
 	1e5a  7 Series Chipset Family LPC Controller
 	1e5b  UM77 Express Chipset LPC Controller
 	1e5c  7 Series Chipset Family LPC Controller
 	1e5d  HM75 Express Chipset LPC Controller
-		144d c652  NP300E5C series laptop
 	1e5e  7 Series Chipset Family LPC Controller
-		1043 108d  VivoBook X202EV
 	1e5f  7 Series Chipset Family LPC Controller
 	1f00  Atom processor C2000 SoC Transaction Router
 	1f01  Atom processor C2000 SoC Transaction Router
@@ -24163,7 +13629,6 @@ var pciids = []byte(`#
 	1f3e  Atom processor C2000 RAID SATA3 Controller
 	1f3f  Atom processor C2000 RAID SATA3 Controller
 	1f40  Ethernet Connection I354 1.0 GbE Backplane
-		1028 05f1  Ethernet Connection I354 1.0 GbE Backplane
 	1f41  Ethernet Connection I354
 	1f42  Atom processor C2000 GbE
 	1f44  Atom processor C2000 GbE Virtual Function
@@ -24207,7 +13672,7 @@ var pciids = []byte(`#
 	208e  Sky Lake-E CHA Registers
 	2250  Xeon Phi coprocessor 5100 series
 	225c  Xeon Phi coprocessor SE10/7120 series
-	225d  Xeon Phi coprocessor 3120 series 
+	225d  Xeon Phi coprocessor 3120 series
 	225e  Xeon Phi coprocessor 31S1
 	2280  Atom/Celeron/Pentium Processor x5-E8000/J3xxx/N3xxx Series SoC Transaction Register
 	2284  Atom/Celeron/Pentium Processor x5-E8000/J3xxx/N3xxx Series High Definition Audio Controller
@@ -24283,14 +13748,6 @@ var pciids = []byte(`#
 	2412  82801AA USB Controller
 	2413  82801AA SMBus Controller
 	2415  82801AA AC'97 Audio Controller
-		1028 0095  Precision Workstation 220 Integrated Digital Audio
-		1028 00b4  OptiPlex GX110
-		110a 0051  Activy 2xx
-		11d4 0040  SoundMAX Integrated Digital Audio
-		11d4 0048  SoundMAX Integrated Digital Audio
-		11d4 5340  SoundMAX Integrated Digital Audio
-		1734 1025  Activy 3xx
-		1af4 1100  QEMU Virtual Machine
 	2416  82801AA AC'97 Modem Controller
 	2418  82801AA PCI Bridge
 	2420  82801AB ISA Bridge (LPC)
@@ -24298,158 +13755,20 @@ var pciids = []byte(`#
 	2422  82801AB USB Controller
 	2423  82801AB SMBus Controller
 	2425  82801AB AC'97 Audio Controller
-		11d4 0040  SoundMAX Integrated Digital Audio
-		11d4 0048  SoundMAX Integrated Digital Audio
 	2426  82801AB AC'97 Modem Controller
 	2428  82801AB PCI Bridge
 	2440  82801BA ISA Bridge (LPC)
-		8086 5744  S845WD1-E
 	2442  82801BA/BAM UHCI USB 1.1 Controller #1
-		1014 01c6  Netvista A40/A40p
-		1025 1016  Travelmate 612 TX
-		1028 00c7  Dimension 8100
-		1028 00d8  Precision 530
-		1028 010e  Optiplex GX240
-		103c 126f  e-pc 40
-		1043 8027  TUSL2-C Mainboard
-		104d 80df  Vaio PCG-FX403
-		147b 0505  BL7 motherboard
-		147b 0507  TH7II-RAID
-		8086 4532  Desktop Board D815EEA2/D815EFV
-		8086 4557  D815EGEW Mainboard
-		8086 5744  S845WD1-E mainboard
 	2443  82801BA/BAM SMBus Controller
-		1014 01c6  Netvista A40/A40p
-		1025 1016  Travelmate 612 TX
-		1028 00c7  Dimension 8100
-		1028 00d8  Precision 530
-		1028 010e  Optiplex GX240
-		103c 126f  e-pc 40
-		1043 8027  TUSL2-C Mainboard
-		104d 80df  Vaio PCG-FX403
-		147b 0505  BL7 motherboard
-		147b 0507  TH7II-RAID
-		15d9 3280  Supermicro P4SBE Mainboard
-		8086 4532  Desktop Board D815EEA2/D815EFV
-		8086 4557  D815EGEW Mainboard
-		8086 5744  S845WD1-E mainboard
 	2444  82801BA/BAM UHCI USB 1.1 Controller #2
-		1025 1016  Travelmate 612 TX
-		1028 00c7  Dimension 8100
-		1028 00d8  Precision 530
-		1028 010e  Optiplex GX240
-		103c 126f  e-pc 40
-		1043 8027  TUSL2-C Mainboard
-		104d 80df  Vaio PCG-FX403
-		147b 0505  BL7 motherboard
-		147b 0507  TH7II-RAID
-		8086 4532  Desktop Board D815EEA2/D815EFV
-		8086 5744  S845WD1-E mainboard
 	2445  82801BA/BAM AC'97 Audio Controller
-		0e11 000b  Compaq Deskpro EN Audio
-		0e11 0088  Evo D500
-		1014 01c6  Netvista A40/A40p
-		1025 1016  Travelmate 612 TX
-		1028 00d8  Precision 530
-		103c 126f  e-pc 40
-		104d 80df  Vaio PCG-FX403
-		1462 3370  STAC9721 AC
-		147b 0505  BL7 motherboard
-		147b 0507  TH7II-RAID
-		8086 4557  D815EGEW Mainboard
-		8086 4656  Desktop Board D815EFV
 	2446  82801BA/BAM AC'97 Modem Controller
-		1025 1016  Travelmate 612 TX
-		104d 80df  Vaio PCG-FX403
 	2448  82801 Mobile PCI Bridge
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		103c 0934  Compaq nw8240 Mobile Workstation
-		103c 099c  NX6110/NC6120
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a3  Compaq nw8440
-		103c 30c1  Compaq 6910p
-		104d 902d  VAIO VGN-NR120E
-		105b 0d7c  D270S/D250S Motherboard
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		144d c00c  P30 notebook
-		144d c06a  R730 Laptop
-		144d c072  Notebook N150P
-		1458 5000  GA-D525TUD
-		1734 1055  Amilo M1420
-		17aa 2013  ThinkPad R60e
-		17aa 20ae  ThinkPad T61/R61
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		8086 544b  Desktop Board D425KT
-		e4bf cc47  CCG-RUMBA
 	2449  82801BA/BAM/CA/CAM Ethernet Controller
-		0e11 0012  EtherExpress PRO/100 VM
-		0e11 0091  EtherExpress PRO/100 VE
-		1014 01ce  EtherExpress PRO/100 VE
-		1014 01dc  EtherExpress PRO/100 VE
-		1014 01eb  EtherExpress PRO/100 VE
-		1014 01ec  EtherExpress PRO/100 VE
-		1014 0202  EtherExpress PRO/100 VE
-		1014 0205  EtherExpress PRO/100 VE
-		1014 0217  EtherExpress PRO/100 VE
-		1014 0234  EtherExpress PRO/100 VE
-		1014 023d  EtherExpress PRO/100 VE
-		1014 0244  EtherExpress PRO/100 VE
-		1014 0245  EtherExpress PRO/100 VE
-		1014 0265  PRO/100 VE Desktop Connection
-		1014 0267  PRO/100 VE Desktop Connection
-		1014 026a  PRO/100 VE Desktop Connection
-		109f 315d  EtherExpress PRO/100 VE
-		109f 3181  EtherExpress PRO/100 VE
-		1179 ff01  PRO/100 VE Network Connection
-		1186 7801  EtherExpress PRO/100 VE
-		144d 2602  HomePNA 1M CNR
-		1af4 1100  QEMU Virtual Machine
-		8086 3010  EtherExpress PRO/100 VE
-		8086 3011  EtherExpress PRO/100 VM
-		8086 3012  82562EH based Phoneline
-		8086 3013  EtherExpress PRO/100 VE
-		8086 3014  EtherExpress PRO/100 VM
-		8086 3015  82562EH based Phoneline
-		8086 3016  EtherExpress PRO/100 P Mobile Combo
-		8086 3017  EtherExpress PRO/100 P Mobile
-		8086 3018  EtherExpress PRO/100
 	244a  82801BAM IDE U100 Controller
-		1025 1016  Travelmate 612TX
-		104d 80df  Vaio PCG-FX403
 	244b  82801BA IDE U100 Controller
-		1014 01c6  Netvista A40/A40p
-		1028 00c7  Dimension 8100
-		1028 00d8  Precision 530
-		1028 010e  Optiplex GX240
-		103c 126f  e-pc 40
-		1043 8027  TUSL2-C Mainboard
-		147b 0505  BL7 motherboard
-		147b 0507  TH7II-RAID
-		15d9 3280  Supermicro P4SBE Mainboard
-		8086 4532  Desktop Board D815EEA2/D815EFV
-		8086 4557  D815EGEW Mainboard
-		8086 5744  S845WD1-E mainboard
 	244c  82801BAM ISA Bridge (LPC)
 	244e  82801 PCI Bridge
-		1014 0267  NetVista A30p
-		1028 020d  Inspiron 530
-		1028 0211  Optiplex 755
-		1028 02da  OptiPlex 980
-		103c 2a3b  Pavilion A1512X
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		103c 31fe  ProLiant DL140 G3
-		103c 330b  ProLiant ML150 G6 Server
-# same ID possibly also on other ASUS boards
-		1043 8277  P5K PRO Motherboard
-		1043 844d  P8 series motherboard
-		1458 5000  Motherboard
-		1462 7418  Wind PC MS-7418
-		15d9 060d  C7SIM-Q Motherboard
-		15d9 9680  X7DBN Motherboard
-		1775 11cc  CC11/CL11
-		8086 7270  Server Board S1200BTS
 	2450  82801E ISA Bridge (LPC)
 	2452  82801E USB Controller
 	2453  82801E SMBus Controller
@@ -24459,517 +13778,64 @@ var pciids = []byte(`#
 	245e  82801E PCI Bridge
 	2480  82801CA LPC Interface Controller
 	2482  82801CA/CAM USB Controller #1
-		0e11 0030  Evo N600c
-		1014 0220  ThinkPad A/T/X Series
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		15d9 3480  P4DP6
-		8086 1958  vpr Matrix 170B4
-		8086 3424  SE7501HG2 Mainboard
-		8086 4541  Latitude C640
 	2483  82801CA/CAM SMBus Controller
-		1014 0220  ThinkPad A/T/X Series
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		15d9 3480  P4DP6
-		8086 1958  vpr Matrix 170B4
 	2484  82801CA/CAM USB Controller #2
-		0e11 0030  Evo N600c
-		1014 0220  ThinkPad A/T/X Series
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		15d9 3480  P4DP6
-		8086 1958  vpr Matrix 170B4
 	2485  82801CA/CAM AC'97 Audio Controller
-		1013 5959  Crystal WMD Audio Codec
-		1014 0222  ThinkPad A30/A30p/T23
-		1014 0508  ThinkPad T30
-		1014 051c  ThinkPad A/T/X Series
-		1043 1583  L3C (SPDIF)
-		1043 1623  L2B (no SPDIF)
-		1043 1643  L3F
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		144d c006  vpr Matrix 170B4
 	2486  82801CA/CAM AC'97 Modem Controller
-		1014 0223  ThinkPad A/T/X Series
-		1014 0503  ThinkPad R31
-		1014 051a  ThinkPad A/T/X Series
-		101f 1025  620 Series
-		1043 1496  PCtel HSP56 MR
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		134d 4c21  Dell Inspiron 2100 internal modem
-		144d 2115  vpr Matrix 170B4 internal modem
-		14f1 5421  MD56ORD V.92 MDC Modem
 	2487  82801CA/CAM USB Controller #3
-		0e11 0030  Evo N600c
-		1014 0220  ThinkPad A/T/X Series
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		15d9 3480  P4DP6
-		8086 1958  vpr Matrix 170B4
 	248a  82801CAM IDE U100 Controller
-		0e11 0030  Evo N600c
-		1014 0220  ThinkPad A/T/X Series
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
-		8086 1958  vpr Matrix 170B4
-		8086 4541  Latitude C640
 	248b  82801CA Ultra ATA Storage Controller
-		15d9 3480  P4DP6
 	248c  82801CAM ISA Bridge (LPC)
 	24c0  82801DB/DBL (ICH4/ICH4-L) LPC Interface Bridge
-		1014 0267  NetVista A30p
-		1462 5800  845PE Max (MS-6580)
 	24c1  82801DBL (ICH4-L) IDE Controller
 	24c2  82801DB/DBL/DBM (ICH4/ICH4-L/ICH4-M) USB UHCI Controller #1
-		1014 0267  NetVista A30p
-		1014 052d  ThinkPad
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: Intel 82801DBM (ICH4-M)
-		1028 0126  Optiplex GX260
-		1028 0160  Dimension 2400
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		1043 8089  P4B533
-		1071 8160  MIM2000
-		114a 0582  PC8 onboard USB 1.x
-		144d c005  X10 Laptop
-		144d c00c  P30/P35 notebook
-		1462 5800  845PE Max (MS-6580)
-		1509 2990  Averatec 5110H laptop
-		1734 1004  D1451 Mainboard (SCENIC N300, i845GV)
-		1734 1055  Amilo M1420
-		4c53 1090  Cx9 / Vx9 mainboard
-		8086 24c2  Latitude X300
-		8086 4541  Latitude D400/D500
-		e4bf 0cc9  CC9-SAMBA
-		e4bf 0cd2  CD2-BEBOP
 	24c3  82801DB/DBL/DBM (ICH4/ICH4-L/ICH4-M) SMBus Controller
-		1014 0267  NetVista A30p
-		1014 052d  ThinkPad
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: Intel 82801DBM (ICH4-M)
-		1028 0126  Optiplex GX260
-		1028 014f  Latitude X300
-		1028 0160  Dimension 2400
-		1028 018d  Inspiron 700m/710m
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		1071 8160  MIM2000
-		114a 0582  PC8 onboard SMbus
-		144d c005  X10 Laptop
-		144d c00c  P30/P35 notebook
-		1458 24c2  GA-8PE667 Ultra
-		1462 5800  845PE Max (MS-6580)
-		1734 1004  D1451 Mainboard (SCENIC N300, i845GV)
-		1734 1055  Amilo M1420
-		4c53 1090  Cx9 / Vx9 mainboard
-		e4bf 0cc9  CC9-SAMBA
-		e4bf 0cd2  CD2-BEBOP
 	24c4  82801DB/DBL/DBM (ICH4/ICH4-L/ICH4-M) USB UHCI Controller #2
-		1014 0267  NetVista A30p
-		1014 052d  ThinkPad
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: Intel 82801DBM (ICH4-M)
-		1028 0126  Optiplex GX260
-		1028 0160  Dimension 2400
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		1043 8089  P4B533
-		1071 8160  MIM2000
-		144d c00c  P30/P35 notebook
-		1462 5800  845PE Max (MS-6580)
-		1509 2990  Averatec 5110H
-		1734 1004  D1451 Mainboard (SCENIC N300, i845GV)
-		4c53 1090  Cx9 / Vx9 mainboard
-		8086 24c2  Latitude X300
-		8086 4541  Latitude D400/D500
-		e4bf 0cc9  CC9-SAMBA
-		e4bf 0cd2  CD2-BEBOP
 	24c5  82801DB/DBL/DBM (ICH4/ICH4-L/ICH4-M) AC'97 Audio Controller
-		0e11 00b8  Analog Devices Inc. codec [SoundMAX]
-		1014 0267  NetVista A30p
-		1014 0537  ThinkPad T4x Series
-		1014 055f  Thinkpad R50e model 1634
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: Intel 82801DBM (ICH4-M)
-		1028 0139  Latitude D400
-		1028 014f  Latitude X300
-		1028 0152  Latitude D500
-		1028 0160  Dimension 2400
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m [SigmaTel STAC9750,51]
-		1028 0196  Inspiron 5160
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		1043 1713  M2400N/M6800N laptop
-		1043 80b0  P4B533
-		1071 8160  MIM2000
-		1179 0201  Toshiba Tecra M1
-		144d c005  X10 Laptop
-		144d c00c  P30/P35 notebook
-		1458 a002  GA-8PE667 Ultra
-		1462 5800  845PE Max (MS-6580)
-		1734 1005  D1451 (SCENIC N300, i845GV) Sigmatel STAC9750T
-		1734 1055  Amilo M1420
 	24c6  82801DB/DBL/DBM (ICH4/ICH4-L/ICH4-M) AC'97 Modem Controller
-		1014 0524  ThinkPad T4x Series
-		1014 0525  ThinkPad
-		1014 0559  ThinkPad R50e
-		1025 003c  Aspire 2001WLCi (Compal CL50 motherboard) implementation
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: Intel 82801DBM (ICH4-M)
-		1028 0196  Inspiron 5160
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		1043 1716  M2400N laptop
-		1043 1826  M6800N
-		1071 8160  MIM2000
-		134d 4c21  Latitude D500
-		144d 2115  X10 Laptop
-		144d c00c  P30/P35 notebook
-# Conexant HSF Softmodem (CXT22)
-		14f1 5422  D480 MDC V.9x Modem
 	24c7  82801DB/DBL/DBM (ICH4/ICH4-L/ICH4-M) USB UHCI Controller #3
-		1014 0267  NetVista A30p
-		1014 052d  ThinkPad
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: Intel 82801DBM (ICH4-M)
-		1028 0126  Optiplex GX260
-		1028 0160  Dimension 2400
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		1043 8089  P4B533
-		1071 8160  MIM2000
-		144d c00c  P30/P35 notebook
-		1462 5800  845PE Max (MS-6580)
-		1509 2990  Averatec 5110H
-		1734 1004  D1451 Mainboard (SCENIC N300, i845GV)
-		4c53 1090  Cx9 / Vx9 mainboard
-		8086 24c2  Latitude X300
-		8086 4541  Latitude D400/D500
-		e4bf 0cc9  CC9-SAMBA
-		e4bf 0cd2  CD2-BEBOP
 	24ca  82801DBM (ICH4-M) IDE Controller
-		1014 052d  ThinkPad
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: Intel 82801DBM (ICH4-M)
-		1028 014f  Latitude X300
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		1071 8160  MIM2000
-		144d c005  X10 Laptop
-		144d c00c  P30/P35 notebook
-		1734 1055  Amilo M1420
-		8086 4541  Latitude D400/D500
 	24cb  82801DB (ICH4) IDE Controller
-		1014 0267  NetVista A30p
-		1028 0126  Optiplex GX260
-		1028 0160  Dimension 2400
-		1043 8089  P4B533
-		114a 0582  PC8 onboard IDE
-		1458 24c2  GA-8PE667 Ultra
-		1462 5800  845PE Max (MS-6580)
-		1734 1004  D1451 Mainboard (SCENIC N300, i845GV)
-		4c53 1090  Cx9 / Vx9 mainboard
-		e4bf 0cc9  CC9-SAMBA
-		e4bf 0cd2  CD2-BEBOP
 	24cc  82801DBM (ICH4-M) LPC Interface Bridge
-		144d c00c  P30 notebook
-		1734 1055  Amilo M1420
 	24cd  82801DB/DBM (ICH4/ICH4-M) USB2 EHCI Controller
-		1014 0267  NetVista A30p
-		1014 052e  ThinkPad
-		1025 005a  TravelMate 290
-		1025 0064  Extensa 3000 series laptop: Intel 82801DBM (ICH4-M)
-		1028 011d  Latitude D600
-		1028 0126  Optiplex GX260
-		1028 0139  Latitude D400
-		1028 0152  Latitude D500
-		1028 0160  Dimension 2400
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		1043 8089  P4B533
-		1071 8160  MIM2000
-		114a 0582  PC8 onboard USB 2.0
-		1179 ff00  Satellite 2430
-		144d c005  X10 Laptop
-		144d c00c  P30/P35 notebook
-		1462 3981  845PE Max (MS-6580)
-		1509 1968  Averatec 5110H
-		1734 1004  D1451 Mainboard (SCENIC N300, i845GV)
-		1734 1055  Amilo M1420
-		1af4 1100  QEMU Virtual Machine
-		4c53 1090  Cx9 / Vx9 mainboard
-		8086 24c2  Latitude X300
-		e4bf 0cc9  CC9-SAMBA
-		e4bf 0cd2  CD2-BEBOP
 	24d0  82801EB/ER (ICH5/ICH5R) LPC Interface Bridge
 	24d1  82801EB (ICH5) SATA Controller
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		1028 019a  PowerEdge SC1425
-		103c 12bc  d530 CMT (DG746A)
-		103c 3208  ProLiant DL140 G2
-		1043 80a6  P4P800 series motherboard
-		1458 24d1  GA-8IPE1000 Pro2 motherboard (865PE)
-		1462 7280  865PE Neo2 (MS-6728)
-		1462 7650  Hetis 865GV-E (MS-7065)
-		1565 5200  P4TSV Motherboard (865G)
-		15d9 4580  P4SCE Mainboard
-		8086 3427  S875WP1-E mainboard
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
-		8086 524c  D865PERL mainboard
 	24d2  82801EB/ER (ICH5/ICH5R) USB UHCI Controller #1
-		1014 02dd  eServer xSeries server mainboard
-		1014 02ed  eServer xSeries server mainboard
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		1028 016c  PowerEdge 1850 onboard UHCI
-		1028 016d  PowerEdge 2850 onboard UHCI
-		1028 0170  PowerEdge 6850 onboard UHCI
-		1028 0183  PowerEdge 1800
-		1028 019a  PowerEdge SC1425
-		103c 006a  NX9500
-		103c 12bc  d530 CMT (DG746A)
-		103c 3208  ProLiant DL140 G2
-		1043 80a6  P4P800/P5P800 series motherboard
-		1458 24d2  GA-8IPE1000/8KNXP motherboard
-		1462 7280  865PE Neo2 (MS-6728)
-		1565 3101  P4TSV Motherboard (865G)
-		15d9 4580  P4SCE Mainboard
-		1734 101c  PRIMERGY RX/TX series onboard UHCI
-		8086 3427  S875WP1-E mainboard
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
-		8086 524c  D865PERL mainboard
 	24d3  82801EB/ER (ICH5/ICH5R) SMBus Controller
-		1014 02dd  eServer xSeries server mainboard
-		1014 02ed  eServer xSeries server mainboard
-		1028 0156  Precision 360
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		103c 12bc  d330 uT
-		103c 3208  ProLiant DL140 G2
-		1043 80a6  P4P800/P5P800 series motherboard
-		1458 24d2  GA-8IPE1000 Pro2 motherboard (865PE)
-		1462 7280  865PE Neo2 (MS-6728)
-		1462 7650  Hetis 865GV-E (MS-7065)
-		1565 3101  P4TSV Motherboard (865G)
-		15d9 4580  P4SCE Mainboard
-		1734 101c  PRIMERGY RX/TX S2 series SMBus
-		8086 3427  S875WP1-E mainboard
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
-		8086 524c  D865PERL mainboard
 	24d4  82801EB/ER (ICH5/ICH5R) USB UHCI Controller #2
-		1014 02dd  eServer xSeries server mainboard
-		1014 02ed  eServer xSeries server mainboard
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		1028 016c  PowerEdge 1850 onboard UHCI
-		1028 016d  PowerEdge 2850 onboard UHCI
-		1028 0170  PowerEdge 6850 onboard UHCI
-		1028 0183  PowerEdge 1800
-		1028 019a  PowerEdge SC1425
-		103c 006a  NX9500
-		103c 12bc  d530 CMT (DG746A)
-		103c 3208  ProLiant DL140 G2
-		1043 80a6  P4P800/P5P800 series motherboard
-		1458 24d2  GA-8IPE1000 Pro2 motherboard (865PE)
-		1462 7280  865PE Neo2 (MS-6728)
-		1462 7650  Hetis 865GV-E (MS-7065)
-		1565 3101  P4TSV Motherboard (865G)
-		15d9 4580  P4SCE Mainboard
-		1734 101c  PRIMERGY RX/TX S2 series onboard UHCI
-		8086 3427  S875WP1-E mainboard
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
-		8086 524c  D865PERL mainboard
 	24d5  82801EB/ER (ICH5/ICH5R) AC'97 Audio Controller
-		100a 147b  Abit IS7-E motherboard
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		103c 006a  NX9500
-		103c 12bc  d330 uT
-		1043 80f3  P4P800 series motherboard
-		1043 810f  P5P800-MX Mainboard
-		1458 a002  GA-8IPE1000/8KNXP motherboard
-		1462 0080  865PE Neo2-V (MS-6788) Mainboard
-		1462 7280  865PE Neo2 (MS-6728)
-		1462 7650  Hetis 865GV-E (MS-7065)
-		8086 a000  D865PERL mainboard
-		8086 e000  D865PERL mainboard
-		8086 e001  Desktop Board D865GBF
-		8086 e002  SoundMax Integrated Digital Audio
 	24d6  82801EB/ER (ICH5/ICH5R) AC'97 Modem Controller
-		103c 006a  NX9500
 	24d7  82801EB/ER (ICH5/ICH5R) USB UHCI Controller #3
-		1014 02ed  xSeries server mainboard
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		1028 016c  PowerEdge 1850 onboard UHCI
-		1028 016d  PowerEdge 2850 onboard UHCI
-		1028 0170  PowerEdge 6850 onboard UHCI
-		1028 0183  PowerEdge 1800
-		103c 006a  NX9500
-		103c 12bc  d530 CMT (DG746A)
-		1043 80a6  P4P800/P5P800 series motherboard
-		1458 24d2  GA-8IPE1000 Pro2 motherboard (865PE)
-		1462 7280  865PE Neo2 (MS-6728)
-		1462 7650  Hetis 865GV-E (MS-7065)
-		1565 3101  P4TSV Motherboard (865G)
-		15d9 4580  P4SCE Mainboard
-		1734 101c  PRIMERGY RX/TX S2 series onboard UHCI
-		8086 3427  S875WP1-E mainboard
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
-		8086 524c  D865PERL mainboard
 	24db  82801EB/ER (ICH5/ICH5R) IDE Controller
-		1014 02dd  eServer xSeries server mainboard
-		1014 02ed  eServer xSeries server mainboard
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		1028 016c  PowerEdge 1850 IDE Controller
-		1028 016d  PowerEdge 2850 IDE Controller
-		1028 0170  PowerEdge 6850 IDE Controller
-		1028 019a  PowerEdge SC1425
-		103c 006a  NX9500
-		103c 12bc  d530 CMT (DG746A)
-		1043 80a6  P4P800/P5P800 series motherboard
-		1458 24d2  GA-8IPE1000 Pro2 motherboard (865PE)
-		1462 7280  865PE Neo2 (MS-6728)
-		1462 7580  MSI 875P
-		1462 7650  Hetis 865GV-E (MS-7065)
-		1565 3101  P4TSV Motherboard (865G)
-		15d9 4580  P4SCE Mainboard
-		1734 101c  PRIMERGY RX/TX S2 series onboard IDE
-		8086 24db  P4C800 Mainboard
-		8086 3427  S875WP1-E mainboard
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
-		8086 524c  D865PERL mainboard
 	24dc  82801EB (ICH5) LPC Interface Bridge
 	24dd  82801EB/ER (ICH5/ICH5R) USB2 EHCI Controller
-		1014 02dd  eServer xSeries server mainboard
-		1014 02ed  eServer xSeries server mainboard
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		1028 016c  PowerEdge 1850 onboard EHCI
-		1028 016d  PowerEdge 2850 onboard EHCI
-		1028 0170  PowerEdge 6850 onboard EHCI
-		1028 0183  PowerEdge 1800
-		1028 019a  PowerEdge SC1425
-		103c 006a  NX9500
-		103c 12bc  d530 CMT (DG746A)
-		103c 3208  ProLiant DL140 G2
-		1043 80a6  P4P800/P5P800 series motherboard
-		1458 5006  GA-8IPE1000 Pro2 motherboard (865PE)
-		1462 7280  865PE Neo2 (MS-6728)
-		1462 7650  Hetis 865GV-E (MS-7065)
-		8086 3427  S875WP1-E mainboard
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
-		8086 524c  D865PERL mainboard
 	24de  82801EB/ER (ICH5/ICH5R) USB UHCI Controller #4
-		1014 02ed  xSeries server mainboard
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		1043 80a6  P4P800/P5P800 series motherboard
-		1458 24d2  GA-8IPE1000 Pro2 motherboard (865PE)
-		1462 7280  865PE Neo2 (MS-6728)
-		1462 7650  Hetis 865GV-E (MS-7065)
-		1565 3101  P4TSV Motherboard (865G)
-		15d9 4580  P4SCE Mainboard
-		1734 101c  PRIMERGY RX/TX S2 series onboard UHCI
-		8086 3427  S875WP1-E mainboard
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
-		8086 524c  D865PERL mainboard
 	24df  82801ER (ICH5R) SATA Controller
-		1028 0168  Precision Workstation 670 Mainboard
 	24f0  Omni-Path HFI Silicon 100 Series [discrete]
-		10a9 802e  Omni-path HFI 100 Series, 1-port A-board
-		10a9 802f  Omni-path HFI 100 Series, 2-port A-board
-		10a9 8030  Omni-path HFI 100 Series, 1-port B-board
-		10a9 8031  Omni-path HFI 100 Series, 2-port B-board
-		1590 00e7  100Gb 1-port OP101 QSFP28 x8 PCIe Gen3 with Intel Omni-Path Adapter
-		1590 00e8  100Gb 1-port OP101 QSFP28 x16 PCIe Gen3 with Intel Omni-Path Adapter
-		1590 021c  Apollo 100Gb 1-port Intel Omni-Path Architecture 860z Mezzanine FIO Adapter
-		15d9 0934  Omni-Path HFI Adapter 100 Series, 1 Port, PCIe x16, SIOM Module
-		15d9 099b  Omni-path HFI Mezz AOC, 1 Port, PCIe x16.
-		1cb8 0001  Omni-Path HFI Adapter 100 Series, 1 Port, PCIe x16, TC4600 QSFP28
-		1cb8 0002  Omni-Path HFI Adapter 100 Series, 1 Port, PCIe x16, TC6600 Fixed Port
-		1cb8 0003  Omni-Path HFI Adapter 100 Series, 2 Port, 2 PCIe x16, Earth Simulation QSFP28
-		1cb8 0004  Omni-Path HFI Adapter 100 Series, 1 Port, PCIe x16, TC4600E QSFP28
-		8086 2628  Omni-Path HFI Adapter 100 Series, 1 Port, PCIe x16
-		8086 2629  Omni-Path HFI Adapter 100 Series, 1 Port, PCIe x8
-		8086 262a  Omni-Path HFI Adapter 100 Series, 2 Ports, Split PCIe x16
-		8086 262d  Omni-Path HFI Adapter 100 Series, 1 Port, PCIe x16, IO Module AHWKPTP100HF
 	24f1  Omni-Path HFI Silicon 100 Series [integrated]
 	24f3  Wireless 8260
-# Snow Field Peak AC
-		8086 0010  Dual Band Wireless-AC 8260
-		8086 1010  Dual Band Wireless-AC 8260
 	24f4  Wireless 8260
-# Snow Field Peak AC
-		8086 0030  Dual Band Wireless-AC 8260
 	24fd  Wireless 8265 / 8275
-# Windstorm Peak
-		8086 0010  Dual Band Wireless-AC 8265
-		8086 1130  Dual Band Wireless-AC 8265
 	2500  82820 820 (Camino) Chipset Host Bridge (MCH)
-		1028 0095  Precision Workstation 220 Chipset
-		1043 801c  P3C-2000 system chipset
 	2501  82820 820 (Camino) Chipset Host Bridge (MCH)
-		1043 801c  P3C-2000 system chipset
 	250b  82820 820 (Camino) Chipset Host Bridge
 	250f  82820 820 (Camino) Chipset AGP Bridge
 	2520  82805AA MTH Memory Translator Hub
 	2521  82804AA MRH-S Memory Repeater Hub for SDRAM
 	2530  82850 850 (Tehama) Chipset Host Bridge (MCH)
-		1028 00c7  Dimension 8100
-		147b 0507  TH7II-RAID
 	2531  82860 860 (Wombat) Chipset Host Bridge (MCH)
-		1028 00d8  Precision 530
 	2532  82850 850 (Tehama) Chipset AGP Bridge
 	2533  82860 860 (Wombat) Chipset AGP Bridge
 	2534  82860 860 (Wombat) Chipset PCI Bridge
 	2540  E7500 Memory Controller Hub
-		15d9 3480  P4DP6
 	2541  E7500/E7501 Host RASUM Controller
-		15d9 3480  P4DP6
-		4c53 1090  Cx9 / Vx9 mainboard
-		8086 3424  SE7501HG2 Mainboard
 	2543  E7500/E7501 Hub Interface B PCI-to-PCI Bridge
 	2544  E7500/E7501 Hub Interface B RASUM Controller
-		4c53 1090  Cx9 / Vx9 mainboard
 	2545  E7500/E7501 Hub Interface C PCI-to-PCI Bridge
 	2546  E7500/E7501 Hub Interface C RASUM Controller
 	2547  E7500/E7501 Hub Interface D PCI-to-PCI Bridge
 	2548  E7500/E7501 Hub Interface D RASUM Controller
 	254c  E7501 Memory Controller Hub
-		4c53 1090  Cx9 / Vx9 mainboard
-		8086 3424  SE7501HG2 Mainboard
 	2550  E7505 Memory Controller Hub
 	2551  E7505/E7205 Series RAS Controller
 	2552  E7505/E7205 PCI-to-AGP Bridge
@@ -24977,157 +13843,45 @@ var pciids = []byte(`#
 	2554  E7505 Hub Interface B PCI-to-PCI Bridge RAS Controller
 	255d  E7205 Memory Controller Hub
 	2560  82845G/GL[Brookdale-G]/GE/PE DRAM Controller/Host-Hub Interface
-		1028 0126  Optiplex GX260
-		1458 2560  GA-8PE667 Ultra
-		1462 5800  845PE Max (MS-6580)
 	2561  82845G/GL[Brookdale-G]/GE/PE Host-to-AGP Bridge
 	2562  82845G/GL[Brookdale-G]/GE Chipset Integrated Graphics Device
-		0e11 00b9  Evo D510 SFF
-		1014 0267  NetVista A30p
-		1028 0160  Dimension 2400
-		1734 1003  D1521 Mainboard (Fujitsu-Siemens)
-		1734 1004  D1451 Mainboard (SCENIC N300, i845GV)
 	2570  82865G/PE/P DRAM Controller/Host-Hub Interface
-		103c 006a  NX9500
-		103c 12bc  d330 uT
-		1043 80f2  P4P800/P5P800 series motherboard
-		1458 2570  GA-8IPE1000 Pro2 motherboard (865PE)
 	2571  82865G/PE/P AGP Bridge
 	2572  82865G Integrated Graphics Controller
-		1028 019d  Dimension 3000
-		103c 12bc  D530 sff(dc578av)
-		1043 80a5  P5P800-MX Mainboard
-		1462 7650  Hetis 865GV-E (MS-7065)
-		1734 101b  Fujitsu-Siemens Scenic E300 i865GV
-		8086 4246  Desktop Board D865GBF
-		8086 4c43  Desktop Board D865GLC
 	2573  82865G/PE/P PCI to CSA Bridge
 	2576  82865G/PE/P Processor to I/O Memory Interface
 	2578  82875P/E7210 Memory Controller Hub
-		1458 2578  GA-8KNXP motherboard (875P)
-		1462 7580  MS-6758 (875P Neo)
-		15d9 4580  P4SCE Motherboard
 	2579  82875P Processor to AGP Controller
 	257b  82875P/E7210 Processor to PCI to CSA Bridge
 	257e  82875P/E7210 Processor to I/O Memory Interface
 	2580  82915G/P/GV/GL/PL/910GL Memory Controller Hub
-		1458 2580  GA-8I915ME-G Mainboard
-		1462 7028  915P/G Neo2
-		1734 105b  Scenic W620
 	2581  82915G/P/GV/GL/PL/910GL PCI Express Root Port
 	2582  82915G/GV/910GL Integrated Graphics Controller
-		1028 1079  Optiplex GX280
-		103c 3006  DC7100 SFF(DX878AV)
-		1043 2582  P5GD1-VW Mainboard
-		1458 2582  GA-8I915ME-G Mainboard
-		1734 105b  Scenic W620
-		1849 2582  ASRock P4Dual-915GL
 	2584  82925X/XE Memory Controller Hub
-		1028 0177  Dimension 8400
 	2585  82925X/XE PCI Express Root Port
 	2588  E7220/E7221 Memory Controller Hub
 	2589  E7220/E7221 PCI Express Root Port
 	258a  E7221 Integrated Graphics Controller
 	2590  Mobile 915GM/PM/GMS/910GML Express Processor to DRAM Controller
-		1014 0575  ThinkPad X41 / Z60t
-		1028 0182  Latitude C610
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		104d 81b7  Vaio VGN-S3XP
-		a304 81b7  Vaio VGN-S3XP
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2591  Mobile 915GM/PM Express PCI Express Root Port
-		103c 0934  Compaq nw8240 Mobile Workstation
 	2592  Mobile 915GM/GMS/910GML Express Graphics Controller
-		1014 0582  ThinkPad X41
-		103c 099c  NX6110/NC6120
-		103c 308a  NC6220
-		1043 1881  GMA 900 915GM Integrated Graphics
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	25a1  6300ESB LPC Interface Controller
 	25a2  6300ESB PATA Storage Controller
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		1775 10d0  V5D Single Board Computer IDE
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10e0  PSL09 PrPMC
 	25a3  6300ESB SATA Storage Controller
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10d0  Telum ASLP10 Processor AMC
-		4c53 10e0  PSL09 PrPMC
 	25a4  6300ESB SMBus Controller
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		1775 10d0  V5D Single Board Computer
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10d0  Telum ASLP10 Processor AMC
-		4c53 10e0  PSL09 PrPMC
 	25a6  6300ESB AC'97 Audio Controller
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
 	25a7  6300ESB AC'97 Modem Controller
 	25a9  6300ESB USB Universal Host Controller
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		1775 10d0  V5D Single Board Computer USB
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10d0  Telum ASLP10 Processor AMC
-		4c53 10e0  PSL09 PrPMC
 	25aa  6300ESB USB Universal Host Controller
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10d0  Telum ASLP10 Processor AMC
-		4c53 10e0  PSL09 PrPMC
 	25ab  6300ESB Watchdog Timer
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		1775 10d0  V5D Single Board Computer
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		1af4 1100  QEMU Virtual Machine
-		4c53 10b0  CL9 mainboard
-		4c53 10d0  Telum ASLP10 Processor AMC
-		4c53 10e0  PSL09 PrPMC
 	25ac  6300ESB I/O Advanced Programmable Interrupt Controller
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		1775 10d0  V5D Single Board Computer
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10d0  Telum ASLP10 Processor AMC
-		4c53 10e0  PSL09 PrPMC
 	25ad  6300ESB USB2 Enhanced Host Controller
-		1734 1073  Primergy Econel 200 D2020 mainboard
-		1775 10d0  V5D Single Board Computer USB 2.0
-		1775 1100  CR11/VR11 Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10d0  Telum ASLP10 Processor AMC
-		4c53 10e0  PSL09 PrPMC
 	25ae  6300ESB 64-bit PCI-X Bridge
 	25b0  6300ESB SATA RAID Controller
-		1775 1100  CR11/VR11 Single Board Computer
-		4c53 10d0  Telum ASLP10 Processor AMC
-		4c53 10e0  PSL09 PrPMC
 	25c0  5000X Chipset Memory Controller Hub
 	25d0  5000Z Chipset Memory Controller Hub
 	25d4  5000V Chipset Memory Controller Hub
-		15d9 8680  X7DVL-E-O motherboard
 	25d8  5000P Chipset Memory Controller Hub
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	25e2  5000 Series Chipset PCI Express x4 Port 2
 	25e3  5000 Series Chipset PCI Express x4 Port 3
 	25e4  5000 Series Chipset PCI Express x4 Port 4
@@ -25135,37 +13889,15 @@ var pciids = []byte(`#
 	25e6  5000 Series Chipset PCI Express x4 Port 6
 	25e7  5000 Series Chipset PCI Express x4 Port 7
 	25f0  5000 Series Chipset FSB Registers
-		1028 01bb  PowerEdge 1955 FSB Registers
-		103c 31fd  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	25f1  5000 Series Chipset Reserved Registers
-		103c 31fd  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	25f3  5000 Series Chipset Reserved Registers
-		103c 31fd  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	25f5  5000 Series Chipset FBD Registers
-		103c 31fd  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	25f6  5000 Series Chipset FBD Registers
-		103c 31fd  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	25f7  5000 Series Chipset PCI Express x8 Port 2-3
 	25f8  5000 Series Chipset PCI Express x8 Port 4-5
 	25f9  5000 Series Chipset PCI Express x8 Port 6-7
 	25fa  5000X Chipset PCI Express x16 Port 4-7
 	2600  E8500/E8501 Hub Interface 1.5
-		1028 0170  PowerEdge 6850 Hub Interface
 	2601  E8500/E8501 PCI Express x4 Port D
 	2602  E8500/E8501 PCI Express x4 Port C0
 	2603  E8500/E8501 PCI Express x4 Port C1
@@ -25192,1060 +13924,169 @@ var pciids = []byte(`#
 	261d  E8500/E8501 Reserved Registers
 	261e  E8500/E8501 Reserved Registers
 	2620  E8500/E8501 eXternal Memory Bridge
-		1028 0170  PowerEdge 6850 Memory Bridge
 	2621  E8500/E8501 XMB Miscellaneous Registers
-		1028 0170  PowerEdge 6850 XMB Registers
 	2622  E8500/E8501 XMB Memory Interleaving Registers
-		1028 0170  PowerEdge 6850 Memory Interleaving Registers
 	2623  E8500/E8501 XMB DDR Initialization and Calibration
-		1028 0170  PowerEdge 6850 DDR Initialization and Calibration
 	2624  E8500/E8501 XMB Reserved Registers
-		1028 0170  PowerEdge 6850 Reserved Registers
 	2625  E8500/E8501 XMB Reserved Registers
-		1028 0170  PowerEdge 6850 Reserved Registers
 	2626  E8500/E8501 XMB Reserved Registers
-		1028 0170  PowerEdge 6850 Reserved Registers
 	2627  E8500/E8501 XMB Reserved Registers
-		1028 0170  PowerEdge 6850 Reserved Registers
 	2640  82801FB/FR (ICH6/ICH6R) LPC Interface Bridge
-		1462 7028  915P/G Neo2
-		1734 105c  Scenic W620
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2641  82801FBM (ICH6M) LPC Interface Bridge
-		1014 0568  ThinkPad X41
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
 	2642  82801FW/FRW (ICH6W/ICH6RW) LPC Interface Bridge
 	2651  82801FB/FW (ICH6/ICH6W) SATA Controller
-		1028 0179  Optiplex GX280
-		1043 2601  P5GD1-VW Mainboard
-		1734 105c  Scenic W620
-		8086 4147  D915GAG Motherboard
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2652  82801FR/FRW (ICH6R/ICH6RW) SATA Controller
-		1028 0177  Dimension 8400
-		1462 7028  915P/G Neo2
 	2653  82801FBM (ICH6M) SATA Controller
-		1014 056a  ThinkPad X41
 	2658  82801FB/FBM/FR/FW/FRW (ICH6 Family) USB UHCI #1
-		1014 0565  ThinkPad X41
-		1028 0177  Dimension 8400
-		1028 0179  Optiplex GX280
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		1043 80a6  P5GD1-VW Mainboard
-		1458 2558  GA-8I915ME-G Mainboard
-		1462 7028  915P/G Neo2
-		1734 105c  Scenic W620
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2659  82801FB/FBM/FR/FW/FRW (ICH6 Family) USB UHCI #2
-		1014 0565  ThinkPad X41
-		1028 0177  Dimension 8400
-		1028 0179  Optiplex GX280
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		1043 80a6  P5GD1-VW Mainboard
-		1458 2659  GA-8I915ME-G Mainboard
-		1462 7028  915P/G Neo2
-		1734 105c  Scenic W620
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	265a  82801FB/FBM/FR/FW/FRW (ICH6 Family) USB UHCI #3
-		1014 0565  ThinkPad X41
-		1028 0177  Dimension 8400
-		1028 0179  Optiplex GX280
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		1043 80a6  P5GD1-VW Mainboard
-		1458 265a  GA-8I915ME-G Mainboard
-		1462 7028  915P/G Neo2
-		1734 105c  Scenic W620
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	265b  82801FB/FBM/FR/FW/FRW (ICH6 Family) USB UHCI #4
-		1014 0565  ThinkPad X41
-		1028 0177  Dimension 8400
-		1028 0179  Optiplex GX280
-		103c 099c  NX6110/NC6120
-		1043 80a6  P5GD1-VW Mainboard
-		1458 265a  GA-8I915ME-G Mainboard
-		1462 7028  915P/G Neo2
-		1734 105c  Scenic W620
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	265c  82801FB/FBM/FR/FW/FRW (ICH6 Family) USB2 EHCI Controller
-		1014 0566  ThinkPad X41
-		1028 0177  Dimension 8400
-		1028 0179  Optiplex GX280
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		1043 80a6  P5GD1-VW Mainboard
-		1458 5006  GA-8I915ME-G Mainboard
-		1462 7028  915P/G Neo2
-		1734 105c  Scenic W620
-		8086 265c  Dimension 3100
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2660  82801FB/FBM/FR/FW/FRW (ICH6 Family) PCI Express Port 1
-		103c 0934  Compaq nw8240 Mobile Workstation
-		103c 099c  NX6110/NC6120
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2662  82801FB/FBM/FR/FW/FRW (ICH6 Family) PCI Express Port 2
-		103c 0934  Compaq nw8240 Mobile Workstation
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2664  82801FB/FBM/FR/FW/FRW (ICH6 Family) PCI Express Port 3
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2666  82801FB/FBM/FR/FW/FRW (ICH6 Family) PCI Express Port 4
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2668  82801FB/FBM/FR/FW/FRW (ICH6 Family) High Definition Audio Controller
-		1014 05b7  ThinkPad Z60t
-# based on the PTGD1-LA motherboard
-		103c 2a09  PufferM-UL8E
-		1043 1173  A6VC
-		1043 814e  P5GD1-VW Mainboard
-		1462 7028  915P/G Neo2
-		1af4 1100  QEMU Virtual Machine
 	266a  82801FB/FBM/FR/FW/FRW (ICH6 Family) SMBus Controller
-		1014 056b  ThinkPad X41
-		1028 0177  Dimension 8400
-		1028 0179  Optiplex GX280
-		1043 80a6  P5GD1-VW Mainboard
-		1458 266a  GA-8I915ME-G Mainboard
-		1462 7028  915P/G Neo2
-		1734 105c  Scenic W620
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	266c  82801FB/FBM/FR/FW/FRW (ICH6 Family) LAN Controller
 	266d  82801FB/FBM/FR/FW/FRW (ICH6 Family) AC'97 Modem Controller
-		1025 006a  Conexant AC'97 CoDec (in Acer TravelMate 2410 serie laptop)
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
 	266e  82801FB/FBM/FR/FW/FRW (ICH6 Family) AC'97 Audio Controller
-		1014 0581  ThinkPad X41 (Analog Devices AD1981B codec)
-		1025 006a  Realtek ALC 655 codec (in Acer TravelMate 2410 serie laptop)
-		1028 0177  Dimension 8400
-		1028 0179  Optiplex GX280
-		1028 0182  Latitude D610 Laptop
-		1028 0187  Precision M70 Laptop
-		1028 0188  Inspiron 6000 laptop
-		103c 0934  Compaq nw8240/nx8220
-		103c 0944  Compaq NC6220
-		103c 099c  NX6110/NC6120
-		103c 3006  DC7100 SFF(DX878AV)
-		1458 a002  GA-8I915ME-G Mainboard
-		152d 0745  Packard Bell A8550 Laptop
-		1734 105a  Scenic W620
 	266f  82801FB/FBM/FR/FW/FRW (ICH6 Family) IDE Controller
-		1028 0177  Dimension 8400
-		103c 0934  Compaq nw8240/nx8220
-		103c 099c  NX6110/NC6120
-		1043 80a6  P5GD1-VW Mainboard
-		1458 266f  GA-8I915ME-G Mainboard
-		1462 7028  915P/G Neo2
-		1734 105c  Scenic W620
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	2670  631xESB/632xESB/3100 Chipset LPC Interface Controller
-		103c 31fe  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	2680  631xESB/632xESB/3100 Chipset SATA IDE Controller
 	2681  631xESB/632xESB SATA AHCI Controller
-		103c 31fe  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	2682  631xESB/632xESB SATA RAID Controller
-		103c 31fe  Adaptec Serial ATA HostRAID
 	2683  631xESB/632xESB SATA RAID Controller
 	2688  631xESB/632xESB/3100 Chipset UHCI USB Controller #1
-		1028 01bb  PowerEdge 1955 onboard USB
-		1028 01f0  PowerEdge R900 onboard USB
-		103c 31fe  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	2689  631xESB/632xESB/3100 Chipset UHCI USB Controller #2
-		1028 01bb  PowerEdge 1955 onboard USB
-		1028 01f0  PowerEdge R900 onboard USB
-		103c 31fe  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	268a  631xESB/632xESB/3100 Chipset UHCI USB Controller #3
-		1028 01f0  PowerEdge R900 onboard USB
-		103c 31fe  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	268b  631xESB/632xESB/3100 Chipset UHCI USB Controller #4
-		1028 01f0  PowerEdge R900 onboard USB
-		15d9 8680  X7DVL-E-O motherboard
-		8086 3476  S5000PSLSATA Server Board
 	268c  631xESB/632xESB/3100 Chipset EHCI USB2 Controller
-		1028 01bb  PowerEdge 1955 onboard USB
-		1028 01f0  PowerEdge R900 onboard USB
-		103c 31fe  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	2690  631xESB/632xESB/3100 Chipset PCI Express Root Port 1
-		103c 31fe  ProLiant DL140 G3
-		15d9 9680  X7DBN Motherboard
 	2692  631xESB/632xESB/3100 Chipset PCI Express Root Port 2
-		103c 31fe  ProLiant DL140 G3
 	2694  631xESB/632xESB/3100 Chipset PCI Express Root Port 3
 	2696  631xESB/632xESB/3100 Chipset PCI Express Root Port 4
 	2698  631xESB/632xESB AC '97 Audio Controller
 	2699  631xESB/632xESB AC '97 Modem Controller
 	269a  631xESB/632xESB High Definition Audio Controller
 	269b  631xESB/632xESB/3100 Chipset SMBus Controller
-		103c 31fe  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
-		8086 3476  S5000PSLSATA Server Board
 	269e  631xESB/632xESB IDE Controller
-		103c 31fe  ProLiant DL140 G3
-		15d9 8680  X7DVL-E-O motherboard
-		15d9 9680  X7DBN Motherboard
 	2770  82945G/GZ/P/PL Memory Controller Hub
-		1028 01ad  OptiPlex GX620
-		103c 2a3b  Pavilion A1512X
-		1043 817a  P5LD2-VM Mainboard
-		107b 5048  E4500
-		1462 7418  Wind PC MS-7418
-		8086 544e  DeskTop Board D945GTP
 	2771  82945G/GZ/P/PL PCI Express Root Port
 	2772  82945G/GZ Integrated Graphics Controller
-		103c 2a3b  Pavilion A1512X
-		1462 7418  Wind PC MS-7418
-		8086 544e  DeskTop Board D945GTP
-		8086 d605  Desktop Board D945GCCR
 	2774  82955X Memory Controller Hub
 	2775  82955X PCI Express Root Port
 	2776  82945G/GZ Integrated Graphics Controller
 	2778  E7230/3000/3010 Memory Controller Hub
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
 	2779  E7230/3000/3010 PCI Express Root Port
 	277a  82975X/3010 PCI Express Root Port
 	277c  82975X Memory Controller Hub
-		1043 8178  P5WDG2 WS Professional motherboard
 	277d  82975X PCI Express Root Port
 	2782  82915G Integrated Graphics Controller
-		1043 2582  P5GD1-VW Mainboard
-		1734 105b  Scenic W620
 	2792  Mobile 915GM/GMS/910GML Express Graphics Controller
-		1014 0582  ThinkPad X41
-		103c 099c  NX6110/NC6120
-		1043 1881  GMA 900 915GM Integrated Graphics
-		e4bf 0ccd  CCD-CALYPSO
-		e4bf 0cd3  CD3-JIVE
-		e4bf 58b1  XB1
 	27a0  Mobile 945GM/PM/GMS, 943/940GML and 945GT Express Memory Controller Hub
-		1025 006c  9814 WKMI
-		1028 01d7  XPS M1210
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		103c 30d5  530 Laptop
-		1043 1237  A6J-Q008
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		17aa 2015  ThinkPad T60
-		17aa 2017  ThinkPad R60/T60/X60 series
 	27a1  Mobile 945GM/PM/GMS, 943/940GML and 945GT Express PCI Express Root Port
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a3  Compaq nw8440
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
 	27a2  Mobile 945GM/GMS, 943/940GML Express Integrated Graphics Controller
-		103c 30a1  NC2400
-		103c 30d5  530 Laptop
-		17aa 201a  ThinkPad R60/T60/X60 series
-		9902 1584  CCE MPL-D10H120F
 	27a6  Mobile 945GM/GMS/GME, 943/940GML Express Integrated Graphics Controller
-		103c 30a1  NC2400
-		103c 30d5  530 Laptop
-		1775 11cc  CC11/CL11 integrated graphics (secondary)
-		17aa 201a  ThinkPad R60/T60/X60 series
 	27ac  Mobile 945GSE Express Memory Controller Hub
-		1775 11cc  CC11/CL11
 	27ad  Mobile 945GSE Express PCI Express Root Port
 	27ae  Mobile 945GSE Express Integrated Graphics Controller
-		1775 11cc  CC11/CL11 integrated graphics (primary)
 	27b0  82801GH (ICH7DH) LPC Interface Bridge
-		103c 2a3b  Pavilion A1512X
-		8086 544e  DeskTop Board D945GTP
 	27b8  82801GB/GR (ICH7 Family) LPC Interface Bridge
-		1028 01e6  PowerEdge 860
-		103c 2a8c  Compaq 500B Microtower
-		1043 8179  P5KPL-VM Motherboard
-		107b 5048  E4500
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		8086 544e  DeskTop Board D945GTP
 	27b9  82801GBM (ICH7-M) LPC Interface Bridge
-		1028 01d7  XPS M1210
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		103c 30d5  530 Laptop
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		10f7 8338  Panasonic CF-Y5 laptop
-		17aa 2009  ThinkPad R60/T60/X60 series
 	27bc  NM10 Family LPC Controller
-		105b 0d7c  D270S/D250S Motherboard
-		144d c072  Notebook N150P
-		1458 5001  GA-D525TUD
-		8086 4f4d  DeskTop Board D510MO
-		8086 544b  Desktop Board D425KT
 	27bd  82801GHM (ICH7-M DH) LPC Interface Bridge
-		1025 006c  9814 WKMI
 	27c0  NM10/ICH7 Family SATA Controller [IDE mode]
-		1028 01ad  OptiPlex GX620
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
-		103c 2a8c  Compaq 500B Microtower
-		1043 8179  P5KPL-VM Motherboard
-		107b 5048  E4500
-		1462 2310  MSI Hetis 945
-		1462 7236  945P Neo3-F Rev. 2.2 motherboard
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		8086 544b  Desktop Board D425KT
-		8086 544e  DeskTop Board D945GTP
 	27c1  NM10/ICH7 Family SATA Controller [AHCI mode]
-		1028 01df  PowerEdge SC440
-		103c 2a3b  Pavilion A1512X
-		105b 0d7c  D270S/D250S Motherboard
-		144d c072  Notebook N150P
-		1458 b005  GA-D525TUD
-		1775 11cc  CC11/CL11
-		8086 4f4d  DeskTop Board D510MO
-		8086 5842  DeskTop Board D975XBX
 	27c3  82801GR/GDH (ICH7R/ICH7DH) SATA Controller [RAID mode]
-		1775 11cc  CC11/CL11
-		8086 544e  DeskTop Board D945GTP
 	27c4  82801GBM/GHM (ICH7-M Family) SATA Controller [IDE mode]
-		1025 006c  9814 WKMI
-		1028 01d7  XPS M1210
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		17aa 200e  ThinkPad T60
 	27c5  82801GBM/GHM (ICH7-M Family) SATA Controller [AHCI mode]
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a3  Compaq nw8440
-		103c 30d5  530 Laptop
-		17aa 200d  ThinkPad R60/T60/X60 series
 	27c6  82801GHM (ICH7-M DH) SATA Controller [RAID mode]
 	27c8  NM10/ICH7 Family USB UHCI Controller #1
-		1025 006c  9814 WKMI
-		1028 01ad  OptiPlex GX620
-		1028 01d7  XPS M1210
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
-		103c 2a3b  Pavilion A1512X
-		103c 2a8c  Compaq 500B Microtower
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		103c 30d5  530 Laptop
-		1043 1237  A6J-Q008
-		1043 8179  P5KPL-VM,P5LD2-VM Mainboard
-		105b 0d7c  D270S/D250S Motherboard
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		107b 5048  E4500
-		144d c072  Notebook N150P
-		1458 5004  GA-D525TUD
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 200a  ThinkPad R60/T60/X60 series
-		8086 4f4d  DeskTop Board D510MO
-		8086 544b  Desktop Board D425KT
-		8086 544e  DeskTop Board D945GTP
 	27c9  NM10/ICH7 Family USB UHCI Controller #2
-		1025 006c  9814 WKMI
-		1028 01ad  OptiPlex GX620
-		1028 01d7  XPS M1210
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
-		103c 2a3b  Pavilion A1512X
-		103c 2a8c  Compaq 500B Microtower
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		1043 1237  A6J-Q008
-		1043 8179  P5KPL-VM,P5LD2-VM Mainboard
-		105b 0d7c  D270S/D250S Motherboard
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		107b 5048  E4500
-		144d c072  Notebook N150P
-		1458 5004  GA-D525TUD
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 200a  ThinkPad R60/T60/X60 series
-		8086 4f4d  DeskTop Board D510MO
-		8086 544b  Desktop Board D425KT
-		8086 544e  DeskTop Board D945GTP
 	27ca  NM10/ICH7 Family USB UHCI Controller #3
-		1025 006c  9814 WKMI
-		1028 01ad  OptiPlex GX620
-		1028 01d7  XPS M1210
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
-		103c 2a3b  Pavilion A1512X
-		103c 2a8c  Compaq 500B Microtower
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		1043 1237  A6J-Q008
-		1043 8179  P5KPL-VM,P5LD2-VM Mainboard
-		105b 0d7c  D270S/D250S Motherboard
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		107b 5048  E4500
-		144d c072  Notebook N150P
-		1458 5004  GA-D525TUD
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 200a  ThinkPad R60/T60/X60 series
-		8086 4f4d  DeskTop Board D510MO
-		8086 544e  DeskTop Board D945GTP
 	27cb  NM10/ICH7 Family USB UHCI Controller #4
-		1025 006c  9814 WKMI
-		1028 01ad  OptiPlex GX620
-		1028 01d7  XPS M1210
-		1028 01df  PowerEdge SC440
-		103c 2a3b  Pavilion A1512X
-		103c 2a8c  Compaq 500B Microtower
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		1043 1237  A6J-Q008
-		1043 8179  P5KPL-VM,P5LD2-VM Mainboard
-		105b 0d7c  D270S/D250S Motherboard
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		107b 5048  E4500
-		144d c072  Notebook N150P
-		1458 5004  GA-D525TUD
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 200a  ThinkPad R60/T60/X60 series
-		8086 4f4d  DeskTop Board D510MO
-		8086 544e  DeskTop Board D945GTP
 	27cc  NM10/ICH7 Family USB2 EHCI Controller
-		1025 006c  9814 WKMI
-		1028 01ad  OptiPlex GX620
-		1028 01d7  XPS M1210
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
-		103c 2a3b  Pavilion A1512X
-		103c 2a8c  Compaq 500B Microtower
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		103c 30d5  530 Laptop
-		1043 1237  A6J-Q008
-		1043 8179  P5KPL-VM,P5LD2-VM Mainboard
-		105b 0d7c  D270S/D250S Motherboard
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		144d c072  Notebook N150P
-		1458 5006  GA-D525TUD
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 200b  ThinkPad R60/T60/X60 series
-		8086 4f4d  DeskTop Board D510MO
-		8086 544b  Desktop Board D425KT
-		8086 544e  DeskTop Board D945GTP
 	27d0  NM10/ICH7 Family PCI Express Port 1
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a3  Compaq nw8440
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		144d c072  Notebook N150P
-		1458 5001  GA-D525TUD
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 2011  ThinkPad R60e
-		8086 544b  Desktop Board D425KT
 	27d2  NM10/ICH7 Family PCI Express Port 2
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a3  Compaq nw8440
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		144d c072  Notebook N150P
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 2011  ThinkPad R60e
-		8086 544b  Desktop Board D425KT
 	27d4  NM10/ICH7 Family PCI Express Port 3
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		144d c072  Notebook N150P
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 2011  ThinkPad R60e
-		8086 544b  Desktop Board D425KT
 	27d6  NM10/ICH7 Family PCI Express Port 4
-		103c 30a3  Compaq nw8440
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		144d c072  Notebook N150P
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 2011  ThinkPad R60e
-		8086 544b  Desktop Board D425KT
 	27d8  NM10/ICH7 Family High Definition Audio Controller
-		1025 006c  9814 WKMI
-		1028 01d7  XPS M1210
-		103c 2a3b  Pavilion A1512X
-		103c 2a8c  Compaq 500B Microtower
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		103c 30d5  530 Laptop
-		1043 1123  A6J-Q008
-		1043 13c4  G2P
-		1043 817f  P5LD2-VM Mainboard (Realtek ALC 882 codec)
-		1043 8290  P5KPL-VM Motherboard
-		1043 82ea  P5KPL-CM Motherboard
-		105b 0d7c  D270S/D250S Motherboard
-		1071 8207  Medion MIM 2240 Notebook PC [MD98100]
-		107b 5048  E4500
-		10f7 8338  Panasonic CF-Y5 laptop
-		1179 ff10  Toshiba Satellite A100-796 audio (Realtek ALC861)
-		1179 ff31  AC97 Data Fax SoftModem with SmartCP
-		1447 1043  Asus A8JP (Analog Devices AD1986A)
-		144d c072  Notebook N150P
-		1458 a002  GA-D525TUD (Realtek ALC887)
-		1458 a102  GA-8I945PG-RH Mainboard
-		1462 7418  Wind PC MS-7418
-		152d 0753  Softmodem
-		1734 10ad  Conexant softmodem SmartCP
-		17aa 2010  ThinkPad R60/T60/X60 series
-		17aa 3802  3000 C200 audio [Realtek ALC861VD]
-		8086 1112  DeskTop Board D945GTP
-		8086 27d8  DeskTop Board D945GTP
-		8086 d618  DeskTop Board D510MO
-		8384 7680  STAC9221 HD Audio Codec
 	27da  NM10/ICH7 Family SMBus Controller
-		1025 006c  9814 WKMI
-		1028 01ad  OptiPlex GX620
-		1028 01d7  XPS M1210
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
-		103c 2a3b  Pavilion A1512X
-		103c 2a8c  Compaq 500B Microtower
-		1043 8179  P5KPL-VM Motherboard
-		105b 0d7c  D270S/D250S Motherboard
-		1071 8209  Medion MIM 2240 Notebook PC [MD98100]
-		10f7 8338  Panasonic CF-Y5 laptop
-		144d c072  Notebook N150P
-		1458 5001  GA-8I945PG-RH/GA-D525TUD Mainboard
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 200f  ThinkPad R60/T60/X60 series
-		8086 4f4d  DeskTop Board D510MO
-		8086 544b  Desktop Board D425KT
-		8086 544e  DeskTop Board D945GTP
-		8086 5842  DeskTop Board D975XBX
 	27dc  NM10/ICH7 Family LAN Controller
-		103c 2a3b  Pavilion A1512X
-		8086 308d  DeskTop Board D945GTP
 	27dd  82801G (ICH7 Family) AC'97 Modem Controller
 	27de  82801G (ICH7 Family) AC'97 Audio Controller
-		1028 01ad  OptiPlex GX620
-		1462 7267  Realtek ALC883 Audio Controller
-		1775 11cc  CC11 integrated audio (AD1981BL codec)
 	27df  82801G (ICH7 Family) IDE Controller
-		1028 01df  PowerEdge SC440
-		1028 01e6  PowerEdge 860
-		103c 2a3b  Pavilion A1512X
-		103c 2a8c  Compaq 500B Microtower
-		103c 309f  Compaq nx9420 Notebook
-		103c 30a1  NC2400
-		103c 30a3  Compaq nw8440
-		103c 30d5  530 Laptop
-		1043 1237  A6J-Q008
-		1043 8179  P5KPL-VM Motherboard
-		107b 5048  E4500
-		10f7 8338  Panasonic CF-Y5 laptop
-		1462 7418  Wind PC MS-7418
-		1775 11cc  CC11/CL11
-		17aa 200c  ThinkPad R60/T60/X60 series
-		8086 544e  DeskTop Board D945GTP
 	27e0  82801GR/GH/GHM (ICH7 Family) PCI Express Port 5
-		1775 11cc  CC11/CL11
 	27e2  82801GR/GH/GHM (ICH7 Family) PCI Express Port 6
-		1775 11cc  CC11/CL11
 	2810  82801HB/HR (ICH8/R) LPC Interface Controller
-		1043 81ec  P5B
 	2811  82801HEM (ICH8M-E) LPC Interface Controller
-		103c 30c1  Compaq 6910p
-		17aa 20b6  ThinkPad T61/R61
-		e4bf cc47  CCG-RUMBA
 	2812  82801HH (ICH8DH) LPC Interface Controller
 	2814  82801HO (ICH8DO) LPC Interface Controller
 	2815  82801HM (ICH8M) LPC Interface Controller
-		1025 0121  Aspire 5920G
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30cc  Pavilion dv6700
-		103c 30d9  Presario C700
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		17aa 20a5  ThinkPad R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 	2820  82801H (ICH8 Family) 4 port SATA Controller [IDE mode]
-		1028 01da  OptiPlex 745
-		1462 7235  P965 Neo MS-7235 mainboard
 	2821  82801HR/HO/HH (ICH8R/DO/DH) 6 port SATA Controller [AHCI mode]
 	2822  SATA Controller [RAID mode]
-		1028 020d  Inspiron 530
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
 	2823  C610/X99 series chipset sSATA Controller [RAID mode]
 	2824  82801HB (ICH8) 4 port SATA Controller [AHCI mode]
-		1043 81ec  P5B
 	2825  82801HR/HO/HH (ICH8R/DO/DH) 2 port SATA Controller [IDE mode]
-		1028 01da  OptiPlex 745
-		1462 7235  P965 Neo MS-7235 mainboard
 	2826  C600/X79 series chipset SATA RAID Controller
-		1d49 0100  Intel RSTe SATA Software RAID
-		1d49 0101  Intel RSTe SATA Software RAID
-		1d49 0102  Intel RSTe SATA Software RAID
-		1d49 0103  Intel RSTe SATA Software RAID
-		1d49 0104  Intel RSTe SATA Software RAID
-		1d49 0105  Intel RSTe SATA Software RAID
 	2827  C610/X99 series chipset sSATA Controller [RAID mode]
 	2828  82801HM/HEM (ICH8M/ICH8M-E) SATA Controller [IDE mode]
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		17aa 20a8  ThinkPad R61
-		e4bf cc47  CCG-RUMBA
 	2829  82801HM/HEM (ICH8M/ICH8M-E) SATA Controller [AHCI mode]
-		1025 0121  Aspire 5920G
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30d9  Presario C700
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		17aa 20a7  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	282a  82801 Mobile SATA Controller [RAID mode]
-		1028 040b  Latitude E6510
-		e4bf 50c1  PC1-GROOVE
 	2830  82801H (ICH8 Family) USB UHCI Controller #1
-		1025 0121  Aspire 5920G
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30d9  Presario C700
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		1462 7235  P965 Neo MS-7235 mainboard
-		17aa 20aa  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2831  82801H (ICH8 Family) USB UHCI Controller #2
-		1025 0121  Aspire 5920G
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30d9  Presario C700
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		1462 7235  P965 Neo MS-7235 mainboard
-		17aa 20aa  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2832  82801H (ICH8 Family) USB UHCI Controller #3
-		1025 0121  Aspire 5920G
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30d9  Presario C700
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		17aa 20aa  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2833  82801H (ICH8 Family) USB UHCI Controller #4
-		1043 81ec  P5B
 	2834  82801H (ICH8 Family) USB UHCI Controller #4
-		1025 0121  Aspire 5920G
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		1462 7235  P965 Neo MS-7235 mainboard
-		17aa 20aa  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2835  82801H (ICH8 Family) USB UHCI Controller #5
-		1025 0121  Aspire 5920G
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		17aa 20aa  Thinkpad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2836  82801H (ICH8 Family) USB2 EHCI Controller #1
-		1025 0121  Aspire 5920G
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30d9  Presario C700
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		1462 7235  P965 Neo MS-7235 mainboard
-		17aa 20ab  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	283a  82801H (ICH8 Family) USB2 EHCI Controller #2
-		1025 0121  Aspire 5920G
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		17aa 20ab  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	283e  82801H (ICH8 Family) SMBus Controller
-		1025 0121  Aspire 5920G
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		103c 30d9  Presario C700
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 9008  Vaio VGN-SZ79SN_C
-		104d 902d  VAIO VGN-NR120E
-		1462 7235  P965 Neo MS-7235 mainboard
-		17aa 20a9  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	283f  82801H (ICH8 Family) PCI Express Port 1
-		1028 01da  OptiPlex 745
-		103c 30c1  Compaq 6910p
-		104d 902d  VAIO VGN-NR120E
-		17aa 20ad  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 	2841  82801H (ICH8 Family) PCI Express Port 2
-		103c 30c1  Compaq 6910p
-		104d 902d  VAIO VGN-NR120E
-		17aa 20ad  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 	2843  82801H (ICH8 Family) PCI Express Port 3
-		104d 902d  VAIO VGN-NR120E
-		17aa 20ad  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 	2845  82801H (ICH8 Family) PCI Express Port 4
-		17aa 20ad  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 	2847  82801H (ICH8 Family) PCI Express Port 5
-		1028 01da  OptiPlex 745
-		103c 30c1  Compaq 6910p
-		17aa 20ad  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
 	2849  82801H (ICH8 Family) PCI Express Port 6
 	284b  82801H (ICH8 Family) HD Audio Controller
-		1025 011f  Realtek ALC268 audio codec
-		1025 0121  Aspire 5920G
-		1025 0145  Realtek ALC889 (Aspire 8920G w. Dolby Theater)
-		1028 01da  OptiPlex 745
-		1028 01f3  Inspiron 1420
-		1028 01f9  Latitude D630
-		1028 01ff  Precision M4300
-		1028 0256  Studio 1735
-		103c 2802  Compaq dc7700p
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		1043 1339  M51S series
-		1043 81ec  P5B
-		104d 9005  Vaio VGN-FZ260E
-		104d 9008  Vaio VGN-SZ79SN_C
-		104d 9016  Sony VAIO VGN-AR51M
-		104d 902d  VAIO VGN-NR120E
-		14f1 5051  Presario C700
-		17aa 20ac  ThinkPad T61/R61
-		17c0 4088  Medion WIM 2210 Notebook PC [MD96850]
-		8384 7616  Dell Vostro 1400
-		e4bf cc47  CCG-RUMBA
 	284f  82801H (ICH8 Family) Thermal Reporting Device
 	2850  82801HM/HEM (ICH8M/ICH8M-E) IDE Controller
-		1025 0121  Aspire 5920G
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30d9  Presario C700
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		17aa 20a6  ThinkPad T61/R61
-		17c0 4083  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2912  82801IH (ICH9DH) LPC Interface Controller
 	2914  82801IO (ICH9DO) LPC Interface Controller
-		1028 0211  Optiplex 755
 	2916  82801IR (ICH9R) LPC Interface Controller
-		1028 020d  Inspiron 530
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		8086 5044  Desktop Board DP35DP
 	2917  ICH9M-E LPC Interface Controller
-		e4bf cc4d  CCM-BOOGIE
 	2918  82801IB (ICH9) LPC Interface Controller
-		1028 0236  PowerEdge R610 82801IB (ICH9) LPC Interface Controller
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
 	2919  ICH9M LPC Interface Controller
 	2920  82801IR/IO/IH (ICH9R/DO/DH) 4 port SATA Controller [IDE mode]
-		1028 020d  Inspiron 530
-		1028 020f  PowerEdge R300 onboard SATA Controller
-		1028 0210  PowerEdge T300 onboard SATA Controller
-		1028 0211  Optiplex 755
-		1028 023c  PowerEdge R200 onboard SATA Controller
-		1043 8277  P5K PRO Motherboard
 	2921  82801IB (ICH9) 2 port SATA Controller [IDE mode]
-		1028 0235  PowerEdge R710 SATA IDE Controller
-		1028 0236  PowerEdge R610 SATA IDE Controller
-		1028 0237  PowerEdge T610 SATA IDE Controller
-		1462 7360  G33/P35 Neo
 	2922  82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]
-		1043 8277  P5K PRO Motherboard
-		1af4 1100  QEMU Virtual Machine
-		8086 5044  Desktop Board DP35DP
 	2923  82801IB (ICH9) 4 port SATA Controller [AHCI mode]
 	2925  82801IR/IO (ICH9R/DO) SATA Controller [RAID mode]
-		1734 10e0  System Board D2542
-		8086 2925  System Board D2542
 	2926  82801I (ICH9 Family) 2 port SATA Controller [IDE mode]
-		1028 020d  Inspiron 530
-		1028 020f  PowerEdge R300 onboard SATA Controller
-		1028 0210  PowerEdge T300 onboard SATA Controller
-		1028 0211  Optiplex 755
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
 	2928  82801IBM/IEM (ICH9M/ICH9M-E) 2 port SATA Controller [IDE mode]
 	2929  82801IBM/IEM (ICH9M/ICH9M-E) 4 port SATA Controller [AHCI mode]
-		103c 3628  dv6-1190en
-		e4bf cc4d  CCM-BOOGIE
 	292c  82801IEM (ICH9M-E) SATA Controller [RAID mode]
 	292d  82801IBM/IEM (ICH9M/ICH9M-E) 2 port SATA Controller [IDE mode]
-		e4bf cc4d  CCM-BOOGIE
 	2930  82801I (ICH9 Family) SMBus Controller
-		1028 020d  Inspiron 530
-		1028 0211  Optiplex 755
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		103c 3628  dv6-1190en
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	2932  82801I (ICH9 Family) Thermal Subsystem
-		103c 3628  dv6-1190en
 	2934  82801I (ICH9 Family) USB UHCI Controller #1
-		1028 020d  Inspiron 530
-		1028 020f  PowerEdge R300 onboard UHCI
-		1028 0210  PowerEdge T300 onboard UHCI
-		1028 0211  Optiplex 755
-		1028 0235  PowerEdge R710 USB UHCI Controller
-		1028 0236  PowerEdge R610 USB UHCI Controller
-		1028 0237  PowerEdge T610 USB UHCI Controller
-		1028 023c  PowerEdge R200 onboard UHCI
-		1028 0287  PowerEdge M610 onboard UHCI
-		1028 029c  PowerEdge M710 USB UHCI Controller
-		1028 2011  Optiplex 755
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	2935  82801I (ICH9 Family) USB UHCI Controller #2
-		1028 020d  Inspiron 530
-		1028 020f  PowerEdge R300 onboard UHCI
-		1028 0210  PowerEdge T300 onboard UHCI
-		1028 0211  Optiplex 755
-		1028 0235  PowerEdge R710 USB UHCI Controller
-		1028 0236  PowerEdge R610 USB UHCI Controller
-		1028 0237  PowerEdge T610 USB UHCI Controller
-		1028 023c  PowerEdge R200 onboard UHCI
-		1028 0287  PowerEdge M610 onboard UHCI
-		1028 029c  PowerEdge M710 USB UHCI Controller
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	2936  82801I (ICH9 Family) USB UHCI Controller #3
-		1028 020d  Inspiron 530
-		1028 020f  PowerEdge R300 onboard UHCI
-		1028 0210  PowerEdge T300 onboard UHCI
-		1028 0211  Optiplex 755
-		1028 0237  PowerEdge T610 USB UHCI Controller
-		1028 023c  PowerEdge R200 onboard UHCI
-		1028 0287  PowerEdge M610 onboard UHCI
-		1028 029c  PowerEdge M710 USB UHCI Controller
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	2937  82801I (ICH9 Family) USB UHCI Controller #4
-		1028 020d  Inspiron 530
-		1028 0211  Optiplex 755
-		1028 0235  PowerEdge R710 USB UHCI Controller
-		1028 0236  PowerEdge R610 USB UHCI Controller
-		1028 0237  PowerEdge T610 USB UHCI Controller
-		1028 0287  PowerEdge M610 onboard UHCI
-		1028 029c  PowerEdge M710 USB UHCI Controller
-		1028 2011  Optiplex 755
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 2937  Optiplex 755
-		8086 2942  828011 (ICH9 Family ) USB UHCI Controller
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	2938  82801I (ICH9 Family) USB UHCI Controller #5
-		1028 020d  Inspiron 530
-		1028 0211  Optiplex 755
-		1028 0235  PowerEdge R710 USB UHCI Controller
-		1028 0236  PowerEdge R610 USB UHCI Controller
-		1028 0237  PowerEdge T610 USB UHCI Controller
-		1028 0287  PowerEdge M610 onboard UHCI
-		1028 029c  PowerEdge M710 USB UHCI Controller
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 2938  Optiplex 755
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	2939  82801I (ICH9 Family) USB UHCI Controller #6
-		1028 020d  Inspiron 530
-		1028 0210  PowerEdge T300 onboard UHCI
-		1028 0237  PowerEdge T610 USB UHCI Controller
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	293a  82801I (ICH9 Family) USB2 EHCI Controller #1
-		1028 020d  Inspiron 530
-		1028 020f  PowerEdge R300 onboard EHCI
-		1028 0210  PowerEdge T300 onboard EHCI
-		1028 0211  Optiplex 755
-		1028 0235  PowerEdge R710 USB EHCI Controller
-		1028 0236  PowerEdge R610 USB EHCI Controller
-		1028 0237  PowerEdge T610 USB EHCI Controller
-		1028 023c  PowerEdge R200 onboard EHCI
-		1028 0287  PowerEdge M610 onboard EHCI
-		1028 029c  PowerEdge M710 USB EHCI Controller
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	293c  82801I (ICH9 Family) USB2 EHCI Controller #2
-		1028 020d  Inspiron 530
-		1028 0211  Optiplex 755
-		1028 0235  PowerEdge R710 USB EHCI Controller
-		1028 0236  PowerEdge R610 USB EHCI Controller
-		1028 0237  PowerEdge T610 USB EHCI Controller
-		1028 0287  PowerEdge M610 onboard EHCI
-		1028 029c  PowerEdge M710 USB EHCI Controller
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		1043 8277  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 293c  Optiplex 755
-		8086 5044  Desktop Board DP35DP
-		e4bf cc4d  CCM-BOOGIE
 	293e  82801I (ICH9 Family) HD Audio Controller
-		1028 020d  Inspiron 530
-		1028 0211  Optiplex 755
-		103c 2a6f  Asus IPIBL-LB Motherboard
-		103c 3628  dv6-1190en
-		1043 829f  P5K PRO Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 293e  Optiplex 755
-		8086 2940  Optiplex 755
-		e4bf cc4d  CCM-BOOGIE
 	2940  82801I (ICH9 Family) PCI Express Port 1
-		1028 020d  Inspiron 530
-		1028 0211  Optiplex 755
-		103c 2a6f  Asus IPIBL-LB Motherboard
-# same ID possibly also on other ASUS boards
-		1043 8277  P5K PRO Motherboard
-		8086 2940  Optiplex 755
 	2942  82801I (ICH9 Family) PCI Express Port 2
-		1028 020d  Inspiron 530
 	2944  82801I (ICH9 Family) PCI Express Port 3
-		1028 020d  Inspiron 530
-		103c 2a6f  Asus IPIBL-LB Motherboard
 	2946  82801I (ICH9 Family) PCI Express Port 4
-		1028 020d  Inspiron 530
 	2948  82801I (ICH9 Family) PCI Express Port 5
-		1028 020d  Inspiron 530
-# same ID possibly also on other ASUS boards
-		1043 8277  P5K PRO Motherboard
 	294a  82801I (ICH9 Family) PCI Express Port 6
-		1028 020d  Inspiron 530
-# same ID possibly also on other ASUS boards
-		1043 8277  P5K PRO Motherboard
 	294c  82566DC-2 Gigabit Network Connection
-		17aa 302e  82566DM-2 Gigabit Network Connection
 	2970  82946GZ/PL/GL Memory Controller Hub
 	2971  82946GZ/PL/GL PCI Express Root Port
 	2972  82946GZ/GL Integrated Graphics Controller
@@ -26260,7 +14101,6 @@ var pciids = []byte(`#
 	2983  82G35 Express Integrated Graphics Controller
 	2984  82G35 Express HECI Controller
 	2990  82Q963/Q965 Memory Controller Hub
-		1028 01da  OptiPlex 745
 	2991  82Q963/Q965 PCI Express Root Port
 	2992  82Q963/Q965 Integrated Graphics Controller
 	2993  82Q963/Q965 Integrated Graphics Controller
@@ -26269,52 +14109,26 @@ var pciids = []byte(`#
 	2996  82Q963/Q965 PT IDER Controller
 	2997  82Q963/Q965 KT Controller
 	29a0  82P965/G965 Memory Controller Hub
-		1043 81ea  P5B
-		1462 7276  MS-7276 [G965MDH]
 	29a1  82P965/G965 PCI Express Root Port
 	29a2  82G965 Integrated Graphics Controller
-		1462 7276  MS-7276 [G965MDH]
 	29a3  82G965 Integrated Graphics Controller
 	29a4  82P965/G965 HECI Controller
 	29a5  82P965/G965 HECI Controller
 	29a6  82P965/G965 PT IDER Controller
 	29a7  82P965/G965 KT Controller
 	29b0  82Q35 Express DRAM Controller
-		1028 0211  OptiPlex 755
 	29b1  82Q35 Express PCI Express Root Port
-		1028 0211  OptiPlex 755
 	29b2  82Q35 Express Integrated Graphics Controller
-		1028 0211  OptiPlex 755
 	29b3  82Q35 Express Integrated Graphics Controller
-		1028 0211  OptiPlex 755
 	29b4  82Q35 Express MEI Controller
-		1028 0211  OptiPlex 755
 	29b5  82Q35 Express MEI Controller
 	29b6  82Q35 Express PT IDER Controller
-		1028 0211  OptiPlex 755
 	29b7  82Q35 Express Serial KT Controller
-		1028 0211  OptiPlex 755
 	29c0  82G33/G31/P35/P31 Express DRAM Controller
-		1028 020d  Inspiron 530
-		103c 2a6f  Asus IPIBL-LB Motherboard
-# same ID possibly also on other ASUS boards
-		1043 8276  P5K PRO Motherboard
-		1043 82b0  P5KPL-VM Motherboard
-		1462 7360  G33/P35 Neo
-		1af4 1100  QEMU Virtual Machine
-		8086 5044  Desktop Board DP35DP
 	29c1  82G33/G31/P35/P31 Express PCI Express Root Port
-		1028 020d  Inspiron 530
-# same ID possibly also on other ASUS boards
-		1043 8276  P5K PRO Motherboard
 	29c2  82G33/G31 Express Integrated Graphics Controller
-		1028 020d  Inspiron 530
-		1043 82b0  P5KPL-VM Motherboard
 	29c3  82G33/G31 Express Integrated Graphics Controller
-		1028 020d  Inspiron 530
-		1043 82b0  P5KPL-VM Motherboard
 	29c4  82G33/G31/P35/P31 Express MEI Controller
-		8086 5044  Desktop Board DP35DP
 	29c5  82G33/G31/P35/P31 Express MEI Controller
 	29c6  82G33/G31/P35/P31 Express PT IDER Controller
 	29c7  82G33/G31/P35/P31 Express Serial KT Controller
@@ -26342,62 +14156,25 @@ var pciids = []byte(`#
 	29f7  3200/3210 Chipset Serial KT Controller
 	29f9  3210 Chipset Host-Secondary PCI Express Bridge
 	2a00  Mobile PM965/GM965/GL960 Memory Controller Hub
-		1025 0121  Aspire 5920G
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30c1  Compaq 6910p
-		103c 30cc  Pavilion dv6700
-		103c 30d9  Presario C700
-		104d 9005  Vaio VGN-FZ260E
-		104d 902d  VAIO VGN-NR120E
-		17aa 20b1  ThinkPad T61
-		17aa 20b3  ThinkPad T61/R61
-		17c0 4082  Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2a01  Mobile PM965/GM965/GL960 PCI Express Root Port
 	2a02  Mobile GM965/GL960 Integrated Graphics Controller (primary)
-		1028 01f3  Inspiron 1420
-		1028 01f9  Latitude D630
-		103c 30c0  Compaq 6710b
-		103c 30d9  Presario C700
-		104d 902d  VAIO VGN-NR120E
-		17aa 20b5  GM965 [X3100] on ThinkPad T61/R61
-		17c0 4082  GM965 on Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2a03  Mobile GM965/GL960 Integrated Graphics Controller (secondary)
-		1028 01f3  Inspiron 1420
-		103c 30c0  Compaq 6710b
-		103c 30d9  Presario C700
-		104d 902d  VAIO VGN-NR120E
-		17aa 20b5  GM965 [X3100] on ThinkPad T61/R61
-		17c0 4082  GM965 on Medion WIM 2210 Notebook PC [MD96850]
-		e4bf cc47  CCG-RUMBA
 	2a04  Mobile PM965/GM965 MEI Controller
-		103c 30c1  Compaq 6910p
 	2a05  Mobile PM965/GM965 MEI Controller
 	2a06  Mobile PM965/GM965 PT IDER Controller
-		103c 30c1  Compaq 6910p
 	2a07  Mobile PM965/GM965 KT Controller
-		103c 30c1  Compaq 6910p
 	2a10  Mobile GME965/GLE960 Memory Controller Hub
-		e4bf cc47  CCG-RUMBA
 	2a11  Mobile GME965/GLE960 PCI Express Root Port
 	2a12  Mobile GME965/GLE960 Integrated Graphics Controller
-		e4bf cc47  CCG-RUMBA
 	2a13  Mobile GME965/GLE960 Integrated Graphics Controller
-		e4bf cc47  CCG-RUMBA
 	2a14  Mobile GME965/GLE960 MEI Controller
 	2a15  Mobile GME965/GLE960 MEI Controller
 	2a16  Mobile GME965/GLE960 PT IDER Controller
 	2a17  Mobile GME965/GLE960 KT Controller
 	2a40  Mobile 4 Series Chipset Memory Controller Hub
-		e4bf cc4d  CCM-BOOGIE
 	2a41  Mobile 4 Series Chipset PCI Express Graphics Port
-		e4bf cc4d  CCM-BOOGIE
 	2a42  Mobile 4 Series Chipset Integrated Graphics Controller
-		e4bf cc4d  CCM-BOOGIE
 	2a43  Mobile 4 Series Chipset Integrated Graphics Controller
-		e4bf cc4d  CCM-BOOGIE
 	2a44  Mobile 4 Series Chipset MEI Controller
 	2a45  Mobile 4 Series Chipset MEI Controller
 	2a46  Mobile 4 Series Chipset PT IDER Controller
@@ -26566,33 +14343,23 @@ var pciids = []byte(`#
 	2e10  4 Series Chipset DRAM Controller
 	2e11  4 Series Chipset PCI Express Root Port
 	2e12  4 Series Chipset Integrated Graphics Controller
-		17aa 3048  ThinkCentre M6258
 	2e13  4 Series Chipset Integrated Graphics Controller
 	2e14  4 Series Chipset HECI Controller
 	2e15  4 Series Chipset HECI Controller
 	2e16  4 Series Chipset PT IDER Controller
 	2e17  4 Series Chipset Serial KT Controller
 	2e20  4 Series Chipset DRAM Controller
-		1028 0283  Vostro 220
-		1043 82d3  P5Q Deluxe Motherboard
-		1458 5000  GA-EP45-DS5/GA-EG45M-DS2H Motherboard
 	2e21  4 Series Chipset PCI Express Root Port
-		1043 82d3  P5Q Deluxe Motherboard
-		1458 5000  GA-EP45-DS5 Motherboard
 	2e22  4 Series Chipset Integrated Graphics Controller
-		1458 d000  GA-EG45M-DS2H Mainboard
 	2e23  4 Series Chipset Integrated Graphics Controller
-		1458 d000  GA-EG45M-DS2H Mainboard
 	2e24  4 Series Chipset HECI Controller
 	2e25  4 Series Chipset HECI Controller
 	2e26  4 Series Chipset PT IDER Controller
 	2e27  4 Series Chipset Serial KT Controller
 	2e29  4 Series Chipset PCI Express Root Port
 	2e30  4 Series Chipset DRAM Controller
-		103c 2a8c  Compaq 500B Microtower
 	2e31  4 Series Chipset PCI Express Root Port
 	2e32  4 Series Chipset Integrated Graphics Controller
-		103c 2a8c  Compaq 500B Microtower
 	2e33  4 Series Chipset Integrated Graphics Controller
 	2e34  4 Series Chipset HECI Controller
 	2e35  4 Series Chipset HECI Controller
@@ -26800,30 +14567,15 @@ var pciids = []byte(`#
 	2ffd  Xeon E7 v3/Xeon E5 v3/Core i7 System Address Decoder & Broadcast Registers
 	2ffe  Xeon E7 v3/Xeon E5 v3/Core i7 System Address Decoder & Broadcast Registers
 	3165  Wireless 3165
-# Stone Peak 1x1
-		8086 4010  Dual Band Wireless AC 3165
-# Stone Peak 1x1
-		8086 4210  Dual Band Wireless AC 3165
 	3166  Dual Band Wireless-AC 3165 Plus Bluetooth
 	3200  GD31244 PCI-X SATA HBA
-		1775 c200  C2K onboard SATA host bus adapter
 	3310  IOP348 I/O Processor
-		1054 3030  HRA380 Hitachi RAID Adapter to PCIe
-		1054 3034  HRA381 Hitachi RAID Adapter to PCIe
 	3313  IOP348 I/O Processor (SL8e) in IOC Mode SAS/SATA
 	331b  IOP348 I/O Processor (SL8x) in IOC Mode SAS/SATA
 	3331  IOC340 I/O Controller (VV8e) SAS/SATA
 	3339  IOC340 I/O Controller (VV8x) SAS/SATA
 	3340  82855PM Processor to I/O Controller
-		1014 0529  Thinkpad T40 series
-		1025 005a  TravelMate 290
-		103c 088c  NC8000 laptop
-		103c 0890  NC6000 laptop
-		103c 08b0  tc1100 tablet
-		144d c005  X10 Laptop
-		144d c00c  P30/P35 notebook
 	3341  82855PM Processor to AGP Controller
-		144d c00c  P30 notebook
 	3363  IOC340 I/O Controller in IOC Mode SAS/SATA
 	3382  81342 [Chevelon] I/O Processor (ATUe)
 	33c3  IOP348 I/O Processor (SL8De) in IOC Mode SAS/SATA
@@ -26832,26 +14584,17 @@ var pciids = []byte(`#
 	3401  5520/5500/X58 I/O Hub to ESI Port
 	3402  5520/5500/X58 I/O Hub to ESI Port
 	3403  5500 I/O Hub to ESI Port
-		1028 0236  PowerEdge R610 I/O Hub to ESI Port
-		1028 0287  PowerEdge M610 I/O Hub to ESI Port
-		1028 028c  PowerEdge R410 I/O Hub to ESI Port
-		1028 028d  PowerEdge T410 I/O Hub to ESI Port
-		103c 330b  ProLiant ML150 G6 Server
 	3404  5520/5500/X58 I/O Hub to ESI Port
 	3405  5520/5500/X58 I/O Hub to ESI Port
 	3406  5520 I/O Hub to ESI Port
-		103c 330b  ProLiant G6 series
 	3407  5520/5500/X58 I/O Hub to ESI Port
 	3408  5520/5500/X58 I/O Hub PCI Express Root Port 1
-		103c 330b  ProLiant G6 series
 	3409  5520/5500/X58 I/O Hub PCI Express Root Port 2
 	340a  5520/5500/X58 I/O Hub PCI Express Root Port 3
-		103c 330b  ProLiant ML150 G6 Server
 	340b  5520/X58 I/O Hub PCI Express Root Port 4
 	340c  5520/X58 I/O Hub PCI Express Root Port 5
 	340d  5520/X58 I/O Hub PCI Express Root Port 6
 	340e  5520/5500/X58 I/O Hub PCI Express Root Port 7
-		103c 330b  ProLiant ML150 G6 Server
 	340f  5520/5500/X58 I/O Hub PCI Express Root Port 8
 	3410  7500/5520/5500/X58 I/O Hub PCI Express Root Port 9
 	3411  7500/5520/5500/X58 I/O Hub PCI Express Root Port 10
@@ -26860,9 +14603,7 @@ var pciids = []byte(`#
 	3420  7500/5520/5500/X58 I/O Hub PCI Express Root Port 0
 	3421  7500/5520/5500/X58 I/O Hub PCI Express Root Port 0
 	3422  7500/5520/5500/X58 I/O Hub GPIO and Scratch Pad Registers
-		103c 330b  ProLiant G6 series
 	3423  7500/5520/5500/X58 I/O Hub Control Status and RAS Registers
-		103c 330b  ProLiant G6 series
 	3425  7500/5520/5500/X58 Physical and Link Layer Registers Port 0
 	3426  7500/5520/5500/X58 Routing and Protocol Layer Registers Port 0
 	3427  7500/5520/5500 Physical and Link Layer Registers Port 1
@@ -26873,7 +14614,6 @@ var pciids = []byte(`#
 	342c  5520/5500/X58 Chipset QuickData Technology Device
 	342d  7500/5520/5500/X58 I/O Hub I/OxAPIC Interrupt Controller
 	342e  7500/5520/5500/X58 I/O Hub System Management Registers
-		103c 330b  ProLiant G6 series
 	342f  7500/5520/5500/X58 Trusted Execution Technology Registers
 	3430  5520/5500/X58 Chipset QuickData Technology Device
 	3431  5520/5500/X58 Chipset QuickData Technology Device
@@ -26881,133 +14621,41 @@ var pciids = []byte(`#
 	3433  5520/5500/X58 Chipset QuickData Technology Device
 	3438  7500/5520/5500/X58 I/O Hub Throttle Registers
 	3500  6311ESB/6321ESB PCI Express Upstream Port
-		103c 31fe  ProLiant DL140 G3
-		15d9 9680  X7DBN Motherboard
 	3501  6310ESB PCI Express Upstream Port
 	3504  6311ESB/6321ESB I/OxAPIC Interrupt Controller
 	3505  6310ESB I/OxAPIC Interrupt Controller
 	350c  6311ESB/6321ESB PCI Express to PCI-X Bridge
-		103c 31fe  ProLiant DL140 G3
-		15d9 9680  X7DBN Motherboard
 	350d  6310ESB PCI Express to PCI-X Bridge
 	3510  6311ESB/6321ESB PCI Express Downstream Port E1
-		103c 31fe  ProLiant DL140 G3
-		15d9 9680  X7DBN Motherboard
 	3511  6310ESB PCI Express Downstream Port E1
 	3514  6311ESB/6321ESB PCI Express Downstream Port E2
 	3515  6310ESB PCI Express Downstream Port E2
 	3518  6311ESB/6321ESB PCI Express Downstream Port E3
-		15d9 9680  X7DBN Motherboard
 	3519  6310ESB PCI Express Downstream Port E3
 	3575  82830M/MG/MP Host Bridge
-		0e11 0030  Evo N600c
-		1014 021d  ThinkPad A/T/X Series
-		104d 80e7  VAIO PCG-GR214EP/GR214MP/GR215MP/GR314MP/GR315MP
 	3576  82830M/MP AGP Bridge
 	3577  82830M/MG Integrated Graphics Controller
-		1014 0513  ThinkPad A/T/X Series
 	3578  82830M/MG/MP Host Bridge
 	3580  82852/82855 GM/GME/PM/GMV Processor to I/O Controller
-		1014 055c  ThinkPad R50e
-		1025 0064  Extensa 3000 series laptop
-		1028 0139  Latitude D400
-		1028 014f  Latitude X300
-		1028 0152  Latitude D500
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		114a 0582  PC8
-		1734 1055  Amilo M1420
-		1775 10d0  V5D Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10e0  PSL09 PrPMC
-		e4bf 0cc9  CC9-SAMBA
-		e4bf 0cd2  CD2-BEBOP
 	3581  82852/82855 GM/GME/PM/GMV Processor to AGP Controller
-		1734 1055  Amilo M1420
 	3582  82852/855GM Integrated Graphics Device
-		1014 0562  ThinkPad R50e
-		1028 0139  Latitude D400
-		1028 014f  Latitude X300
-		1028 0152  Latitude D500
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		114a 0582  PC8 integrated graphics
-		1775 10d0  V5D Single Board Computer VGA
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10e0  PSL09 PrPMC
-		e4bf 0cc9  CC9-SAMBA
-		e4bf 0cd2  CD2-BEBOP
 	3584  82852/82855 GM/GME/PM/GMV Processor to I/O Controller
-		1014 055d  ThinkPad R50e
-		1025 0064  Extensa 3000 series laptop
-		1028 0139  Latitude D400
-		1028 014f  Latitude X300
-		1028 0152  Latitude D500
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		114a 0582  PC8
-		1734 1055  Amilo M1420
-		1775 10d0  V5D Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10e0  PSL09 PrPMC
 	3585  82852/82855 GM/GME/PM/GMV Processor to I/O Controller
-		1014 055e  ThinkPad R50e
-		1025 0064  Extensa 3000 series laptop
-		1028 0139  Latitude D400
-		1028 014f  Latitude X300
-		1028 0152  Latitude D500
-		1028 0163  Latitude D505
-		1028 018d  Inspiron 700m/710m
-		1028 0196  Inspiron 5160
-		114a 0582  PC8
-		1734 1055  Amilo M1420
-		1775 10d0  V5D Single Board Computer
-		1775 ce90  CE9
-		4c53 10b0  CL9 mainboard
-		4c53 10e0  PSL09 PrPMC
 	358c  82854 GMCH
 	358e  82854 GMCH Integrated Graphics Device
 	3590  E7520 Memory Controller Hub
-		1014 02dd  eServer xSeries server mainboard
-		1028 016c  PowerEdge 1850 Memory Controller Hub
-		1028 016d  PowerEdge 2850 Memory Controller Hub
-		1028 019a  PowerEdge SC1425
-		1734 103e  PRIMERGY RX/TX S2 series
-		1775 1100  CR11/VR11 Single Board Computer
-		4c53 10d0  Telum ASLP10 Processor AMC
 	3591  E7525/E7520 Error Reporting Registers
-		1014 02dd  eServer xSeries server mainboard
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
-		103c 3208  ProLiant DL140 G2
-		4c53 10d0  Telum ASLP10 Processor AMC
 	3592  E7320 Memory Controller Hub
-		1734 1073  Primergy Econel 200 D2020 mainboard
 	3593  E7320 Error Reporting Registers
-		1734 1073  Primergy Econel 200 D2020 mainboard
 	3594  E7520 DMA Controller
-		1775 1100  CR11/VR11 Single Board Computer
-		4c53 10d0  Telum ASLP10 Processor AMC
 	3595  E7525/E7520/E7320 PCI Express Port A
-		1775 1100  CR11/VR11 Single Board Computer
 	3596  E7525/E7520/E7320 PCI Express Port A1
 	3597  E7525/E7520 PCI Express Port B
-		1775 1100  CR11/VR11 Single Board Computer
 	3598  E7520 PCI Express Port B1
-		1775 1100  CR11/VR11 Single Board Computer
 	3599  E7520 PCI Express Port C
-		1775 1100  CR11/VR11 Single Board Computer
 	359a  E7520 PCI Express Port C1
 	359b  E7525/E7520/E7320 Extended Configuration Registers
-		1014 02dd  eServer xSeries server mainboard
 	359e  E7525 Memory Controller Hub
-		1028 0168  Precision Workstation 670 Mainboard
-		1028 0169  Precision 470
 	35b0  3100 Chipset Memory I/O Controller Hub
 	35b1  3100 DRAM Controller Error Reporting Registers
 	35b5  3100 Chipset Enhanced DMA Controller
@@ -27024,7 +14672,6 @@ var pciids = []byte(`#
 	360a  7300 Chipset PCI Express Port 7
 	360b  7300 Chipset QuickData Technology Device
 	360c  7300 Chipset FSB Registers
-		1028 01f0  PowerEdge R900 7300 Chipset FSB Registers
 	360d  7300 Chipset Snoop Filter Registers
 	360e  7300 Chipset Debug and Miscellaneous Registers
 	360f  7300 Chipset FBD Branch 0 Registers
@@ -27074,31 +14721,11 @@ var pciids = []byte(`#
 	373f  Xeon C5500/C3500 IOxAPIC
 	37cd  Ethernet Virtual Function 700 Series
 	37ce  Ethernet Connection X722 for 10GbE backplane
-		1590 0215  Ethernet 10Gb 2-port 568i Adapter
-		17aa 4023  Intel Ethernet Connection X722 for 10GbE backplane
 	37cf  Ethernet Connection X722 for 10GbE QSFP+
 	37d0  Ethernet Connection X722 for 10GbE SFP+
-		17aa 4020  Intel Ethernet Connection X722 for 10G SFP+
-		17aa 4021  Intel Ethernet Connection X722 for 10G SFP+
-		17aa 4022  Ethernet Connection X722 for 10GbE SFP+
 	37d1  Ethernet Connection X722 for 1GbE
-		14cd 0010  88E1514 Ethernet OCP 2x1G RJ45 Phy Card [USI-1514-1GbaseT]
-		1590 0216  Ethernet 1Gb 2-port 368i Adapter
-		1590 0217  Ethernet 1Gb 2-port 368FLR-MMT Adapter
-		1590 0247  Ethernet 1Gb 4-port 369i Adapter
-		17aa 4020  Ethernet Connection X722 for 1GbE
-		17aa 4021  Ethernet Connection X722 for 1GbE
-		17aa 4022  Ethernet Connection X722 for 1GbE
 	37d2  Ethernet Connection X722 for 10GBASE-T
-		14cd 0030  Ethernet OCP 2x10G RJ45 Phy Card [USI-X557-10GbaseT]
-		1590 0218  Ethernet 10Gb 2-port 568FLR-MMT Adapter
-		17aa 4020  Ethernet Connection X722 for 10GBASE-T
-		17aa 4021  Ethernet Connection X722 for 10GBASE-T
-		17aa 4022  Ethernet Connection X722 for 10GBASE-T
 	37d3  Ethernet Connection X722 for 10GbE SFP+
-		1590 0219  Ethernet 10Gb 2-port 568FLR-MMSFP+ Adapter
-		17aa 4020  Ethernet Connection X722 for 10GbE SFP+
-		17aa 4021  Ethernet Connection X722 for 10GbE SFP+
 	37d4  Ethernet Connection X722 for 10GbE QSFP+
 	37d9  X722 Hyper-V Virtual Function
 	3a00  82801JD/DO (ICH10 Family) 4-port SATA IDE Controller
@@ -27107,105 +14734,29 @@ var pciids = []byte(`#
 	3a06  82801JD/DO (ICH10 Family) 2-port SATA IDE Controller
 	3a14  82801JDO (ICH10DO) LPC Interface Controller
 	3a16  82801JIR (ICH10R) LPC Interface Controller
-		1028 028c  PowerEdge R410 LPC Interface Controller
-		1028 028d  PowerEdge T410 LPC Interface Controller
-		103c 330b  ProLiant G6 series
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5001  GA-EP45-DS5 Motherboard
 	3a18  82801JIB (ICH10) LPC Interface Controller
 	3a1a  82801JD (ICH10D) LPC Interface Controller
 	3a20  82801JI (ICH10 Family) 4 port SATA IDE Controller #1
-		1028 028c  PowerEdge R410 SATA IDE Controller
-		1028 028d  PowerEdge T410 SATA IDE Controller
 	3a22  82801JI (ICH10 Family) SATA AHCI Controller
-		103c 330b  ProLiant G6 series
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 b005  GA-EP45-DS5/GA-EG45M-DS2H Motherboard
 	3a25  82801JIR (ICH10R) SATA RAID Controller
-		1028 028c  PERC S100 Controller (PE R410)
-		1028 028d  PERC S100 Controller (PE T410)
-		1028 02f1  PERC S100 Controller (PE R510)
 	3a26  82801JI (ICH10 Family) 2 port SATA IDE Controller #2
-		1028 028c  PowerEdge R410 SATA IDE Controller
-		1028 028d  PowerEdge T410 SATA IDE Controller
 	3a30  82801JI (ICH10 Family) SMBus Controller
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5001  GA-EP45-DS5/GA-EG45M-DS2H Motherboard
 	3a32  82801JI (ICH10 Family) Thermal Subsystem
 	3a34  82801JI (ICH10 Family) USB UHCI Controller #1
-		1028 028c  PowerEdge R410 USB UHCI Controller
-		1028 028d  PowerEdge T410 USB UHCI Controller
-		103c 330b  ProLiant G6 series
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5004  GA-EP45-DS5 Motherboard
 	3a35  82801JI (ICH10 Family) USB UHCI Controller #2
-		1028 028c  PowerEdge R410 USB UHCI Controller
-		1028 028d  PowerEdge T410 USB UHCI Controller
-		103c 330b  ProLiant G6 series
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5004  GA-EP45-DS5 Motherboard
 	3a36  82801JI (ICH10 Family) USB UHCI Controller #3
-		1028 028c  PowerEdge R410 USB UHCI Controller
-		1028 028d  PowerEdge T410 USB UHCI Controller
-		103c 330b  ProLiant G6 series
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5004  GA-EP45-DS5 Motherboard
 	3a37  82801JI (ICH10 Family) USB UHCI Controller #4
-		1028 028c  PowerEdge R410 USB UHCI Controller
-		1028 028d  PowerEdge T410 USB UHCI Controller
-		103c 330b  ProLiant G6 series
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5004  Motherboard
 	3a38  82801JI (ICH10 Family) USB UHCI Controller #5
-		1028 028c  PowerEdge R410 USB UHCI Controller
-		1028 028d  PowerEdge T410 USB UHCI Controller
-		103c 330b  ProLiant ML150 G6 Server
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5004  Motherboard
 	3a39  82801JI (ICH10 Family) USB UHCI Controller #6
-		1028 028c  PowerEdge R410 USB UHCI Controller
-		1028 028d  PowerEdge T410 USB UHCI Controller
-		103c 330b  ProLiant ML150 G6 Server
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5004  Motherboard
 	3a3a  82801JI (ICH10 Family) USB2 EHCI Controller #1
-		1028 028c  PowerEdge R410 USB EHCI Controller
-		1028 028d  PowerEdge T410 USB EHCI Controller
-		103c 330b  ProLiant G6 series
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5006  GA-EP45-DS5 Motherboard
 	3a3c  82801JI (ICH10 Family) USB2 EHCI Controller #2
-		1028 028c  PowerEdge R410 USB EHCI Controller
-		1028 028d  PowerEdge T410 USB EHCI Controller
-		103c 330b  ProLiant G6 series
-		1043 82d4  P5Q Deluxe Motherboard
-		1458 5006  Motherboard
 	3a3e  82801JI (ICH10 Family) HD Audio Controller
-		1043 8311  P5Q Deluxe Motherboard
-		1458 a002  GA-EP45-UD3R Motherboard
-		1458 a102  GA-EP45-DS5/GA-EG45M-DS2H Motherboard
 	3a40  82801JI (ICH10 Family) PCI Express Root Port 1
-		1028 028c  PowerEdge R410 PCI Express Port 1
-		1028 028d  PowerEdge T410 PCI Express Port 1
-		103c 330b  ProLiant ML150 G6 Server
-		1043 82d4  P5Q Deluxe Motherboard
-		1043 82ea  P6T DeLuxe Motherboard
-		1458 5001  GA-EP45-DS5/GA-EG45M-DS2H Motherboard
 	3a42  82801JI (ICH10 Family) PCI Express Port 2
 	3a44  82801JI (ICH10 Family) PCI Express Root Port 3
-		1043 82ea  P6T DeLuxe Motherboard
 	3a46  82801JI (ICH10 Family) PCI Express Root Port 4
-		1043 82ea  P6T DeLuxe Motherboard
-		1458 5001  GA-EP45-DS5 Motherboard
 	3a48  82801JI (ICH10 Family) PCI Express Root Port 5
-		103c 330b  ProLiant ML150 G6 Server
-		1043 82ea  P6T Deluxe Motherboard
-		1458 5001  GA-EP45-DS5 Motherboard
 	3a4a  82801JI (ICH10 Family) PCI Express Root Port 6
-		103c 330b  ProLiant ML150 G6 Server
-		1043 82d4  P5Q Deluxe Motherboard
-		1043 82ea  P6T DeLuxe Motherboard
-		1458 5001  GA-EP45-DS5/GA-EG45M-DS2H Motherboard
 	3a4c  82801JI (ICH10 Family) Gigabit Ethernet Controller
 	3a51  82801JDO (ICH10DO) VECI Controller
 	3a55  82801JD/DO (ICH10 Family) Virtual SATA Controller
@@ -27235,17 +14786,9 @@ var pciids = []byte(`#
 	3b05  Mobile 5 Series Chipset LPC Interface Controller
 	3b06  H55 Chipset LPC Interface Controller
 	3b07  QM57 Chipset LPC Interface Controller
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		e4bf 50c1  PC1-GROOVE
 	3b08  H57 Chipset LPC Interface Controller
 	3b09  HM55 Chipset LPC Interface Controller
-		1025 0347  Aspire 7740G
-		144d c06a  R730 Laptop
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	3b0a  Q57 Chipset LPC Interface Controller
-		1028 02da  OptiPlex 980
-		15d9 060d  C7SIM-Q Motherboard
 	3b0b  HM57 Chipset LPC Interface Controller
 	3b0c  5 Series Chipset LPC Interface Controller
 	3b0d  5 Series/3400 Series Chipset LPC Interface Controller
@@ -27270,53 +14813,18 @@ var pciids = []byte(`#
 	3b20  5 Series/3400 Series Chipset 4 port SATA IDE Controller
 	3b21  5 Series/3400 Series Chipset 2 port SATA IDE Controller
 	3b22  5 Series/3400 Series Chipset 6 port SATA AHCI Controller
-		1028 02da  OptiPlex 980
-		15d9 060d  C7SIM-Q Motherboard
 	3b23  5 Series/3400 Series Chipset 4 port SATA AHCI Controller
 	3b25  5 Series/3400 Series Chipset SATA RAID Controller
-		103c 3118  Smart Array B110i SATA RAID Controller
 	3b26  5 Series/3400 Series Chipset 2 port SATA IDE Controller
 	3b28  5 Series/3400 Series Chipset 4 port SATA IDE Controller
-		144d c06a  R730 Laptop
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	3b29  5 Series/3400 Series Chipset 4 port SATA AHCI Controller
-		1025 0347  Aspire 7740G
-		144d c06a  R730 Laptop
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	3b2c  5 Series/3400 Series Chipset SATA RAID Controller
 	3b2d  5 Series/3400 Series Chipset 2 port SATA IDE Controller
-		144d c06a  R730 Laptop
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
-		e4bf 50c1  PC1-GROOVE
 	3b2e  5 Series/3400 Series Chipset 4 port SATA IDE Controller
-		e4bf 50c1  PC1-GROOVE
 	3b2f  5 Series/3400 Series Chipset 6 port SATA AHCI Controller
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		e4bf 50c1  PC1-GROOVE
 	3b30  5 Series/3400 Series Chipset SMBus Controller
-		1025 0347  Aspire 7740G
-		1028 02da  OptiPlex 980
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		144d c06a  R730 Laptop
-		15d9 060d  C7SIM-Q Motherboard
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
-		e4bf 50c1  PC1-GROOVE
 	3b32  5 Series/3400 Series Chipset Thermal Subsystem
-		1025 0347  Aspire 7740G
-		1028 040a  Latitude E6410
-		144d c06a  R730 Laptop
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	3b34  5 Series/3400 Series Chipset USB2 Enhanced Host Controller
-		1025 0347  Aspire 7740G
-		1028 02da  OptiPlex 980
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		144d c06a  R730 Laptop
-		15d9 060d  C7SIM-Q Motherboard
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
-		e4bf 50c1  PC1-GROOVE
 	3b36  5 Series/3400 Series Chipset USB Universal Host Controller
 	3b37  5 Series/3400 Series Chipset USB Universal Host Controller
 	3b38  5 Series/3400 Series Chipset USB Universal Host Controller
@@ -27324,66 +14832,25 @@ var pciids = []byte(`#
 	3b3a  5 Series/3400 Series Chipset USB Universal Host Controller
 	3b3b  5 Series/3400 Series Chipset USB Universal Host Controller
 	3b3c  5 Series/3400 Series Chipset USB2 Enhanced Host Controller
-		1025 0347  Aspire 7740G
-		1028 02da  OptiPlex 980
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		144d c06a  R730 Laptop
-		15d9 060d  C7SIM-Q Motherboard
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
-		e4bf 50c1  PC1-GROOVE
 	3b3e  5 Series/3400 Series Chipset USB Universal Host Controller
 	3b3f  5 Series/3400 Series Chipset USB Universal Host Controller
 	3b40  5 Series/3400 Series Chipset USB Universal Host Controller
 	3b41  5 Series/3400 Series Chipset LAN Controller
 	3b42  5 Series/3400 Series Chipset PCI Express Root Port 1
-		1028 02da  OptiPlex 980
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		144d c06a  R730 Laptop
-		15d9 060d  C7SIM-Q Motherboard
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	3b44  5 Series/3400 Series Chipset PCI Express Root Port 2
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		15d9 060d  C7SIM-Q Motherboard
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	3b46  5 Series/3400 Series Chipset PCI Express Root Port 3
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		144d c06a  R730 Laptop
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	3b48  5 Series/3400 Series Chipset PCI Express Root Port 4
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		144d c06a  R730 Laptop
 	3b4a  5 Series/3400 Series Chipset PCI Express Root Port 5
-		1028 02da  OptiPlex 980
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
 	3b4c  5 Series/3400 Series Chipset PCI Express Root Port 6
 	3b4e  5 Series/3400 Series Chipset PCI Express Root Port 7
 	3b50  5 Series/3400 Series Chipset PCI Express Root Port 8
 	3b53  5 Series/3400 Series Chipset VECI Controller
 	3b56  5 Series/3400 Series Chipset High Definition Audio
-		1025 0347  Aspire 7740G
-		1028 02da  OptiPlex 980
-		1028 040a  Latitude E6410
-		1028 040b  Latitude E6510
-		1043 1373  G73-series gaming laptop
-		144d c06a  R730 Laptop
-		15d9 060d  C7SIM-Q Motherboard
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
-		e4bf 50c1  PC1-GROOVE
 	3b57  5 Series/3400 Series Chipset High Definition Audio
 	3b64  5 Series/3400 Series Chipset HECI Controller
-		1025 0347  Aspire 7740G
-		15d9 060d  C7SIM-Q Motherboard
-		17c0 10d2  Medion Akoya E7214 Notebook PC [MD98410]
-		e4bf 50c1  PC1-GROOVE
 	3b65  5 Series/3400 Series Chipset HECI Controller
 	3b66  5 Series/3400 Series Chipset PT IDER Controller
 	3b67  5 Series/3400 Series Chipset KT Controller
-		e4bf 50c1  PC1-GROOVE
 	3c00  Xeon E5/Core i7 DMI2
 	3c01  Xeon E5/Core i7 DMI2 in PCI Express Mode
 	3c02  Xeon E5/Core i7 IIO PCI Express Root Port 1a
@@ -27493,94 +14960,24 @@ var pciids = []byte(`#
 	4116  Atom Processor E6xx PCI Host Bridge #3
 	4117  Atom Processor E6xx PCI Host Bridge #4
 	4220  PRO/Wireless 2200BG [Calexico2] Network Connection
-		103c 0934  Compaq nw8240/nx8220
-		103c 12f6  nc6120/nx8220/nw8240
-		8086 2701  WM3B2200BG Mini-PCI Card
-		8086 2712  IBM ThinkPad R50e
-		8086 2721  Dell B130 laptop integrated WLAN
-		8086 2722  Dell Latitude D600
-		8086 2731  Samsung P35 integrated WLAN
 	4222  PRO/Wireless 3945ABG [Golan] Network Connection
-		103c 135c  PRO/Wireless 3945ABG [Golan] Network Connection
-		8086 1000  PRO/Wireless 3945ABG Network Connection
-		8086 1001  WM3945ABG MOW2
-		8086 1005  PRO/Wireless 3945BG Network Connection
-		8086 1034  PRO/Wireless 3945BG Network Connection
-		8086 1044  PRO/Wireless 3945BG Network Connection
-		8086 1c00  PRO/Wireless 3945ABG Network Connection
 	4223  PRO/Wireless 2915ABG [Calexico2] Network Connection
-		1000 8086  mPCI 3B Americas/Europe ZZA
-		1001 8086  mPCI 3B Europe ZZE
-		1002 8086  mPCI 3B Japan ZZJ
-		1003 8086  mPCI 3B High-Band ZZH
-		103c 1351  Compaq nc6220
 	4224  PRO/Wireless 2915ABG [Calexico2] Network Connection
 	4227  PRO/Wireless 3945ABG [Golan] Network Connection
-		8086 1010  ThinkPad R60e
-		8086 1011  ThinkPad T60/R60e/X60s/R61
-		8086 1014  PRO/Wireless 3945BG Network Connection
 	4229  PRO/Wireless 4965 AG or AGN [Kedron] Network Connection
-		8086 1100  Vaio VGN-SZ79SN_C
-		8086 1101  PRO/Wireless 4965 AG or AGN
 	422b  Centrino Ultimate-N 6300
-		8086 1101  Centrino Ultimate-N 6300 3x3 AGN
-		8086 1121  Centrino Ultimate-N 6300 3x3 AGN
 	422c  Centrino Advanced-N 6200
-		8086 1301  Centrino Advanced-N 6200 2x2 AGN
-		8086 1306  Centrino Advanced-N 6200 2x2 ABG
-		8086 1307  Centrino Advanced-N 6200 2x2 BG
-		8086 1321  Centrino Advanced-N 6200 2x2 AGN
-		8086 1326  Centrino Advanced-N 6200 2x2 ABG
 	4230  PRO/Wireless 4965 AG or AGN [Kedron] Network Connection
-		8086 1110  Lenovo ThinkPad T51
-		8086 1111  Lenovo ThinkPad T61
 	4232  WiFi Link 5100
-		8086 1201  WiFi Link 5100 AGN
-		8086 1204  WiFi Link 5100 AGN
-		8086 1205  WiFi Link 5100 BGN
-		8086 1206  WiFi Link 5100 ABG
-		8086 1221  WiFi Link 5100 AGN
-		8086 1224  WiFi Link 5100 AGN
-		8086 1225  WiFi Link 5100 BGN
-		8086 1226  WiFi Link 5100 ABG
-		8086 1301  WiFi Link 5100 AGN
-		8086 1304  WiFi Link 5100 AGN
-		8086 1305  WiFi Link 5100 BGN
-		8086 1306  WiFi Link 5100 ABG
-		8086 1321  WiFi Link 5100 AGN
-		8086 1324  WiFi Link 5100 AGN
-		8086 1325  WiFi Link 5100 BGN
-		8086 1326  WiFi Link 5100 ABG
 	4235  Ultimate N WiFi Link 5300
 	4236  Ultimate N WiFi Link 5300
 	4237  PRO/Wireless 5100 AGN [Shiloh] Network Connection
-		8086 1211  WiFi Link 5100 AGN
-		8086 1214  WiFi Link 5100 AGN
-		8086 1215  WiFi Link 5100 BGN
-		8086 1216  WiFi Link 5100 ABG
-		8086 1311  WiFi Link 5100 AGN
-		8086 1314  WiFi Link 5100 AGN
-		8086 1315  WiFi Link 5100 BGN
-		8086 1316  WiFi Link 5100 ABG
 	4238  Centrino Ultimate-N 6300
-		8086 1111  Centrino Ultimate-N 6300 3x3 AGN
 	4239  Centrino Advanced-N 6200
-		8086 1311  Centrino Advanced-N 6200 2x2 AGN
-		8086 1316  Centrino Advanced-N 6200 2x2 ABG
 	423a  PRO/Wireless 5350 AGN [Echo Peak] Network Connection
 	423b  PRO/Wireless 5350 AGN [Echo Peak] Network Connection
 	423c  WiMAX/WiFi Link 5150
-		8086 1201  WiMAX/WiFi Link 5150 AGN
-		8086 1206  WiMAX/WiFi Link 5150 ABG
-		8086 1221  WiMAX/WiFi Link 5150 AGN
-		8086 1301  WiMAX/WiFi Link 5150 AGN
-		8086 1306  WiMAX/WiFi Link 5150 ABG
-		8086 1321  WiMAX/WiFi Link 5150 AGN
 	423d  WiMAX/WiFi Link 5150
-		8086 1211  WiMAX/WiFi Link 5150 AGN
-		8086 1216  WiMAX/WiFi Link 5150 ABG
-		8086 1311  WiMAX/WiFi Link 5150 AGN
-		8086 1316  WiMAX/WiFi Link 5150 ABG
 	444e  Turbo Memory Controller
 	5001  LE80578
 	5002  LE80578 Graphics Processor Unit
@@ -27631,20 +15028,14 @@ var pciids = []byte(`#
 	504c  EP80579 Integrated Processor with QuickAssist TDM
 	5200  EtherExpress PRO/100 Intelligent Server PCI Bridge
 	5201  EtherExpress PRO/100 Intelligent Server Fast Ethernet Controller
-		8086 0001  EtherExpress PRO/100 Server Ethernet Adapter
 	530d  80310 (IOP) IO Processor
 	5845  QEMU NVM Express Controller
-		1af4 1100  QEMU Virtual Machine
 	5902  HD Graphics 610
 	5904  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
-		17aa 2247  ThinkPad T570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
 	590f  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 	5910  Xeon E3-1200 v6/7th Gen Core Processor Host Bridge/DRAM Registers
 	5912  HD Graphics 630
 	5916  HD Graphics 620
-		17aa 2248  ThinkPad T570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
 	591d  HD Graphics P630
 	591f  Intel Kaby Lake Host Bridge
 	5a84  Celeron N3350/Pentium N4200/Atom E3900 Series Integrated Graphics Controller
@@ -27690,10 +15081,7 @@ var pciids = []byte(`#
 	65e6  5100 Chipset PCI Express x4 Port 6
 	65e7  5100 Chipset PCI Express x4 Port 7
 	65f0  5100 Chipset FSB Registers
-		1028 020f  PowerEdge R300
-		1028 0210  PowerEdge T300
 	65f1  5100 Chipset Reserved Registers
-		1028 0210  PowerEdge T300
 	65f3  5100 Chipset Reserved Registers
 	65f5  5100 Chipset DDR Channel 0 Registers
 	65f6  5100 Chipset DDR Channel 1 Registers
@@ -27868,90 +15256,45 @@ var pciids = []byte(`#
 	6ffd  Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent
 	6ffe  Xeon E7 v4/Xeon E5 v4/Xeon E3 v4/Xeon D Caching Agent
 	7000  82371SB PIIX3 ISA [Natoma/Triton II]
-		1af4 1100  Qemu virtual machine
 	7010  82371SB PIIX3 IDE [Natoma/Triton II]
-		1af4 1100  Qemu virtual machine
 	7020  82371SB PIIX3 USB [Natoma/Triton II]
-		1af4 1100  QEMU Virtual Machine
 	7030  430VX - 82437VX TVX [Triton VX]
 	7050  Intercast Video Capture Card
 	7051  PB 642365-003 (Business Video Conferencing Card)
 	7100  430TX - 82439TX MTXC
 	7110  82371AB/EB/MB PIIX4 ISA
-		15ad 1976  Virtual Machine Chipset
 	7111  82371AB/EB/MB PIIX4 IDE
-		15ad 1976  Virtual Machine Chipset
 	7112  82371AB/EB/MB PIIX4 USB
-		15ad 1976  Virtual Machine Chipset
-		1af4 1100  QEMU Virtual Machine
 	7113  82371AB/EB/MB PIIX4 ACPI
-		15ad 1976  Virtual Machine Chipset
-		1af4 1100  Qemu virtual machine
 	7120  82810 GMCH (Graphics Memory Controller Hub)
-		4c53 1040  CL7 mainboard
-		4c53 1060  PC7 mainboard
 	7121  82810 (CGC) Chipset Graphics Controller
-		4c53 1040  CL7 mainboard
-		4c53 1060  PC7 mainboard
-		8086 4341  Cayman (CA810) Mainboard
 	7122  82810 DC-100 (GMCH) Graphics Memory Controller Hub
 	7123  82810 DC-100 (CGC) Chipset Graphics Controller
 	7124  82810E DC-133 (GMCH) Graphics Memory Controller Hub
-		1028 00b4  OptiPlex GX110
 	7125  82810E DC-133 (CGC) Chipset Graphics Controller
-		1028 00b4  OptiPlex GX110
 	7126  82810 DC-133 System and Graphics Controller
 	7128  82810-M DC-100 System and Graphics Controller
 	712a  82810-M DC-133 System and Graphics Controller
 	7180  440LX/EX - 82443LX/EX Host bridge
 	7181  440LX/EX - 82443LX/EX AGP bridge
 	7190  440BX/ZX/DX - 82443BX/ZX/DX Host bridge
-		0e11 0500  Armada 1750 Laptop System Chipset
-		0e11 b110  Armada M700/E500
-		1028 008e  PowerEdge 1300 mainboard
-		1043 803b  CUBX-L/E Mainboard
-		1179 0001  Toshiba Tecra 8100 Laptop System Chipset
-		15ad 1976  Virtual Machine Chipset
-		4c53 1050  CT7 mainboard
-		4c53 1051  CE7 mainboard
 	7191  440BX/ZX/DX - 82443BX/ZX/DX AGP bridge
-		1028 008e  PowerEdge 1300 mainboard
 	7192  440BX/ZX/DX - 82443BX/ZX/DX Host bridge (AGP disabled)
-		0e11 0460  Armada 1700 Laptop System Chipset
-		1179 0001  Satellite 4010
-		4c53 1000  CC7/CR7/CP7/VC7/VP7/VR7 mainboard
-		8086 7190  Dell PowerEdge 350
 	7194  82440MX Host Bridge
-		1033 0000  Versa Note Vxi
-		4c53 10a0  CA3/CR3 mainboard
 	7195  82440MX AC'97 Audio Controller
-		1033 80cc  Versa Note VXi
-		10cf 1099  QSound_SigmaTel Stac97 PCI Audio
-		11d4 0040  SoundMAX Integrated Digital Audio
-		11d4 0048  SoundMAX Integrated Digital Audio
 	7196  82440MX AC'97 Modem Controller
 	7198  82440MX ISA Bridge
 	7199  82440MX EIDE Controller
 	719a  82440MX USB Universal Host Controller
 	719b  82440MX Power Management Controller
 	71a0  440GX - 82443GX Host bridge
-		4c53 1050  CT7 mainboard
-		4c53 1051  CE7 mainboard
 	71a1  440GX - 82443GX AGP bridge
 	71a2  440GX - 82443GX Host bridge (AGP disabled)
-		4c53 1000  CC7/CR7/CP7/VC7/VP7/VR7 mainboard
 	7600  82372FB PIIX5 ISA
 	7601  82372FB PIIX5 IDE
 	7602  82372FB PIIX5 USB
 	7603  82372FB PIIX5 SMBus
 	7800  82740 (i740) AGP Graphics Accelerator
-		003d 0008  Starfighter AGP
-		003d 000b  Starfighter AGP
-		1092 0100  Stealth II G460
-		10b4 201a  Lightspeed 740
-		10b4 202f  Lightspeed 740
-		8086 0000  Terminator 2x/i
-		8086 0100  Intel740 Graphics Accelerator
 	8002  Trusted Execution Technology Registers
 	8003  Trusted Execution Technology Registers
 	8100  System Controller Hub (SCH Poulsbo)
@@ -27988,9 +15331,6 @@ var pciids = []byte(`#
 	84e6  460GX - 82466GX Wide and fast PCI eXpander Bridge (WXB)
 	84ea  460GX - 84460GX AGP Bridge (GXB function 1)
 	8500  IXP4XX Network Processor (IXP420/421/422/425/IXC1100)
-		1993 0ded  mGuard-PCI AV#2
-		1993 0dee  mGuard-PCI AV#1
-		1993 0def  mGuard-PCI AV#0
 	8800  Platform Controller Hub EG20T PCI Express Port
 	8801  Platform Controller Hub EG20T Packet Hub
 	8802  Platform Controller Hub EG20T Gigabit Ethernet Controller
@@ -28021,8 +15361,6 @@ var pciids = []byte(`#
 	8c01  8 Series Chipset Family 4-port SATA Controller 1 [IDE mode] - Mobile
 	8c02  8 Series/C220 Series Chipset Family 6-port SATA Controller 1 [AHCI mode]
 	8c03  8 Series/C220 Series Chipset Family 6-port SATA Controller 1 [AHCI mode]
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	8c04  8 Series/C220 Series Chipset Family SATA Controller 1 [RAID mode]
 	8c05  8 Series/C220 Series Chipset Family SATA Controller 1 [RAID mode]
 	8c06  8 Series/C220 Series Chipset Family SATA Controller 1 [RAID mode]
@@ -28032,10 +15370,8 @@ var pciids = []byte(`#
 	8c0e  8 Series/C220 Series Chipset Family SATA Controller 1 [RAID mode]
 	8c0f  8 Series/C220 Series Chipset Family SATA Controller 1 [RAID mode]
 	8c10  8 Series/C220 Series Chipset Family PCI Express Root Port #1
-		17aa 220e  ThinkPad T440p
 	8c11  8 Series/C220 Series Chipset Family PCI Express Root Port #1
 	8c12  8 Series/C220 Series Chipset Family PCI Express Root Port #2
-		17aa 220e  ThinkPad T440p
 	8c13  8 Series/C220 Series Chipset Family PCI Express Root Port #2
 	8c14  8 Series/C220 Series Chipset Family PCI Express Root Port #3
 	8c15  8 Series/C220 Series Chipset Family PCI Express Root Port #3
@@ -28050,28 +15386,16 @@ var pciids = []byte(`#
 	8c1e  8 Series/C220 Series Chipset Family PCI Express Root Port #8
 	8c1f  8 Series/C220 Series Chipset Family PCI Express Root Port #8
 	8c20  8 Series/C220 Series Chipset High Definition Audio Controller
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	8c21  8 Series/C220 Series Chipset High Definition Audio Controller
 	8c22  8 Series/C220 Series Chipset Family SMBus Controller
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	8c23  8 Series Chipset Family CHAP Counters
 	8c24  8 Series Chipset Family Thermal Management Controller
 	8c26  8 Series/C220 Series Chipset Family USB EHCI #1
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	8c2d  8 Series/C220 Series Chipset Family USB EHCI #2
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	8c31  8 Series/C220 Series Chipset Family USB xHCI
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	8c33  8 Series/C220 Series Chipset Family LAN Controller
 	8c34  8 Series/C220 Series Chipset Family NAND Controller
 	8c3a  8 Series/C220 Series Chipset Family MEI Controller #1
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	8c3b  8 Series/C220 Series Chipset Family MEI Controller #2
 	8c3c  8 Series/C220 Series Chipset Family IDE-r Controller
 	8c3d  8 Series/C220 Series Chipset Family KT Controller
@@ -28091,8 +15415,6 @@ var pciids = []byte(`#
 	8c4d  8 Series/C220 Series Chipset Family LPC Controller
 	8c4e  Q87 Express LPC Controller
 	8c4f  QM87 Express LPC Controller
-		103c 1909  ZBook 15
-		17aa 220e  ThinkPad T440p
 	8c50  B85 Express LPC Controller
 	8c51  8 Series/C220 Series Chipset Family LPC Controller
 	8c52  C222 Series Chipset Family Server Essential SKU LPC Controller
@@ -28149,7 +15471,6 @@ var pciids = []byte(`#
 	8d02  C610/X99 series chipset 6-Port SATA Controller [AHCI mode]
 	8d04  C610/X99 series chipset SATA Controller [RAID mode]
 	8d06  C610/X99 series chipset SATA Controller [RAID mode]
-		17aa 1031  ThinkServer RAID 110i
 	8d08  C610/X99 series chipset 2-port SATA Controller [IDE mode]
 	8d0e  C610/X99 series chipset SATA Controller [RAID mode]
 	8d10  C610/X99 series chipset PCI Express Root Port #1
@@ -28219,7 +15540,6 @@ var pciids = []byte(`#
 	9c01  8 Series SATA Controller 1 [IDE mode]
 	9c02  8 Series SATA Controller 1 [AHCI mode]
 	9c03  8 Series SATA Controller 1 [AHCI mode]
-		17aa 2214  ThinkPad X240
 	9c04  8 Series SATA Controller 1 [RAID mode]
 	9c05  8 Series SATA Controller 1 [RAID mode]
 	9c06  8 Series SATA Controller 1 [RAID mode]
@@ -28249,23 +15569,16 @@ var pciids = []byte(`#
 	9c1e  8 Series PCI Express Root Port 8
 	9c1f  8 Series PCI Express Root Port 8
 	9c20  8 Series HD Audio Controller
-		17aa 2214  ThinkPad X240
 	9c21  8 Series HD Audio Controller
 	9c22  8 Series SMBus Controller
-		17aa 2214  ThinkPad X240
 	9c23  8 Series CHAP Counters
 	9c24  8 Series Thermal
 	9c26  8 Series USB EHCI #1
-		17aa 220c  T440s
-		17aa 2214  ThinkPad X240
 	9c2d  8 Series USB EHCI #2
 	9c31  8 Series USB xHCI HC
-		17aa 2214  ThinkPad X240
-		8086 7270  Apple MacBookAir6,2 / MacBookPro11,1
 	9c35  8 Series SDIO Controller
 	9c36  8 Series Audio DSP Controller
 	9c3a  8 Series HECI #0
-		17aa 2214  ThinkPad X240
 	9c3b  8 Series HECI #1
 	9c3c  8 Series HECI IDER
 	9c3d  8 Series HECI KT
@@ -28273,7 +15586,6 @@ var pciids = []byte(`#
 	9c41  8 Series LPC Controller
 	9c42  8 Series LPC Controller
 	9c43  8 Series LPC Controller
-		17aa 2214  ThinkPad X240
 	9c44  8 Series LPC Controller
 	9c45  8 Series LPC Controller
 	9c46  8 Series LPC Controller
@@ -28321,59 +15633,30 @@ var pciids = []byte(`#
 	9ce5  Wildcat Point-LP Serial IO GSPI Controller #0
 	9ce6  Wildcat Point-LP Serial IO GSPI Controller #1
 	9d03  Sunrise Point-LP SATA Controller [AHCI mode]
-		1028 06f3  Latitude 3570
-		17aa 382a  B51-80 Laptop
 	9d10  Sunrise Point-LP PCI Express Root Port #1
 	9d12  Sunrise Point-LP PCI Express Root Port #3
 	9d14  Sunrise Point-LP PCI Express Root Port #5
-		17aa 382a  B51-80 Laptop
 	9d15  Sunrise Point-LP PCI Express Root Port #6
-		17aa 382a  B51-80 Laptop
 	9d16  Sunrise Point-LP PCI Express Root Port #7
 	9d17  Sunrise Point-LP PCI Express Root Port #8
 	9d18  Sunrise Point-LP PCI Express Root Port #9
-		17aa 382a  B51-80 Laptop
 	9d19  Sunrise Point-LP PCI Express Root Port #10
 	9d21  Sunrise Point-LP PMC
-		1028 06f3  Latitude 3570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
-		17aa 382a  B51-80 Laptop
 	9d23  Sunrise Point-LP SMBus
-		1028 06f3  Latitude 3570
-		17aa 2247  ThinkPad T570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
-		17aa 382a  B51-80 Laptop
 	9d27  Sunrise Point-LP Serial IO UART Controller #0
 	9d28  Sunrise Point-LP Serial IO UART Controller #1
 	9d29  Sunrise Point-LP Serial IO SPI Controller #0
 	9d2a  Sunrise Point-LP Serial IO SPI Controller #1
 	9d2d  Sunrise Point-LP Secure Digital IO Controller
 	9d2f  Sunrise Point-LP USB 3.0 xHCI Controller
-		1028 06f3  Latitude 3570
-		17aa 2247  ThinkPad T570
-		17aa 382a  B51-80 Laptop
 	9d31  Sunrise Point-LP Thermal subsystem
-		1028 06f3  Latitude 3570
-		17aa 2247  ThinkPad T570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
-		17aa 382a  B51-80 Laptop
 	9d35  Sunrise Point-LP Integrated Sensor Hub
 	9d3a  Sunrise Point-LP CSME HECI #1
-		1028 06f3  Latitude 3570
-		17aa 2247  ThinkPad T570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
-		17aa 382a  B51-80 Laptop
 	9d43  Sunrise Point-LP LPC Controller
-		17aa 382a  B51-80 Laptop
 	9d48  Sunrise Point-LP LPC Controller
-		1028 06f3  Latitude 3570
 	9d56  Sunrise Point-LP LPC Controller
 	9d58  Sunrise Point-LP LPC Controller
-		17aa 2247  ThinkPad T570
-		17aa 224f  ThinkPad X1 Carbon 5th Gen
 	9d60  Sunrise Point-LP Serial IO I2C Controller #0
-		1028 06f3  Latitude 3570
-		8086 9d60  100 Series PCH/Sunrise Point PCH I2C0 [Skylake/Kaby Lake LPSS I2C]
 	9d61  Sunrise Point-LP Serial IO I2C Controller #1
 	9d62  Sunrise Point-LP Serial IO I2C Controller #2
 	9d63  Sunrise Point-LP Serial IO I2C Controller #3
@@ -28381,25 +15664,14 @@ var pciids = []byte(`#
 	9d65  Sunrise Point-LP Serial IO I2C Controller #5
 	9d66  Sunrise Point-LP Serial IO UART Controller #2
 	9d70  Sunrise Point-LP HD Audio
-		1028 06f3  Latitude 3570
-		17aa 382a  B51-80 Laptop
 	9d71  Sunrise Point-LP HD Audio
 	a000  Atom Processor D4xx/D5xx/N4xx/N5xx DMI Bridge
-		1458 5000  GA-D525TUD
-		8086 4f4d  DeskTop Board D510MO
-		8086 544b  Desktop Board D425KT
 	a001  Atom Processor D4xx/D5xx/N4xx/N5xx Integrated Graphics Controller
-		1458 d000  GA-D525TUD
-		8086 4f4d  DeskTop Board D510MO
-		8086 544b  Desktop Board D425KT
 	a002  Atom Processor D4xx/D5xx/N4xx/N5xx Integrated Graphics Controller
 	a003  Atom Processor D4xx/D5xx/N4xx/N5xx CHAPS counter
 	a010  Atom Processor D4xx/D5xx/N4xx/N5xx DMI Bridge
-		144d c072  Notebook N150P
 	a011  Atom Processor D4xx/D5xx/N4xx/N5xx Integrated Graphics Controller
-		144d c072  Notebook N150P
 	a012  Atom Processor D4xx/D5xx/N4xx/N5xx Integrated Graphics Controller
-		144d c072  Notebook N150P
 	a013  Atom Processor D4xx/D5xx/N4xx/N5xx CHAPS counter
 	a102  Sunrise Point-H SATA controller [AHCI mode]
 	a103  Sunrise Point-H SATA Controller [AHCI mode]
@@ -28592,31 +15864,17 @@ var pciids = []byte(`#
 	a620  6400/6402 Advanced Memory Buffer (AMB)
 	abc0  Omni-Path Fabric Switch Silicon 100 Series
 	b152  21152 PCI-to-PCI Bridge
-		8086 b152  21152 PCI-to-PCI Bridge
-# observed, and documented in Intel revision note; new mask of 1011:0026
 	b154  21154 PCI-to-PCI Bridge
 	b555  21555 Non transparent PCI-to-PCI Bridge
-		12c7 5005  SS7HD PCI Adaptor Card
-		12c7 5006  SS7HDC cPCI Adaptor Card
-		12d9 000a  PCI VoIP Gateway
-		4c53 1050  CT7 mainboard
-		4c53 1051  CE7 mainboard
-		e4bf 1000  CC8-1-BLUES
 	d130  Core Processor DMI
 	d131  Core Processor DMI
-		1028 02da  OptiPlex 980
-		15d9 060d  C7SIM-Q Motherboard
 	d132  Core Processor DMI
-		1028 040b  Latitude E6510
 	d133  Core Processor DMI
 	d134  Core Processor DMI
 	d135  Core Processor DMI
 	d136  Core Processor DMI
 	d137  Core Processor DMI
 	d138  Core Processor PCI Express Root Port 1
-		1028 02da  OptiPlex 980
-		1028 040b  Latitude E6510
-		15d9 060d  C7SIM-Q Motherboard
 	d139  Core Processor PCI Express Root Port 2
 	d13a  Core Processor PCI Express Root Port 3
 	d13b  Core Processor PCI Express Root Port 4
@@ -28640,7 +15898,6 @@ var pciids = []byte(`#
 8866  T-Square Design Inc.
 8888  Silicon Magic
 8912  TRX
-# 8c4a is not Winbond but there is a board misprogrammed
 8c4a  Winbond
 	1980  W89C940 misprogrammed [ne2k]
 8e0e  Computone Corporation
@@ -28655,7 +15912,6 @@ var pciids = []byte(`#
 	3b78  AHA-4844W/4844UW
 	5075  AIC-755x
 	5078  AIC-7850T/7856T [AVA-2902/4/6 / AHA-2910]
-		9004 7850  AIC-7850T/7856T [AVA-290x / AHA-2910]
 	5175  AIC-755x
 	5178  AIC-7851
 	5275  AIC-755x
@@ -28667,8 +15923,6 @@ var pciids = []byte(`#
 	5575  AVA-2930
 	5578  AIC-7855
 	5647  ANA-7711 TCP Offload Engine
-		9004 7710  ANA-7711F TCP Offload Engine - Optical
-		9004 7711  ANA-7711LP TCP Offload Engine - Copper
 	5675  AIC-755x
 	5678  AIC-7856
 	5775  AIC-755x
@@ -28678,10 +15932,8 @@ var pciids = []byte(`#
 	5905  ANA-5910A/5930A/5940A ATM Adapter
 	6038  AIC-3860
 	6075  AIC-1480 / APA-1480
-		9004 7560  AIC-1480 / APA-1480 Cardbus
 	6078  AIC-7860
 	6178  AIC-7861
-		9004 7861  AHA-2940AU Single
 	6278  AIC-7860
 	6378  AIC-7860
 	6478  AIC-786x
@@ -28689,20 +15941,6 @@ var pciids = []byte(`#
 	6678  AIC-786x
 	6778  AIC-786x
 	6915  ANA620xx/ANA69011A
-		9004 0008  ANA69011A/TX 10/100
-		9004 0009  ANA69011A/TX 10/100
-		9004 0010  ANA62022 2-port 10/100
-		9004 0018  ANA62044 4-port 10/100
-		9004 0019  ANA62044 4-port 10/100
-		9004 0020  ANA62022 2-port 10/100
-		9004 0028  ANA69011A/TX 10/100
-		9004 8008  ANA69011A/TX 64 bit 10/100
-		9004 8009  ANA69011A/TX 64 bit 10/100
-		9004 8010  ANA62022 2-port 64 bit 10/100
-		9004 8018  ANA62044 4-port 64 bit 10/100
-		9004 8019  ANA62044 4-port 64 bit 10/100
-		9004 8020  ANA62022 2-port 64 bit 10/100
-		9004 8028  ANA69011A/TX 64 bit 10/100
 	7078  AHA-294x / AIC-7870
 	7178  AIC-7870P/7871 [AHA-2940/W/S76]
 	7278  AHA-3940/3940W / AIC-7872
@@ -28715,8 +15953,6 @@ var pciids = []byte(`#
 	7778  AIC-787x
 	7810  AIC-7810
 	7815  AIC-7815 RAID+Memory Controller IC
-		9004 7815  ARO-1130U2 RAID Controller
-		9004 7840  AIC-7815 RAID+Memory Controller IC
 	7850  AIC-7850
 	7855  AHA-2930
 	7860  AIC-7860
@@ -28732,296 +15968,92 @@ var pciids = []byte(`#
 	7893  AIC-789x
 	7894  AIC-789x
 	7895  AHA-2940U/UW / AHA-39xx / AIC-7895
-		9004 7890  AHA-2940U/2940UW Dual AHA-394xAU/AUW/AUWD AIC-7895B
-		9004 7891  AHA-2940U/2940UW Dual
-		9004 7892  AHA-3940AU/AUW/AUWD/UWD
-		9004 7894  AHA-3944AUWD
-		9004 7895  AHA-2940U/2940UW Dual AHA-394xAU/AUW/AUWD AIC-7895B
-		9004 7896  AHA-2940U/2940UW Dual AHA-394xAU/AUW/AUWD AIC-7895B
-		9004 7897  AHA-2940U/2940UW Dual AHA-394xAU/AUW/AUWD AIC-7895B
 	7896  AIC-789x
 	7897  AIC-789x
 	8078  AIC-7880U
-		9004 7880  AIC-7880P Ultra/Ultra Wide SCSI Chipset
 	8178  AIC-7870P/7881U [AHA-2940U/UW/D/S76]
-		9004 7881  AHA-2940UW SCSI Host Adapter
 	8278  AHA-3940U/UW/UWD / AIC-7882U
 	8378  AHA-3940U/UW / AIC-7883U
 	8478  AHA-2944UW / AIC-7884U
 	8578  AHA-3944U/UWD / AIC-7885
 	8678  AHA-4944UW / AIC-7886
 	8778  AHA-2940UW Pro / AIC-788x
-		9004 7887  2940UW Pro Ultra-Wide SCSI Controller
 	8878  AHA-2930UW / AIC-7888
-		9004 7888  AHA-2930UW SCSI Controller
 	8b78  ABA-1030
 	ec78  AHA-4944W/UW
-# acquired by Microsemi
 9005  Adaptec
 	0010  AHA-2940U2/U2W
-		9005 2180  AHA-2940U2 SCSI Controller
-		9005 8100  AHA-2940U2B SCSI Controller
-		9005 a100  AHA-2940U2B SCSI Controller
-		9005 a180  AIC-3860Q [AHA-2940U2W/GE] SCSI Controller
-		9005 e100  AHA-2950U2B SCSI Controller
 	0011  AHA-2930U2
 	0013  78902
-		9005 0003  AAA-131U2 Array1000 1 Channel RAID Controller
-		9005 000f  AIC7890_ARO
 	001f  AHA-2940U2/U2W / 7890/7891
-		9005 000f  2940U2W SCSI Controller
-		9005 a180  2940U2W SCSI Controller
 	0020  AIC-7890
 	002f  AIC-7890
 	0030  AIC-7890
 	003f  AIC-7890
 	0050  AHA-3940U2x/395U2x
-		9005 f500  AHA-3950U2B
-		9005 ffff  AHA-3950U2B
 	0051  AHA-3950U2D
-		9005 b500  AHA-3950U2D
 	0053  AIC-7896 SCSI Controller
-		9005 ffff  AIC-7896 SCSI Controller mainboard implementation
 	005f  AIC-7896U2/7897U2
 	0080  AIC-7892A U160/m
-		0e11 e2a0  Compaq 64-Bit/66MHz Wide Ultra3 SCSI Adapter
-		9005 6220  AHA-29160C
-		9005 62a0  29160N Ultra160 SCSI Controller
-		9005 e220  29160LP Low Profile Ultra160 SCSI Controller
-		9005 e2a0  29160 Ultra160 SCSI Controller
 	0081  AIC-7892B U160/m
-		9005 62a1  19160 Ultra160 SCSI Controller
 	0083  AIC-7892D U160/m
 	008f  AIC-7892P U160/m
-		1179 0001  Magnia Z310
-		15d9 9005  Onboard SCSI Host Adapter
 	0092  AVC-2010 [VideoH!]
 	0093  AVC-2410 [VideoH!]
 	00c0  AHA-3960D / AIC-7899A U160/m
-		0e11 f620  Compaq 64-Bit/66MHz Dual Channel Wide Ultra3 SCSI Adapter
-		9005 f620  AHA-3960D U160/m
 	00c1  AIC-7899B U160/m
 	00c3  AIC-7899D U160/m
 	00c5  RAID subsystem HBA
-		1028 00c5  PowerEdge 2400,2500,2550,4400
 	00cf  AIC-7899P U160/m
-		1028 00ce  PowerEdge 1400
-		1028 00d1  PowerEdge 2550
-		1028 00d9  PowerEdge 2500
-		10f1 2462  Thunder K7 S2462
-		15d9 9005  Onboard SCSI Host Adapter
-		8086 3411  SDS2 Mainboard
 	0241  Serial ATA II RAID 1420SA
 	0242  Serial ATA II RAID 1220SA
 	0243  Serial ATA II RAID 1430SA
 	0244  eSATA II RAID 1225SA
 	0250  ServeRAID Controller
-		1014 0279  ServeRAID 6M
-		1014 028c  ServeRAID 6i/6i+
-		1014 028e  ServeRAID 7k
 	0279  ServeRAID 6M
 	0283  AAC-RAID
-		9005 0283  Catapult
 	0284  AAC-RAID
-		9005 0284  Tomcat
 	0285  AAC-RAID
-		0e11 0295  SATA 6Ch (Bearcat)
-		1014 02f2  ServeRAID 8i
-		1028 0287  PowerEdge Expandable RAID Controller 320/DC
-		1028 0291  CERC SATA RAID 2 PCI SATA 6ch (DellCorsair)
-		103c 3227  AAR-2610SA
-		108e 0286  Sun StorageTek SAS RAID HBA, Internal
-		108e 0287  STK RAID EXT
-		108e 7aac  STK RAID REM
-		108e 7aae  STK RAID EX
-		15d9 02b5  SMC AOC-USAS-S4i
-		15d9 02b6  SMC AOC-USAS-S8i
-		15d9 02c9  SMC AOC-USAS-S4iR
-		15d9 02ca  SMC AOC-USAS-S8iR
-		15d9 02d2  SMC AOC-USAS-S8i-LP
-		15d9 02d3  SMC AOC-USAS-S8iR-LP
-		17aa 0286  Legend S220 (Legend Crusader)
-		17aa 0287  Legend S230 (Legend Vulcan)
-		9005 0285  2200S (Vulcan)
-		9005 0286  2120S (Crusader)
-		9005 0287  2200S (Vulcan-2m)
-		9005 0288  3230S (Harrier)
-		9005 0289  3240S (Tornado)
-# Some early versions reported 2020S
-		9005 028a  ASR-2020ZCR
-# Some early versions reported 2025S
-		9005 028b  ASR-2025ZCR (Terminator)
-		9005 028e  ASR-2020SA (Skyhawk)
-		9005 028f  ASR-2025SA
-		9005 0290  AAR-2410SA PCI SATA 4ch (Jaguar II)
-		9005 0292  AAR-2810SA PCI SATA 8ch (Corsair-8)
-		9005 0293  AAR-21610SA PCI SATA 16ch (Corsair-16)
-		9005 0294  ESD SO-DIMM PCI-X SATA ZCR (Prowler)
-		9005 0296  ASR-2240S
-		9005 0297  ASR-4005SAS
-		9005 0298  ASR-4000
-		9005 0299  ASR-4800SAS
-		9005 029a  4805SAS
-		9005 02a4  ICP ICP9085LI
-		9005 02a5  ICP ICP5085BR
-		9005 02b5  ASR5800
-		9005 02b6  ASR5805
-		9005 02b7  ASR5808
-		9005 02b8  ICP5445SL
-		9005 02b9  ICP5085SL
-		9005 02ba  ICP5805SL
-		9005 02bb  3405
-		9005 02bc  3805
-		9005 02bd  31205
-		9005 02be  31605
-		9005 02bf  ICP ICP5045BL
-		9005 02c0  ICP ICP5085BL
-		9005 02c1  ICP ICP5125BR
-		9005 02c2  ICP ICP5165BR
-		9005 02c3  51205
-		9005 02c4  51605
-		9005 02c5  ICP ICP5125SL
-		9005 02c6  ICP ICP5165SL
-		9005 02c7  3085
-		9005 02c8  ICP5805BL
-		9005 02ce  51245
-		9005 02cf  51645
-		9005 02d0  52445
-		9005 02d1  5405
-		9005 02d4  ASR-2045
-		9005 02d5  ASR-2405
-		9005 02d6  ASR-2445
-		9005 02d7  ASR-2805
-		9005 02d8  5405G
-		9005 02d9  5445G
-		9005 02da  5805G
-		9005 02db  5085G
-		9005 02dc  51245G
-		9005 02dd  51645G
-		9005 02de  52445G
-		9005 02df  ASR-2045G
-		9005 02e0  ASR-2405G
-		9005 02e1  ASR-2445G
-		9005 02e2  ASR-2805G
 	0286  AAC-RAID (Rocket)
-		1014 034d  8s
-		1014 9540  ServeRAID 8k/8k-l4
-		1014 9580  ServeRAID 8k/8k-l8
-		9005 028c  ASR-2230S + ASR-2230SLP PCI-X (Lancer)
-		9005 028d  ASR-2130S
-		9005 029b  ASR-2820SA
-		9005 029c  ASR-2620SA
-		9005 029d  ASR-2420SA
-		9005 029e  ICP ICP9024R0
-		9005 029f  ICP ICP9014R0
-		9005 02a0  ICP ICP9047MA
-		9005 02a1  ICP ICP9087MA
-		9005 02a2  3800
-		9005 02a3  ICP ICP5445AU
-		9005 02a4  ICP ICP9085LI
-		9005 02a5  ICP ICP5085BR
-		9005 02a6  ICP9067MA
-		9005 02a7  3805
-		9005 02a8  3400
-		9005 02a9  ICP ICP5085AU
-		9005 02aa  ICP ICP5045AU
-		9005 02ac  1800
-		9005 02b3  2400
-		9005 02b4  ICP ICP5045AL
-		9005 0800  Callisto
 	028b  Series 6 - 6G SAS/PCIe 2
-		9005 0200  Series 6 Entry Level - ASR-6405E - 4 internal 6G SAS ports
-		9005 0201  Series 6 Entry Level - ASR-6805E - 8 internal 6G SAS ports
-		9005 0300  Series 6 - ASR-6405 - 4 internal 6G SAS ports
-		9005 0301  Series 6 - ASR-6805 - 8 internal 6G SAS ports
-		9005 0302  Series 6 - ASR-6445 - 4 internal and 4 external 6G SAS ports
-		9005 0310  Series 6 Connectors on Top - ASR-6405T - 4 internal 6G SAS ports
-		9005 0311  Series 6 Connectors on Top - ASR-6805T - 8 internal 6G SAS
-		9005 0400  Series 6 - ASR-61205 - 12 internal 6G SAS ports
-		9005 0401  Series 6 - ASR-61605 - 16 internal 6G SAS ports
-		9005 0403  Series 6 - ASR-62405 - 24 internal 6G SAS ports
 	028c  Series 7 6G SAS/PCIe 3
-		9005 0500  Series 7 - ASR-7805 - 8 internal 6G SAS Port/PCIe 3.0
-		9005 0501  Series 7 - ASR-71605 - 16 internal 6G SAS Port/PCIe 3.0
-		9005 0502  Series 7 - ASR-71685 - 16 internal 8 external 6G SAS Port/PCIe 3.0
-		9005 0503  Series 7 - ASR-72405 - 24 internal 0 external 6G SAS Port/PCIe 3.0
-		9005 0504  Series 7 - ASR-7885 - 8 internal 8 external 6G SAS Port/PCIe 3.0
-		9005 0505  Series 7 Entry Level - ASR-71685E - 16 internal 8 external 6G SAS Port/PCIe 3.0
-		9005 0506  Series 7 Entry Level - ASR-72405E - 24 internal 0 external 6G SAS Port/PCIe 3.0
 	028d  Series 8 12G SAS/PCIe 3
-		9005 0550  Series 8 - ASR-82405 - 24 internal 0 external 12G SAS Port/PCIe 3.0
-		9005 0551  Series 8 - ASR-81605 - 16 internal 0 external 12G SAS Port/PCIe 3.0
-		9005 0552  Series 8 - ASR-8805 - 8 internal 0 external 12G SAS Port/PCIe 3.0
-		9005 0553  Series 8 - ASR-8085 - 0 internal 8 external 12G SAS Port/PCIe 3.0
-		9005 0554  Series 8 - ASR-8885 - 8 internal 8 external 12G SAS Port/PCIe 3.0
 	028f  Smart Storage PQI 12G SAS/PCIe 3
-		103c 0600  Smart Array P408i-p SR Gen10
-		103c 0601  Smart Array P408e-p SR Gen10
-		103c 0602  Smart Array P408i-a SR Gen10
-		103c 0603  Smart Array P408i-c SR Gen10
-		103c 0650  Smart Array E208i-p SR Gen10
-		103c 0651  Smart Array E208e-p SR Gen10
-		103c 0652  Smart Array E208i-c SR Gen10
-		103c 0654  Smart Array E208i-a SR Gen10
-		103c 0655  Smart Array P408e-m SR Gen10
-		103c 0700  Smart Array P204i-c SR Gen10
-		103c 0701  Smart Array P204i-b SR Gen10
-		103c 1100  Smart Array P816i-a SR Gen10
-		103c 1101  Smart Array P416ie-m SR G10
 	0410  AIC-9410W SAS (Razor HBA RAID)
-		9005 0410  ASC-48300(Spirit RAID)
-		9005 0411  ASC-58300 (Oakmont RAID)
 	0412  AIC-9410W SAS (Razor HBA non-RAID)
-		9005 0412  ASC-48300 (Spirit non-RAID)
-		9005 0413  ASC-58300 (Oakmont non-RAID)
 	0415  ASC-58300 SAS (Razor-External HBA RAID)
 	0416  ASC-58300 SAS (Razor-External HBA non-RAID)
 	041e  AIC-9410W SAS (Razor ASIC non-RAID)
 	041f  AIC-9410W SAS (Razor ASIC RAID)
-		9005 041f  AIC-9410W SAS (Razor ASIC RAID)
 	042f  VSC7250/7251 SAS (Aurora ASIC non-RAID)
 	0430  AIC-9405W SAS (Razor-Lite HBA RAID)
-		9005 0430  ASC-44300 (Spirit-Lite RAID)
 	0432  AIC-9405W SAS (Razor-Lite HBA non-RAID)
-		9005 0432  ASC-44300 (Spirit-Lite non-RAID)
 	043e  AIC-9405W SAS (Razor-Lite ASIC non-RAID)
 	043f  AIC-9405W SAS (Razor-Lite ASIC RAID)
 	0450  ASC-1405 Unified Serial HBA
 	0500  Obsidian chipset SCSI controller
-		1014 02c1  PCI-X DDR 3Gb SAS Adapter (572A/572C)
-		1014 02c2  PCI-X DDR 3Gb SAS RAID Adapter (572B/572D)
 	0503  Scamp chipset SCSI controller
-		1014 02bf  Quad Channel PCI-X DDR U320 SCSI RAID Adapter (571E)
-		1014 02c3  PCI-X DDR 3Gb SAS RAID Adapter (572F)
-		1014 02d5  Quad Channel PCI-X DDR U320 SCSI RAID Adapter (571F)
 	0910  AUA-3100B
 	091e  AUA-3100B
 	8000  ASC-29320A U320
 	800f  AIC-7901 U320
 	8010  ASC-39320 U320
 	8011  ASC-39320D
-		0e11 00ac  ASC-39320D U320
-		9005 0041  ASC-39320D U320
 	8012  ASC-29320 U320
 	8013  ASC-29320B U320
 	8014  ASC-29320LP U320
 	8015  ASC-39320B U320
 	8016  ASC-39320A U320
 	8017  ASC-29320ALP U320
-		9005 0044  ASC-29320ALP PCIx U320
-		9005 0045  ASC-29320LPE PCIe U320
 	801c  ASC-39320D U320
 	801d  AIC-7902B U320
-		1014 02cc  ServeRAID 7e
 	801e  AIC-7901A U320
 	801f  AIC-7902 U320
-		1734 1011  PRIMERGY RX300 onboard SCSI
 	8080  ASC-29320A U320 w/HostRAID
 	8081  PMC-Sierra PM8001 SAS HBA [Series 6H]
 	8088  PMC-Sierra PM8018 SAS HBA [Series 7H]
 	8089  PMC-Sierra PM8019 SAS encryption HBA [Series 7He]
 	808f  AIC-7901 U320 w/HostRAID
-		1028 0168  Precision Workstation 670 Mainboard
 	8090  ASC-39320 U320 w/HostRAID
 	8091  ASC-39320D U320 w/HostRAID
 	8092  ASC-29320 U320 w/HostRAID
@@ -29032,7 +16064,6 @@ var pciids = []byte(`#
 	8097  ASC-29320ALP U320 w/HostRAID
 	809c  ASC-39320D(B) U320 w/HostRAID
 	809d  AIC-7902(B) U320 w/HostRAID
-		1014 02cc  ServeRAID 7e
 	809e  AIC-7901A U320 w/HostRAID
 	809f  AIC-7902 U320 w/HostRAID
 907f  Atronics
@@ -29047,35 +16078,20 @@ var pciids = []byte(`#
 	0001  JusonTech Gigabit Ethernet Controller
 9699  Omni Media Technology Inc
 	6565  6565
-# nee Netmos Technology
 9710  MosChip Semiconductor Technology Ltd.
 	9250  PCI-to-PCI bridge [MCS9250]
 	9805  PCI 1 port parallel adapter
 	9815  PCI 9815 Multi-I/O Controller
-		1000 0020  2P0S (2 port parallel adaptor)
 	9820  PCI 9820 Multi-I/O Controller
 	9835  PCI 9835 Multi-I/O Controller
-		1000 0002  2S (16C550 UART)
-		1000 0012  1P2S
 	9845  PCI 9845 Multi-I/O Controller
-# Serial ports at BAR0-3
-		1000 0004  0P4S (4 port 16550A serial card)
-		1000 0006  0P6S (6 port 16550a serial card)
-# Serial ports at BAR0-3, Parallel port at BAR4
-		1000 0014  1P4S (1 Parallel / 4 16550A Serial Port Adapter)
 	9855  PCI 9855 Multi-I/O Controller
-# Parallel port at BAR0. Serial ports at BAR2-5
-		1000 0014  1P4S
-# Parallel ports at BAR0,BAR2. Serial ports at BAR4-5
-		1000 0022  2P2S (2 Parallel / 2 16550A Serial Port Adapter)
 	9865  PCI 9865 Multi-I/O Controller
 	9901  PCIe 9901 Multi-I/O Controller
 	9904  4-Port PCIe Serial Adapter
-# 2-port Serial 1-port Parallel Adaptor
 	9912  PCIe 9912 Multi-I/O Controller
 	9922  MCS9922 PCIe Multi-I/O Controller
 	9990  MCS9990 PCIe to 4‐Port USB 2.0 Host Controller
-# Subsystem ID on a 3c985B-SX network card
 9850  3Com (wrong ID)
 9902  Stargen Inc.
 	0001  SG2010 PCI over Starfabric Bridge
@@ -29123,11 +16139,9 @@ affe  Sirrix AG security technologies
 	450e  PCI4S0EC 4-port ISDN S0 interface
 	dead  Sirrix.PCI4S0 4-port ISDN S0 interface
 b100  OpenVox Communication Co. Ltd.
-# Not registered officially
 b10b  Uakron PCI Project
 b1b3  Shiva Europe Limited
 b1d9  ATCOM Technology co., LTD.
-# Pinnacle should be 11bd, but they got it wrong several times --mj
 bd11  Pinnacle Systems, Inc. (Wrong ID)
 bdbd  Blackmagic Design
 	a106  Multibridge Extreme
@@ -29236,52 +16250,29 @@ db10  Diablo Technologies
 dc93  Dawicontrol GmbH
 dcba  Dynamic Engineering
 	0046  PCIe Altera Cyclone IV
-# VPX format Receiver Controller Board
 	0047  VPX-RCB
-# PMC Format FPGA design with 8 high speed UART channels
 	0048  PMC-Biserial-III-BAE9
 	004e  PC104p-Biserial-III-NVY5
 	004f  PC104p-Biserial-III-NVY6
 	0052  PCIeBiSerialDb37 BA22 LVDS IO
 dd01  Digital Devices GmbH
 	0003  Octopus DVB Adapter
-		dd01 0001  Octopus DVB adapter
-		dd01 0002  Octopus LE DVB adapter
-		dd01 0003  Octopus OEM
-		dd01 0004  Octopus V3 DVB adapter
-		dd01 0010  Octopus Mini
-		dd01 0020  Cine S2 V6 DVB adapter
-		dd01 0021  Cine S2 V6.5 DVB adapter
-		dd01 0030  Cine CT V6.1 DVB adapter
-		dd01 db03  Mystique SaTiX-S2 V3 DVB adapter
 	0006  Cine V7
 	0007  Max
-		dd01 0023  Max S8 4/8
 	0011  Octopus CI DVB Adapter
-		dd01 0040  Octopus CI
-		dd01 0041  Octopus CI Single
 	0201  Resi DVB-C Modulator
-		dd01 0001  Resi DVB-C Modulator
 dead  Indigita Corporation
 deaf  Middle Digital Inc.
 	9050  PC Weasel Virtual VGA
 	9051  PC Weasel Serial Port
 	9052  PC Weasel Watchdog Timer
-# formerly SoftHard Technology Ltd.
 deda  XIMEA
 	4001  Camera CB
-# Thunderbolt based camera MT family
 	4021  Camera MT
 e000  Winbond
 	e000  W89C940
 e159  Tiger Jet Network Inc.
 	0001  Tiger3XX Modem/ISDN interface
-		0059 0001  128k ISDN-S/T Adapter
-		0059 0003  128k ISDN-U Adapter
-		00a7 0001  TELES.S0/PCI 2.x ISDN Adapter
-		8086 0003  Digium X100P/X101P analogue PSTN FXO interface
-		b100 0003  OpenVox A400P 4-port analog card
-		b1d9 0003  AX400P 4-port analog card
 	0002  Tiger100APC ISDN chipset
 e1c5  Elcus
 e4bf  EKF Elektronik GmbH
@@ -29305,7 +16296,6 @@ ea01  Eagle Technology
 	0046  PCI-766 Analog Output Card
 	0052  PCI-703 Analog I/O Card
 	0800  PCI-800 Digital I/O Card
-# The main chip of all these devices is by Xilinx -> It could also be a Xilinx ID.
 ea60  RME
 	9896  Digi32
 	9897  Digi32 Pro
@@ -29373,7 +16363,6 @@ edd8  ARK Logic Inc
 	a099  2000PV [Stingray]
 	a0a1  2000MT
 	a0a9  2000MI
-# Found on M2N68-AM Motherboard
 f043  ASUSTeK Computer Inc. (Wrong ID)
 f05b  Foxconn International, Inc. (Wrong ID)
 f1d0  AJA Video
@@ -29390,13 +16379,11 @@ f1d0  AJA Video
 	efac  Xena SD-MM/SD-22-MM
 	facd  Xena HD-MM
 f5f5  F5 Networks, Inc.
-# Subsystem ID for PATA controller on nForce motherboard
 f849  ASRock Incorporation (Wrong ID)
 fa57  Interagon AS
 	0001  PMC [Pattern Matching Chip]
 fab7  Fabric7 Systems, Inc.
 febd  Ultraview Corp.
-# Nee Epigram
 feda  Broadcom Inc
 	a0fa  BCM4210 iLine10 HomePNA 2.0
 	a10e  BCM4230 iLine10 HomePNA 2.0
@@ -29404,204 +16391,9 @@ fede  Fedetec Inc.
 	0003  TABIC PCI v3
 fffd  XenSource, Inc.
 	0101  PCI Event Channel Controller
-# Used in some old VMWare products before they got a real ID assigned
 fffe  VMWare Inc (temporary ID)
 	0710  Virtual SVGA
 ffff  Illegal Vendor ID
-
-
-# List of known device classes, subclasses and programming interfaces
-
-# Syntax:
-# C class	class_name
-#	subclass	subclass_name  		<-- single tab
-#		prog-if  prog-if_name  	<-- two tabs
-
-C 00  Unclassified device
-	00  Non-VGA unclassified device
-	01  VGA compatible unclassified device
-C 01  Mass storage controller
-	00  SCSI storage controller
-	01  IDE interface
-	02  Floppy disk controller
-	03  IPI bus controller
-	04  RAID bus controller
-	05  ATA controller
-		20  ADMA single stepping
-		30  ADMA continuous operation
-	06  SATA controller
-		00  Vendor specific
-		01  AHCI 1.0
-		02  Serial Storage Bus
-	07  Serial Attached SCSI controller
-		01  Serial Storage Bus
-	08  Non-Volatile memory controller
-		01  NVMHCI
-		02  NVM Express
-	80  Mass storage controller
-C 02  Network controller
-	00  Ethernet controller
-	01  Token ring network controller
-	02  FDDI network controller
-	03  ATM network controller
-	04  ISDN controller
-	05  WorldFip controller
-	06  PICMG controller
-	07  Infiniband controller
-	08  Fabric controller
-	80  Network controller
-C 03  Display controller
-	00  VGA compatible controller
-		00  VGA controller
-		01  8514 controller
-	01  XGA compatible controller
-	02  3D controller
-	80  Display controller
-C 04  Multimedia controller
-	00  Multimedia video controller
-	01  Multimedia audio controller
-	02  Computer telephony device
-	03  Audio device
-	80  Multimedia controller
-C 05  Memory controller
-	00  RAM memory
-	01  FLASH memory
-	80  Memory controller
-C 06  Bridge
-	00  Host bridge
-	01  ISA bridge
-	02  EISA bridge
-	03  MicroChannel bridge
-	04  PCI bridge
-		00  Normal decode
-		01  Subtractive decode
-	05  PCMCIA bridge
-	06  NuBus bridge
-	07  CardBus bridge
-	08  RACEway bridge
-		00  Transparent mode
-		01  Endpoint mode
-	09  Semi-transparent PCI-to-PCI bridge
-		40  Primary bus towards host CPU
-		80  Secondary bus towards host CPU
-	0a  InfiniBand to PCI host bridge
-	80  Bridge
-C 07  Communication controller
-	00  Serial controller
-		00  8250
-		01  16450
-		02  16550
-		03  16650
-		04  16750
-		05  16850
-		06  16950
-	01  Parallel controller
-		00  SPP
-		01  BiDir
-		02  ECP
-		03  IEEE1284
-		fe  IEEE1284 Target
-	02  Multiport serial controller
-	03  Modem
-		00  Generic
-		01  Hayes/16450
-		02  Hayes/16550
-		03  Hayes/16650
-		04  Hayes/16750
-	04  GPIB controller
-	05  Smard Card controller
-	80  Communication controller
-C 08  Generic system peripheral
-	00  PIC
-		00  8259
-		01  ISA PIC
-		02  EISA PIC
-		10  IO-APIC
-		20  IO(X)-APIC
-	01  DMA controller
-		00  8237
-		01  ISA DMA
-		02  EISA DMA
-	02  Timer
-		00  8254
-		01  ISA Timer
-		02  EISA Timers
-		03  HPET
-	03  RTC
-		00  Generic
-		01  ISA RTC
-	04  PCI Hot-plug controller
-	05  SD Host controller
-	06  IOMMU
-	80  System peripheral
-C 09  Input device controller
-	00  Keyboard controller
-	01  Digitizer Pen
-	02  Mouse controller
-	03  Scanner controller
-	04  Gameport controller
-		00  Generic
-		10  Extended
-	80  Input device controller
-C 0a  Docking station
-	00  Generic Docking Station
-	80  Docking Station
-C 0b  Processor
-	00  386
-	01  486
-	02  Pentium
-	10  Alpha
-	20  Power PC
-	30  MIPS
-	40  Co-processor
-C 0c  Serial bus controller
-	00  FireWire (IEEE 1394)
-		00  Generic
-		10  OHCI
-	01  ACCESS Bus
-	02  SSA
-	03  USB controller
-		00  UHCI
-		10  OHCI
-		20  EHCI
-		30  XHCI
-		80  Unspecified
-		fe  USB Device
-	04  Fibre Channel
-	05  SMBus
-	06  InfiniBand
-	07  IPMI SMIC interface
-	08  SERCOS interface
-	09  CANBUS
-C 0d  Wireless controller
-	00  IRDA controller
-	01  Consumer IR controller
-	10  RF controller
-	11  Bluetooth
-	12  Broadband
-	20  802.1a controller
-	21  802.1b controller
-	80  Wireless controller
-C 0e  Intelligent controller
-	00  I2O
-C 0f  Satellite communications controller
-	01  Satellite TV controller
-	02  Satellite audio communication controller
-	03  Satellite voice communication controller
-	04  Satellite data communication controller
-C 10  Encryption controller
-	00  Network and computing encryption device
-	10  Entertainment encryption device
-	80  Encryption controller
-C 11  Signal processing controller
-	00  DPIO module
-	01  Performance counters
-	10  Communication synchronizer
-	20  Signal processing management
-	80  Signal processing controller
-C 12  Processing accelerators
-	00  Processing accelerators
-C 13  Non-Essential Instrumentation
-C 40  Coprocessor
-C ff  Unassigned class
 `)
+	return parse(pciids)
+}

--- a/pkg/pci/lookup_test.go
+++ b/pkg/pci/lookup_test.go
@@ -1,0 +1,46 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package pci
+
+import (
+	"testing"
+)
+
+func TestLookup(t *testing.T) {
+
+	var idLookupTests = []struct {
+		vendor     string
+		device     string
+		vendorName string
+		deviceName string
+	}{
+		{"1055", "e420", "Efar Microsystems", "LAN9420/LAN9420i"},
+		{"8086", "1237", "Intel Corporation", "440FX - 82441FX PMC [Natoma]"},
+		{"8086", "7000", "Intel Corporation", "82371SB PIIX3 ISA [Natoma/Triton II]"},
+		{"8086", "7111", "Intel Corporation", "82371AB/EB/MB PIIX4 IDE"},
+		{"80ee", "beef", "InnoTek Systemberatung GmbH", "VirtualBox Graphics Adapter"},
+		{"8086", "100e", "Intel Corporation", "82540EM Gigabit Ethernet Controller"},
+		{"80ee", "cafe", "InnoTek Systemberatung GmbH", "VirtualBox Guest Service"},
+		{"8086", "2415", "Intel Corporation", "82801AA AC'97 Audio Controller"},
+		{"8086", "7113", "Intel Corporation", "82371AB/EB/MB PIIX4 ACPI"},
+		{"8086", "100f", "Intel Corporation", "82545EM Gigabit Ethernet Controller (Copper)"},
+	}
+
+	t.Run("Lookup Using IDs", func(t *testing.T) {
+		ids, err := NewIDs()
+		if err != nil {
+			t.Fatalf("NewIDs error:%s\n", err)
+		}
+		for _, tt := range idLookupTests {
+			v, d := Lookup(ids, tt.vendor, tt.device)
+			if v != tt.vendorName {
+				t.Errorf("Vendor mismatch, found %s, expected %s\n", v, tt.vendorName)
+			}
+			if d != tt.deviceName {
+				t.Errorf("Device mismatch, found %s, expected %s\n", d, tt.deviceName)
+			}
+		}
+	})
+
+}

--- a/pkg/pci/parse.go
+++ b/pkg/pci/parse.go
@@ -1,0 +1,41 @@
+package pci
+
+import (
+	"bufio"
+	"bytes"
+)
+
+func isHex(b byte) bool {
+	return ('a' <= b && b <= 'f') || ('A' <= b && b <= 'F') || ('0' <= b && b <= '9')
+}
+
+// scan searches for Vendor and Device lines from the input *bufio.Scanner based
+// on pci.ids format. Found Vendors and Devices are added to the input map.
+// This implimentation expects an input pci.ids to have comments, blank lines,
+// sub-devices, and classes already removed.
+func scan(s *bufio.Scanner, ids map[string]Vendor) error {
+	var currentVendor string
+	var line string
+
+	for s.Scan() {
+		line = s.Text()
+
+		switch {
+		case isHex(line[0]) && isHex(line[1]):
+			currentVendor = line[:4]
+			ids[currentVendor] = Vendor{Name: line[6:], Devices: make(map[string]Device)}
+		case currentVendor != "" && line[0] == '\t' && isHex(line[1]):
+			ids[currentVendor].Devices[line[1:5]] = Device(line[7:])
+		}
+	}
+	return nil
+}
+
+func parse(input []byte) (map[string]Vendor, error) {
+	ids := make(map[string]Vendor)
+
+	s := bufio.NewScanner(bytes.NewReader(input))
+	err := scan(s, ids)
+
+	return ids, err
+}

--- a/pkg/pci/parse.go
+++ b/pkg/pci/parse.go
@@ -10,9 +10,7 @@ func isHex(b byte) bool {
 }
 
 // scan searches for Vendor and Device lines from the input *bufio.Scanner based
-// on pci.ids format. Found Vendors and Devices are added to the input map.
-// This implimentation expects an input pci.ids to have comments, blank lines,
-// sub-devices, and classes already removed.
+// on pci.ids format. Found Vendors and Devices are added to the input ids map.
 func scan(s *bufio.Scanner, ids map[string]Vendor) error {
 	var currentVendor string
 	var line string
@@ -24,7 +22,7 @@ func scan(s *bufio.Scanner, ids map[string]Vendor) error {
 		case isHex(line[0]) && isHex(line[1]):
 			currentVendor = line[:4]
 			ids[currentVendor] = Vendor{Name: line[6:], Devices: make(map[string]Device)}
-		case currentVendor != "" && line[0] == '\t' && isHex(line[1]):
+		case currentVendor != "" && line[0] == '\t' && isHex(line[1]) && isHex(line[3]):
 			ids[currentVendor].Devices[line[1:5]] = Device(line[7:])
 		}
 	}

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -4,7 +4,9 @@
 
 package pci
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // PCI is a PCI device. We will fill this in as we add options.
 // For now it just holds two uint16 per the PCI spec.
@@ -19,15 +21,15 @@ type PCI struct {
 // ToString concatenates PCI address, Vendor, and Device to make a useful
 // display for the user. Boolean argument toggles displaying numeric IDs or
 // human readable labels.
-func (p PCI) ToString(n bool) string {
+func (p PCI) ToString(n bool, ids map[string]Vendor) string {
 	if n {
 		return fmt.Sprintf("%s: %s:%s", p.Addr, p.Vendor, p.Device)
 	}
-	p.VendorName, p.DeviceName = lookup(p.Vendor, p.Device)
+	p.VendorName, p.DeviceName = Lookup(ids, p.Vendor, p.Device)
 	return fmt.Sprintf("%s: %v %v", p.Addr, p.VendorName, p.DeviceName)
 }
 
 // String is a Stringer for fmt and others' convenience.
 func (p PCI) String() string {
-	return p.ToString(false)
+	return p.ToString(true, nil)
 }

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -50,8 +50,8 @@ func (bus *bus) Read() (Devices, error) {
 	return devices, nil
 }
 
-// NewBusReader returns a BusReader. If we can't at least glob in
-// /sys/bus/pci/devices then we just give up. We don't provide an option
+// NewBusReader returns a BusReader. If it can't glob in
+// /sys/bus/pci/devices then it gives up. We don't provide an option
 // (yet) to do type I or PCIe MMIO config stuff.
 func NewBusReader() (busReader, error) {
 	globs, err := filepath.Glob("/sys/bus/pci/devices/*")

--- a/pkg/pci/types.go
+++ b/pkg/pci/types.go
@@ -7,3 +7,13 @@ package pci
 type busReader interface {
 	Read() (Devices, error)
 }
+
+// Vendor is a PCI vendor human readable label. It contains a map of one or
+// more Devices keyed by hex ID.
+type Vendor struct {
+	Name    string
+	Devices map[string]Device
+}
+
+// Device is a PCI device human readable label
+type Device string


### PR DESCRIPTION
- Strip unused text from literal pci.ids slice of bytes
- Add NewIDs() function which contains the pci.ids itself, but returns the parsed
map. This is now only done on start of the pci cmd.
- Add a test for Lookup
- Minimize scan() since we can assume more about pci.ids' format
- PCI and Device stringers now return the numeric IDs, because they
don't have a way to get to the ids map now thats its not global.
- Add a Vendor and Device type for the generated lookup map.
- Runtime reduce by ~50%.
- Compressed bb cpio image reduced by 79kB.

Signed-off-by: Ben Allen bensallen@me.com