### PR TITLE
Fix #326 replace flag with github.com/juju/gnuflag

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,6 +75,12 @@
   version = "v0.2.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/juju/gnuflag"
+  packages = ["."]
+  revision = "2ce1bb71843d6d179b3f1c1c9cb4a72cd067fc65"
+
+[[projects]]
   name = "github.com/klauspost/compress"
   packages = ["flate"]
   revision = "6c8db69c4b49dd4df1fff66996cf556176d0b9bf"
@@ -185,6 +191,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "22ce9fa037a428293d3133f40f661ac3355c759ff33e1e87cd76e5a6c7b803bf"
+  inputs-digest = "0a4f5f9bca7547f03a267500d5305945a40e64078e1dd18d46aee2ac3ff445f4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmds/archive/archive.go
+++ b/cmds/archive/archive.go
@@ -21,9 +21,10 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 )
 
 // You'll see the name VTOC used a lot.
@@ -50,7 +51,7 @@ func usage() {
 
 func main() {
 	var err error
-	flag.Parse()
+
 	if *d {
 		debug = log.Printf
 	}

--- a/cmds/boot/boot.go
+++ b/cmds/boot/boot.go
@@ -29,9 +29,7 @@ package main
 
 import (
 	"encoding/binary"
-	"flag"
 	"fmt"
-	"github.com/u-root/u-root/pkg/kexec"
 	"io"
 	"io/ioutil"
 	"log"
@@ -40,6 +38,9 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
+	"github.com/u-root/u-root/pkg/kexec"
 )
 
 const (
@@ -380,7 +381,6 @@ func kexecLoad(grubConfPath string, grub []string, mountPoint string) error {
 }
 
 func main() {
-	flag.Parse()
 
 	if *v {
 		verbose = log.Printf

--- a/cmds/builtin/builtin.go
+++ b/cmds/builtin/builtin.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -13,6 +12,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 
 	"golang.org/x/tools/imports"
 )
@@ -49,7 +50,7 @@ func main() {
 		TabIndent: true,
 		TabWidth:  8,
 	}
-	flag.Parse()
+
 	a := flag.Args()
 	if len(a) < 2 || len(a)%2 != 0 {
 		log.Fatalf("Usage: builtin <command> <code> [<command> <code>]*")

--- a/cmds/cat/cat.go
+++ b/cmds/cat/cat.go
@@ -15,10 +15,11 @@
 package main
 
 import (
-	"flag"
 	"io"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -46,7 +47,6 @@ func cat(w io.Writer, files []string) error {
 }
 
 func main() {
-	flag.Parse()
 
 	if len(os.Args) == 1 {
 		if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {

--- a/cmds/cbmem/main.go
+++ b/cmds/cbmem/main.go
@@ -10,12 +10,13 @@ package main
 import (
 	"bufio"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"reflect"
+
+	flag "github.com/juju/gnuflag"
 )
 
 // The C version of cbmem has a complex function to list
@@ -220,7 +221,7 @@ func DumpMem(cbmem *CBmem) {
 }
 
 func main() {
-	flag.Parse()
+
 	if version {
 		fmt.Println("cbmem in Go, a superset of cbmem v1.1 from coreboot")
 		os.Exit(0)

--- a/cmds/chmod/chmod.go
+++ b/cmds/chmod/chmod.go
@@ -12,12 +12,13 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -43,7 +44,7 @@ func init() {
 }
 
 func main() {
-	flag.Parse()
+
 	if len(flag.Args()) < 1 {
 		fmt.Fprintf(os.Stderr, "Usage of %s: [mode] filepath\n", os.Args[0])
 		flag.PrintDefaults()

--- a/cmds/cmp/cmp.go
+++ b/cmds/cmp/cmp.go
@@ -23,12 +23,13 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"strconv"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -69,7 +70,7 @@ func openFile(name string) (*os.File, error) {
 }
 
 func main() {
-	flag.Parse()
+
 	var offset [2]int64
 	var f *os.File
 	var err error

--- a/cmds/comm/comm.go
+++ b/cmds/comm/comm.go
@@ -22,11 +22,12 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 const cmd = "comm [-123i] file1 file2"
@@ -94,7 +95,7 @@ func outer(c1, c2 chan string, c chan out) {
 }
 
 func main() {
-	flag.Parse()
+
 	if flag.NArg() != 2 || *help {
 		flag.Usage()
 		os.Exit(1)

--- a/cmds/console/console.go
+++ b/cmds/console/console.go
@@ -11,11 +11,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/pty"
 	"github.com/u-root/u-root/pkg/uroot/util"
@@ -28,7 +29,6 @@ var (
 
 func main() {
 	fmt.Printf("console -- starting")
-	flag.Parse()
 
 	a := flag.Args()
 	if len(a) == 0 {

--- a/cmds/cp/cp.go
+++ b/cmds/cp/cp.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -28,6 +27,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 // buffSize is the length of buffer during
@@ -61,7 +62,7 @@ func init() {
 	flag.BoolVar(&force, "f", false, "force overwrite files")
 	flag.BoolVar(&verbose, "v", false, "verbose copy mode")
 	flag.BoolVar(&symlink, "P", false, "don't follow symlinks")
-	flag.Parse()
+
 	go nextOff()
 }
 

--- a/cmds/cpio/cpio.go
+++ b/cmds/cpio/cpio.go
@@ -27,11 +27,12 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/cpio"
 	_ "github.com/u-root/u-root/pkg/cpio/newc"
@@ -48,7 +49,7 @@ func usage() {
 }
 
 func main() {
-	flag.Parse()
+
 	if *d {
 		debug = log.Printf
 	}

--- a/cmds/date/date.go
+++ b/cmds/date/date.go
@@ -9,7 +9,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -18,6 +17,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -59,7 +60,7 @@ func init() {
 	}
 	flag.BoolVar(&flags.universal, "u", false, "Coordinated Universal Time (UTC)")
 	flag.StringVar(&flags.reference, "r", "", "Display the last midification time of FILE")
-	flag.Parse()
+
 }
 
 // regex search for +format POSIX patterns

--- a/cmds/dd/dd.go
+++ b/cmds/dd/dd.go
@@ -28,7 +28,6 @@ package main
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -39,6 +38,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/rck/unit"
 )
@@ -430,7 +431,6 @@ func main() {
 	// convert the arguments and then run flag.Parse. Gross, but hey, it
 	// works.
 	os.Args = convertArgs(os.Args)
-	flag.Parse()
 
 	if len(flag.Args()) > 0 {
 		usage()

--- a/cmds/dhclient/dhclient.go
+++ b/cmds/dhclient/dhclient.go
@@ -16,7 +16,6 @@ package main
 import (
 	"crypto/rand"
 	"encoding/binary"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -25,6 +24,8 @@ import (
 	"regexp"
 	"sync"
 	"time"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/d2g/dhcp4"
 	"github.com/d2g/dhcp4client"
@@ -241,7 +242,7 @@ func dhclient6(iface netlink.Link, numRenewals int, timeout time.Duration, retry
 }
 
 func main() {
-	flag.Parse()
+
 	if *verbose {
 		debug = log.Printf
 	}

--- a/cmds/dmesg/dmesg.go
+++ b/cmds/dmesg/dmesg.go
@@ -13,11 +13,12 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 	"syscall"
 	"unsafe"
+
+	flag "github.com/juju/gnuflag"
 )
 
 const (
@@ -39,7 +40,7 @@ func init() {
 }
 
 func main() {
-	flag.Parse()
+
 	if clear && readClear {
 		log.Fatalf("cannot specify both -clear and -read-clear")
 	}

--- a/cmds/echo/echo.go
+++ b/cmds/echo/echo.go
@@ -10,11 +10,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var nonewline = flag.Bool("n", false, "suppress newline")
@@ -30,6 +31,6 @@ func echo(w io.Writer, s ...string) error {
 }
 
 func main() {
-	flag.Parse()
+
 	echo(os.Stdout, flag.Args()...)
 }

--- a/cmds/ectool/ectool.go
+++ b/cmds/ectool/ectool.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"time"
+
+	flag "github.com/juju/gnuflag"
 )
 
 type cmd func(...string) error
@@ -25,7 +26,7 @@ func debug(s string, v ...interface{}) {
 
 func main() {
 	d := debug
-	flag.Parse()
+
 	if !*lpcdebug {
 		d = nil
 	}

--- a/cmds/ed/ed.go
+++ b/cmds/ed/ed.go
@@ -14,11 +14,12 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"io"
 	"log"
 	"os"
 	"regexp"
+
+	flag "github.com/juju/gnuflag"
 )
 
 type editorArg func(Editor) error
@@ -63,8 +64,6 @@ func main() {
 		args []editorArg
 		err  error
 	)
-
-	flag.Parse()
 
 	if *d {
 		debug = log.Printf

--- a/cmds/field/field.go
+++ b/cmds/field/field.go
@@ -17,13 +17,14 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"os"
 	"regexp"
 	"strconv"
 	"unicode"
 	"unicode/utf8"
+
+	flag "github.com/juju/gnuflag"
 )
 
 type frange struct {
@@ -58,7 +59,6 @@ func init() {
 }
 
 func main() {
-	flag.Parse()
 
 	fstate := make(map[string]bool)
 	flag.Visit(func(f *flag.Flag) { fstate[f.Name] = true })

--- a/cmds/find/find.go
+++ b/cmds/find/find.go
@@ -14,11 +14,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/find"
 )
@@ -49,7 +50,7 @@ func init() {
 }
 
 func main() {
-	flag.Parse()
+
 	a := flag.Args()
 	if len(a) != 1 {
 		flag.Usage()

--- a/cmds/freq/freq.go
+++ b/cmds/freq/freq.go
@@ -25,11 +25,12 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"os"
 	"unicode/utf8"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var utf = flag.Bool("r", false, "treat input as UTF-8")
@@ -72,7 +73,6 @@ func doFreq(f *os.File) {
 }
 
 func main() {
-	flag.Parse()
 
 	if flag.NArg() > 0 {
 		for _, v := range flag.Args() {

--- a/cmds/gpgv/gpgv.go
+++ b/cmds/gpgv/gpgv.go
@@ -24,11 +24,12 @@ package main
 
 import (
 	"crypto"
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 
 	"golang.org/x/crypto/openpgp/errors"
 	"golang.org/x/crypto/openpgp/packet"
@@ -41,7 +42,7 @@ var (
 
 func main() {
 	flag.BoolVar(&verbose, "v", false, "verbose")
-	flag.Parse()
+
 	if verbose {
 		debug = log.Printf
 	}

--- a/cmds/gpt/gpt.go
+++ b/cmds/gpt/gpt.go
@@ -16,10 +16,11 @@ package main
 
 import (
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/gpt"
 )
@@ -40,7 +41,7 @@ func init() {
 }
 
 func main() {
-	flag.Parse()
+
 	if flag.NArg() != 1 {
 		flag.Usage()
 	}

--- a/cmds/grep/grep.go
+++ b/cmds/grep/grep.go
@@ -26,11 +26,12 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+
+	flag "github.com/juju/gnuflag"
 )
 
 type grepResult struct {
@@ -104,7 +105,7 @@ func printmatch(r *grepResult) {
 
 func main() {
 	r := ".*"
-	flag.Parse()
+
 	a := flag.Args()
 	if len(a) > 0 {
 		r = a[0]

--- a/cmds/gzip/gzip.go
+++ b/cmds/gzip/gzip.go
@@ -5,10 +5,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/gzip"
 )

--- a/cmds/hexdump/hexdump.go
+++ b/cmds/hexdump/hexdump.go
@@ -14,14 +14,14 @@ package main
 
 import (
 	"encoding/hex"
-	"flag"
 	"io"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 )
 
 func main() {
-	flag.Parse()
 
 	var readers []io.Reader
 

--- a/cmds/id/id.go
+++ b/cmds/id/id.go
@@ -17,13 +17,14 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"strconv"
 	"strings"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -53,7 +54,7 @@ func initFlags() error {
 	flag.BoolVar(&flags.groups, "G", false, "print all group IDs")
 	flag.BoolVar(&flags.name, "n", false, "print a name instead of a number, for -ugG")
 	flag.BoolVar(&flags.user, "u", false, "print only the effective user ID")
-	flag.Parse()
+
 	if !correctFlags(flags.groups, flags.group, flags.user) {
 		return fmt.Errorf("cannot print \"only\" of more than one choice")
 

--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -11,7 +11,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -21,6 +20,8 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/uroot/util"
 )
@@ -33,7 +34,7 @@ var (
 
 func main() {
 	a := []string{"build"}
-	flag.Parse()
+
 	log.Printf("Welcome to u-root")
 	util.Rootfs()
 

--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -27,7 +27,6 @@ package main
 //     -noforce:   do not build if a file already exists at the destination
 //     -v:         print all build commands
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
@@ -35,6 +34,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/uroot/util"
 )
@@ -80,7 +81,7 @@ func parseCommandLine() form {
 
 	// Second form:
 	//     installcommand [INSTALLCOMMAND_ARGS...] COMMAND [ARGS...]
-	flag.Parse()
+
 	if flag.NArg() < 1 {
 		log.Println("Second form requires a COMMAND argument")
 		usage()

--- a/cmds/ip/ip.go
+++ b/cmds/ip/ip.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,6 +12,8 @@ import (
 	"math"
 	"os"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/vishvananda/netlink"
 )
@@ -318,7 +319,7 @@ func main() {
 	// When this is embedded in busybox we need to reinit some things.
 	whatIWant = []string{"addr", "route", "link"}
 	cursor = 0
-	flag.Parse()
+
 	arg = flag.Args()
 
 	defer func() {

--- a/cmds/kexec/kexec_linux.go
+++ b/cmds/kexec/kexec_linux.go
@@ -25,9 +25,10 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/kexec"
 )
@@ -61,7 +62,6 @@ func registerFlags() *options {
 
 func main() {
 	opts := registerFlags()
-	flag.Parse()
 
 	if opts.exec == false && len(flag.Args()) == 0 {
 		flag.PrintDefaults()

--- a/cmds/ln/ln.go
+++ b/cmds/ln/ln.go
@@ -24,12 +24,13 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 type config struct {
@@ -218,7 +219,6 @@ func main() {
 	flag.BoolVar(&conf.physical, "P", false, "make hard links directly to symbolic links")
 	flag.BoolVar(&conf.relative, "r", false, "create symlinks relative to link location")
 	flag.StringVar(&conf.dirtgt, "t", "", "specify the directory to put the links")
-	flag.Parse()
 
 	args := flag.Args()
 	if len(args) == 0 {

--- a/cmds/losetup/losetup.go
+++ b/cmds/losetup/losetup.go
@@ -14,11 +14,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 )
 
 const (
@@ -65,7 +66,7 @@ func findloop() (name string, err error) {
 }
 
 func main() {
-	flag.Parse()
+
 	args := flag.Args()
 	if *detach {
 		l.Fatalf("detach: not yet")

--- a/cmds/ls/ls.go
+++ b/cmds/ls/ls.go
@@ -17,13 +17,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"text/tabwriter"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -79,7 +80,6 @@ func listName(d string, w io.Writer, prefix bool) error {
 }
 
 func main() {
-	flag.Parse()
 
 	// Write output in tabular form.
 	w := new(tabwriter.Writer)

--- a/cmds/mkdir/mkdir.go
+++ b/cmds/mkdir/mkdir.go
@@ -14,9 +14,10 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -27,7 +28,7 @@ var (
 )
 
 func main() {
-	flag.Parse()
+
 	if len(flag.Args()) < 1 {
 		fmt.Printf("Usage: mkdir [-m mode] [-v] [-p] <directory> [more directories]\n")
 		os.Exit(1)

--- a/cmds/mknod/mknod_linux.go
+++ b/cmds/mknod/mknod_linux.go
@@ -6,9 +6,10 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"strconv"
+
+	flag "github.com/juju/gnuflag"
 
 	"golang.org/x/sys/unix"
 )
@@ -31,7 +32,7 @@ func parseDevices(args []string, devtype string) (int, error) {
 }
 
 func mknod() error {
-	flag.Parse()
+
 	a := flag.Args()
 	if len(a) != 2 && len(a) != 4 {
 		return errors.New("Usage: mknod path type [major minor]")

--- a/cmds/mm/mm.go
+++ b/cmds/mm/mm.go
@@ -5,10 +5,11 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 	"os/exec"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/uroot/util"
 )
@@ -42,7 +43,7 @@ var (
 )
 
 func main() {
-	flag.Parse()
+
 	// We won't do wholesale removal. That's up to you if this fails.
 	if err := os.Chdir(*dest); err == nil {
 		log.Printf("Directory exists, skipping namespace setup")

--- a/cmds/mount/mount.go
+++ b/cmds/mount/mount.go
@@ -12,8 +12,9 @@
 package main
 
 import (
-	"flag"
 	"log"
+
+	flag "github.com/juju/gnuflag"
 
 	"golang.org/x/sys/unix"
 )
@@ -28,7 +29,7 @@ func main() {
 	// The need for this conversion is not clear to me, but we get an overflow error
 	// on ARM without it.
 	flags := uintptr(unix.MS_MGC_VAL)
-	flag.Parse()
+
 	a := flag.Args()
 	if len(a) < 2 {
 		log.Fatalf("Usage: mount [-r] [-t fstype] dev path")

--- a/cmds/mv/mv.go
+++ b/cmds/mv/mv.go
@@ -13,11 +13,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+
+	flag "github.com/juju/gnuflag"
 )
 
 func usage() {
@@ -46,7 +47,6 @@ func mv(files []string, todir bool) error {
 
 func main() {
 	var todir bool
-	flag.Parse()
 
 	if flag.NArg() < 2 {
 		usage()

--- a/cmds/netcat/netcat.go
+++ b/cmds/netcat/netcat.go
@@ -6,12 +6,13 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"net"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/uroot/util"
 )
@@ -25,7 +26,7 @@ func init() {
 }
 
 func main() {
-	flag.Parse()
+
 	var c net.Conn
 	var err error
 	if len(flag.Args()) < 1 {

--- a/cmds/pci/pci.go
+++ b/cmds/pci/pci.go
@@ -14,11 +14,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"strconv"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/pci"
 )
@@ -106,7 +107,7 @@ func registers(d pci.Devices, cmds ...string) {
 	}
 }
 func main() {
-	flag.Parse()
+
 	r, err := pci.NewBusReader(*devs)
 	if err != nil {
 		log.Fatalf("%v", err)

--- a/cmds/pe/pe.go
+++ b/cmds/pe/pe.go
@@ -15,15 +15,16 @@ package main
 import (
 	"debug/pe"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 )
 
 func main() {
 	// Parse flags
-	flag.Parse()
+
 	var (
 		f   *pe.File
 		err error

--- a/cmds/pflask/pflask.go
+++ b/cmds/pflask/pflask.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -17,6 +16,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	flag "github.com/juju/gnuflag"
 
 	"unsafe"
 
@@ -300,7 +301,6 @@ var (
 )
 
 func main() {
-	flag.Parse()
 
 	if len(flag.Args()) < 1 {
 		os.Exit(1)

--- a/cmds/ping/ping.go
+++ b/cmds/ping/ping.go
@@ -18,12 +18,13 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"net"
 	"os"
 	"time"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -70,7 +71,6 @@ func beatifulLatency(before time.Time) (latency string) {
 }
 
 func main() {
-	flag.Parse()
 
 	// options without parameters (right now just: -hV)
 	if flag.NArg() < 1 {

--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -21,13 +21,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"sort"
 	"strconv"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -262,7 +263,7 @@ func ps(pT ProcessTable) error {
 }
 
 func main() {
-	flag.Parse()
+
 	pT := ProcessTable{}
 	if err := pT.LoadTable(); err != nil {
 		log.Fatal(err)

--- a/cmds/pwd/pwd.go
+++ b/cmds/pwd/pwd.go
@@ -16,11 +16,12 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -52,7 +53,7 @@ func pwd() error {
 
 func main() {
 	args := os.Args[1:]
-	flag.Parse()
+
 	for _, flag := range args {
 		switch flag {
 		case "-L":

--- a/cmds/readlink/readlink.go
+++ b/cmds/readlink/readlink.go
@@ -14,10 +14,11 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+
+	flag "github.com/juju/gnuflag"
 )
 
 const cmd = "readlink [-fv] FILE"
@@ -33,7 +34,7 @@ func init() {
 		os.Args[0] = cmd
 		defUsage()
 	}
-	flag.Parse()
+
 }
 
 func readLink(file string) error {

--- a/cmds/rm/rm.go
+++ b/cmds/rm/rm.go
@@ -17,13 +17,14 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -93,7 +94,7 @@ func rm(stdin io.Reader, files []string) error {
 }
 
 func main() {
-	flag.Parse()
+
 	if flag.NArg() < 1 {
 		flag.Usage()
 		os.Exit(1)

--- a/cmds/run/run.go
+++ b/cmds/run/run.go
@@ -15,10 +15,11 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 	"os/exec"
+
+	flag "github.com/juju/gnuflag"
 
 	"golang.org/x/tools/imports"
 )
@@ -33,7 +34,7 @@ func main() {
 		TabIndent: true,
 		TabWidth:  8,
 	}
-	flag.Parse()
+
 	// Interesting problem:
 	// We want a combination of args and arbitrary Go code.
 	// Possibly, we should take the entire Go code as the one arg,

--- a/cmds/seq/seq.go
+++ b/cmds/seq/seq.go
@@ -23,12 +23,13 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -109,7 +110,6 @@ func seq(w io.Writer, args []string) error {
 }
 
 func main() {
-	flag.Parse()
 
 	if err := seq(os.Stdout, flag.Args()); err != nil {
 		log.Println(err)

--- a/cmds/shutdown/shutdown.go
+++ b/cmds/shutdown/shutdown.go
@@ -16,9 +16,10 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 
 	"golang.org/x/sys/unix"
 )
@@ -38,7 +39,7 @@ func usage() {
 }
 
 func main() {
-	flag.Parse()
+
 	switch len(flag.Args()) {
 	default:
 		usage()

--- a/cmds/sleep/sleep.go
+++ b/cmds/sleep/sleep.go
@@ -24,9 +24,10 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"log"
 	"time"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var errDuration = errors.New("invalid duration")
@@ -43,7 +44,6 @@ func parseDuration(s string) (time.Duration, error) {
 }
 
 func main() {
-	flag.Parse()
 
 	if flag.NArg() != 1 {
 		log.Fatal("Incorrect number of arguments")

--- a/cmds/sort/sort.go
+++ b/cmds/sort/sort.go
@@ -18,12 +18,13 @@
 package main
 
 import (
-	"flag"
 	"io/ioutil"
 	"log"
 	"os"
 	"sort"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -95,7 +96,6 @@ func writeOutput(s string) {
 }
 
 func main() {
-	flag.Parse()
 
 	// Input files must be closed before writing to output files to solve
 	// the situtation in which the output file is the same as an input.

--- a/cmds/srvfiles/srvfiles.go
+++ b/cmds/srvfiles/srvfiles.go
@@ -14,9 +14,10 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"net/http"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -26,6 +27,6 @@ var (
 )
 
 func main() {
-	flag.Parse()
+
 	log.Fatal(http.ListenAndServe(*host+":"+*port, http.FileServer(http.Dir(*dir))))
 }

--- a/cmds/switch_root/switch_root.go
+++ b/cmds/switch_root/switch_root.go
@@ -5,13 +5,14 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -169,7 +170,6 @@ func switchRoot(newRoot string, init string) error {
 }
 
 func main() {
-	flag.Parse()
 
 	if len(flag.Args()) == 0 {
 		fmt.Println(usage())

--- a/cmds/tcz/tcz.go
+++ b/cmds/tcz/tcz.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -15,6 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 )
 
 const (
@@ -285,7 +286,7 @@ func init() {
 }
 
 func main() {
-	flag.Parse()
+
 	if *debugPrint {
 		debug = l.Printf
 	}

--- a/cmds/tee/tee.go
+++ b/cmds/tee/tee.go
@@ -15,11 +15,12 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"io"
 	"log"
 	"os"
 	"os/signal"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -39,7 +40,6 @@ func copyinput(files []io.Writer, buf []byte) error {
 
 // Parses all the flags and sets variables accordingly
 func handleflags() int {
-	flag.Parse()
 
 	oflags := os.O_WRONLY | os.O_CREATE
 

--- a/cmds/truncate/truncate.go
+++ b/cmds/truncate/truncate.go
@@ -16,10 +16,11 @@
 package main
 
 import (
-	"flag"
 	"io/ioutil"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/rck/unit"
 )
@@ -47,7 +48,6 @@ func usageAndExit() {
 }
 
 func main() {
-	flag.Parse()
 
 	if !size.IsSet {
 		log.Println("truncate: ERROR: You need to specify -s <number>.")

--- a/cmds/umount/umount_linux.go
+++ b/cmds/umount/umount_linux.go
@@ -6,8 +6,9 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
+
+	flag "github.com/juju/gnuflag"
 
 	"golang.org/x/sys/unix"
 )
@@ -19,7 +20,7 @@ var (
 
 func umount() error {
 	var flags = unix.UMOUNT_NOFOLLOW
-	flag.Parse()
+
 	a := flag.Args()
 	if len(a) != 1 {
 		return errors.New("Usage: umount [-f | -l] path")

--- a/cmds/uname/uname.go
+++ b/cmds/uname/uname.go
@@ -19,10 +19,11 @@ package main
 
 import (
 	"bytes"
-	"flag"
 	"fmt"
 	"log"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 
 	"golang.org/x/sys/unix"
 )
@@ -75,7 +76,6 @@ end:
 }
 
 func main() {
-	flag.Parse()
 
 	var u unix.Utsname
 	if err := unix.Uname(&u); err != nil {

--- a/cmds/uniq/uniq.go
+++ b/cmds/uniq/uniq.go
@@ -32,11 +32,12 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var uniques = flag.Bool("u", false, "print unique lines")
@@ -96,7 +97,6 @@ func uniq(f *os.File) {
 }
 
 func main() {
-	flag.Parse()
 
 	if flag.NArg() > 0 {
 		for _, fn := range flag.Args() {

--- a/cmds/unshare/unshare.go
+++ b/cmds/unshare/unshare.go
@@ -33,11 +33,12 @@
 package main
 
 import (
-	"flag"
 	"log"
 	"os"
 	"os/exec"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -51,7 +52,6 @@ var (
 )
 
 func main() {
-	flag.Parse()
 
 	a := flag.Args()
 	if len(a) == 0 {

--- a/cmds/validate/validate.go
+++ b/cmds/validate/validate.go
@@ -19,12 +19,13 @@ package main
 
 import (
 	"crypto"
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 
 	_ "crypto/md5"
 	_ "crypto/sha1"
@@ -103,7 +104,7 @@ func sign(n string, k crypto.PrivateKey, b []byte, sig string) bool {
 }
 
 func main() {
-	flag.Parse()
+
 	if flag.NArg() < 2 {
 		log.Fatalf("Need at least a file to be validated and one public key")
 	}

--- a/cmds/vboot/vboot.go
+++ b/cmds/vboot/vboot.go
@@ -3,12 +3,13 @@ package main
 import (
 	"crypto/sha1"
 	"crypto/sha256"
-	"flag"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
 	"syscall"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/zaolin/go-tpm/tpm"
 	"golang.org/x/crypto/ed25519"
@@ -42,7 +43,6 @@ func die(err error) {
 }
 
 func main() {
-	flag.Parse()
 
 	if err := os.MkdirAll(mountPath, os.ModePerm); err != nil {
 		die(err)

--- a/cmds/wc/wc.go
+++ b/cmds/wc/wc.go
@@ -45,12 +45,13 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strings"
 	"unicode/utf8"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var lines = flag.Bool("l", false, "count lines")
@@ -134,8 +135,6 @@ func report(c cnt, fname string) {
 
 func main() {
 	var totals cnt
-
-	flag.Parse()
 
 	if !(*lines || *words || *runes || *broken || *chars) {
 		*lines, *words, *chars = true, true, true

--- a/cmds/wget/wget.go
+++ b/cmds/wget/wget.go
@@ -20,12 +20,13 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 )
 
 func wget(arg string, w io.Writer) error {
@@ -48,7 +49,7 @@ func usage() {
 }
 
 func main() {
-	flag.Parse()
+
 	if flag.NArg() != 1 {
 		usage()
 	}

--- a/cmds/which/which.go
+++ b/cmds/which/which.go
@@ -12,12 +12,13 @@
 package main
 
 import (
-	"flag"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var (
@@ -56,7 +57,6 @@ func which(p string, writer io.Writer, cmds []string) {
 }
 
 func main() {
-	flag.Parse()
 
 	p := os.Getenv("PATH")
 	if len(p) == 0 {

--- a/cmds/wifi/wifi.go
+++ b/cmds/wifi/wifi.go
@@ -5,12 +5,13 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
+
+	flag "github.com/juju/gnuflag"
 )
 
 const (
@@ -44,7 +45,6 @@ func main() {
 		conf  []byte
 	)
 
-	flag.Parse()
 	a := flag.Args()
 	essid = a[0]
 

--- a/pkg/gzip/options.go
+++ b/pkg/gzip/options.go
@@ -2,11 +2,12 @@ package gzip
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/klauspost/pgzip"
 )
@@ -57,7 +58,7 @@ func (o *Options) ParseArgs(args []string, cmdLine *flag.FlagSet) error {
 	cmdLine.BoolVar(&levels[8], "8", false, "Compression Level 8")
 	cmdLine.BoolVar(&levels[9], "9", false, "Compression Level 9")
 
-	if err := cmdLine.Parse(args[1:]); err != nil {
+	if err := cmdLine.Parse(true, args[1:]); err != nil {
 		return err
 	}
 

--- a/pkg/gzip/options_test.go
+++ b/pkg/gzip/options_test.go
@@ -1,9 +1,10 @@
 package gzip
 
 import (
-	"flag"
 	"runtime"
 	"testing"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/klauspost/pgzip"
 )

--- a/pkg/uroot/bb.go
+++ b/pkg/uroot/bb.go
@@ -43,7 +43,7 @@ func {{.CmdName}}Init() {
 
 	bbsetupGo = `package {{.CmdName}}
 
-import "flag"
+import flag "github.com/juju/gnuflag"
 
 var {{.CmdName}}flag = flag.NewFlagSet("{{.CmdName}}", flag.ExitOnError)
 `
@@ -53,14 +53,14 @@ var {{.CmdName}}flag = flag.NewFlagSet("{{.CmdName}}", flag.ExitOnError)
 const initGo = `package main
 
 import (
-	"flag"
+	flag "github.com/juju/gnuflag"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
-        "syscall"
+    "syscall"
 
 	"github.com/u-root/u-root/pkg/uroot/util"
 )
@@ -126,10 +126,10 @@ func init() {
 // Commands to skip building in bb mode. init and rush should be obvious
 // builtin and script we skip as we have no toolchain in this mode.
 var skip = map[string]struct{}{
-	"builtin": struct{}{},
-	"init":    struct{}{},
-	"rush":    struct{}{},
-	"script":  struct{}{},
+	"builtin": {},
+	"init":    {},
+	"rush":    {},
+	"script":  {},
 }
 
 type bbBuilder struct {

--- a/pkg/uroot/util/usage.go
+++ b/pkg/uroot/util/usage.go
@@ -5,8 +5,9 @@
 package util
 
 import (
-	"flag"
 	"os"
+
+	flag "github.com/juju/gnuflag"
 )
 
 func Usage(cmd string) {

--- a/scripts/checklicenses/checklicenses.go
+++ b/scripts/checklicenses/checklicenses.go
@@ -8,7 +8,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -16,6 +15,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 )
 
 var absPath = flag.Bool("a", false, "Print absolute paths")
@@ -60,7 +61,7 @@ var rules = []rule{
 }
 
 func main() {
-	flag.Parse()
+
 	uroot := os.ExpandEnv(uroot)
 	incorrect := []string{}
 

--- a/u-root.go
+++ b/u-root.go
@@ -5,12 +5,13 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"strings"
+
+	flag "github.com/juju/gnuflag"
 
 	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/uroot"
@@ -32,7 +33,6 @@ var (
 )
 
 func main() {
-	flag.Parse()
 
 	// Main is in a separate functions so defer's run on return.
 	if err := Main(); err != nil {

--- a/vendor/github.com/juju/gnuflag/LICENSE
+++ b/vendor/github.com/juju/gnuflag/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2012 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/juju/gnuflag/README.md
+++ b/vendor/github.com/juju/gnuflag/README.md
@@ -1,0 +1,10 @@
+Gnuflag
+-----
+
+The gnuflag package is a fork of the Go standard library
+package that supports GNU-compatible flag syntax.
+
+In particular, it supports `--longflag` and `-l` single-character
+flag syntax.
+
+Full documentation can be found here: https://godoc.org/github.com/juju/gnuflag.

--- a/vendor/github.com/juju/gnuflag/export_test.go
+++ b/vendor/github.com/juju/gnuflag/export_test.go
@@ -1,0 +1,19 @@
+// Copyright 2010 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gnuflag
+
+import (
+	"os"
+)
+
+// Additional routines compiled into the package only during testing.
+
+// ResetForTesting clears all flag state and sets the usage function as directed.
+// After calling ResetForTesting, parse errors in flag handling will not
+// exit the program.
+func ResetForTesting(usage func()) {
+	CommandLine = NewFlagSet(os.Args[0], ContinueOnError)
+	Usage = usage
+}

--- a/vendor/github.com/juju/gnuflag/flag.go
+++ b/vendor/github.com/juju/gnuflag/flag.go
@@ -1,0 +1,954 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+/*
+	Package flag implements command-line flag parsing in the GNU style.
+	It is almost exactly the same as the standard flag package,
+	the only difference being the extra argument to Parse.
+
+	Command line flag syntax:
+		-f		// single letter flag
+		-fg		// two single letter flags together
+		--flag	// multiple letter flag
+		--flag x  // non-boolean flags only
+		-f x		// non-boolean flags only
+		-fx		// if f is a non-boolean flag, x is its argument.
+
+	The last three forms are not permitted for boolean flags because the
+	meaning of the command
+		cmd -f *
+	will change if there is a file called 0, false, etc.  There is currently
+	no way to turn off a boolean flag.
+
+	Flag parsing stops after the terminator "--", or just before the first
+	non-flag argument ("-" is a non-flag argument) if the interspersed
+	argument to Parse is false.
+*/
+package gnuflag
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+	"unicode/utf8"
+)
+
+// ErrHelp is the error returned if the -help or -h flag is invoked
+// but no such flag is defined.
+var ErrHelp = errors.New("help requested")
+
+// -- bool Value
+type boolValue bool
+
+func newBoolValue(val bool, p *bool) *boolValue {
+	*p = val
+	return (*boolValue)(p)
+}
+
+func (b *boolValue) Set(s string) error {
+	v, err := strconv.ParseBool(s)
+	*b = boolValue(v)
+	return err
+}
+
+func (b *boolValue) Get() interface{} { return bool(*b) }
+
+func (b *boolValue) String() string { return fmt.Sprintf("%v", *b) }
+
+func (b *boolValue) IsBoolFlag() bool { return true }
+
+// optional interface to indicate boolean flags that can be
+// supplied without "=value" text
+type boolFlag interface {
+	Value
+	IsBoolFlag() bool
+}
+
+// -- int Value
+type intValue int
+
+func newIntValue(val int, p *int) *intValue {
+	*p = val
+	return (*intValue)(p)
+}
+
+func (i *intValue) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = intValue(v)
+	return err
+}
+
+func (i *intValue) Get() interface{} { return int(*i) }
+
+func (i *intValue) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- int64 Value
+type int64Value int64
+
+func newInt64Value(val int64, p *int64) *int64Value {
+	*p = val
+	return (*int64Value)(p)
+}
+
+func (i *int64Value) Set(s string) error {
+	v, err := strconv.ParseInt(s, 0, 64)
+	*i = int64Value(v)
+	return err
+}
+
+func (i *int64Value) Get() interface{} { return int64(*i) }
+
+func (i *int64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- uint Value
+type uintValue uint
+
+func newUintValue(val uint, p *uint) *uintValue {
+	*p = val
+	return (*uintValue)(p)
+}
+
+func (i *uintValue) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uintValue(v)
+	return err
+}
+
+func (i *uintValue) Get() interface{} { return uint(*i) }
+
+func (i *uintValue) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- uint64 Value
+type uint64Value uint64
+
+func newUint64Value(val uint64, p *uint64) *uint64Value {
+	*p = val
+	return (*uint64Value)(p)
+}
+
+func (i *uint64Value) Set(s string) error {
+	v, err := strconv.ParseUint(s, 0, 64)
+	*i = uint64Value(v)
+	return err
+}
+
+func (i *uint64Value) Get() interface{} { return uint64(*i) }
+
+func (i *uint64Value) String() string { return fmt.Sprintf("%v", *i) }
+
+// -- string Value
+type stringValue string
+
+func newStringValue(val string, p *string) *stringValue {
+	*p = val
+	return (*stringValue)(p)
+}
+
+func (s *stringValue) Set(val string) error {
+	*s = stringValue(val)
+	return nil
+}
+
+func (s *stringValue) Get() interface{} { return string(*s) }
+
+func (s *stringValue) String() string { return fmt.Sprintf("%s", *s) }
+
+// -- float64 Value
+type float64Value float64
+
+func newFloat64Value(val float64, p *float64) *float64Value {
+	*p = val
+	return (*float64Value)(p)
+}
+
+func (f *float64Value) Set(s string) error {
+	v, err := strconv.ParseFloat(s, 64)
+	*f = float64Value(v)
+	return err
+}
+
+func (f *float64Value) Get() interface{} { return float64(*f) }
+
+func (f *float64Value) String() string { return fmt.Sprintf("%v", *f) }
+
+// -- time.Duration Value
+type durationValue time.Duration
+
+func newDurationValue(val time.Duration, p *time.Duration) *durationValue {
+	*p = val
+	return (*durationValue)(p)
+}
+
+func (d *durationValue) Set(s string) error {
+	v, err := time.ParseDuration(s)
+	*d = durationValue(v)
+	return err
+}
+
+func (d *durationValue) Get() interface{} { return time.Duration(*d) }
+
+func (d *durationValue) String() string { return (*time.Duration)(d).String() }
+
+// Value is the interface to the dynamic value stored in a flag.
+// (The default value is represented as a string.)
+type Value interface {
+	String() string
+	Set(string) error
+}
+
+// Getter is an interface that allows the contents of a Value to be retrieved.
+// It wraps the Value interface, rather than being part of it, because it
+// appeared after Go 1 and its compatibility rules. All Value types provided
+// by this package satisfy the Getter interface.
+type Getter interface {
+	Value
+	Get() interface{}
+}
+
+// ErrorHandling defines how to handle flag parsing errors.
+type ErrorHandling int
+
+const (
+	ContinueOnError ErrorHandling = iota
+	ExitOnError
+	PanicOnError
+)
+
+// A FlagSet represents a set of defined flags.
+type FlagSet struct {
+	// Usage is the function called when an error occurs while parsing flags.
+	// The field is a function (not a method) that may be changed to point to
+	// a custom error handler.
+	Usage func()
+
+	name             string
+	parsed           bool
+	actual           map[string]*Flag
+	formal           map[string]*Flag
+	args             []string // arguments after flags
+	procArgs         []string // arguments being processed (gnu only)
+	procFlag         string   // flag being processed (gnu only)
+	allowIntersperse bool     // (gnu only)
+	exitOnError      bool     // does the program exit if there's an error?
+	errorHandling    ErrorHandling
+	output           io.Writer // nil means stderr; use out() accessor
+
+	// FlagKnownAs allows different projects to customise what their flags are
+	// known as, e.g. 'flag', 'option', 'item'. All error/log messages
+	// will use that name when referring to an individual items/flags in this set.
+	// For example, if this value is 'option', the default message 'value for flag'
+	// will become 'value for option'.
+	// Default value is 'flag'.
+	FlagKnownAs string
+}
+
+// A Flag represents the state of a flag.
+type Flag struct {
+	Name     string // name as it appears on command line
+	Usage    string // help message
+	Value    Value  // value as set
+	DefValue string // default value (as text); for usage message
+}
+
+// sortFlags returns the flags as a slice in lexicographical sorted order.
+func sortFlags(flags map[string]*Flag) []*Flag {
+	list := make(sort.StringSlice, len(flags))
+	i := 0
+	for _, f := range flags {
+		list[i] = f.Name
+		i++
+	}
+	list.Sort()
+	result := make([]*Flag, len(list))
+	for i, name := range list {
+		result[i] = flags[name]
+	}
+	return result
+}
+
+func (f *FlagSet) out() io.Writer {
+	if f.output == nil {
+		return os.Stderr
+	}
+	return f.output
+}
+
+// SetOutput sets the destination for usage and error messages.
+// If output is nil, os.Stderr is used.
+func (f *FlagSet) SetOutput(output io.Writer) {
+	f.output = output
+}
+
+// VisitAll visits the flags in lexicographical order, calling fn for each.
+// It visits all flags, even those not set.
+func (f *FlagSet) VisitAll(fn func(*Flag)) {
+	for _, flag := range sortFlags(f.formal) {
+		fn(flag)
+	}
+}
+
+// VisitAll visits the command-line flags in lexicographical order, calling
+// fn for each.  It visits all flags, even those not set.
+func VisitAll(fn func(*Flag)) {
+	CommandLine.VisitAll(fn)
+}
+
+// Visit visits the flags in lexicographical order, calling fn for each.
+// It visits only those flags that have been set.
+func (f *FlagSet) Visit(fn func(*Flag)) {
+	for _, flag := range sortFlags(f.actual) {
+		fn(flag)
+	}
+}
+
+// Visit visits the command-line flags in lexicographical order, calling fn
+// for each.  It visits only those flags that have been set.
+func Visit(fn func(*Flag)) {
+	CommandLine.Visit(fn)
+}
+
+// Lookup returns the Flag structure of the named flag, returning nil if none exists.
+func (f *FlagSet) Lookup(name string) *Flag {
+	return f.formal[name]
+}
+
+// Lookup returns the Flag structure of the named command-line flag,
+// returning nil if none exists.
+func Lookup(name string) *Flag {
+	return CommandLine.formal[name]
+}
+
+// Set sets the value of the named flag.
+func (f *FlagSet) Set(name, value string) error {
+	flag, ok := f.formal[name]
+	if !ok {
+		return fmt.Errorf("no such %v -%v", f.FlagKnownAs, name)
+	}
+	err := flag.Value.Set(value)
+	if err != nil {
+		return err
+	}
+	if f.actual == nil {
+		f.actual = make(map[string]*Flag)
+	}
+	f.actual[name] = flag
+	return nil
+}
+
+// Set sets the value of the named command-line flag.
+func Set(name, value string) error {
+	return CommandLine.Set(name, value)
+}
+
+// flagsByLength is a slice of flags implementing sort.Interface,
+// sorting primarily by the length of the flag, and secondarily
+// alphabetically.
+type flagsByLength []*Flag
+
+func (f flagsByLength) Less(i, j int) bool {
+	s1, s2 := f[i].Name, f[j].Name
+	if len(s1) != len(s2) {
+		return len(s1) < len(s2)
+	}
+	return s1 < s2
+}
+func (f flagsByLength) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+func (f flagsByLength) Len() int {
+	return len(f)
+}
+
+// flagsByName is a slice of slices of flags implementing sort.Interface,
+// alphabetically sorting by the name of the first flag in each slice.
+type flagsByName [][]*Flag
+
+func (f flagsByName) Less(i, j int) bool {
+	return f[i][0].Name < f[j][0].Name
+}
+func (f flagsByName) Swap(i, j int) {
+	f[i], f[j] = f[j], f[i]
+}
+func (f flagsByName) Len() int {
+	return len(f)
+}
+
+// PrintDefaults prints, to standard error unless configured
+// otherwise, the default values of all defined flags in the set.
+// If there is more than one name for a given flag, the usage information and
+// default value from the shortest will be printed (or the least alphabetically
+// if there are several equally short flag names).
+func (f *FlagSet) PrintDefaults() {
+	// group together all flags for a given value
+	flags := make(map[interface{}]flagsByLength)
+	f.VisitAll(func(f *Flag) {
+		flags[f.Value] = append(flags[f.Value], f)
+	})
+
+	// sort the output flags by shortest name for each group.
+	var byName flagsByName
+	for _, f := range flags {
+		sort.Sort(f)
+		byName = append(byName, f)
+	}
+	sort.Sort(byName)
+
+	var line bytes.Buffer
+	for _, fs := range byName {
+		line.Reset()
+		for i, f := range fs {
+			if i > 0 {
+				line.WriteString(", ")
+			}
+			line.WriteString(flagWithMinus(f.Name))
+		}
+		format := "%s  (= %s)\n    %s\n"
+		if _, ok := fs[0].Value.(*stringValue); ok {
+			// put quotes on the value
+			format = "%s (= %q)\n    %s\n"
+		}
+		fmt.Fprintf(f.out(), format, line.Bytes(), fs[0].DefValue, fs[0].Usage)
+	}
+}
+
+// PrintDefaults prints to standard error the default values of all defined command-line flags.
+func PrintDefaults() {
+	CommandLine.PrintDefaults()
+}
+
+// defaultUsage is the default function to print a usage message.
+func defaultUsage(f *FlagSet) {
+	if f.name == "" {
+		fmt.Fprintf(f.out(), "Usage:\n")
+	} else {
+		fmt.Fprintf(f.out(), "Usage of %s:\n", f.name)
+	}
+	f.PrintDefaults()
+}
+
+// NOTE: Usage is not just defaultUsage(CommandLine)
+// because it serves (via godoc flag Usage) as the example
+// for how to write your own usage function.
+
+// Usage prints to standard error a usage message documenting all defined command-line flags.
+// The function is a variable that may be changed to point to a custom function.
+var Usage = func() {
+	fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+	PrintDefaults()
+}
+
+// NFlag returns the number of flags that have been set.
+func (f *FlagSet) NFlag() int { return len(f.actual) }
+
+// NFlag returns the number of command-line flags that have been set.
+func NFlag() int { return len(CommandLine.actual) }
+
+// Arg returns the i'th argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func (f *FlagSet) Arg(i int) string {
+	if i < 0 || i >= len(f.args) {
+		return ""
+	}
+	return f.args[i]
+}
+
+// Arg returns the i'th command-line argument.  Arg(0) is the first remaining argument
+// after flags have been processed.
+func Arg(i int) string {
+	return CommandLine.Arg(i)
+}
+
+// NArg is the number of arguments remaining after flags have been processed.
+func (f *FlagSet) NArg() int { return len(f.args) }
+
+// NArg is the number of arguments remaining after flags have been processed.
+func NArg() int { return len(CommandLine.args) }
+
+// Args returns the non-flag arguments.
+func (f *FlagSet) Args() []string { return f.args }
+
+// Args returns the non-flag command-line arguments.
+func Args() []string { return CommandLine.args }
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func (f *FlagSet) BoolVar(p *bool, name string, value bool, usage string) {
+	f.Var(newBoolValue(value, p), name, usage)
+}
+
+// BoolVar defines a bool flag with specified name, default value, and usage string.
+// The argument p points to a bool variable in which to store the value of the flag.
+func BoolVar(p *bool, name string, value bool, usage string) {
+	CommandLine.Var(newBoolValue(value, p), name, usage)
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func (f *FlagSet) Bool(name string, value bool, usage string) *bool {
+	p := new(bool)
+	f.BoolVar(p, name, value, usage)
+	return p
+}
+
+// Bool defines a bool flag with specified name, default value, and usage string.
+// The return value is the address of a bool variable that stores the value of the flag.
+func Bool(name string, value bool, usage string) *bool {
+	return CommandLine.Bool(name, value, usage)
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func (f *FlagSet) IntVar(p *int, name string, value int, usage string) {
+	f.Var(newIntValue(value, p), name, usage)
+}
+
+// IntVar defines an int flag with specified name, default value, and usage string.
+// The argument p points to an int variable in which to store the value of the flag.
+func IntVar(p *int, name string, value int, usage string) {
+	CommandLine.Var(newIntValue(value, p), name, usage)
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func (f *FlagSet) Int(name string, value int, usage string) *int {
+	p := new(int)
+	f.IntVar(p, name, value, usage)
+	return p
+}
+
+// Int defines an int flag with specified name, default value, and usage string.
+// The return value is the address of an int variable that stores the value of the flag.
+func Int(name string, value int, usage string) *int {
+	return CommandLine.Int(name, value, usage)
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func (f *FlagSet) Int64Var(p *int64, name string, value int64, usage string) {
+	f.Var(newInt64Value(value, p), name, usage)
+}
+
+// Int64Var defines an int64 flag with specified name, default value, and usage string.
+// The argument p points to an int64 variable in which to store the value of the flag.
+func Int64Var(p *int64, name string, value int64, usage string) {
+	CommandLine.Var(newInt64Value(value, p), name, usage)
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func (f *FlagSet) Int64(name string, value int64, usage string) *int64 {
+	p := new(int64)
+	f.Int64Var(p, name, value, usage)
+	return p
+}
+
+// Int64 defines an int64 flag with specified name, default value, and usage string.
+// The return value is the address of an int64 variable that stores the value of the flag.
+func Int64(name string, value int64, usage string) *int64 {
+	return CommandLine.Int64(name, value, usage)
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint variable in which to store the value of the flag.
+func (f *FlagSet) UintVar(p *uint, name string, value uint, usage string) {
+	f.Var(newUintValue(value, p), name, usage)
+}
+
+// UintVar defines a uint flag with specified name, default value, and usage string.
+// The argument p points to a uint  variable in which to store the value of the flag.
+func UintVar(p *uint, name string, value uint, usage string) {
+	CommandLine.Var(newUintValue(value, p), name, usage)
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func (f *FlagSet) Uint(name string, value uint, usage string) *uint {
+	p := new(uint)
+	f.UintVar(p, name, value, usage)
+	return p
+}
+
+// Uint defines a uint flag with specified name, default value, and usage string.
+// The return value is the address of a uint  variable that stores the value of the flag.
+func Uint(name string, value uint, usage string) *uint {
+	return CommandLine.Uint(name, value, usage)
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func (f *FlagSet) Uint64Var(p *uint64, name string, value uint64, usage string) {
+	f.Var(newUint64Value(value, p), name, usage)
+}
+
+// Uint64Var defines a uint64 flag with specified name, default value, and usage string.
+// The argument p points to a uint64 variable in which to store the value of the flag.
+func Uint64Var(p *uint64, name string, value uint64, usage string) {
+	CommandLine.Var(newUint64Value(value, p), name, usage)
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func (f *FlagSet) Uint64(name string, value uint64, usage string) *uint64 {
+	p := new(uint64)
+	f.Uint64Var(p, name, value, usage)
+	return p
+}
+
+// Uint64 defines a uint64 flag with specified name, default value, and usage string.
+// The return value is the address of a uint64 variable that stores the value of the flag.
+func Uint64(name string, value uint64, usage string) *uint64 {
+	return CommandLine.Uint64(name, value, usage)
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func (f *FlagSet) StringVar(p *string, name string, value string, usage string) {
+	f.Var(newStringValue(value, p), name, usage)
+}
+
+// StringVar defines a string flag with specified name, default value, and usage string.
+// The argument p points to a string variable in which to store the value of the flag.
+func StringVar(p *string, name string, value string, usage string) {
+	CommandLine.Var(newStringValue(value, p), name, usage)
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func (f *FlagSet) String(name string, value string, usage string) *string {
+	p := new(string)
+	f.StringVar(p, name, value, usage)
+	return p
+}
+
+// String defines a string flag with specified name, default value, and usage string.
+// The return value is the address of a string variable that stores the value of the flag.
+func String(name string, value string, usage string) *string {
+	return CommandLine.String(name, value, usage)
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func (f *FlagSet) Float64Var(p *float64, name string, value float64, usage string) {
+	f.Var(newFloat64Value(value, p), name, usage)
+}
+
+// Float64Var defines a float64 flag with specified name, default value, and usage string.
+// The argument p points to a float64 variable in which to store the value of the flag.
+func Float64Var(p *float64, name string, value float64, usage string) {
+	CommandLine.Var(newFloat64Value(value, p), name, usage)
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func (f *FlagSet) Float64(name string, value float64, usage string) *float64 {
+	p := new(float64)
+	f.Float64Var(p, name, value, usage)
+	return p
+}
+
+// Float64 defines a float64 flag with specified name, default value, and usage string.
+// The return value is the address of a float64 variable that stores the value of the flag.
+func Float64(name string, value float64, usage string) *float64 {
+	return CommandLine.Float64(name, value, usage)
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func (f *FlagSet) DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	f.Var(newDurationValue(value, p), name, usage)
+}
+
+// DurationVar defines a time.Duration flag with specified name, default value, and usage string.
+// The argument p points to a time.Duration variable in which to store the value of the flag.
+func DurationVar(p *time.Duration, name string, value time.Duration, usage string) {
+	CommandLine.Var(newDurationValue(value, p), name, usage)
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func (f *FlagSet) Duration(name string, value time.Duration, usage string) *time.Duration {
+	p := new(time.Duration)
+	f.DurationVar(p, name, value, usage)
+	return p
+}
+
+// Duration defines a time.Duration flag with specified name, default value, and usage string.
+// The return value is the address of a time.Duration variable that stores the value of the flag.
+func Duration(name string, value time.Duration, usage string) *time.Duration {
+	return CommandLine.Duration(name, value, usage)
+}
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func (f *FlagSet) Var(value Value, name string, usage string) {
+	// Remember the default value as a string; it won't change.
+	flag := &Flag{name, usage, value, value.String()}
+	_, alreadythere := f.formal[name]
+	if alreadythere {
+		fmt.Fprintf(f.out(), "%s %v redefined: %s\n", f.name, f.FlagKnownAs, name)
+		panic(fmt.Sprintf("%v redefinition", f.FlagKnownAs)) // Happens only if flags are declared with identical names
+	}
+	if f.formal == nil {
+		f.formal = make(map[string]*Flag)
+	}
+	f.formal[name] = flag
+}
+
+// Var defines a flag with the specified name and usage string. The type and
+// value of the flag are represented by the first argument, of type Value, which
+// typically holds a user-defined implementation of Value. For instance, the
+// caller could create a flag that turns a comma-separated string into a slice
+// of strings by giving the slice the methods of Value; in particular, Set would
+// decompose the comma-separated string into the slice.
+func Var(value Value, name string, usage string) {
+	CommandLine.Var(value, name, usage)
+}
+
+// failf prints to standard error a formatted error and usage message and
+// returns the error.
+func (f *FlagSet) failf(format string, a ...interface{}) error {
+	err := fmt.Errorf(format, a...)
+	fmt.Fprintln(f.out(), err)
+	f.usage()
+	return err
+}
+
+// usage calls the Usage method for the flag set, or the usage function if
+// the flag set is CommandLine.
+func (f *FlagSet) usage() {
+	if f.Usage == nil {
+		if f == CommandLine {
+			Usage()
+		} else {
+			defaultUsage(f)
+		}
+	} else {
+		f.Usage()
+	}
+}
+
+func (f *FlagSet) parseOne() (flagName string, long, finished bool, err error) {
+	if len(f.procArgs) == 0 {
+		finished = true
+		return
+	}
+
+	// processing previously encountered single-rune flag
+	if flag := f.procFlag; len(flag) > 0 {
+		_, n := utf8.DecodeRuneInString(flag)
+		f.procFlag = flag[n:]
+		flagName = flag[0:n]
+		return
+	}
+
+	a := f.procArgs[0]
+
+	// one non-flag argument
+	if a == "-" || a == "" || a[0] != '-' {
+		if f.allowIntersperse {
+			f.args = append(f.args, a)
+			f.procArgs = f.procArgs[1:]
+			return
+		}
+		f.args = append(f.args, f.procArgs...)
+		f.procArgs = nil
+		finished = true
+		return
+	}
+
+	// end of flags
+	if f.procArgs[0] == "--" {
+		f.args = append(f.args, f.procArgs[1:]...)
+		f.procArgs = nil
+		finished = true
+		return
+	}
+
+	// long flag signified with "--" prefix
+	if a[1] == '-' {
+		long = true
+		i := strings.Index(a, "=")
+		if i < 0 {
+			f.procArgs = f.procArgs[1:]
+			flagName = a[2:]
+			return
+		}
+		flagName = a[2:i]
+		if flagName == "" {
+			err = fmt.Errorf("empty %v in argument %q", f.FlagKnownAs, a)
+			return
+		}
+		f.procArgs = f.procArgs[1:]
+		f.procFlag = a[i:]
+		return
+	}
+
+	// some number of single-rune flags
+	a = a[1:]
+	_, n := utf8.DecodeRuneInString(a)
+	flagName = a[0:n]
+	f.procFlag = a[n:]
+	f.procArgs = f.procArgs[1:]
+	return
+}
+
+func flagWithMinus(name string) string {
+	if len(name) > 1 {
+		return "--" + name
+	}
+	return "-" + name
+}
+
+func (f *FlagSet) parseFlagArg(name string, long bool) (finished bool, err error) {
+	m := f.formal
+	flag, alreadythere := m[name] // BUG
+	if !alreadythere {
+		if name == "help" || name == "h" { // special case for nice help message.
+			f.usage()
+			ErrHelp = errors.New(fmt.Sprintf("%v: %v", f.FlagKnownAs, ErrHelp.Error()))
+			return false, ErrHelp
+		}
+		// TODO print --xxx when flag is more than one rune.
+		return false, f.failf("%v provided but not defined: %s", f.FlagKnownAs, flagWithMinus(name))
+	}
+	if fv, ok := flag.Value.(boolFlag); ok && fv.IsBoolFlag() && !strings.HasPrefix(f.procFlag, "=") {
+		// special case: doesn't need an arg, and an arg hasn't
+		// been provided explicitly.
+		if err := fv.Set("true"); err != nil {
+			return false, f.failf("invalid boolean %v %s: %v", f.FlagKnownAs, name, err)
+		}
+	} else {
+		// It must have a value, which might be the next argument.
+		var hasValue bool
+		var value string
+		if f.procFlag != "" {
+			// value directly follows flag
+			value = f.procFlag
+			if long {
+				if value[0] != '=' {
+					panic(fmt.Sprintf("no leading '=' in long %v", f.FlagKnownAs))
+				}
+				value = value[1:]
+			}
+			hasValue = true
+			f.procFlag = ""
+		}
+		if !hasValue && len(f.procArgs) > 0 {
+			// value is the next arg
+			hasValue = true
+			value, f.procArgs = f.procArgs[0], f.procArgs[1:]
+		}
+		if !hasValue {
+			return false, f.failf("%v needs an argument: %s", f.FlagKnownAs, flagWithMinus(name))
+		}
+		if err := flag.Value.Set(value); err != nil {
+			return false, f.failf("invalid value %q for %v %s: %v", value, f.FlagKnownAs, flagWithMinus(name), err)
+		}
+	}
+	if f.actual == nil {
+		f.actual = make(map[string]*Flag)
+	}
+	f.actual[name] = flag
+	return
+}
+
+// Parse parses flag definitions from the argument list, which should not
+// include the command name.  Must be called after all flags in the FlagSet
+// are defined and before flags are accessed by the program.
+// The return value will be ErrHelp if --help or -h was set but not defined.
+// If allowIntersperse is set, arguments and flags can be interspersed, that
+// is flags can follow positional arguments.
+func (f *FlagSet) Parse(allowIntersperse bool, arguments []string) error {
+	f.parsed = true
+	f.procArgs = arguments
+	f.procFlag = ""
+	f.args = nil
+	f.allowIntersperse = allowIntersperse
+	for {
+		name, long, finished, err := f.parseOne()
+		if !finished {
+			if name != "" {
+				finished, err = f.parseFlagArg(name, long)
+			}
+		}
+		if err != nil {
+			switch f.errorHandling {
+			case ContinueOnError:
+				return err
+			case ExitOnError:
+				os.Exit(2)
+			case PanicOnError:
+				panic(err)
+			}
+		}
+		if !finished {
+			continue
+		}
+		if err == nil {
+			break
+		}
+	}
+	return nil
+}
+
+// Parsed reports whether f.Parse has been called.
+func (f *FlagSet) Parsed() bool {
+	return f.parsed
+}
+
+// Parse parses the command-line flags from os.Args[1:].  Must be called
+// after all flags are defined and before flags are accessed by the program.
+// If allowIntersperse is set, arguments and flags can be interspersed, that
+// is flags can follow positional arguments.
+func Parse(allowIntersperse bool) {
+	// Ignore errors; CommandLine is set for ExitOnError.
+	CommandLine.Parse(allowIntersperse, os.Args[1:])
+}
+
+// Parsed returns true if the command-line flags have been parsed.
+func Parsed() bool {
+	return CommandLine.Parsed()
+}
+
+// CommandLine is the default set of command-line flags, parsed from os.Args.
+// The top-level functions such as BoolVar, Arg, and so on are wrappers for the
+// methods of CommandLine.
+var CommandLine = NewFlagSet(os.Args[0], ExitOnError)
+
+// NewFlagSet returns a new, empty flag set with the specified name and
+// error handling property.
+func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {
+	return NewFlagSetWithFlagKnownAs(name, errorHandling, "flag")
+}
+
+// NewFlagSetWithFlagKnownAs returns a new, empty flag set with the specified name and
+// error handling property. All error messages and other references to the
+// individual flags will use aka, for e.g. if aka = 'option', the message will be
+// 'value for option' not 'value for flag'.
+func NewFlagSetWithFlagKnownAs(name string, errorHandling ErrorHandling, aka string) *FlagSet {
+	f := &FlagSet{
+		name:          name,
+		errorHandling: errorHandling,
+		FlagKnownAs:   aka,
+	}
+	return f
+}
+
+// Init sets the name and error handling property for a flag set.
+// By default, the zero FlagSet uses an empty name and the
+// ContinueOnError error handling policy.
+func (f *FlagSet) Init(name string, errorHandling ErrorHandling) {
+	f.name = name
+	f.errorHandling = errorHandling
+}

--- a/vendor/github.com/juju/gnuflag/flag_test.go
+++ b/vendor/github.com/juju/gnuflag/flag_test.go
@@ -1,0 +1,668 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gnuflag_test
+
+import (
+	"bytes"
+	"fmt"
+	. "github.com/juju/gnuflag"
+	"os"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+var (
+	test_bool     = Bool("test_bool", false, "bool value")
+	test_int      = Int("test_int", 0, "int value")
+	test_int64    = Int64("test_int64", 0, "int64 value")
+	test_uint     = Uint("test_uint", 0, "uint value")
+	test_uint64   = Uint64("test_uint64", 0, "uint64 value")
+	test_string   = String("test_string", "0", "string value")
+	test_float64  = Float64("test_float64", 0, "float64 value")
+	test_duration = Duration("test_duration", 0, "time.Duration value")
+)
+
+func boolString(s string) string {
+	if s == "0" {
+		return "false"
+	}
+	return "true"
+}
+
+func TestEverything(t *testing.T) {
+	m := make(map[string]*Flag)
+	desired := "0"
+	visitor := func(f *Flag) {
+		if len(f.Name) > 5 && f.Name[0:5] == "test_" {
+			m[f.Name] = f
+			ok := false
+			switch {
+			case f.Value.String() == desired:
+				ok = true
+			case f.Name == "test_bool" && f.Value.String() == boolString(desired):
+				ok = true
+			case f.Name == "test_duration" && f.Value.String() == desired+"s":
+				ok = true
+			}
+			if !ok {
+				t.Error("Visit: bad value", f.Value.String(), "for", f.Name)
+			}
+		}
+	}
+	VisitAll(visitor)
+	if len(m) != 8 {
+		t.Error("VisitAll misses some flags")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	m = make(map[string]*Flag)
+	Visit(visitor)
+	if len(m) != 0 {
+		t.Errorf("Visit sees unset flags")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	// Now set all flags
+	Set("test_bool", "true")
+	Set("test_int", "1")
+	Set("test_int64", "1")
+	Set("test_uint", "1")
+	Set("test_uint64", "1")
+	Set("test_string", "1")
+	Set("test_float64", "1")
+	Set("test_duration", "1s")
+	desired = "1"
+	Visit(visitor)
+	if len(m) != 8 {
+		t.Error("Visit fails after set")
+		for k, v := range m {
+			t.Log(k, *v)
+		}
+	}
+	// Now test they're visited in sort order.
+	var flagNames []string
+	Visit(func(f *Flag) { flagNames = append(flagNames, f.Name) })
+	if !sort.StringsAreSorted(flagNames) {
+		t.Errorf("flag names not sorted: %v", flagNames)
+	}
+}
+
+func TestGet(t *testing.T) {
+	ResetForTesting(nil)
+	Bool("test_bool", true, "bool value")
+	Int("test_int", 1, "int value")
+	Int64("test_int64", 2, "int64 value")
+	Uint("test_uint", 3, "uint value")
+	Uint64("test_uint64", 4, "uint64 value")
+	String("test_string", "5", "string value")
+	Float64("test_float64", 6, "float64 value")
+	Duration("test_duration", 7, "time.Duration value")
+
+	visitor := func(f *Flag) {
+		if len(f.Name) > 5 && f.Name[0:5] == "test_" {
+			g, ok := f.Value.(Getter)
+			if !ok {
+				t.Errorf("Visit: value does not satisfy Getter: %T", f.Value)
+				return
+			}
+			switch f.Name {
+			case "test_bool":
+				ok = g.Get() == true
+			case "test_int":
+				ok = g.Get() == int(1)
+			case "test_int64":
+				ok = g.Get() == int64(2)
+			case "test_uint":
+				ok = g.Get() == uint(3)
+			case "test_uint64":
+				ok = g.Get() == uint64(4)
+			case "test_string":
+				ok = g.Get() == "5"
+			case "test_float64":
+				ok = g.Get() == float64(6)
+			case "test_duration":
+				ok = g.Get() == time.Duration(7)
+			}
+			if !ok {
+				t.Errorf("Visit: bad value %T(%v) for %s", g.Get(), g.Get(), f.Name)
+			}
+		}
+	}
+	VisitAll(visitor)
+}
+
+func TestUsage(t *testing.T) {
+	called := false
+	ResetForTesting(func() { called = true })
+	f := CommandLine
+	f.SetOutput(nullWriter{})
+	if f.Parse(true, []string{"-x"}) == nil {
+		t.Error("parse did not fail for unknown flag")
+	}
+	if !called {
+		t.Error("did not call Usage for unknown flag")
+	}
+}
+
+var parseTests = []struct {
+	about       string
+	intersperse bool
+	args        []string
+	vals        map[string]interface{}
+	remaining   []string
+	error       string
+}{{
+	about:       "regular args",
+	intersperse: true,
+	args: []string{
+		"--bool2",
+		"--int", "22",
+		"--int64", "0x23",
+		"--uint", "24",
+		"--uint64", "25",
+		"--string", "hello",
+		"--float64", "2718e28",
+		"--duration", "2m",
+		"one - extra - argument",
+	},
+	vals: map[string]interface{}{
+		"bool":     false,
+		"bool2":    true,
+		"int":      22,
+		"int64":    int64(0x23),
+		"uint":     uint(24),
+		"uint64":   uint64(25),
+		"string":   "hello",
+		"float64":  2718e28,
+		"duration": 2 * 60 * time.Second,
+	},
+	remaining: []string{
+		"one - extra - argument",
+	},
+}, {
+	about:       "playing with -",
+	intersperse: true,
+	args: []string{
+		"-a",
+		"-",
+		"-bc",
+		"2",
+		"-de1s",
+		"-f2s",
+		"-g", "3s",
+		"--h",
+		"--long",
+		"--long2", "-4s",
+		"3",
+		"4",
+		"--", "-5",
+	},
+	vals: map[string]interface{}{
+		"a":     true,
+		"b":     true,
+		"c":     true,
+		"d":     true,
+		"e":     "1s",
+		"f":     "2s",
+		"g":     "3s",
+		"h":     true,
+		"long":  true,
+		"long2": "-4s",
+		"z":     "default",
+		"www":   99,
+	},
+	remaining: []string{
+		"-",
+		"2",
+		"3",
+		"4",
+		"-5",
+	},
+}, {
+	about:       "flag after explicit --",
+	intersperse: true,
+	args: []string{
+		"-a",
+		"--",
+		"-b",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+		"b": false,
+	},
+	remaining: []string{
+		"-b",
+	},
+}, {
+	about: "flag after end",
+	args: []string{
+		"-a",
+		"foo",
+		"-b",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+		"b": false,
+	},
+	remaining: []string{
+		"foo",
+		"-b",
+	},
+}, {
+	about: "arg and flag after explicit end",
+	args: []string{
+		"-a",
+		"--",
+		"foo",
+		"-b",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+		"b": false,
+	},
+	remaining: []string{
+		"foo",
+		"-b",
+	},
+}, {
+	about: "boolean args, explicitly and non-explicitly given",
+	args: []string{
+		"--a=false",
+		"--b=true",
+		"--c",
+	},
+	vals: map[string]interface{}{
+		"a": false,
+		"b": true,
+		"c": true,
+	},
+}, {
+	about: "using =",
+	args: []string{
+		"--arble=bar",
+		"--bletch=",
+		"--a=something",
+		"-b=other",
+		"-cdand more",
+		"--curdle=--milk",
+		"--sandwich", "=",
+		"--darn=",
+		"=arg",
+	},
+	vals: map[string]interface{}{
+		"arble":    "bar",
+		"bletch":   "",
+		"a":        "something",
+		"b":        "=other",
+		"c":        true,
+		"d":        "and more",
+		"curdle":   "--milk",
+		"sandwich": "=",
+		"darn":     "",
+	},
+	remaining: []string{"=arg"},
+}, {
+	about: "empty flag #1",
+	args: []string{
+		"--=bar",
+	},
+	error: `empty %v in argument "--=bar"`,
+}, {
+	about: "single-letter equals",
+	args: []string{
+		"-=bar",
+	},
+	error: `%v provided but not defined: -=`,
+}, {
+	about: "empty flag #2",
+	args: []string{
+		"--=",
+	},
+	error: `empty %v in argument "--="`,
+}, {
+	about: "no equals",
+	args: []string{
+		"-=",
+	},
+	error: `%v provided but not defined: -=`,
+}, {
+	args: []string{
+		"-a=true",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+	},
+	error: `invalid value "=true" for %v -a: strconv.ParseBool: parsing "=true": invalid syntax`,
+}, {
+	intersperse: true,
+	args: []string{
+		"-a",
+		"-b",
+	},
+	vals: map[string]interface{}{
+		"a": true,
+	},
+	error: "%v provided but not defined: -b",
+}, {
+	intersperse: true,
+	args: []string{
+		"-a",
+	},
+	vals: map[string]interface{}{
+		"a": "default",
+	},
+	error: "%v needs an argument: -a",
+}, {
+	intersperse: true,
+	args: []string{
+		"-a", "b",
+	},
+	vals: map[string]interface{}{
+		"a": 0,
+	},
+	error: `invalid value "b" for %v -a: strconv.ParseInt: parsing "b": invalid syntax`,
+},
+}
+
+func testParse(newFlagSet func() *FlagSet, t *testing.T) {
+	for i, g := range parseTests {
+		t.Logf("test %d. %s", i, g.about)
+		f := newFlagSet()
+		flags := make(map[string]interface{})
+		for name, val := range g.vals {
+			switch val.(type) {
+			case bool:
+				flags[name] = f.Bool(name, false, "bool value "+name)
+			case string:
+				flags[name] = f.String(name, "default", "string value "+name)
+			case int:
+				flags[name] = f.Int(name, 99, "int value "+name)
+			case uint:
+				flags[name] = f.Uint(name, 0, "uint value")
+			case uint64:
+				flags[name] = f.Uint64(name, 0, "uint64 value")
+			case int64:
+				flags[name] = f.Int64(name, 0, "uint64 value")
+			case float64:
+				flags[name] = f.Float64(name, 0, "float64 value")
+			case time.Duration:
+				flags[name] = f.Duration(name, 5*time.Second, "duration value")
+			default:
+				t.Fatalf("unhandled type %T", val)
+			}
+		}
+		err := f.Parse(g.intersperse, g.args)
+		if g.error != "" {
+			expectedError := g.error
+			if strings.Contains(expectedError, "%v") {
+				expectedError = fmt.Sprintf(expectedError, f.FlagKnownAs)
+			}
+			if err == nil {
+				t.Errorf("expected error %q got nil", expectedError)
+			} else if err.Error() != expectedError {
+				t.Errorf("expected error %q got %q", expectedError, err.Error())
+			}
+			continue
+		}
+		for name, val := range g.vals {
+			actual := reflect.ValueOf(flags[name]).Elem().Interface()
+			if val != actual {
+				t.Errorf("flag %q, expected %v got %v", name, val, actual)
+			}
+		}
+		if len(f.Args()) != len(g.remaining) {
+			t.Fatalf("remaining args, expected %q got %q", g.remaining, f.Args())
+		}
+		for j, a := range f.Args() {
+			if a != g.remaining[j] {
+				t.Errorf("arg %d, expected %q got %q", j, g.remaining[i], a)
+			}
+		}
+	}
+}
+
+func TestParse(t *testing.T) {
+	testParse(func() *FlagSet {
+		ResetForTesting(func() {})
+		CommandLine.SetOutput(nullWriter{})
+		return CommandLine
+	}, t)
+}
+
+func TestFlagSetParse(t *testing.T) {
+	// Flags are to be known as 'flag'
+	testParse(func() *FlagSet {
+		f := NewFlagSet("test", ContinueOnError)
+		f.SetOutput(nullWriter{})
+		return f
+	}, t)
+	// Flags are to be known as 'options', using alt constructor
+	testParse(func() *FlagSet {
+		f := NewFlagSetWithFlagKnownAs("test", ContinueOnError, "option")
+		f.SetOutput(nullWriter{})
+		return f
+	}, t)
+	// Flags are to be known as 'fluff', using a setter
+	testParse(func() *FlagSet {
+		f := NewFlagSet("test", ContinueOnError)
+		f.FlagKnownAs = "fluff"
+		f.SetOutput(nullWriter{})
+		return f
+	}, t)
+}
+
+// Declare a user-defined flag type.
+type flagVar []string
+
+func (f *flagVar) String() string {
+	return fmt.Sprint([]string(*f))
+}
+
+func (f *flagVar) Set(value string) error {
+	*f = append(*f, value)
+	return nil
+}
+
+func TestUserDefined(t *testing.T) {
+	var flags FlagSet
+	flags.Init("test", ContinueOnError)
+	var v flagVar
+	flags.Var(&v, "v", "usage")
+	if err := flags.Parse(true, []string{"-v", "1", "-v", "2", "-v3"}); err != nil {
+		t.Error(err)
+	}
+	if len(v) != 3 {
+		t.Fatal("expected 3 args; got ", len(v))
+	}
+	expect := "[1 2 3]"
+	if v.String() != expect {
+		t.Errorf("expected value %q got %q", expect, v.String())
+	}
+}
+
+func TestUserDefinedForCommandLine(t *testing.T) {
+	const help = "HELP"
+	var result string
+	ResetForTesting(func() { result = help })
+	Usage()
+	if result != help {
+		t.Fatalf("got %q; expected %q", result, help)
+	}
+}
+
+// Declare a user-defined boolean flag type.
+type boolFlagVar struct {
+	count int
+}
+
+func (b *boolFlagVar) String() string {
+	return fmt.Sprintf("%d", b.count)
+}
+
+func (b *boolFlagVar) Set(value string) error {
+	if value == "true" {
+		b.count++
+	}
+	return nil
+}
+
+func (b *boolFlagVar) IsBoolFlag() bool {
+	return b.count < 4
+}
+
+func TestUserDefinedBool(t *testing.T) {
+	var flags FlagSet
+	flags.Init("test", ContinueOnError)
+	var b boolFlagVar
+	var err error
+	flags.Var(&b, "b", "usage")
+	if err = flags.Parse(true, []string{"-b", "-b", "-b", "-b=true", "-b=false", "-b", "barg", "-b"}); err != nil {
+		if b.count < 4 {
+			t.Error(err)
+		}
+	}
+
+	if b.count != 4 {
+		t.Errorf("want: %d; got: %d", 4, b.count)
+	}
+
+	if err == nil {
+		t.Error("expected error; got none")
+	}
+}
+
+func TestSetOutput(t *testing.T) {
+	var flags FlagSet
+	var buf bytes.Buffer
+	flags.SetOutput(&buf)
+	flags.Init("test", ContinueOnError)
+	flags.Parse(true, []string{"-unknown"})
+	if out := buf.String(); !strings.Contains(out, "-unknown") {
+		t.Logf("expected output mentioning unknown; got %q", out)
+	}
+}
+
+// This tests that one can reset the flags. This still works but not well, and is
+// superseded by FlagSet.
+func TestChangingArgs(t *testing.T) {
+	ResetForTesting(func() { t.Fatal("bad parse") })
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = []string{"cmd", "--before", "subcmd", "--after", "args"}
+	before := Bool("before", false, "")
+	if err := CommandLine.Parse(false, os.Args[1:]); err != nil {
+		t.Fatal(err)
+	}
+	cmd := Arg(0)
+	os.Args = Args()
+	after := Bool("after", false, "")
+	Parse(false)
+	args := Args()
+
+	if !*before || cmd != "subcmd" || !*after || len(args) != 1 || args[0] != "args" {
+		t.Fatalf("expected true subcmd true [args] got %v %v %v %v", *before, cmd, *after, args)
+	}
+}
+
+// Test that -help invokes the usage message and returns ErrHelp.
+func TestHelp(t *testing.T) {
+	var helpCalled = false
+	fs := NewFlagSet("help test", ContinueOnError)
+	fs.SetOutput(nullWriter{})
+	fs.Usage = func() { helpCalled = true }
+	var flag bool
+	fs.BoolVar(&flag, "flag", false, "regular flag")
+	// Regular flag invocation should work
+	err := fs.Parse(true, []string{"--flag"})
+	if err != nil {
+		t.Fatal("expected no error; got ", err)
+	}
+	if !flag {
+		t.Error("flag was not set by --flag")
+	}
+	if helpCalled {
+		t.Error("help called for regular flag")
+		helpCalled = false // reset for next test
+	}
+	// Help flag should work as expected.
+	itemName := "flag/option/item/anything"
+	fs.FlagKnownAs = itemName
+	err = fs.Parse(true, []string{"--help"})
+	if err == nil {
+		t.Fatal("error expected")
+	}
+	if err != ErrHelp {
+		t.Fatal("expected ErrHelp; got ", err)
+	}
+	if !helpCalled {
+		t.Fatal("help was not called")
+	}
+	// check message
+	expectedErrMsg := fmt.Sprintf("%v: help requested", itemName)
+	if err.Error() != expectedErrMsg {
+		t.Fatal(fmt.Sprintf("expected error `%v`; got ", expectedErrMsg), err)
+	}
+	// If we define a help flag, that should override.
+	var help bool
+	fs.BoolVar(&help, "help", false, "help flag")
+	helpCalled = false
+	err = fs.Parse(true, []string{"--help"})
+	if err != nil {
+		t.Fatal("expected no error for defined --help; got ", err)
+	}
+	if helpCalled {
+		t.Fatal("help was called; should not have been for defined help flag")
+	}
+}
+
+type nullWriter struct{}
+
+func (nullWriter) Write(buf []byte) (int, error) {
+	return len(buf), nil
+}
+
+func TestPrintDefaults(t *testing.T) {
+	f := NewFlagSet("print test", ContinueOnError)
+	f.SetOutput(nullWriter{})
+	var b bool
+	var c int
+	var d string
+	var e float64
+	f.IntVar(&c, "trapclap", 99, "usage not shown")
+	f.IntVar(&c, "c", 99, "c usage")
+
+	f.BoolVar(&b, "bal", false, "usage not shown")
+	f.BoolVar(&b, "x", false, "usage not shown")
+	f.BoolVar(&b, "b", false, "b usage")
+	f.BoolVar(&b, "balalaika", false, "usage not shown")
+
+	f.StringVar(&d, "d", "d default", "d usage")
+
+	f.Float64Var(&e, "elephant", 3.14, "elephant usage")
+
+	var buf bytes.Buffer
+	f.SetOutput(&buf)
+	f.PrintDefaults()
+	f.SetOutput(nullWriter{})
+
+	expect :=
+		`-b, -x, --bal, --balalaika  (= false)
+    b usage
+-c, --trapclap  (= 99)
+    c usage
+-d (= "d default")
+    d usage
+--elephant  (= 3.14)
+    elephant usage
+`
+	if buf.String() != expect {
+		t.Errorf("expect %q got %q", expect, buf.String())
+	}
+}


### PR DESCRIPTION
Go's default flag package does not handle compound boolean flags,
requiring they be separate. Example: `rm -r -f` instead of the gnu
coreutils version `rm -rf`.  github.com/juju/gnuflag provides this
option with a boolean passed to flag.Parse (example "flag.Parse(true)")
which would enable interspersed option parsing.