### PR TITLE
pci pkg/cmd: simplify printing and name lookup

### DIFF
--- a/cmds/pci/pci.go
+++ b/cmds/pci/pci.go
@@ -38,13 +38,7 @@ func main() {
 	}
 
 	if !*numbers {
-		ids, err := pci.NewIDs()
-		if err != nil {
-			log.Fatalf("pci.NewIDs: %v\n", err)
-		}
-		fmt.Print(d.ToString(*numbers, ids))
-	} else {
-		fmt.Print(d)
+		d.SetVendorDeviceName()
 	}
-
+	fmt.Print(d)
 }

--- a/cmds/pci/pci.go
+++ b/cmds/pci/pci.go
@@ -40,5 +40,8 @@ func main() {
 	if !*numbers {
 		d.SetVendorDeviceName()
 	}
+	if *dumpConfig {
+		d.ReadConfig()
+	}
 	fmt.Print(d)
 }

--- a/cmds/pci/pci.go
+++ b/cmds/pci/pci.go
@@ -19,11 +19,15 @@ import (
 	"github.com/u-root/u-root/pkg/pci"
 )
 
-var numbers = flag.Bool("n", false, "Show numeric IDs")
+var (
+	numbers    = flag.Bool("n", false, "Show numeric IDs")
+	dumpConfig = flag.Bool("c", false, "Dump config space")
+	devs       = flag.String("s", "*", "Devices to match")
+)
 
 func main() {
 	flag.Parse()
-	r, err := pci.NewBusReader()
+	r, err := pci.NewBusReader(*devs)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}
@@ -39,7 +43,6 @@ func main() {
 			log.Fatalf("pci.NewIDs: %v\n", err)
 		}
 		fmt.Print(d.ToString(*numbers, ids))
-
 	} else {
 		fmt.Print(d)
 	}

--- a/pkg/pci/devices.go
+++ b/pkg/pci/devices.go
@@ -28,3 +28,13 @@ func (d Devices) SetVendorDeviceName() {
 		p.SetVendorDeviceName()
 	}
 }
