### PR TITLE
Remove resolv.conf override to allow users to specify their own

### DIFF
--- a/pkg/uroot/util/root.go
+++ b/pkg/uroot/util/root.go
@@ -131,7 +131,6 @@ var (
 		Dir{Name: "/go/pkg/linux_amd64", Mode: 0777},
 
 		Dir{Name: "/etc", Mode: 0777},
-		File{Name: "/etc/resolv.conf", Contents: `nameserver 8.8.8.8`, Mode: 0644},
 
 		Dir{Name: "/proc", Mode: 0555},
 		Mount{Target: "/proc", FSType: "proc"},


### PR DESCRIPTION
Removed the override on `/etc/resolv.conf`. This lets users specify their own `resolv.conf`, but it still leaves the default `nameserver 8.8.8.8` that is set in  https://github.com/u-root/u-root/blob/master/pkg/uroot/uroot.go#L29 .
This is the only entry in the namespace that doesn't seem necessary to have there.

* Tested with `go run u-root.go`: the content is "nameserver 8.8.8.8" from `pkg/uroot/uroot.go`
* tested with `go run u-root.go -files /etc/resolv.conf:etc/resolv.conf`: the content is copied from my local machine

The above steps were tested in both `bb` and `source` mode.