### PR TITLE
cmds/uname: use unix.Uname directly

### DIFF
--- a/pkg/uroot/util/uname.go
+++ b/pkg/uroot/util/uname.go
@@ -3,38 +3,3 @@
 // license that can be found in the LICENSE file.
 
 package util
-
-import (
-	"bytes"
-
-	"golang.org/x/sys/unix"
-)
-
-type Utsname struct {
-	Sysname    string
-	Nodename   string
-	Release    string
-	Version    string
-	Machine    string
-	Domainname string
-}
-
-func toString(d []byte) string {
-	return string(d[:bytes.IndexByte(d[:], 0)])
-}
-
-// Uname returns name and information about the current OS kernel
-func Uname() (*Utsname, error) {
-	var u unix.Utsname
-	if err := unix.Uname(&u); err != nil {
-		return nil, err
-	}
-	return &Utsname{
-		Sysname:    toString(u.Sysname[:]),
-		Nodename:   toString(u.Nodename[:]),
-		Release:    toString(u.Release[:]),
-		Version:    toString(u.Version[:]),
-		Machine:    toString(u.Machine[:]),
-		Domainname: toString(u.Domainname[:]),
-	}, nil
-}


### PR DESCRIPTION
After PR #454, util.Uname is merely a wrapper around unix.Uname. Make
its only user in cmds/uname use unix.Uname directly and drop the uname
related parts of pkg/uroot/util.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>