### PR TITLE
Remove $GOPATH check from travis.sh

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-if [ -z "${GOPATH}" ]; then
-        export GOPATH=/home/travis/gopath
-fi
+
 set -e
 
 echo "Check vendored dependencies"


### PR DESCRIPTION
[Travis always sets `$GOPATH` to `/home/travis/gopath`](https://travis-ci.org/y0ssar1an/u-root/jobs/309876685#L441), so we don't need this check.