### PR TITLE
cmds/shutdown: fix typo in dryrun help message

### DIFF
--- a/cmds/shutdown/shutdown.go
+++ b/cmds/shutdown/shutdown.go
@@ -24,7 +24,7 @@ import (
 )
 
 var (
-	dryrun  = flag.Bool("dryrun", false, "Do not do kexec system calls")
+	dryrun  = flag.Bool("dryrun", false, "Do not do reboot system calls")
 	op      = "reboot"
 	opcodes = map[string]int{
 		"halt":    unix.LINUX_REBOOT_CMD_POWER_OFF,


### PR DESCRIPTION
shutdown uses the reboot syscall, not kexec.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>