### PR TITLE
(Experimental) Make wifi cmd RESTful

### DIFF
--- a/cmds/wifi/wifiCommsUtils.go
+++ b/cmds/wifi/wifiCommsUtils.go
@@ -4,17 +4,15 @@
 
 package main
 
-type ServerToServiceMessage struct {
-	essid string
-	id    string
-	pass  string
+type UserInputMessage struct {
+	args []string
 }
 
-type ServiceToServerMessage struct {
+type StatusMessage struct {
 	essid string
 }
 
 var (
-	ServerToServiceChan = make(chan ServerToServiceMessage)
-	ServiceToServerChan = make(chan ServiceToServerMessage)
+	UserInputChannel = make(chan UserInputMessage)
+	StatusChannel    = make(chan StatusMessage)
 )

--- a/cmds/wifi/wifiCommsUtils.go
+++ b/cmds/wifi/wifiCommsUtils.go
@@ -1,0 +1,20 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+type ServerToServiceMessage struct {
+	essid string
+	id    string
+	pass  string
+}
+
+type ServiceToServerMessage struct {
+	essid string
+}
+
+var (
+	ServerToServiceChan = make(chan ServerToServiceMessage)
+	ServiceToServerChan = make(chan ServiceToServerMessage)
+)

--- a/cmds/wifi/wifiServer.go
+++ b/cmds/wifi/wifiServer.go
@@ -1,0 +1,172 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"io"
+	"log"
+	"net/http"
+)
+
+type SecProto int
+
+const (
+	NoEnc SecProto = iota
+	WpaPsk
+	WpaEap
+)
+
+const (
+	PortNum  = "8080"
+	HtmlPage = `
+<head>
+<style>
+table {
+    font-family: arial, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+}
+
+td, th {
+    border: 1px solid #dddddd;
+    text-align: left;
+    padding: 8px;
+}
+
+input {
+	font-size: 120%;
+}
+
+.essid {
+	border-width: 0;
+}
+</style>
+<script>
+function replaceWithConnecting(elem) {
+    connectingTxt = document.createTextNode("Connecting...")
+    elem.style.display = "none"
+    elem.parentNode.appendChild(connectingTxt);
+    btns = document.getElementsByClassName("btn");
+    var i;
+    for (i = 0; i < btns.length; i++) {
+    	if (btns[i] === elem) {
+    		continue;
+    	}
+    	btns[i].setAttribute("disabled", "true")
+    }
+}
+</script>
+</head>
+<body>
+{{$NoEnc := 0}}
+{{$WpaPsk := 1}}
+{{$WpaEap := 2}}
+{{$connectedEssid := .ConnectedEssid}}
+<h1>Please choose your Wifi</h1>
+<table style="width:100%">
+	<tr>
+    	<th>Essid</th>
+    	<th>Identity</th>
+    	<th>Password / Passphrase</th>
+    	<th></th>
+  	</tr>
+	{{range $idx, $opt := .WifiOpts}}
+		<form id="f{{$idx}}" method="post"></form>
+		{{if eq $opt.AuthSuite $NoEnc}}
+			<tr>
+    			<td><input type="text" name="essid" class="essid" form="f{{$idx}}" readonly value={{$opt.Essid}}></td>
+    			<td></td>
+    			<td></td>
+    			{{if eq $connectedEssid $opt.Essid}}
+    				<td>Connected</td>
+				{{else}}
+    				<td><input type="submit" class="btn" form="f{{$idx}}" onclick=replaceWithConnecting(this) value="Connect"></td>
+    			{{end}}
+  			</tr>
+		{{else if eq $opt.AuthSuite $WpaPsk}}
+			<tr>
+    			<td><input type="text" name="essid" class="essid" form="f{{$idx}}" readonly value={{$opt.Essid}}></td>
+    			<td></td>
+    			<td><input type="password" name="pass" form="f{{$idx}}"></td>
+    			{{if eq $connectedEssid $opt.Essid}}
+    				<td>Connected</td>
+				{{else}}
+    				<td><input type="submit" class="btn" form="f{{$idx}}" onclick=replaceWithConnecting(this) value="Connect"></td>
+    			{{end}}
+  			</tr>
+		{{else if eq $opt.AuthSuite $WpaEap}}
+			<tr>
+    			<td><input type="text" name="essid" class="essid" form="f{{$idx}}" readonly value={{$opt.Essid}}></td>
+    			<td><input type="text" name="identity" form="f{{$idx}}"></td>
+				<td><input type="password" name="pass" form="f{{$idx}}"></td>
+				{{if eq $connectedEssid $opt.Essid}}
+    				<td>Connected</td>
+				{{else}}
+    				<td><input type="submit" class="btn" form="f{{$idx}}" onclick=replaceWithConnecting(this) value="Connect"></td>
+    			{{end}}
+  			</tr>
+		{{else}}
+			<tr>
+    			<td><input type="text" name="essid" class="essid" form="f{{$idx}}" readonly value={{$opt.Essid}}></td>
+    			<td colspan="3">Not a supported protocol</td>
+  			</tr>
+		{{end}}
+	{{else}}
+		<td colspan="4">No essids found</td>
+	{{end}}
+</table>
+</body>
+`
+)
+
+func startServer() {
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		stubWifis := []WifiOptions{
+			{"stub1", NoEnc},
+			{"stub2", WpaPsk},
+			{"stub3", WpaEap},
+			{"stub4", 123},
+		}
+
+		if r.Method != http.MethodPost {
+			err := displayWifi(w, stubWifis, "")
+			if err != nil {
+				log.Fatalf("error: %v", err)
+			}
+			return
+		}
+
+		msg := ServerToServiceMessage{
+			essid: r.FormValue("essid"),
+			id:    r.FormValue("identity"),
+			pass:  r.FormValue("pass"),
+		}
+
+		ServerToServiceChan <- msg
+
+		serviceMsg := <-ServiceToServerChan
+		displayWifi(w, stubWifis, serviceMsg.essid)
+	})
+
+	http.ListenAndServe(fmt.Sprintf(":%s", PortNum), nil)
+}
+
+type WifiOptions struct {
+	Essid     string
+	AuthSuite SecProto
+}
+
+func displayWifi(wr io.Writer, wifiOpts []WifiOptions, connectedEssid string) error {
+	wifiData := struct {
+		WifiOpts       []WifiOptions
+		ConnectedEssid string
+	}{wifiOpts, connectedEssid}
+
+	tmpl := template.Must(template.New("name").Parse(HtmlPage))
+
+	return tmpl.Execute(wr, wifiData)
+}

