### PR TITLE
mv 'kB' to default units, switch tools that defined it

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,7 +120,7 @@
   branch = "master"
   name = "github.com/rck/unit"
   packages = ["."]
-  revision = "59a01d40f639d257b406e932ee8bb206006d5fc2"
+  revision = "16d9ed3d60d943bbb0ed704264795a2541457601"
 
 [[projects]]
   branch = "master"

--- a/cmds/cmp/cmp.go
+++ b/cmds/cmp/cmp.go
@@ -84,7 +84,6 @@ func main() {
 	fnames := flag.Args()
 
 	cmpUnits := unit.DefaultUnits
-	cmpUnits["kB"] = unit.DefaultUnits["KB"]
 
 	off, err := unit.NewUnit(cmpUnits)
 	if err != nil {

--- a/cmds/dd/dd.go
+++ b/cmds/dd/dd.go
@@ -75,7 +75,6 @@ func init() {
 	ddUnits["c"] = 1
 	ddUnits["w"] = 2
 	ddUnits["b"] = 512
-	ddUnits["kB"] = unit.DefaultUnits["KB"]
 	delete(ddUnits, "B")
 
 	ibs = unit.MustNewUnit(ddUnits).MustNewValue(512, unit.None)

--- a/vendor/github.com/rck/unit/unit.go
+++ b/vendor/github.com/rck/unit/unit.go
@@ -37,6 +37,7 @@ var DefaultUnits = map[string]int64{
 	"T":  T,
 	"P":  P,
 	"E":  E,
+	"kB": 1000,
 	"KB": 1000,
 	"MB": 1000 * 1000,
 	"GB": 1000 * 1000 * 1000,
@@ -53,7 +54,7 @@ const (
 	None Sign = iota
 	// Negative signals that an explicit negative sign is set.
 	Negative
-	// Positive signals that an explicit positve sign is set.
+	// Positive signals that an explicit positive sign is set.
 	Positive
 )
 

--- a/vendor/github.com/rck/unit/unit_test.go
+++ b/vendor/github.com/rck/unit/unit_test.go
@@ -37,18 +37,18 @@ var unitTests = []struct {
 		out:   "23B",
 		value: 23,
 	}, {
-		// With valid unit, mutliple of another unit
+		// With valid unit, multiple of another unit
 		in:    "1024KiB",
 		out:   "1MiB",
 		value: 1024 * 1024,
 	}, {
-		// With valid unit, mutliple of another unit, explicit +
+		// With valid unit, multiple of another unit, explicit +
 		in:           "+1024KiB",
 		out:          "+1MiB",
 		value:        1024 * 1024,
 		explicitSign: Positive,
 	}, {
-		// With valid unit, mutliple of another unit, explicit -
+		// With valid unit, multiple of another unit, explicit -
 		in:           "-1024KiB",
 		out:          "-1MiB",
 		value:        -1024 * 1024,


### PR DESCRIPTION
Just some cleanup that resulted from the previous work on the unit package. At least the GNU tools have this rule, so no need for every command to define it on its own.