### PR TITLE
archive, cat, ectool, ip, kill, msr, mv, rm, rush, which: Tidy ranges

### DIFF
--- a/cmds/archive/toc.go
+++ b/cmds/archive/toc.go
@@ -18,8 +18,8 @@ func toc(files ...string) error {
 		if err != nil {
 			fmt.Printf("%v", err)
 		}
-		for i := range vtoc {
-			fmt.Printf("%v\n", vtoc[i])
+		for _, vv := range vtoc {
+			fmt.Printf("%v\n", vv)
 		}
 	}
 	return nil

--- a/cmds/cat/cat_test.go
+++ b/cmds/cat/cat_test.go
@@ -24,9 +24,9 @@ func setup(t *testing.T, data []byte) (string, error) {
 		return "", err
 	}
 
-	for i := range data {
+	for i, d := range data {
 		n := fmt.Sprintf("%v%d", filepath.Join(dir, "file"), i)
-		if err := ioutil.WriteFile(n, []byte{data[i]}, 0666); err != nil {
+		if err := ioutil.WriteFile(n, []byte{d}, 0666); err != nil {
 			return "", err
 		}
 	}

--- a/cmds/ectool/lpc.go
+++ b/cmds/ectool/lpc.go
@@ -67,12 +67,12 @@ func (l *lpc) Command(c command, v version, idata []byte, outsize int, timeout t
 	flags := uint8(ecHostArgsFlagFromHost)
 	csum := flags + uint8(c) + uint8(v) + uint8(len(idata))
 
-	for i := range idata {
-		err := l.Outb(l.statusAddr+ioaddr(i), idata[i])
+	for i, d := range idata {
+		err := l.Outb(l.statusAddr+ioaddr(i), d)
 		if err != nil {
 			return nil, err
 		}
-		csum += idata[i]
+		csum += d
 	}
 
 	cmd := []uint8{ecHostArgsFlagFromHost, uint8(v), uint8(len(idata)), uint8(csum)}

--- a/cmds/ip/ip.go
+++ b/cmds/ip/ip.go
@@ -62,8 +62,8 @@ func usage() {
 
 func one(cmd string, cmds []string) string {
 	var x, n int
-	for i := range cmds {
-		if strings.HasPrefix(cmds[i], cmd) {
+	for i, v := range cmds {
+		if strings.HasPrefix(v, cmd) {
 			n++
 			x = i
 		}

--- a/cmds/kill/list_linux.go
+++ b/cmds/kill/list_linux.go
@@ -204,8 +204,8 @@ var (
 )
 
 func siglist() (s string) {
-	for i := range signames {
-		s = s + fmt.Sprintf("%d: %v\n", i, signames[i])
+	for i, sig := range signames {
+		s = s + fmt.Sprintf("%d: %v\n", i, sig)
 	}
 	return
 }

--- a/cmds/msr/msr.go
+++ b/cmds/msr/msr.go
@@ -47,11 +47,11 @@ func main() {
 	switch a[0] {
 	case "r":
 		data, errs := rdmsr(m, uint32(reg))
-		for i := range m {
+		for i, v := range m {
 			if errs[i] != nil {
-				fmt.Printf("%v: %v\n", m[i], errs[i])
+				fmt.Printf("%v: %v\n", v, errs[i])
 			} else {
-				fmt.Printf("%v: %#016x\n", m[i], data[i])
+				fmt.Printf("%v: %#016x\n", v, data[i])
 			}
 		}
 
@@ -76,9 +76,9 @@ func main() {
 			log.Fatalf("%v: %v", a, err)
 		}
 		errs := wrmsr(m, uint32(reg), v)
-		for i := range errs {
-			if errs[i] != nil {
-				fmt.Printf("%v: %v\n", m[i], errs[i])
+		for i, e := range errs {
+			if e != nil {
+				fmt.Printf("%v: %v\n", m[i], e)
 			}
 		}
 

--- a/cmds/mv/mv.go
+++ b/cmds/mv/mv.go
@@ -34,9 +34,9 @@ func mv(files []string, todir bool) error {
 	} else {
 		lf := files[len(files)-1]
 		// "copying" N files to 1 directory
-		for i := range files[:len(files)-1] {
-			ndir := filepath.Join(lf, filepath.Base(files[i]))
-			if err := os.Rename(files[i], ndir); err != nil {
+		for _, f := range files[:len(files)-1] {
+			ndir := filepath.Join(lf, filepath.Base(f))
+			if err := os.Rename(f, ndir); err != nil {
 				return err
 			}
 		}

--- a/cmds/mv/mv_test.go
+++ b/cmds/mv/mv_test.go
@@ -42,8 +42,8 @@ func setup() (string, error) {
 		return "", err
 	}
 
-	for i := range tests {
-		if err := ioutil.WriteFile(filepath.Join(d, tests[i].n), []byte("hi"), tests[i].m); err != nil {
+	for _, t := range tests {
+		if err := ioutil.WriteFile(filepath.Join(d, t.n), []byte("hi"), t.m); err != nil {
 			return "", err
 		}
 	}

--- a/cmds/rm/rm_test.go
+++ b/cmds/rm/rm_test.go
@@ -51,8 +51,8 @@ func setup() (string, error) {
 		return "", err
 	}
 
-	for i := range tests {
-		if err := ioutil.WriteFile(filepath.Join(d, tests[i].n), []byte("Go is cool!"), tests[i].m); err != nil {
+	for _, t := range tests {
+		if err := ioutil.WriteFile(filepath.Join(d, t.n), []byte("Go is cool!"), t.m); err != nil {
 			return "", err
 		}
 	}

--- a/cmds/rush/parse.go
+++ b/cmds/rush/parse.go
@@ -256,17 +256,17 @@ func getCommand(b *bufio.Reader) (c []*Command, t string, err error) {
 	// the rules.
 	// For now, no empty commands.
 	// Can't have a redir and a redirect for fd1.
-	for i := range c {
-		if len(c[i].args) == 0 {
+	for i, v := range c {
+		if len(v.args) == 0 {
 			return nil, "", errors.New("empty commands not allowed (yet)")
 		}
-		if c[i].link == "|" && c[i].fdmap[1] != "" {
+		if v.link == "|" && v.fdmap[1] != "" {
 			return nil, "", errors.New("Can't have a pipe and > on one command")
 		}
-		if c[i].link == "|" && i == len(c)-1 {
+		if v.link == "|" && i == len(c)-1 {
 			return nil, "", errors.New("Can't have a pipe to nowhere")
 		}
-		if i < len(c)-1 && c[i].link == "|" && c[i+1].fdmap[0] != "" {
+		if i < len(c)-1 && v.link == "|" && c[i+1].fdmap[0] != "" {
 			return nil, "", errors.New("Can't have a pipe to command with redirect on stdin")
 		}
 	}

--- a/cmds/rush/rush.go
+++ b/cmds/rush/rush.go
@@ -245,20 +245,20 @@ func main() {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			continue
 		}
-		for i := range cmds {
-			if err := command(cmds[i]); err != nil {
+		for _, c := range cmds {
+			if err := command(c); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)
-				if cmds[i].link == "||" {
+				if c.link == "||" {
 					continue
 				}
 				// yes, not needed, but useful so you know
 				// what goes on here.
-				if cmds[i].link == "&&" {
+				if c.link == "&&" {
 					break
 				}
 				break
 			} else {
-				if cmds[i].link == "||" {
+				if c.link == "||" {
 					break
 				}
 			}

--- a/cmds/which/which.go
+++ b/cmds/which/which.go
@@ -36,8 +36,8 @@ func which(p string, writer io.Writer, cmds []string) {
 	// If no matches are found will exit 1, else 0
 	exitValue := 1
 	for _, name := range cmds {
-		for i := range pathArray {
-			f := filepath.Join(pathArray[i], name)
+		for _, p := range pathArray {
+			f := filepath.Join(p, name)
 			if info, err := os.Stat(f); err == nil {
 				// TODO: this test (0111) is not quite right.
 				// Consider a file executable only by root (0100)

--- a/cmds/which/which_test.go
+++ b/cmds/which/which_test.go
@@ -46,8 +46,8 @@ var (
 func setup() error {
 	var err error
 
-	for i := range tests {
-		tests[i].pathOnSys, err = exec.Command("which", tests[i].name).Output()
+	for i, t := range tests {
+		tests[i].pathOnSys, err = exec.Command("which", t.name).Output()
 		if err != nil {
 			return err
 		}
@@ -87,9 +87,9 @@ func TestWhichMultiple(t *testing.T) {
 
 	pathsCombined := []byte{}
 	commands := []string{}
-	for i := range tests {
-		pathsCombined = append(pathsCombined, tests[i].pathOnSys...)
-		commands = append(commands, tests[i].name)
+	for _, t := range tests {
+		pathsCombined = append(pathsCombined, t.pathOnSys...)
+		commands = append(commands, t.name)
 	}
 
 	var b bytes.Buffer


### PR DESCRIPTION
Pull out the value when iterating a range rather than simply iterating
the index and looking up the value in the slice.

Signed-off-by: Alistair Ferguson <ferguson.alistair@gmail.com>