--- a/cmds/wifi/wifi_test.go
+++ b/cmds/wifi/wifi_test.go
@@ -23,13 +23,13 @@ type WifiTestCase struct {
 
 var testcases = []WifiTestCase{
 	{
-		name:   "No Flags, No Args",
-		args:   nil,
+		name:   "More elements than needed",
+		args:   []string{"a", "a", "a", "a"},
 		expect: "Usage",
 	},
 	{
-		name:   "Flags, No Args",
-		args:   []string{"-i=123"},
+		name:   "Flags, More elements than needed",
+		args:   []string{"-i=123", "a", "a", "a", "a"},
 		expect: "Usage",
 	},
 }
@@ -41,7 +41,7 @@ func run(c *exec.Cmd) (string, string, error) {
 	return o.String(), e.String(), err
 }
 
-func TestWifi(t *testing.T) {
+func TestWifiErrors(t *testing.T) {
 	// Set up
 	tmpDir, execPath := testutil.CompileInTempDir(t)
 	defer os.RemoveAll(tmpDir)

--- a/cmds/wifi/wifi_test.go
+++ b/cmds/wifi/wifi_test.go
@@ -71,10 +71,16 @@ var (
 			err:  nil,
 		},
 		{
-			name: "WPA-PSK",
+			name: "WPA-PSK Error",
 			args: []string{EssidStub, BadWpaPskPass},
 			exp:  nil,
 			err:  fmt.Errorf("essid: %v, pass: %v : %v", EssidStub, BadWpaPskPass, expWpaPskErr),
+		},
+		{
+			name: "Invalid Args Length Error",
+			args: nil,
+			exp:  nil,
+			err:  fmt.Errorf("generateConfig needs 1, 2, or 3 args"),
 		},
 	}
 )
@@ -105,7 +111,7 @@ func TestWifiErrors(t *testing.T) {
 
 func TestWifiGenerateConfig(t *testing.T) {
 	for _, test := range generateConfigTestcases {
-		out, err := generateConfig(test.args)
+		out, err := generateConfig(test.args...)
 		if !reflect.DeepEqual(err, test.err) || !bytes.Equal(out, test.exp) {
 			t.Logf("TEST %v", test.name)
 			fncCall := fmt.Sprintf("genrateConfig(%v)", test.args)

--- a/cmds/wifi/wifi_test.go
+++ b/cmds/wifi/wifi_test.go
@@ -9,30 +9,91 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
+	"github.com/u-root/u-root/pkg/wpa/passphrase"
 )
 
-type WifiTestCase struct {
+type WifiErrorTestCase struct {
 	name   string
 	args   []string
 	expect string
 }
 
-var testcases = []WifiTestCase{
-	{
-		name:   "More elements than needed",
-		args:   []string{"a", "a", "a", "a"},
-		expect: "Usage",
-	},
-	{
-		name:   "Flags, More elements than needed",
-		args:   []string{"-i=123", "a", "a", "a", "a"},
-		expect: "Usage",
-	},
+type GenerateConfigTestCase struct {
+	name  string
+	essid string
+	id    string
+	pass  string
+	exp   []byte
+	err   error
 }
+
+var (
+	EssidStub    = "stub"
+	IdStub       = "stub"
+	PassStub     = "123456789"
+	expWpaPsk, _ = passphrase.Run(EssidStub, PassStub)
+
+	errorTestcases = []WifiErrorTestCase{
+		{
+			name:   "More elements than needed",
+			args:   []string{"a", "a", "a", "a"},
+			expect: "Usage",
+		},
+		{
+			name:   "Flags, More elements than needed",
+			args:   []string{"-i=123", "a", "a", "a", "a"},
+			expect: "Usage",
+		},
+	}
+
+	generateConfigTestcases = []GenerateConfigTestCase{
+		{
+			name:  "No Pass Phrase",
+			essid: EssidStub,
+			id:    "",
+			pass:  "",
+			exp:   []byte(fmt.Sprintf(nopassphrase, EssidStub)),
+			err:   nil,
+		},
+		{
+			name:  "WPA-PSK",
+			essid: EssidStub,
+			id:    "",
+			pass:  PassStub,
+			exp:   expWpaPsk,
+			err:   nil,
+		},
+		{
+			name:  "WPA-EAP",
+			essid: EssidStub,
+			id:    IdStub,
+			pass:  PassStub,
+			exp:   []byte(fmt.Sprintf(eap, EssidStub, IdStub, PassStub)),
+			err:   nil,
+		},
+		{
+			name:  "Invalid Argument: ESSID and Id",
+			essid: EssidStub,
+			id:    IdStub,
+			pass:  "",
+			exp:   nil,
+			err:   fmt.Errorf("Invalid Argument: essid: %v, id: %v, pass: %v", EssidStub, IdStub, ""),
+		},
+		{
+			name:  "Invalid Argument: No ESSID",
+			essid: "",
+			id:    IdStub,
+			pass:  PassStub,
+			exp:   nil,
+			err:   fmt.Errorf("Invalid Argument: essid: %v, id: %v, pass: %v", "", IdStub, PassStub),
+		},
+	}
+)
 
 func run(c *exec.Cmd) (string, string, error) {
 	var o, e bytes.Buffer
@@ -47,13 +108,25 @@ func TestWifiErrors(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Tests
-	for _, test := range testcases {
+	for _, test := range errorTestcases {
 		c := exec.Command(execPath, test.args...)
 		_, e, _ := run(c)
 		if !strings.Contains(e, test.expect) {
 			t.Logf("TEST %v", test.name)
 			execStatement := fmt.Sprintf("exec(wifi %s)", strings.Trim(fmt.Sprint(test.args), "[]"))
 			t.Errorf("%s\ngot:%s\nwant:%s", execStatement, e, test.expect)
+		}
+	}
+}
+
+func TestWifiGenerateConfig(t *testing.T) {
+	for _, test := range generateConfigTestcases {
+		out, err := generateConfig(test.essid, test.id, test.pass)
+		if !reflect.DeepEqual(err, test.err) || !bytes.Equal(out, test.exp) {
+			t.Logf("TEST %v", test.name)
+			fncCall := fmt.Sprintf("genrateConfig(%s, %s,%s)", test.essid, test.id, test.pass)
+			t.Errorf("%s\ngot:[%v, %v]\nwant:[%v, %v]", fncCall, string(out), err, string(test.exp), test.err)
+
 		}
 	}
 }


### PR DESCRIPTION
* As a proof of concept, write an http server that will start when wifi cmd is run, thus allowing user to interact with the cmd over a RESTful interface.

* Since this is a proof of concept at the moment, stub data is used to prove that the concept works. 

* Test cases have been written and manual tests have been carried out to ensure backward compatability with previous version of wifi cmd.