### PR TITLE
Fixed a bad test case in rush_test.go

### DIFF
--- a/cmds/rush/rush_test.go
+++ b/cmds/rush/rush_test.go
@@ -29,7 +29,7 @@ var tests = []struct {
 	{"exit 1 2 3\n", "% % ", "Too many arguments\n", 0},
 	{"exit abcd\n", "% % ", "Non numeric argument\n", 0},
 	{"time cd .\n", "% % ", `real 0.0\d\d\n`, 0},
-	{"time sleep 0.25\n", "% % ", `real 0.2\d\d\nuser 0.00\d\nsys 0.00\d\n`, 0},
+	{"time sleep 0.25\n", "% % ", `real \d+.\d{3}\nuser \d+.\d{3}\nsys \d+.\d{3}\n`, 0},
 }
 
 func TestRush(t *testing.T) {


### PR DESCRIPTION
Before: The format of the bad test case was real 0.2\d\d\nuser 0.00\d\nsys 0.00\d\n which assumes that the program will return a result within the 0.200 - 0.299 seconds time range. However, that is not guaranteed.

Now: We only care about the matching format which is \d+.\d{3}. This format does not care about the actual run time, which will prevent any false positive failure.

Signed-off-by: Thien Hoang <thienhoang@google.com>