### PR TITLE
    chrome: make chrome the startup browser in xinit

### DIFF
--- a/cmds/xinit/xinit.go
+++ b/cmds/xinit/xinit.go
@@ -43,7 +43,7 @@ func setup() error {
 		}
 		time.Sleep(time.Second)
 	}
-	for _, f := range []string{"wingo", "flwm", "midori", "opera-12"} {
+	for _, f := range []string{"wingo", "flwm", "chrome"} {
 		log.Printf("Run %v", f)
 		go x11(f)
 	}


### PR DESCRIPTION
    chrome: make chrome the startup browser in xinit
    
    midori is just a bug-filled pit and opera-12 is just
    not good enough to keep trying to start. Chrome works.
    We can add firefox quantum later if anyone cares.