### PR TITLE
uroot package: add : syntax back for extra files

### DIFF
--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/u-root/u-root/pkg/cpio"
 	"github.com/u-root/u-root/pkg/golang"
@@ -139,11 +140,15 @@ func CreateInitramfs(opts Opts) error {
 
 	// Add files from command line.
 	for _, file := range opts.ExtraFiles {
-		path, err := filepath.Abs(file)
+		parts := strings.SplitN(file, ":", 2)
+		path, err := filepath.Abs(filepath.Join(parts...))
+		if len(parts) != 2 {
+			parts = append(parts, parts[0][1:])
+		}
 		if err != nil {
 			return fmt.Errorf("couldn't find absolute path for %q: %v", file, err)
 		}
-		if err := archive.AddFile(path, path[1:]); err != nil {
+		if err := archive.AddFile(path, parts[1]); err != nil {
 			return fmt.Errorf("couldn't add %q to archive: %v", file, err)
 		}
 


### PR DESCRIPTION
The : syntax lets you do stuff like this:
-files /path/to/prototype/root:etc

It will source from /path/to/prototype/root/etc but
put it into the cpio archive as etc. It's impossible to
live without, I keep learning.

I used SplitN, not Split, as there are valid paths (maybe?)
with : in them. That said, we may find we want a more robust
way to do this.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>