### PR TITLE
bgbuild: default to off

### DIFF
--- a/cmds/init/bgbuild.go
+++ b/cmds/init/bgbuild.go
@@ -89,5 +89,5 @@ func cmdlineContainsFlag(flag string) bool {
 }
 
 func isBgBuildEnabled() bool {
-	return !cmdlineContainsFlag("uroot.nobgbuild")
+	return cmdlineContainsFlag("uroot.bgbuild")
 }


### PR DESCRIPTION
bgbuld will now only run if the cmdline comtains
uroot.bgbuild

There is some issue we're seeing with the newer go toolchain
and we need to leave this off until we fix it.

We really should default to off anyway, for small or slow nodes.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>