### PR TITLE
pkg/find: clean up find tests.

### DIFF
--- a/pkg/find/find_test.go
+++ b/pkg/find/find_test.go
@@ -5,109 +5,119 @@
 package find
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/uroot/util"
 )
 
-type tests struct {
-	name  string
-	opts  func(*Finder) error
-	names string
-	errs  string
-}
-
-func noop(f *Finder) error {
-	return nil
-}
-
 // TODO: I don't now where this subtesting stuff originated, I just copied it,
 // but it's bad practice as you can not pick individual tests.
 // Break this out into individual tests.
 func TestSimple(t *testing.T) {
-	var testCases = []tests{
-		{name: "basic find",
-			opts: func(_ *Finder) error { return nil },
-			names: `
+	type tests struct {
+		name  string
+		opts  func(*Finder) error
+		names []string
+	}
 
-/root
-/root/ab
-/root/ab/c
-/root/ab/c/d
-/root/ab/c/d/e
-/root/ab/c/d/e/f
-/root/ab/c/d/e/f/ghij
-/root/ab/c/d/e/f/ghij/k
-/root/ab/c/d/e/f/ghij/k/l
-/root/ab/c/d/e/f/ghij/k/l/m
-/root/ab/c/d/e/f/ghij/k/l/m/n
-/root/ab/c/d/e/f/ghij/k/l/m/n/o
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/0777
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/file`, errs: ""},
-		{name: "just a dir",
+	var testCases = []tests{
+		{
+			name: "basic find",
+			opts: func(_ *Finder) error { return nil },
+			names: []string{
+				"",
+				"/root",
+				"/root/ab",
+				"/root/ab/c",
+				"/root/ab/c/d",
+				"/root/ab/c/d/e",
+				"/root/ab/c/d/e/f",
+				"/root/ab/c/d/e/f/ghij",
+				"/root/ab/c/d/e/f/ghij/k",
+				"/root/ab/c/d/e/f/ghij/k/l",
+				"/root/ab/c/d/e/f/ghij/k/l/m",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/0777",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/file",
+			},
+		},
+		{
+			name: "just a dir",
 			opts: func(f *Finder) error {
 				f.Mode = os.ModeDir
 				f.ModeMask = os.ModeDir
 				return nil
-			}, names: `
-
-/root
-/root/ab
-/root/ab/c
-/root/ab/c/d
-/root/ab/c/d/e
-/root/ab/c/d/e/f
-/root/ab/c/d/e/f/ghij
-/root/ab/c/d/e/f/ghij/k
-/root/ab/c/d/e/f/ghij/k/l
-/root/ab/c/d/e/f/ghij/k/l/m
-/root/ab/c/d/e/f/ghij/k/l/m/n
-/root/ab/c/d/e/f/ghij/k/l/m/n/o
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz`, errs: ""},
-		{name: "just a file",
+			},
+			names: []string{
+				"",
+				"/root",
+				"/root/ab",
+				"/root/ab/c",
+				"/root/ab/c/d",
+				"/root/ab/c/d/e",
+				"/root/ab/c/d/e/f",
+				"/root/ab/c/d/e/f/ghij",
+				"/root/ab/c/d/e/f/ghij/k",
+				"/root/ab/c/d/e/f/ghij/k/l",
+				"/root/ab/c/d/e/f/ghij/k/l/m",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz",
+			},
+		},
+		{
+			name: "just a file",
 			opts: func(f *Finder) error {
 				f.Mode = 0
 				f.ModeMask = os.ModeType
 				return nil
-			}, names: `
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/0777
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/file`, errs: ""},
-		{name: "file by mode",
+			},
+			names: []string{
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/0777",
+				"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/file",
+			},
+		},
+		{
+			name: "file by mode",
 			opts: func(f *Finder) error {
 				f.Mode = 0444
 				f.ModeMask = os.ModePerm
-				f.Debug = t.Logf
 				return nil
-			}, names: `
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/0777`, errs: ""},
-		{name: "file by name",
+			},
+			names: []string{"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/0777"},
+		},
+		{
+			name: "file by name",
 			opts: func(f *Finder) error {
-				f.Debug = t.Logf
 				f.Pattern = "*file"
 				return nil
-			}, names: `
-/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/file`, errs: ""},
+			},
+			names: []string{"/root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/file"},
+		},
 	}
 	d, err := ioutil.TempDir(os.TempDir(), "u-root.cmds.find")
 	if err != nil {
@@ -115,6 +125,8 @@ func TestSimple(t *testing.T) {
 	}
 	defer os.RemoveAll(d)
 
+	// Make sure files are actually created with the permissions we ask for.
+	syscall.Umask(0)
 	var namespace = []util.Creator{
 		util.Dir{Name: filepath.Join(d, "root/ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz"), Mode: 0775},
 		util.File{Name: filepath.Join(d, "root//ab/c/d/e/f/ghij/k/l/m/n/o/p/q/r/s/t/u/v/w/xyz/file"), Mode: 0664},
@@ -137,28 +149,19 @@ func TestSimple(t *testing.T) {
 			}
 			go f.Find()
 
-			var names, errs string
+			var names []string
 			for o := range f.Names {
 				if o.Err != nil {
 					t.Errorf("%v: got %v, want nil", o.Name, o.Err)
 				}
-				// get rid of the prefix, as it changes for every test.
-				names = fmt.Sprintf("%s\n%s", names, o.Name[len(d):])
+				names = append(names, strings.TrimPrefix(o.Name, d))
 			}
 
-			t.Logf("names %v", names)
 			if len(names) != len(tc.names) {
 				t.Errorf("Find output: got %d bytes, want %d bytes", len(names), len(tc.names))
 			}
-			if names != tc.names {
+			if !reflect.DeepEqual(names, tc.names) {
 				t.Errorf("Find output: got %v, want %v", names, tc.names)
-			}
-			t.Logf("errs %v", errs)
-			if len(errs) != len(tc.errs) {
-				t.Errorf("Find output: got %d bytes, want %d bytes", len(errs), len(tc.errs))
-			}
-			if errs != tc.errs {
-				t.Errorf("Find errors: got %v, want %v", errs, tc.errs)
 			}
 		})
 	}


### PR DESCRIPTION
This test failed on my Linux install because of a weird umask. Added a setumask(0) and cleaned up the test.

Signed-off-by: Christopher Koch <chrisko@google.com>