### PR TITLE
Merge /lib with /usr/lib

### DIFF
--- a/pkg/uroot/util/root.go
+++ b/pkg/uroot/util/root.go
@@ -126,8 +126,8 @@ var (
 		Dir{Name: "/tmp", Mode: 0777},
 		Dir{Name: "/env", Mode: 0777},
 		Dir{Name: "/tcz", Mode: 0777},
-		Dir{Name: "/lib", Mode: 0777},
 		Dir{Name: "/usr/lib", Mode: 0777},
+		Symlink{NewPath: "/lib", Target: "/usr/lib"},
 		Dir{Name: "/go/pkg/linux_amd64", Mode: 0777},
 
 		Dir{Name: "/etc", Mode: 0777},


### PR DESCRIPTION
Merge /lib with /usr/lib with a symlink:

/lib -> usr/lib

This is to ensure compatibility with kernels shipped by major distros
that store modules under /usr/lib/modules but look for them under
/lib/modules assuming they have been merged.