### PR TITLE
pkg/uroot: add new compilation format to just compile binaries.

### DIFF
--- a/pkg/uroot/binary.go
+++ b/pkg/uroot/binary.go
@@ -1,0 +1,47 @@
+// Copyright 2015-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package uroot
+
+import (
+	"path/filepath"
+	"sync"
+
+	"github.com/u-root/u-root/pkg/golang"
+)
+
+// BinaryBuild builds all given packages as separate binaries and includes them
+// in the archive.
+func BinaryBuild(opts BuildOpts) (ArchiveFiles, error) {
+	af := NewArchiveFiles()
+
+	result := make(chan error, len(opts.Packages))
+	var wg sync.WaitGroup
+
+	for _, pkg := range opts.Packages {
+		wg.Add(1)
+		go func(p string) {
+			defer wg.Done()
+			result <- opts.Env.Build(
+				p,
+				filepath.Join(opts.TempDir, "bin", filepath.Base(p)),
+				golang.BuildOpts{})
+		}(pkg)
+	}
+
+	wg.Wait()
+	close(result)
+
+	for err := range result {
+		if err != nil {
+			return ArchiveFiles{}, err
+		}
+	}
+
+	// Add bin directory to archive.
+	if err := af.AddFile(opts.TempDir, ""); err != nil {
+		return ArchiveFiles{}, err
+	}
+	return af, nil
+}

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -22,6 +22,7 @@ var (
 	builders = map[string]Build{
 		"source": SourceBuild,
 		"bb":     BBBuild,
+		"binary": BinaryBuild,
 	}
 	archivers = map[string]Archiver{
 		"cpio": CPIOArchiver{


### PR DESCRIPTION
This is mostly meant to be used for local testing and debugging, e.g. to
compare against source and bb mode correctness.

Signed-off-by: Christopher Koch <c@chrisko.ch>