### PR TITLE
cmds/rm: Add force flag

### DIFF
--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -12,6 +12,7 @@
 //     -v: verbose mode
 //     -R: remove file hierarchies
 //     -r: equivalent to -R
+//     -f: ignore nonexistent files and never prompt
 package main
 
 import (
@@ -29,8 +30,9 @@ var (
 		r bool
 		v bool
 		i bool
+		f bool
 	}
-	cmd = "rm [-Rrvi] file..."
+	cmd = "rm [-Rrvif] file..."
 )
 
 func init() {
@@ -43,12 +45,17 @@ func init() {
 	flag.BoolVar(&flags.v, "v", false, "Verbose mode.")
 	flag.BoolVar(&flags.r, "R", false, "Remove file hierarchies")
 	flag.BoolVar(&flags.r, "r", false, "Equivalent to -R.")
+	flag.BoolVar(&flags.f, "f", false, "Ignore nonexistent files and never prompt")
 }
 
 func rm(files []string) error {
 	f := os.Remove
 	if flags.r {
 		f = os.RemoveAll
+	}
+
+	if flags.f {
+		flags.i = false
 	}
 
 	workingPath, err := os.Getwd()
@@ -67,6 +74,9 @@ func rm(files []string) error {
 		}
 
 		if err := f(file); err != nil {
+			if flags.f && os.IsNotExist(err) {
+				continue
+			}
 			return err
 		}
 

--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -5,7 +5,7 @@
 // Delete files.
 //
 // Synopsis:
-//     rm [-Rrvi] FILE...
+//     rm [-Rrvif] FILE...
 //
 // Options:
 //     -i: interactive mode

--- a/cmds/rm/rm_test.go
+++ b/cmds/rm/rm_test.go
@@ -94,8 +94,7 @@ func Test_rm_2(t *testing.T) {
 	}
 }
 
-// using f flag
-func Test_rm_3(t *testing.T) {
+func TestForceRemove(t *testing.T) {
 	d, err := setup()
 	if err != nil {
 		t.Fatal("Error on setup of the test: creating files and folders.")

--- a/cmds/rm/rm_test.go
+++ b/cmds/rm/rm_test.go
@@ -93,3 +93,29 @@ func Test_rm_2(t *testing.T) {
 		t.Error(err)
 	}
 }
+
+// using f flag
+func Test_rm_3(t *testing.T) {
+	d, err := setup()
+	if err != nil {
+		t.Fatal("Error on setup of the test: creating files and folders.")
+	}
+	defer os.RemoveAll(d)
+
+	flags.v = true
+	flags.r = false
+	flags.f = true
+	fmt.Println("== Deleting existing and nonexistent files (using -f flag) ...")
+	files := []string{
+		filepath.Join(d, "hi1.doc"), // does not exist
+		filepath.Join(d, "hi2.txt"), // exists
+		filepath.Join(d, "go.doc"),  // does not exist
+	}
+	if err := rm(files); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := os.Stat(files[1]); !os.IsNotExist(err) {
+		t.Errorf("%q should have been deleted", files[1])
+	}
+}


### PR DESCRIPTION
The force flags disables interactive mode (if enabled) and ignores
errors when trying to delete nonexistent file(s).

This allows to invoke `rm` on multiple files and be sure that they will
all be deleted even if one or more is missing. Suppose we have a folder
`foo/` with files `a` and `c` in there. On `rm foo/a foo/b foo/c` only
`foo/a` will get deleted, because `foo/b` is missing and thus the
command will fail. On `rm -f foo/a foo/b foo/c` on the other hand, the
command will succeed and both `foo/a` and `foo/c` will be deleted.

Fixes #335.

Signed-off-by: Kiril Vladimiroff <kiril@vladimiroff.org>