### PR TITLE
various cpio improvements

### DIFF
--- a/cmds/cpio/cpio.go
+++ b/cmds/cpio/cpio.go
@@ -34,7 +34,6 @@ import (
 	"os"
 
 	"github.com/u-root/u-root/pkg/cpio"
-	_ "github.com/u-root/u-root/pkg/cpio/newc"
 )
 
 var (

--- a/pkg/cpio/cpio.go
+++ b/pkg/cpio/cpio.go
@@ -55,7 +55,8 @@ func (r Reader) ReadRecord() (Record, error) {
 	if err != nil {
 		return Record{}, err
 	}
-	// The end of a CPIO archive is marked by a record whose name is "TRAILER!!!".
+	// The end of a CPIO archive is marked by a record whose name is
+	// "TRAILER!!!".
 	if rec.Name == Trailer {
 		return Record{}, io.EOF
 	}

--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -8,12 +8,11 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"os"
 	"path/filepath"
 	"syscall"
-	//"time"
 
+	"github.com/u-root/u-root/pkg/uio"
 	"golang.org/x/sys/unix"
 )
 
@@ -131,7 +130,7 @@ func CreateFileInRoot(f Record, rootDir string) error {
 			return err
 		}
 		defer nf.Close()
-		if _, err := io.Copy(nf, io.NewSectionReader(f, 0, math.MaxInt64)); err != nil {
+		if _, err := io.Copy(nf, uio.Reader(f)); err != nil {
 			return err
 		}
 		return setModes(f)
@@ -155,7 +154,7 @@ func CreateFileInRoot(f Record, rootDir string) error {
 		return setModes(f)
 
 	case os.ModeSymlink:
-		content, err := ioutil.ReadAll(io.NewSectionReader(f, 0, math.MaxInt64))
+		content, err := ioutil.ReadAll(uio.Reader(f))
 		if err != nil {
 			return err
 		}

--- a/pkg/cpio/newc.go
+++ b/pkg/cpio/newc.go
@@ -10,7 +10,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"math"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 const (
@@ -151,7 +152,7 @@ func (w *writer) WriteRecord(f Record) error {
 	}
 
 	// Write file contents.
-	m, err := io.Copy(w, io.NewSectionReader(f, 0, math.MaxInt64))
+	m, err := io.Copy(w, uio.Reader(f))
 	if err != nil {
 		return err
 	}

--- a/pkg/cpio/newc_test.go
+++ b/pkg/cpio/newc_test.go
@@ -8,10 +8,11 @@ import (
 	"bytes"
 	"io"
 	"io/ioutil"
-	"math"
 	"reflect"
 	"syscall"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 func TestSimple(t *testing.T) {
@@ -76,7 +77,7 @@ func TestWriteRead(t *testing.T) {
 		t.Errorf("Records not equal:\n%#v\n%#v", rec.Info, rec2.Info)
 	}
 
-	contents2, err := ioutil.ReadAll(io.NewSectionReader(rec2, 0, math.MaxInt64))
+	contents2, err := ioutil.ReadAll(uio.Reader(rec2))
 	if err != nil {
 		t.Errorf("Could not read %q: %v", rec2.Name, err)
 	}
@@ -135,11 +136,11 @@ func TestReadWrite(t *testing.T) {
 			t.Errorf("index %d: testCPIO Info\n%v\ngenerated Info\n%v\n", i, f1.Info, f2.Info)
 		}
 
-		contents1, err := ioutil.ReadAll(io.NewSectionReader(f1, 0, math.MaxInt64))
+		contents1, err := ioutil.ReadAll(uio.Reader(f1))
 		if err != nil {
 			t.Errorf("index %d(%q): can't read from the source: %v", i, f1.Name, err)
 		}
-		contents2, err := ioutil.ReadAll(io.NewSectionReader(f2, 0, math.MaxInt64))
+		contents2, err := ioutil.ReadAll(uio.Reader(f2))
 		if err != nil {
 			t.Errorf("index %d(%q): can't read from the dest: %v", i, f2.Name, err)
 		}

--- a/pkg/cpio/types.go
+++ b/pkg/cpio/types.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math"
 	"os"
 	"time"
 
@@ -17,7 +16,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// Record represents a CPIO record, which represents a Linux file.
+// Record represents a CPIO record, which represents a Unix file.
 type Record struct {
 	// ReaderAt contains the content of this CPIO record.
 	io.ReaderAt
@@ -114,14 +113,14 @@ func ReaderAtEqual(r1, r2 io.ReaderAt) bool {
 	var c, d []byte
 	var err error
 	if r1 != nil {
-		c, err = ioutil.ReadAll(io.NewSectionReader(r1, 0, math.MaxInt64))
+		c, err = ioutil.ReadAll(uio.Reader(r1))
 		if err != nil {
 			return false
 		}
 	}
 
 	if r2 != nil {
-		d, err = ioutil.ReadAll(io.NewSectionReader(r2, 0, math.MaxInt64))
+		d, err = ioutil.ReadAll(uio.Reader(r2))
 		if err != nil {
 			return false
 		}

--- a/pkg/pxe/schemes.go
+++ b/pkg/pxe/schemes.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/u-root/u-root/pkg/uio"
 	"pack.ag/tftp"
 )
 
@@ -118,7 +119,7 @@ func (s Schemes) LazyGetFile(u *url.URL) (io.Reader, error) {
 		return nil, &URLError{URL: u, Err: ErrNoSuchScheme}
 	}
 
-	return NewLazyOpener(func() (io.Reader, error) {
+	return uio.NewLazyOpener(func() (io.Reader, error) {
 		r, err := fg.GetFile(u)
 		if err != nil {
 			return nil, &URLError{URL: u, Err: err}
@@ -190,7 +191,7 @@ func (lfs LocalFileClient) GetFile(u *url.URL) (io.Reader, error) {
 }
 
 type cachedFile struct {
-	cr  *CachingReader
+	cr  *uio.CachingReader
 	err error
 }
 
@@ -227,7 +228,7 @@ func (cc *CachedFileScheme) GetFile(u *url.URL) (io.Reader, error) {
 		cc.cache[url] = cachedFile{err: err}
 		return nil, err
 	}
-	cr := NewCachingReader(r)
+	cr := uio.NewCachingReader(r)
 	cc.cache[url] = cachedFile{cr: cr}
 	return cr.NewReader(), nil
 }

--- a/pkg/uio/cached.go
+++ b/pkg/uio/cached.go
@@ -3,7 +3,6 @@ package uio
 import (
 	"bytes"
 	"io"
-	"math"
 )
 
 // CachingReader is a lazily caching wrapper of an io.Reader.
@@ -37,7 +36,7 @@ func (cr *CachingReader) read(p []byte) (int, error) {
 
 // NewReader returns a new io.Reader that reads cr from offset 0.
 func (cr *CachingReader) NewReader() io.Reader {
-	return io.NewSectionReader(cr, 0, math.MaxInt64)
+	return Reader(cr)
 }
 
 // Read reads from cr; implementing io.Reader.

--- a/pkg/uio/cached.go
+++ b/pkg/uio/cached.go
@@ -1,39 +1,10 @@
-package pxe
+package uio
 
 import (
 	"bytes"
 	"io"
 	"math"
 )
-
-// LazyOpener is a lazy io.Reader.
-//
-// LazyOpener will use a given open function to derive an io.Reader when Read
-// is first called on the LazyOpener.
-type LazyOpener struct {
-	r    io.Reader
-	err  error
-	open func() (io.Reader, error)
-}
-
-// NewLazyOpener returns a lazy io.Reader based on `open`.
-func NewLazyOpener(open func() (io.Reader, error)) io.Reader {
-	return &LazyOpener{open: open}
-}
-
-// Read implements io.Reader.Read lazily.
-//
-// If called for the first time, the underlying reader will be obtained and
-// then used for the first and subsequent calls to Read.
-func (lr *LazyOpener) Read(p []byte) (int, error) {
-	if lr.r == nil && lr.err == nil {
-		lr.r, lr.err = lr.open()
-	}
-	if lr.err != nil {
-		return 0, lr.err
-	}
-	return lr.r.Read(p)
-}
 
 // CachingReader is a lazily caching wrapper of an io.Reader.
 //

--- a/pkg/uio/cached_test.go
+++ b/pkg/uio/cached_test.go
@@ -1,4 +1,4 @@
-package pxe
+package uio
 
 import (
 	"bytes"
@@ -6,68 +6,6 @@ import (
 	"io"
 	"testing"
 )
-
-type mockReader struct {
-	// called is whether Read has been called.
-	called bool
-
-	// err is the error to return on Read.
-	err error
-}
-
-func (m *mockReader) Read([]byte) (int, error) {
-	m.called = true
-	return 0, m.err
-}
-
-func TestLazyOpenerRead(t *testing.T) {
-	for i, tt := range []struct {
-		openErr    error
-		openReader *mockReader
-		wantCalled bool
-	}{
-		{
-			openErr:    nil,
-			openReader: &mockReader{},
-			wantCalled: true,
-		},
-		{
-			openErr:    io.EOF,
-			openReader: nil,
-			wantCalled: false,
-		},
-		{
-			openErr: nil,
-			openReader: &mockReader{
-				err: io.ErrUnexpectedEOF,
-			},
-			wantCalled: true,
-		},
-	} {
-		t.Run(fmt.Sprintf("Test #%02d", i), func(t *testing.T) {
-			var opened bool
-			lr := NewLazyOpener(func() (io.Reader, error) {
-				opened = true
-				return tt.openReader, tt.openErr
-			})
-			_, err := lr.Read([]byte{})
-			if !opened {
-				t.Fatalf("Read(): Reader was not opened")
-			}
-			if tt.openErr != nil && err != tt.openErr {
-				t.Errorf("Read() = %v, want %v", err, tt.openErr)
-			}
-			if tt.openReader != nil {
-				if got, want := tt.openReader.called, tt.wantCalled; got != want {
-					t.Errorf("mockReader.Read() called is %v, want %v", got, want)
-				}
-				if tt.openReader.err != nil && err != tt.openReader.err {
-					t.Errorf("Read() = %v, want %v", err, tt.openReader.err)
-				}
-			}
-		})
-	}
-}
 
 func TestCachingReaderRead(t *testing.T) {
 	type read struct {

--- a/pkg/uio/lazy.go
+++ b/pkg/uio/lazy.go
@@ -1,0 +1,82 @@
+package uio
+
+import (
+	"io"
+)
+
+// LazyOpener is a lazy io.Reader.
+//
+// LazyOpener will use a given open function to derive an io.Reader when Read
+// is first called on the LazyOpener.
+type LazyOpener struct {
+	r    io.Reader
+	err  error
+	open func() (io.Reader, error)
+}
+
+// NewLazyOpener returns a lazy io.Reader based on `open`.
+func NewLazyOpener(open func() (io.Reader, error)) io.ReadCloser {
+	return &LazyOpener{open: open}
+}
+
+// Read implements io.Reader.Read lazily.
+//
+// If called for the first time, the underlying reader will be obtained and
+// then used for the first and subsequent calls to Read.
+func (lr *LazyOpener) Read(p []byte) (int, error) {
+	if lr.r == nil && lr.err == nil {
+		lr.r, lr.err = lr.open()
+	}
+	if lr.err != nil {
+		return 0, lr.err
+	}
+	return lr.r.Read(p)
+}
+
+// Close implements io.Closer.Close.
+func (lr *LazyOpener) Close() error {
+	if c, ok := lr.r.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}
+
+// ReadAtCloser is an io.ReaderAt and an io.Closer.
+type ReadAtCloser interface {
+	io.ReaderAt
+	io.Closer
+}
+
+// LazyOpenerAt is a lazy io.ReaderAt.
+//
+// LazyOpenerAt will use a given open function to derive an io.ReaderAt when
+// ReadAt is first called.
+type LazyOpenerAt struct {
+	r    io.ReaderAt
+	err  error
+	open func() (io.ReaderAt, error)
+}
+
+// NewLazyOpenerAt returns a lazy io.ReaderAt based on `open`.
+func NewLazyOpenerAt(open func() (io.ReaderAt, error)) ReadAtCloser {
+	return &LazyOpenerAt{open: open}
+}
+
+// ReadAt implements io.ReaderAt.ReadAt.
+func (loa *LazyOpenerAt) ReadAt(p []byte, off int64) (int, error) {
+	if loa.r == nil && loa.err == nil {
+		loa.r, loa.err = loa.open()
+	}
+	if loa.err != nil {
+		return 0, loa.err
+	}
+	return loa.r.ReadAt(p, off)
+}
+
+// Close implements io.Closer.Close.
+func (loa *LazyOpenerAt) Close() error {
+	if c, ok := loa.r.(io.Closer); ok {
+		return c.Close()
+	}
+	return nil
+}

--- a/pkg/uio/lazy_test.go
+++ b/pkg/uio/lazy_test.go
@@ -1,0 +1,69 @@
+package uio
+
+import (
+	"fmt"
+	"io"
+	"testing"
+)
+
+type mockReader struct {
+	// called is whether Read has been called.
+	called bool
+
+	// err is the error to return on Read.
+	err error
+}
+
+func (m *mockReader) Read([]byte) (int, error) {
+	m.called = true
+	return 0, m.err
+}
+
+func TestLazyOpenerRead(t *testing.T) {
+	for i, tt := range []struct {
+		openErr    error
+		openReader *mockReader
+		wantCalled bool
+	}{
+		{
+			openErr:    nil,
+			openReader: &mockReader{},
+			wantCalled: true,
+		},
+		{
+			openErr:    io.EOF,
+			openReader: nil,
+			wantCalled: false,
+		},
+		{
+			openErr: nil,
+			openReader: &mockReader{
+				err: io.ErrUnexpectedEOF,
+			},
+			wantCalled: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("Test #%02d", i), func(t *testing.T) {
+			var opened bool
+			lr := NewLazyOpener(func() (io.Reader, error) {
+				opened = true
+				return tt.openReader, tt.openErr
+			})
+			_, err := lr.Read([]byte{})
+			if !opened {
+				t.Fatalf("Read(): Reader was not opened")
+			}
+			if tt.openErr != nil && err != tt.openErr {
+				t.Errorf("Read() = %v, want %v", err, tt.openErr)
+			}
+			if tt.openReader != nil {
+				if got, want := tt.openReader.called, tt.wantCalled; got != want {
+					t.Errorf("mockReader.Read() called is %v, want %v", got, want)
+				}
+				if tt.openReader.err != nil && err != tt.openReader.err {
+					t.Errorf("Read() = %v, want %v", err, tt.openReader.err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/uio/reader.go
+++ b/pkg/uio/reader.go
@@ -1,0 +1,11 @@
+package uio
+
+import (
+	"io"
+	"math"
+)
+
+// Reader generates a Reader from a ReaderAt.
+func Reader(r io.ReaderAt) io.Reader {
+	return io.NewSectionReader(r, 0, math.MaxInt64)
+}

--- a/pkg/uroot/cpio.go
+++ b/pkg/uroot/cpio.go
@@ -11,9 +11,6 @@ import (
 	"os"
 
 	"github.com/u-root/u-root/pkg/cpio"
-	// To import newc format for cpio.
-	// TODO(hugelgupf): revise this package structure.
-	_ "github.com/u-root/u-root/pkg/cpio/newc"
 )
 
 // CPIOArchiver is an implementation of Archiver for the cpio format.

--- a/pkg/uroot/files_test.go
+++ b/pkg/uroot/files_test.go
@@ -291,7 +291,7 @@ func sameNameModeContent(r1 cpio.Record, r2 cpio.Record) bool {
 	if r1.Name != r2.Name || r1.Mode != r2.Mode {
 		return false
 	}
-	return cpio.ReadCloserEqual(r1.ReadCloser, r2.ReadCloser)
+	return cpio.ReaderAtEqual(r1.ReaderAt, r2.ReaderAt)
 }
 
 func TestWriteFile(t *testing.T) {
@@ -362,14 +362,14 @@ func TestWriteFile(t *testing.T) {
 						Name: "etc/bla",
 						Mode: unix.S_IFREG | 0644,
 					},
-					ReadCloser: ioutil.NopCloser(bytes.NewReader([]byte("foo"))),
+					ReaderAt: bytes.NewReader([]byte("foo")),
 				},
 				"etc/bla2": cpio.Record{
 					Info: cpio.Info{
 						Name: "etc/bla2",
 						Mode: unix.S_IFREG | 0644,
 					},
-					ReadCloser: ioutil.NopCloser(bytes.NewReader([]byte("foo2"))),
+					ReaderAt: bytes.NewReader([]byte("foo2")),
 				},
 			},
 		},


### PR DESCRIPTION
io.Reader only allows you to read the record once; and there's no point
in reading it from a bytes.buffer into a bytes.Buffer just to be able to
read it multiple times. So, we go with io.ReaderAt.

making these improvements to improve netboot stuff, so i can hand off to samee.