### PR TITLE
Fixing errors in kmodule_linux.go

### DIFF
--- a/pkg/kmodule/kmodule_linux.go
+++ b/pkg/kmodule/kmodule_linux.go
@@ -37,7 +37,7 @@ func (s *SyscallError) Error() string {
 }
 
 // Init loads the kernel module given by image with the given options.
-func Init(image []byte, opts string) *SyscallError {
+func Init(image []byte, opts string) error {
 	optsNull, err := unix.BytePtrFromString(opts)
 	if err != nil {
 		return &SyscallError{Msg: fmt.Sprintf("kmodule.Init: could not convert %q to C string: %v", opts, err)}
@@ -57,7 +57,7 @@ func Init(image []byte, opts string) *SyscallError {
 // flags.
 //
 // FileInit falls back to Init when the finit_module(2) syscall is not available.
-func FileInit(f *os.File, opts string, flags uintptr) *SyscallError {
+func FileInit(f *os.File, opts string, flags uintptr) error {
 	optsNull, err := unix.BytePtrFromString(opts)
 	if err != nil {
 		return &SyscallError{Msg: fmt.Sprintf("kmodule.Init: could not convert %q to C string: %v", opts, err)}
@@ -85,7 +85,7 @@ func FileInit(f *os.File, opts string, flags uintptr) *SyscallError {
 }
 
 // Delete removes a kernel module.
-func Delete(name string, flags uintptr) *SyscallError {
+func Delete(name string, flags uintptr) error {
 	modnameptr, err := unix.BytePtrFromString(name)
 	if err != nil {
 		return &SyscallError{Msg: fmt.Sprintf("could not delete module %q: %v", name, err)}
@@ -122,13 +122,13 @@ type ProbeOpts struct {
 
 // Probe loads the given kernel module and its dependencies.
 // It is calls ProbeOptions with the default ProbeOpts.
-func Probe(name string, modParams string) *SyscallError {
+func Probe(name string, modParams string) error {
 	return ProbeOptions(name, modParams, ProbeOpts{})
 }
 
 // ProbeOptions loads the given kernel module and its dependencies.
 // This functions takes ProbeOpts.
-func ProbeOptions(name, modParams string, opts ProbeOpts) *SyscallError {
+func ProbeOptions(name, modParams string, opts ProbeOpts) error {
 	deps, err := genDeps()
 	if err != nil {
 		return &SyscallError{Msg: fmt.Sprintf("could not generate dependency map %v", err)}
@@ -214,7 +214,7 @@ func findModPath(name string, m depMap) (string, error) {
 	return "", fmt.Errorf("Could not find path for module %q", name)
 }
 
-func loadDeps(path string, m depMap, opts ProbeOpts) *SyscallError {
+func loadDeps(path string, m depMap, opts ProbeOpts) error {
 	dependency, ok := m[path]
 	if !ok {
 		return &SyscallError{Msg: fmt.Sprintf("could not find dependency %q", path)}
@@ -243,7 +243,7 @@ func loadDeps(path string, m depMap, opts ProbeOpts) *SyscallError {
 	return nil
 }
 
-func loadModule(path, modParams string, opts ProbeOpts) *SyscallError {
+func loadModule(path, modParams string, opts ProbeOpts) error {
 	if opts.DryRun {
 		fmt.Println(path)
 		return nil
@@ -255,8 +255,10 @@ func loadModule(path, modParams string, opts ProbeOpts) *SyscallError {
 	}
 	defer f.Close()
 
-	if err := FileInit(f, modParams, 0); err != nil && err.Errno != unix.EEXIST {
-		return err
+	if err := FileInit(f, modParams, 0); err != nil {
+		if serr, ok := err.(*SyscallError); !ok || (ok && serr.Errno != unix.EEXIST) {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
   Summary:

   By returning *SyscallError rather than error in some cases it was always evaluating as != nil [(explanation).](https://golang.org/doc/faq#nil_error)
   This change refactors it to use the error interface.


 [Link to code used for testing](https://gist.github.com/claudiozz/5e932b5929eb63f8e2b1d5b2eb43eedc)

   Before the change:
```
    [root@scw-ffea63 ~]# lsmod | grep ^loop
    [root@scw-ffea63 ~]# ./test
    2018/01/27 13:24:50 Error is not nil and is SyscallError, value is
<nil>
    [root@scw-ffea63 ~]# lsmod | grep ^loop
    loop                   19177  1 cryptoloop
```
   After the change:
```
    [root@scw-ffea63 ~]# lsmod | grep loop
    [root@scw-ffea63 ~]# ./test
    2018/01/27 13:26:37 Success
    [root@scw-ffea63 ~]# lsmod | grep ^loop
    loop                   19177  1 cryptoloop
```