### PR TITLE
cmds/dd: Rewrite dd_test to lower memory use

### DIFF
--- a/cmds/dd/dd_test.go
+++ b/cmds/dd/dd_test.go
@@ -5,7 +5,9 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -14,85 +16,169 @@ import (
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-var tests = []struct {
-	flags  []string
-	stdin  string
-	stdout string
-}{
-	{
-		// Simple copying from input to output.
-		flags:  []string{},
-		stdin:  "1: defaults",
-		stdout: "1: defaults",
-	}, {
-		// Copy from input to output on a non-aligned block size.
-		flags:  []string{"bs=8"},
-		stdin:  "2: bs=8 11b", // len=11 is not multiple of 8
-		stdout: "2: bs=8 11b",
-	}, {
-		//  case change
-		flags:  []string{"bs=8", "conv=lcase"},
-		stdin:  "3: Bs=8 11B", // len=11 is not multiple of 8
-		stdout: "3: bs=8 11b",
-	}, {
-		//  case change
-		flags:  []string{"bs=8", "conv=ucase"},
-		stdin:  "3: Bs=8 11B", // len=11 is not multiple of 8
-		stdout: "3: BS=8 11B",
-	}, {
-		// Copy from input to output on an aligned block size.
-		flags:  []string{"bs=8"},
-		stdin:  "hello world.....", // len=16 is a multiple of 8
-		stdout: "hello world.....",
-	}, {
-		// Create a 64KiB zeroed file in 1KiB blocks
-		flags:  []string{"if=/dev/zero", "bs=1024", "count=64"},
-		stdin:  "",
-		stdout: strings.Repeat("\x00", 64*1024),
-	}, {
-		// Create a 64KiB zeroed file in 1 byte blocks
-		flags:  []string{"if=/dev/zero", "bs=1", "count=65536"},
-		stdin:  "",
-		stdout: strings.Repeat("\x00", 64*1024),
-	}, {
-		// Create a 64KiB zeroed file in one 64KiB block
-		flags:  []string{"if=/dev/zero", "bs=65536", "count=1"},
-		stdin:  "",
-		stdout: strings.Repeat("\x00", 64*1024),
-	}, {
-		// Use skip and count.
-		flags:  []string{"skip=6", "bs=1", "count=5"},
-		stdin:  "hello world.....",
-		stdout: "world",
-	}, {
-		// Count clamps to end of stream.
-		flags:  []string{"bs=2", "skip=3", "count=100000"},
-		stdin:  "hello world.....",
-		stdout: "world.....",
-	}, {
-		// 1 GiB zeroed file in 1024 1KiB blocks.
-		flags:  []string{"bs=1048576", "count=1024", "if=/dev/zero"},
-		stdin:  "",
-		stdout: strings.Repeat("\x00", 1024*1024*1024),
-	},
-}
-
 // TestDd implements a table-driven test.
 func TestDd(t *testing.T) {
+	var tests = []struct {
+		name    string
+		flags   []string
+		stdin   string
+		stdout  []byte
+		count   int64
+		compare func(io.Reader, []byte, int64) error
+	}{
+
+		{
+			name:    "Simple copying from input to output",
+			flags:   []string{},
+			stdin:   "1: defaults",
+			stdout:  []byte("1: defaults"),
+			compare: stdoutEqual,
+		},
+		{
+			name:    "Copy from input to output on a non-aligned block size",
+			flags:   []string{"bs=8"},
+			stdin:   "2: bs=8 11b", // len=11 is not multiple of 8
+			stdout:  []byte("2: bs=8 11b"),
+			compare: stdoutEqual,
+		},
+		{
+			name:    "case lower change",
+			flags:   []string{"bs=8", "conv=lcase"},
+			stdin:   "3: Bs=8 11B", // len=11 is not multiple of 8
+			stdout:  []byte("3: bs=8 11b"),
+			compare: stdoutEqual,
+		},
+		{
+			name:    "case upper change",
+			flags:   []string{"bs=8", "conv=ucase"},
+			stdin:   "3: Bs=8 11B", // len=11 is not multiple of 8
+			stdout:  []byte("3: BS=8 11B"),
+			compare: stdoutEqual,
+		},
+		{
+			name:    "Copy from input to output on an aligned block size",
+			flags:   []string{"bs=8"},
+			stdin:   "hello world.....", // len=16 is a multiple of 8
+			stdout:  []byte("hello world....."),
+			compare: stdoutEqual,
+		},
+		{
+			name:    "Create a 64KiB zeroed file in 1KiB blocks",
+			flags:   []string{"if=/dev/zero", "bs=1024", "count=64"},
+			stdin:   "",
+			stdout:  []byte("\x00"),
+			count:   64 * 1024,
+			compare: byteCount,
+		},
+		{
+			name:    "Create a 64KiB zeroed file in 1 byte blocks",
+			flags:   []string{"if=/dev/zero", "bs=1", "count=65536"},
+			stdin:   "",
+			stdout:  []byte("\x00"),
+			count:   64 * 1024,
+			compare: byteCount,
+		},
+		{
+			name:    "Create a 64KiB zeroed file in one 64KiB block",
+			flags:   []string{"if=/dev/zero", "bs=65536", "count=1"},
+			stdin:   "",
+			stdout:  []byte("\x00"),
+			count:   64 * 1024,
+			compare: byteCount,
+		},
+		{
+			name:    "Use skip and count",
+			flags:   []string{"skip=6", "bs=1", "count=5"},
+			stdin:   "hello world.....",
+			stdout:  []byte("world"),
+			compare: stdoutEqual,
+		},
+		{
+			name:    "Count clamps to end of stream",
+			flags:   []string{"bs=2", "skip=3", "count=100000"},
+			stdin:   "hello world.....",
+			stdout:  []byte("world....."),
+			compare: stdoutEqual,
+		},
+		{
+			name:    "1 GiB zeroed file in 1024 1KiB blocks",
+			flags:   []string{"bs=1048576", "count=1024", "if=/dev/zero"},
+			stdin:   "",
+			stdout:  []byte("\x00"),
+			count:   1024 * 1024 * 1024,
+			compare: byteCount,
+		},
+	}
 	tmpDir, execPath := testutil.CompileInTempDir(t)
 	defer os.RemoveAll(tmpDir)
 
 	for _, tt := range tests {
-		cmd := exec.Command(execPath, tt.flags...)
-		cmd.Stdin = strings.NewReader(tt.stdin)
-		out, err := cmd.Output()
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command(execPath, tt.flags...)
+			cmd.Stdin = strings.NewReader(tt.stdin)
+			out, err := cmd.StdoutPipe()
+			if err != nil {
+				t.Errorf("Test %v exited with error: %v", tt.flags, err)
+			}
+			if err := cmd.Start(); err != nil {
+				t.Errorf("Test %v exited with error: %v", tt.flags, err)
+			}
+			err = tt.compare(out, tt.stdout, tt.count)
+			if err != nil {
+				t.Errorf("Test compare function returned: %v", err)
+			}
+			if err := cmd.Wait(); err != nil {
+				t.Errorf("Test %v exited with error: %v", tt.flags, err)
+			}
+		})
+	}
+}
+
+// stdoutEqual creates a bufio Reader from io.Reader, then compares a byte at a time input []byte.
+// The third argument (int64) is ignored and only exists to make the function signature compatible
+// with func byteCount.
+// Returns an error if mismatch is found with offset.
+func stdoutEqual(i io.Reader, o []byte, _ int64) error {
+	var count int64
+	b := bufio.NewReader(i)
+
+	for {
+		z, err := b.ReadByte()
 		if err != nil {
-			t.Errorf("Test %v exited with error: %v", tt.flags, err)
+			break
 		}
-		if string(out) != tt.stdout {
-			t.Errorf("Want:\n%#v\nGot:\n%#v", tt.stdout, string(out))
+		if o[count] != z {
+			return fmt.Errorf("Found mismatch at offset %d, wanted %s, found %s", count, string(o[count]), string(z))
+		}
+		count++
+	}
+	return nil
+}
+
+// byteCount creates a bufio Reader from io.Reader, then counts the number of sequential bytes
+// that match the first byte in the input []byte. If the count matches input n int64, nil error
+// is returned. Otherwise an error is returned for a non-matching byte or if the count doesn't
+// match.
+func byteCount(i io.Reader, o []byte, n int64) error {
+	b := bufio.NewReader(i)
+	var count int64
+
+	for {
+		z, err := b.ReadByte()
+		if err != nil {
+			break
+		}
+		if z == o[0] {
+			count++
+		} else {
+			return fmt.Errorf("Found non-matching byte: %v, at offset: %d", o[0], count)
 		}
 	}
+
+	if count == n {
+		return nil
+	}
+	return fmt.Errorf("Found %d count of %#v bytes, wanted to find %d count", count, o[0], n)
 }
 
 // BenchmarkDd benchmarks the dd command. Each "op" unit is a 1MiB block.


### PR DESCRIPTION
- Stream stdout of from dd via cmd.Stdoutpipe()
- Add compare function and count fields to the table tests struct to allow for two compare functions to be used.
- For tests that check stdout against a sequential set of identical bytes, create func byteCount. Fixes having to allocate large slices to compare stdout against.
- For tests that need string like comparison, create func stdoutEqual, which compares stdout a byte at a time to the input []byte
- Use byte slices instead of strings where possible
- Don't output error messages including all of stdout, use explicit error messages from new functions.
- Move table tests struct inside test function so its no longer global.
- Make each test a sub-test of TestDd via tt.Run(), changing comments around each test into a new name field.
- Reduces memory consumption of test to ~989MB from 5.8GB (ran on macOS).

Fixes: #483 

Signed-off: Ben Allen <bensallen@me.com>