### PR TITLE
ping: fix fd exhaustion

### DIFF
--- a/cmds/ping/ping.go
+++ b/cmds/ping/ping.go
@@ -96,7 +96,6 @@ func main() {
 		}
 
 		c.SetDeadline(time.Now().Add(waitFor))
-		defer c.Close()
 		msg[0] = byte(i)
 		if _, err := c.Write(msg[:]); err != nil {
 			log.Printf("Write failed: %v", err)
@@ -110,6 +109,7 @@ func main() {
 				log.Printf("Read failed: %v", err)
 			}
 		}
+		c.Close()
 		time.Sleep(time.Millisecond * interval)
 	}
 }


### PR DESCRIPTION
So far "defer" was used in a loop, which keeps fds open till the program
terminates or we run out of fds.

You can watch fd creation without giving them up like this:
watch -n1 sudo ls /proc/`pidof ping`/fd
