### PR TITLE
Add Error Handling for wifi cmd when called with no arguments

### DIFF
--- a/cmds/wifi/wifi.go
+++ b/cmds/wifi/wifi.go
@@ -14,13 +14,12 @@ import (
 )
 
 const (
-	cmd          = "wifi [options] essid [passphrase]"
+	cmd          = "wifi [options] essid [passphrase] [identity]"
 	nopassphrase = `network={
-	ssid="%s"
-	proto=RSN
-	key_mgmt=NONE
-}
-`
+		ssid="%s"
+		proto=RSN
+		key_mgmt=NONE
+	}`
 	eap = `network={
 		ssid="%s"
 		key_mgmt=WPA-EAP
@@ -46,12 +45,13 @@ func main() {
 
 	flag.Parse()
 	a := flag.Args()
-	essid = a[0]
 
 	switch {
 	case len(a) == 3:
-		conf = []byte(fmt.Sprintf(eap, essid, a[1], a[2]))
+		essid = a[0]
+		conf = []byte(fmt.Sprintf(eap, essid, a[2], a[1]))
 	case len(a) == 2:
+		essid = a[0]
 		pass := a[1]
 		o, err := exec.Command("wpa_passphrase", essid, pass).CombinedOutput()
 		if err != nil {
@@ -59,6 +59,7 @@ func main() {
 		}
 		conf = o
 	case len(a) == 1:
+		essid = a[0]
 		conf = []byte(fmt.Sprintf(nopassphrase, essid))
 	default:
 		flag.Usage()

--- a/cmds/wifi/wifi_test.go
+++ b/cmds/wifi/wifi_test.go
@@ -1,0 +1,74 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
+)
+
+type WifiTestCase struct {
+	name      string
+	args      []string
+	out       string
+	exp_error bool
+}
+
+var testcases = []WifiTestCase{
+	{
+		name:      "No Flags, No Args",
+		args:      nil,
+		out:       "Usage",
+		exp_error: true,
+	},
+	{
+		name:      "Flags, No Args",
+		args:      []string{"-i=123"},
+		out:       "Usage",
+		exp_error: true,
+	},
+}
+
+var ERROR_MSG_FORMAT = "\nEXPECTED:\n%s\n\nACTUAL:\n%s\n"
+
+func errorExists(err error) bool {
+	return err != nil
+}
+
+func craftPrintMsg(err_exists bool, out string) string {
+	var msg bytes.Buffer
+
+	if err_exists {
+		msg.WriteString("Error Status: exists\n")
+	} else {
+		msg.WriteString("Error Status: not exists\n")
+	}
+	msg.WriteString("Output:\n")
+	msg.WriteString(out)
+	return msg.String()
+}
+
+func TestWifi(t *testing.T) {
+	// Set up
+	tmpDir, execPath := testutil.CompileInTempDir(t)
+	defer os.RemoveAll(tmpDir)
+
+	// Tests
+	for _, test := range testcases {
+		t.Logf("TEST %v", test.name)
+		c := exec.Command(execPath, test.args...)
+		out, err := c.CombinedOutput()
+		if (test.exp_error != errorExists(err)) || !strings.Contains(string(out), test.out) {
+			expectMsg := craftPrintMsg(test.exp_error, test.out)
+			actualMsg := craftPrintMsg(errorExists(err), string(out))
+			t.Errorf(ERROR_MSG_FORMAT, expectMsg, actualMsg)
+		}
+	}
+}


### PR DESCRIPTION
Before this commit, when call wifi with no arugments, the goroutine will
panic and give you an error.
Now, when call wifi with no arguments, the flag.Usage() function will get
call and the standard usage message will be printed. This is a more
graceful way of handing this error

Signed-off-by: Thien M. Hoang <thienhoang@google.com>