### PR TITLE
pkg/uroot: allow mixed build modes in package API.

### DIFF
--- a/pkg/uroot/bb_test.go
+++ b/pkg/uroot/bb_test.go
@@ -27,8 +27,8 @@ func TestBBBuild(t *testing.T) {
 		},
 		TempDir: dir,
 	}
-	af, err := BBBuild(opts)
-	if err != nil {
+	af := NewArchiveFiles()
+	if err := BBBuild(af, opts); err != nil {
 		t.Error(err)
 	}
 

--- a/u-root.go
+++ b/u-root.go
@@ -288,11 +288,17 @@ func Main() error {
 	}
 
 	opts := uroot.Opts{
-		Env:             env,
-		Builder:         builder,
+		Env: env,
+		// The command-line tool only allows specifying one build mode
+		// right now.
+		Commands: []uroot.Commands{
+			{
+				Builder:  builder,
+				Packages: pkgs,
+			},
+		},
 		Archiver:        archiver,
 		TempDir:         tempDir,
-		Packages:        pkgs,
 		ExtraFiles:      extraFiles,
 		OutputFile:      w,
 		BaseArchive:     baseFile,


### PR DESCRIPTION
@rminnich only allowed by the package right now -- what do you want the command-line API to look like?

Eventually, NiChrome should vendor in u-root and use the package rather than the command-line tool anyway.

Signed-off-by: Christopher Koch <c@chrisko.ch>