### PR TITLE
echo: implement -e argument

### DIFF
--- a/cmds/echo/echo.go
+++ b/cmds/echo/echo.go
@@ -6,7 +6,7 @@
 // the standard output.
 //
 // Synopsis:
-//     echo [STRING]...
+//     echo [-e] [-n] [-E] [STRING]...
 package main
 
 import (
@@ -17,19 +17,85 @@ import (
 	"strings"
 )
 
-var nonewline = flag.Bool("n", false, "suppress newline")
+type flags struct {
+	noNewline, interpretEscapes bool
+}
 
-func echo(w io.Writer, s ...string) error {
-	_, err := fmt.Fprintf(w, "%s", strings.Join(s, " "))
-
-	if !*nonewline {
-		fmt.Fprint(w, "\n")
+func escapeString(s string) (string, error) {
+	if len(s) < 1 {
+		return "", nil
 	}
+
+	s = strings.Split(s, "\\c")[0]
+	s = strings.Replace(s, "\\0", "\\", -1)
+
+	// Quote the string and scan it through %q to interpret backslash escapes
+	s = fmt.Sprintf("\"%s\"", s)
+	_, err := fmt.Sscanf(s, "%q", &s)
+	if err != nil {
+		return "", err
+	}
+
+	return s, nil
+}
+
+func echo(f flags, w io.Writer, s ...string) error {
+	var err error
+	line := strings.Join(s, " ")
+	if f.interpretEscapes {
+		line, err = escapeString(line)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	format := "%s"
+	if !f.noNewline {
+		format += "\n"
+	}
+	_, err = fmt.Fprintf(w, format, line)
 
 	return err
 }
 
+func init() {
+	defUsage := flag.Usage
+	flag.Usage = func() {
+		defUsage()
+		fmt.Println(`
+  If -e is in effect, the following sequences are recognized:
+    \\     backslash
+    \a     alert (BEL)
+    \b     backspace
+    \c     produce no further output
+    \e     escape
+    \f     form feed
+    \n     new line
+    \r     carriage return
+    \t     horizontal tab
+    \v     vertical tab
+    \0NNN  byte with octal value NNN (1 to 3 digits)
+    \xHH   byte with hexadecimal value HH (1 to 2 digits)`)
+	}
+}
+
 func main() {
+	var (
+		f flags
+		E bool
+	)
+	flag.BoolVar(&f.noNewline, "n", false, "suppress newline")
+	flag.BoolVar(&f.interpretEscapes, "e", true, "enable interpretation of backslash escapes (default)")
+	flag.BoolVar(&E, "E", false, "disable interpretation of backslash escapes")
 	flag.Parse()
-	echo(os.Stdout, flag.Args()...)
+	if E {
+		f.interpretEscapes = false
+	}
+
+	err := echo(f, os.Stdout, flag.Args()...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%s", err)
+		os.Exit(1)
+	}
 }

--- a/cmds/echo/echo_test.go
+++ b/cmds/echo/echo_test.go
@@ -10,23 +10,31 @@ import (
 )
 
 func TestEcho(t *testing.T) {
-
 	type test struct {
-		s         string
-		nonewline bool
+		s string
+		r string
+		f flags
 	}
-	tests := []test{{s: "simple\ttest", nonewline: false}, {s: "simple\ttest\t2", nonewline: true}}
-	bufs := make([]bytes.Buffer, len(tests))
+	var buf bytes.Buffer
+	tests := []test{
+		{s: "simple test1", r: "simple test1", f: flags{noNewline: true}},
+		{s: "simple test2", r: "simple test2\n", f: flags{}},
+		{s: "simple\\ttest3", r: "simple\ttest3\n", f: flags{interpretEscapes: true}},
+		{s: "simple\\ttest4", r: "simple\ttest4\n", f: flags{interpretEscapes: true}},
+		{s: "simple\\tte\\cst5", r: "simple\tte\n", f: flags{interpretEscapes: true}},
+		{s: "simple\\tte\\cst6", r: "simple\tte", f: flags{true, true}},
+		{s: "simple\\x56 test7", r: "simpleV test7", f: flags{true, true}},
+		{s: "simple\\x56 \\0113test7", r: "simpleV Ktest7", f: flags{true, true}},
+		{s: "\\\\8", r: "\\8", f: flags{true, true}},
+	}
 
-	for i, v := range tests {
-		if err := echo(&bufs[i], v.s); err != nil {
+	for _, v := range tests {
+		if err := echo(v.f, &buf, v.s); err != nil {
 			t.Errorf("%s", err)
 		}
-		if !*nonewline {
-			v.s = v.s + "\n"
+		if string(buf.Bytes()) != v.r {
+			t.Fatalf("Want \"%v\", got \"%v\"", v.r, string(buf.Bytes()))
 		}
-		if string(bufs[i].Bytes()) != v.s {
-			t.Fatalf("Want %v, got %v", v.s, string(bufs[i].Bytes()))
-		}
+		buf.Reset()
 	}
 }

--- a/roadmap.md
+++ b/roadmap.md
@@ -18,7 +18,7 @@
 | dd             |               |                 |                        |
 | dhcp           |               |                 | u-root specific        |
 | dmesg          | -c            | -Clr            |                        |
-| echo           | -n            | -e              |                        |
+| echo           | -ne           |                 |                        |
 | ectool         |               |                 | u-root specific        |
 | exit           |               |                 | Rush builtin           |
 | false          |               |                 |                        |


### PR DESCRIPTION
The `echo` command now interprets escaped characters when the `-e`
argument is set.

Signed-off-by: Alistair Ferguson <ferguson.alistair@gmail.com>