+
+// ReadConfig reads the config info for all the devices.
+func (d Devices) ReadConfig() error {
+	for _, p := range d {
+		if err := p.ReadConfig(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/pci/devices.go
+++ b/pkg/pci/devices.go
@@ -11,19 +11,20 @@ import (
 //Devices contains a slice of one or more PCI devices
 type Devices []*PCI
 
-// ToString concatenates multiple Devices' PCI address, Vendor, and Device
-// to make a useful display for the user. Boolean argument toggles displaying
-// numeric IDs or human readable labels.
-func (d Devices) ToString(n bool, ids map[string]Vendor) string {
+// String stringifies the PCI devices. Currently it just calls the device String().
+func (d Devices) String() string {
 	var buffer bytes.Buffer
 	for _, pci := range d {
-		buffer.WriteString(pci.ToString(n, ids))
+		buffer.WriteString(pci.String())
 		buffer.WriteString("\n")
 	}
 	return buffer.String()
 }
 
-// String is a Stringer for fmt and others' convenience.
-func (d Devices) String() string {
-	return d.ToString(true, nil)
+// SetVendorDeviceName sets all numeric IDs of all the devices
+// using the pci device SetVendorDeviceName.
+func (d Devices) SetVendorDeviceName() {
+	for _, p := range d {
+		p.SetVendorDeviceName()
+	}
 }

--- a/pkg/pci/ids.go
+++ b/pkg/pci/ids.go
@@ -11,9 +11,21 @@
 
 package pci
 
-// NewIDs contains the plain text contents of pci.ids. It returns
+type idMap map[string]Vendor
+
+var ids idMap
+
+// newIDs contains the plain text contents of pci.ids. It returns
 // a map to be used as lookup from hex ID to human readable lable.
-func NewIDs() (map[string]Vendor, error) {
+// We do not admit of the possibility of error, any failure
+// should be caught by the test. We might just want to just always
+// create ids since the most common use of pci will be with names,
+// not numbers.
+func newIDs() idMap {
+
+	if ids != nil {
+		return ids
+	}
 
 	var pciids = []byte(`0001  SafeNet (wrong ID)
 0010  Allied Telesis, Inc (Wrong ID)
@@ -16395,5 +16407,6 @@ fffe  VMWare Inc (temporary ID)
 	0710  Virtual SVGA
 ffff  Illegal Vendor ID
 `)
-	return parse(pciids)
+	ids = parse(pciids)
+	return ids
 }

--- a/pkg/pci/lookup_test.go
+++ b/pkg/pci/lookup_test.go
@@ -9,36 +9,29 @@ import (
 
 func TestLookup(t *testing.T) {
 
-	var idLookupTests = []struct {
-		vendor     string
-		device     string
-		vendorName string
-		deviceName string
-	}{
-		{"1055", "e420", "Efar Microsystems", "LAN9420/LAN9420i"},
-		{"8086", "1237", "Intel Corporation", "440FX - 82441FX PMC [Natoma]"},
-		{"8086", "7000", "Intel Corporation", "82371SB PIIX3 ISA [Natoma/Triton II]"},
-		{"8086", "7111", "Intel Corporation", "82371AB/EB/MB PIIX4 IDE"},
-		{"80ee", "beef", "InnoTek Systemberatung GmbH", "VirtualBox Graphics Adapter"},
-		{"8086", "100e", "Intel Corporation", "82540EM Gigabit Ethernet Controller"},
-		{"80ee", "cafe", "InnoTek Systemberatung GmbH", "VirtualBox Guest Service"},
-		{"8086", "2415", "Intel Corporation", "82801AA AC'97 Audio Controller"},
-		{"8086", "7113", "Intel Corporation", "82371AB/EB/MB PIIX4 ACPI"},
-		{"8086", "100f", "Intel Corporation", "82545EM Gigabit Ethernet Controller (Copper)"},
+	var idLookupTests = []*PCI{
+		&PCI{Vendor: "1055", Device: "e420", VendorName: "Efar Microsystems", DeviceName: "LAN9420/LAN9420i"},
+		&PCI{Vendor: "8086", Device: "1237", VendorName: "Intel Corporation", DeviceName: "440FX - 82441FX PMC [Natoma]"},
+		&PCI{Vendor: "8086", Device: "7000", VendorName: "Intel Corporation", DeviceName: "82371SB PIIX3 ISA [Natoma/Triton II]"},
+		&PCI{Vendor: "8086", Device: "7111", VendorName: "Intel Corporation", DeviceName: "82371AB/EB/MB PIIX4 IDE"},
+		&PCI{Vendor: "80ee", Device: "beef", VendorName: "InnoTek Systemberatung GmbH", DeviceName: "VirtualBox Graphics Adapter"},
+		&PCI{Vendor: "8086", Device: "100e", VendorName: "Intel Corporation", DeviceName: "82540EM Gigabit Ethernet Controller"},
+		&PCI{Vendor: "80ee", Device: "cafe", VendorName: "InnoTek Systemberatung GmbH", DeviceName: "VirtualBox Guest Service"},
+		&PCI{Vendor: "8086", Device: "2415", VendorName: "Intel Corporation", DeviceName: "82801AA AC'97 Audio Controller"},
+		&PCI{Vendor: "8086", Device: "7113", VendorName: "Intel Corporation", DeviceName: "82371AB/EB/MB PIIX4 ACPI"},
+		&PCI{Vendor: "8086", Device: "100f", VendorName: "Intel Corporation", DeviceName: "82545EM Gigabit Ethernet Controller (Copper)"},
 	}
 
 	t.Run("Lookup Using IDs", func(t *testing.T) {
-		ids, err := NewIDs()
-		if err != nil {
-			t.Fatalf("NewIDs error:%s\n", err)
-		}
 		for _, tt := range idLookupTests {
-			v, d := Lookup(ids, tt.vendor, tt.device)
-			if v != tt.vendorName {
-				t.Errorf("Vendor mismatch, found %s, expected %s\n", v, tt.vendorName)
+			tp := tt
+			tp.SetVendorDeviceName()
+			v, d := tp.VendorName, tp.DeviceName
+			if v != tt.VendorName {
+				t.Errorf("Vendor mismatch, found %s, expected %s\n", v, tt.VendorName)
 			}
-			if d != tt.deviceName {
-				t.Errorf("Device mismatch, found %s, expected %s\n", d, tt.deviceName)
+			if d != tt.DeviceName {
+				t.Errorf("Device mismatch, found %s, expected %s\n", d, tt.DeviceName)
 			}
 		}
 	})

--- a/pkg/pci/parse.go
+++ b/pkg/pci/parse.go
@@ -11,7 +11,7 @@ func isHex(b byte) bool {
 
 // scan searches for Vendor and Device lines from the input *bufio.Scanner based
 // on pci.ids format. Found Vendors and Devices are added to the input ids map.
-func scan(s *bufio.Scanner, ids map[string]Vendor) error {
+func scan(s *bufio.Scanner, ids map[string]Vendor) {
 	var currentVendor string
 	var line string
 
@@ -26,14 +26,11 @@ func scan(s *bufio.Scanner, ids map[string]Vendor) error {
 			ids[currentVendor].Devices[line[1:5]] = Device(line[7:])
 		}
 	}
-	return nil
 }
 
-func parse(input []byte) (map[string]Vendor, error) {
+func parse(input []byte) idMap {
 	ids := make(map[string]Vendor)
-
 	s := bufio.NewScanner(bytes.NewReader(input))
-	err := scan(s, ids)
-
-	return ids, err
+	scan(s, ids)
+	return ids
 }

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -5,7 +5,10 @@
 package pci
 
 import (
+	"encoding/hex"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 	"strings"
 )
 
@@ -32,4 +35,14 @@ func (p *PCI) String() string {
 func (p *PCI) SetVendorDeviceName() {
 	ids = newIDs()
 	p.VendorName, p.DeviceName = Lookup(ids, p.Vendor, p.Device)
+}
+
+// ReadConfig reads the config space and adds it to ExtraInfo as a hexdump.
+func (p *PCI) ReadConfig() error {
+	c, err := ioutil.ReadFile(filepath.Join(p.FullPath, "config"))
+	if err != nil {
+		return err
+	}
+	p.ExtraInfo = append(p.ExtraInfo, hex.Dump(c))
+	return nil
 }

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -6,6 +6,7 @@ package pci
 
 import (
 	"fmt"
+	"strings"
 )
 
 // PCI is a PCI device. We will fill this in as we add options.
@@ -16,20 +17,19 @@ type PCI struct {
 	Device     string `pci:"device"`
 	VendorName string
 	DeviceName string
+	FullPath   string
+	ExtraInfo  []string
 }
 
-// ToString concatenates PCI address, Vendor, and Device to make a useful
-// display for the user. Boolean argument toggles displaying numeric IDs or
-// human readable labels.
-func (p PCI) ToString(n bool, ids map[string]Vendor) string {
-	if n {
-		return fmt.Sprintf("%s: %s:%s", p.Addr, p.Vendor, p.Device)
-	}
+// String concatenates PCI address, Vendor, and Device and other information
+// to make a useful display for the user.
+func (p *PCI) String() string {
+	return strings.Join(append([]string{fmt.Sprintf("%s: %v %v", p.Addr, p.VendorName, p.DeviceName)}, p.ExtraInfo...), "\n")
+}
+
+// SetVendorDeviceName changes VendorName and DeviceName from a name to a number,
+// if possible.
+func (p *PCI) SetVendorDeviceName() {
+	ids = newIDs()
 	p.VendorName, p.DeviceName = Lookup(ids, p.Vendor, p.Device)
-	return fmt.Sprintf("%s: %v %v", p.Addr, p.VendorName, p.DeviceName)
-}
-
-// String is a Stringer for fmt and others' convenience.
-func (p PCI) String() string {
-	return p.ToString(true, nil)
 }

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -36,6 +36,7 @@ func onePCI(dir string) (*PCI, error) {
 		// Linux never understood /proc.
 		reflect.ValueOf(&pci).Elem().Field(ix).SetString(string(s[2 : len(s)-1]))
 	}
+	pci.VendorName, pci.DeviceName = pci.Vendor, pci.Device
 	return &pci, nil
 }
 
@@ -49,6 +50,7 @@ func (bus *bus) Read() (Devices, error) {
 			return nil, err
 		}
 		p.Addr = filepath.Base(d)
+		p.FullPath = d
 		devices[i] = p
 	}
 	return devices, nil

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -12,6 +12,10 @@ import (
 	"reflect"
 )
 
+const (
+	pciPath = "/sys/bus/pci/devices"
+)
+
 type bus struct {
 	Devices []string
 }
@@ -50,11 +54,11 @@ func (bus *bus) Read() (Devices, error) {
 	return devices, nil
 }
 
-// NewBusReader returns a BusReader. If it can't glob in
-// /sys/bus/pci/devices then it gives up. We don't provide an option
-// (yet) to do type I or PCIe MMIO config stuff.
-func NewBusReader() (busReader, error) {
-	globs, err := filepath.Glob("/sys/bus/pci/devices/*")
+// NewBusReader returns a BusReader, given a glob to match PCI devices against.
+// If it can't glob in pciPath/g then it returns an error.
+// We don't provide an option to do type I or PCIe MMIO config stuff.
+func NewBusReader(g string) (busReader, error) {
+	globs, err := filepath.Glob(filepath.Join(pciPath, g))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
To lookup a name, users should not have to be aware of maps. PCI devices
    now have a default VendorName/DeviceName that is numeric. To map them to
    names, one can call p.SetVendorDeviceName, which also works on []*PCI, i.e.
    Devices.

    Since no error checking was done on the parse (it should be done at build
    time anyway), remove the error return and simplify that logic.

    ToString() is no longer needed, so go with String.

    This is all in preparation to make it easy to dump config space.

    pci: allow user to specify the glob

    This may still fail the convenience test, as one could argue you must name
    the glob exactly (e.g. 0000:02:00.0) but otoh you can say pci -s *02:00*
    and it works. That's not much worse, I guess, than pci -s 0:2.0? Or is it?

    Plus pci *18* gets all devices with an 18. So far it's inconvenient in
    theory, convenient in practice.

    Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>