### PR TITLE
cp: fix incorrect handling of error on Stat of dst

### DIFF
--- a/cmds/cp/cp.go
+++ b/cmds/cp/cp.go
@@ -110,7 +110,11 @@ func copyFile(src, dst string, todir bool) error {
 	}
 
 	dstb, err := os.Stat(dst)
-	if !os.IsNotExist(err) {
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("%q: can't handle error %v", dst, err)
+	}
+
+	if dstb != nil {
 		if sameFile(srcb.Sys(), dstb.Sys()) {
 			return fmt.Errorf("%q and %q are the same file", src, dst)
 		}


### PR DESCRIPTION
The code would not correctly handle the case of an errors
that was not ENOENT. Fuse can deliver some very strange
errors and we would end up with a segv.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>