### PR TITLE
pci: allow for dumping and setting of config registers

### DIFF
--- a/cmds/pci/pci.go
+++ b/cmds/pci/pci.go
@@ -9,12 +9,16 @@
 //
 // Options:
 //     -n: just show numbers
+//     -c: dump config space
+//     -s: specify glob for choosing devices.
 package main
 
 import (
 	"flag"
 	"fmt"
 	"log"
+	"strconv"
+	"strings"
 
 	"github.com/u-root/u-root/pkg/pci"
 )
@@ -23,8 +27,84 @@ var (
 	numbers    = flag.Bool("n", false, "Show numeric IDs")
 	dumpConfig = flag.Bool("c", false, "Dump config space")
 	devs       = flag.String("s", "*", "Devices to match")
+	format     = map[int]string{
+		32: "%08x:%08x",
+		16: "%08x:%04x",
+		8:  "%08x:%02x",
+	}
 )
 
+// maybe we need a better syntax than the standard pcitools?
+func registers(d pci.Devices, cmds ...string) {
+	var justCheck bool
+	for _, c := range cmds {
+		// TODO: replace this nonsense with a state machine.
+		// Split into register and value
+		rv := strings.Split(c, "=")
+		if len(rv) != 1 && len(rv) != 2 {
+			log.Printf("%v: only one = allowed. Due to this error no more commands will be issued", c)
+			justCheck = true
+			continue
+		}
+
+		// Split into register offset and size
+		rs := strings.Split(rv[0], ".")
+		if len(rs) != 1 && len(rs) != 2 {
+			log.Printf("%v: only one . allowed. Due to this error no more commands will be issued", rv[1])
+			justCheck = true
+			continue
+		}
+		s := 32
+		if len(rs) == 2 {
+			switch rs[1] {
+			default:
+				log.Printf("Bad size: %v. Due to this error no more commands will be issued", rs[1])
+				justCheck = true
+				continue
+			case "l":
+			case "w":
+				s = 16
+			case "b":
+				s = 8
+			}
+		}
+		if justCheck {
+			continue
+		}
+		reg, err := strconv.ParseUint(rs[0], 0, 16)
+		if err != nil {
+			log.Printf("%v:%v. Due to this error no more commands will be issued", rs[0], err)
+			justCheck = true
+			continue
+		}
+		if len(rv) == 1 {
+			v, err := d.ReadConfigRegister(int64(reg), int64(s))
+			if err != nil {
+				log.Printf("%v:%v. Due to this error no more commands will be issued", rv[1], err)
+				justCheck = true
+				continue
+			}
+			// Should this go in the package somewhere? Not sure.
+			for i := range v {
+				d[i].ExtraInfo = append(d[i].ExtraInfo, fmt.Sprintf(format[s], reg, v[i]))
+			}
+		}
+		if len(rv) == 2 {
+			val, err := strconv.ParseUint(rv[1], 0, s)
+			if err != nil {
+				log.Printf("%v. Due to this error no more commands will be issued", err)
+				justCheck = true
+				continue
+			}
+			if err := d.WriteConfigRegister(int64(reg), int64(s), val); err != nil {
+				log.Printf("%v:%v. Due to this error no more commands will be issued", rv[1], err)
+				justCheck = true
+				continue
+			}
+		}
+
+	}
+}
 func main() {
 	flag.Parse()
 	r, err := pci.NewBusReader(*devs)
@@ -39,6 +119,9 @@ func main() {
 
 	if !*numbers {
 		d.SetVendorDeviceName()
+	}
+	if len(flag.Args()) > 0 {
+		registers(d, flag.Args()...)
 	}
 	if *dumpConfig {
 		d.ReadConfig()

--- a/pkg/pci/devices.go
+++ b/pkg/pci/devices.go
@@ -38,3 +38,26 @@ func (d Devices) ReadConfig() error {
 	}
 	return nil
 }
+
+// ReadConfigRegister reads the config info for all the devices.
+func (d Devices) ReadConfigRegister(offset, size int64) ([]uint64, error) {
+	var vals []uint64
+	for _, p := range d {
+		val, err := p.ReadConfigRegister(offset, size)
+		if err != nil {
+			return nil, err
+		}
+		vals = append(vals, val)
+	}
+	return vals, nil
+}
+
+// WriteConfigRegister writes the config info for all the devices.
+func (d Devices) WriteConfigRegister(offset, size int64, val uint64) error {
+	for _, p := range d {
+		if err := p.WriteConfigRegister(offset, size, val); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -5,9 +5,11 @@
 package pci
 
 import (
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 )
@@ -45,4 +47,75 @@ func (p *PCI) ReadConfig() error {
 	}
 	p.ExtraInfo = append(p.ExtraInfo, hex.Dump(c))
 	return nil
+}
+
+type barreg struct {
+	offset int64
+	*os.File
+}
+
+func (r *barreg) Read(b []byte) (int, error) {
+	return r.ReadAt(b, r.offset)
+}
+
+func (w *barreg) Write(b []byte) (int, error) {
+	return w.WriteAt(b, w.offset)
+}
+
+// ReadConfigRegister reads a configuration register of size 8, 16, 32, or 64.
+// It will only work on little-endian machines.
+func (p *PCI) ReadConfigRegister(offset, size int64) (uint64, error) {
+	f, err := os.Open(filepath.Join(p.FullPath, "config"))
+	if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+	var reg uint64
+	r := &barreg{offset: offset, File: f}
+	switch size {
+	default:
+		return 0, fmt.Errorf("%d is not valid: only options are 8, 16, 32, 64", size)
+	case 64:
+		err = binary.Read(r, binary.LittleEndian, &reg)
+	case 32:
+		var val uint32
+		err = binary.Read(r, binary.LittleEndian, &val)
+		reg = uint64(val)
+	case 16:
+		var val uint16
+		err = binary.Read(r, binary.LittleEndian, &val)
+		reg = uint64(val)
+	case 8:
+		var val uint8
+		err = binary.Read(r, binary.LittleEndian, &val)
+		reg = uint64(val)
+	}
+	return reg, err
+}
+
+// WriteConfigRegister writes a configuration register of size 8, 16, 32, or 64.
+// It will only work on little-endian machines.
+func (p *PCI) WriteConfigRegister(offset, size int64, val uint64) error {
+	f, err := os.OpenFile(filepath.Join(p.FullPath, "config"), os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := &barreg{offset: offset, File: f}
+	switch size {
+	default:
+		return fmt.Errorf("%d is not valid: only options are 8, 16, 32, 64", size)
+	case 64:
+		err = binary.Write(w, binary.LittleEndian, &val)
+	case 32:
+		var v = uint32(val)
+		err = binary.Write(w, binary.LittleEndian, &v)
+	case 16:
+		var v = uint16(val)
+		err = binary.Write(w, binary.LittleEndian, &v)
+	case 8:
+		var v = uint8(val)
+		err = binary.Write(w, binary.LittleEndian, &v)
+	}
+	return err
 }


### PR DESCRIPTION
Back in the day, this pci command would have been incredibly handy.

Suppose you want to dump 16 bits @ 0 and 2, and 32 bits at 4, and 8 bits at 4.
This is device and vendor id, and 32 bits @ 4, and 8 bits of command register.
And you want it for all devices at device 18, a root port.

pci -s *18* 0.w 2.w 4.l 4.b

0000:00:18.0: VMware PCI Express Root Port
00000000:15ad
00000002:07a0
00000004:00100007
00000004:07
0000:00:18.1: VMware PCI Express Root Port
00000000:15ad
00000002:07a0
00000004:00100007
00000004:07
0000:00:18.2: VMware PCI Express Root Port
00000000:15ad
00000002:07a0
00000004:00100007
00000004:07
0000:00:18.3: VMware PCI Express Root Port
00000000:15ad
00000002:07a0
00000004:00100007
00000004:07
0000:00:18.4: VMware PCI Express Root Port
00000000:15ad
00000002:07a0
00000004:00100007
00000004:07
0000:00:18.5: VMware PCI Express Root Port
00000000:15ad
00000002:07a0
00000004:00100007
00000004:07
0000:00:18.6: VMware PCI Express Root Port
00000000:15ad
00000002:07a0
00000004:00100007
00000004:07
0000:00:18.7: VMware PCI Express Root Port
00000000:15ad
00000002:07a0
00000004:00100007
00000004:07

Here is how you can set, and then see what value was really set:
 sudo ./pci -s 0000:00:18.7 4.b=7 4.b
0000:00:18.7: VMware PCI Express Root Port
00000004:07

The *18* version of this command, shown above, would also work here. I've been using bash scripts
looping over TBFN pci notation for 15 years; no longer.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>