### PR TITLE
kmodule_linux: Fix module lookup

### DIFF
--- a/pkg/kmodule/kmodule_linux.go
+++ b/pkg/kmodule/kmodule_linux.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -206,7 +207,7 @@ func genDeps() (depMap, error) {
 
 func findModPath(name string, m depMap) (string, error) {
 	for mp := range m {
-		if strings.HasSuffix(mp, "/"+name+".ko") {
+		if path.Base(mp) == name+".ko" {
 			return mp, nil
 		}
 	}

--- a/pkg/kmodule/kmodule_linux.go
+++ b/pkg/kmodule/kmodule_linux.go
@@ -206,7 +206,7 @@ func genDeps() (depMap, error) {
 
 func findModPath(name string, m depMap) (string, error) {
 	for mp := range m {
-		if strings.HasSuffix(mp, name+".ko") {
+		if strings.HasSuffix(mp, "/"+name+".ko") {
 			return mp, nil
 		}
 	}


### PR DESCRIPTION
Fix module lookup by suffix in kmodule_linux, currently it matches for
moduleName.ko which matches _any_ module ending with that name in the
depMap. In some cases this means random modules are loaded instead of
the correct one.

Before the fix:

      $ for i in {1..5}; do ./modprobe_linux -n loop ; done
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/block/loop.ko
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/sound/soundcore.ko
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/sound/core/snd.ko
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/sound/core/snd-timer.ko
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/sound/core/snd-pcm.ko
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/sound/drivers/snd-aloop.ko
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/block/loop.ko
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/fs/configfs/configfs.ko
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/scsi/scsi_mod.ko
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/target/target_core_mod.ko
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/target/loopback/tcm_loop.ko
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/block/loop.ko

After the fix:

    $ for i in {1..5}; do ./modprobe_linux -n loop ; done
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/block/loop.ko
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/block/loop.ko
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/block/loop.ko
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/block/loop.ko
    Unique dependencies in load order, already loaded ones get skipped:
    /lib/modules/4.14.0-0.bpo.3-amd64/kernel/drivers/block/loop.ko
