### PR TITLE
Implement the functionality to see a list of nearby WiFi and their authorization protocols in to wifi cmd and its server

### DIFF
--- a/cmds/wifi/iwlistStubOutput.txt
+++ b/cmds/wifi/iwlistStubOutput.txt
@@ -1,0 +1,184 @@
+wlan0    Scan completed :
+          Cell 01 - Address: 00:00:00:00:00:01
+                    Channel:001
+                    Frequency:5.58 GHz (Channel 001)
+                    Quality=1/2  Signal level=-23 dBm  
+                    Encryption key:on
+                    ESSID:"stub-wpa-eap-1"
+                    Bit Rates:36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=000000000000000000
+                    Extra: Last beacon: 1260ms ago
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : 802.1x
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+          Cell 02 - Address: 00:00:00:00:00:02
+                    Channel:002
+                    Frequency:5.58 GHz (Channel 001)
+                    Quality=1/2  Signal level=-23 dBm  
+                    Encryption key:on
+                    ESSID:"stub-wpa-eap-1"
+                    Bit Rates:36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=000000000000000000
+                    Extra: Last beacon: 1260ms ago
+                    IE: Unknown: 0000000000000000000000000
+                    IE: Unknown: 0000000
+                    IE: Unknown: 000000000000000000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : 802.1x
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000000
+                    IE: Unknown: 00000000000000000000
+                    IE: Unknown: 000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 0000000000000000000
+                    IE: Unknown: 00000000000000000000000
+                    IE: Unknown: 000000000000000000
+          Cell 03 - Address: 00:00:00:00:00:03
+                    Channel:003
+                    Frequency:5.785 GHz
+                    Quality=50/70  Signal level=-60 dBm  
+                    Encryption key:off
+                    ESSID:"stub-rsa-1"
+                    Bit Rates:36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=000000000000000000
+                    Extra: Last beacon: 188ms ago
+                    IE: Unknown: 0000000000000000000000000
+                    IE: Unknown: 0000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000000
+                    IE: Unknown: 00000000000000000000
+                    IE: Unknown: 000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 0000000000000000000
+                    IE: Unknown: 00000000000000000000000
+                    IE: Unknown: 000000000000000000
+          Cell 04 - Address: 00:00:00:00:00:04
+                    Channel:004
+                    Frequency:5.785 GHz
+                    Quality=50/70  Signal level=-60 dBm  
+                    Encryption key:on
+                    ESSID:"stub-wpa-psk-1"
+                    Bit Rates:24 Mb/s; 36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=000000000000000000
+                    Extra: Last beacon: 188ms ago
+                    IE: Unknown: 0000000000000000000000000
+                    IE: Unknown: 0000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000000
+                    IE: Unknown: 00000000000000000000
+                    IE: Unknown: 000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 0000000000000000000
+                    IE: Unknown: 00000000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : PSK
+          Cell 05 - Address: 00:00:00:00:00:05
+                    Channel:005
+                    Frequency:2.412 GHz (Channel 1)
+                    Quality=48/70  Signal level=-62 dBm  
+                    Encryption key:off
+                    ESSID:"stub-rsa-2"
+                    Bit Rates:36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=000000000000000000
+                    Extra: Last beacon: 3416ms ago
+                    IE: Unknown: 0000000000000000000000000
+                    IE: Unknown: 0000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000000
+                    IE: Unknown: 00000000000000000000
+                    IE: Unknown: 000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 0000000000000000000
+                    IE: Unknown: 00000000000000000000000
+                    IE: Unknown: 000000000000000000
+          Cell 06 - Address: 00:00:00:00:00:06
+                    Channel:006
+                    Frequency:5.785 GHz
+                    Quality=50/70  Signal level=-60 dBm  
+                    Encryption key:on
+                    ESSID:"stub-wpa-psk-2"
+                    Bit Rates:24 Mb/s; 36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=000000000000000000
+                    Extra: Last beacon: 188ms ago
+                    IE: Unknown: 0000000000000000000000000
+                    IE: Unknown: 0000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000000
+                    IE: Unknown: 00000000000000000000
+                    IE: Unknown: 000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 0000000000000000000
+                    IE: Unknown: 00000000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : PSK
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 0000000000000000000
+                    IE: Unknown: 00000000000000000000000
+                    IE: Unknown: 000000000000000000
+          Cell 07 - Address: 00:00:00:00:00:07
+                    Channel:007
+                    Frequency:5.785 GHz
+                    Quality=50/70  Signal level=-60 dBm  
+                    Encryption key:on
+                    ESSID:"stub-wpa-psk-2"
+                    Bit Rates:24 Mb/s; 36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=000000000000000000
+                    Extra: Last beacon: 188ms ago
+                    IE: Unknown: 0000000000000000000000000
+                    IE: Unknown: 0000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000000
+                    IE: Unknown: 00000000000000000000
+                    IE: Unknown: 000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 0000000000000000000
+                    IE: Unknown: 00000000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : PSK
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 0000000000000000000
+                    IE: Unknown: 0000000000000000000000
+                    IE: Unknown: 00000000000000000000
+                    IE: Unknown: 000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000

--- a/cmds/wifi/wifi.go
+++ b/cmds/wifi/wifi.go
@@ -27,7 +27,7 @@ const (
 	eap = `network={
 		ssid="%s"
 		key_mgmt=WPA-EAP
-		identity="%s"WPA Version
+		identity="%s"
 		password="%s"
 	}`
 )

--- a/cmds/wifi/wifi.go
+++ b/cmds/wifi/wifi.go
@@ -50,7 +50,7 @@ func init() {
 
 /*
  * Assumptions:
- *  1) Cell, essid, and encryption key option are 1:1 match
+ *	1) Cell, essid, and encryption key option are 1:1 match
  *	2) We only support IEEE 802.11i/WPA2 Version 1
  *	3) Each WiFi only support (1) authentication suites (based on observations)
  */
@@ -92,7 +92,7 @@ func parseIwlistOut(o []byte) []WifiOption {
 			continue
 		}
 		// Narrow down the scope when looking for Authorization Suites
-		authSearchArea := wpa2SearchArea[l[0]:len(wpa2SearchArea)]
+		authSearchArea := wpa2SearchArea[l[0]:]
 		authSuites := strings.Trim(strings.Split(string(AuthSuitesRE.Find(authSearchArea)), ":")[1], "\n ")
 		switch authSuites {
 		case "PSK":

--- a/cmds/wifi/wifi.go
+++ b/cmds/wifi/wifi.go
@@ -33,6 +33,11 @@ const (
 )
 
 var (
+	// flags
+	iface = flag.String("i", "wlan0", "interface to use")
+	list  = flag.Bool("l", false, "list all nearby WiFi")
+
+	// RegEx for parsing iwlist output
 	CellRE       = regexp.MustCompile("(?m)^\\s*Cell")
 	EssidRE      = regexp.MustCompile("(?m)^\\s*ESSID.*")
 	EncKeyOptRE  = regexp.MustCompile("(?m)^\\s*Encryption key:(on|off)$")
@@ -129,10 +134,8 @@ func main() {
 
 	// Service
 	var (
-		iface = flag.String("i", "wlan0", "interface to use")
-		list  = flag.Bool("l", false, "list all nearby WiFi")
-		conf  []byte
-		err   error
+		conf []byte
+		err  error
 	)
 
 	flag.Parse()

--- a/cmds/wifi/wifiCommsUtils.go
+++ b/cmds/wifi/wifiCommsUtils.go
@@ -4,12 +4,26 @@
 
 package main
 
+type SecProto int
+
+const (
+	NoEnc SecProto = iota
+	WpaPsk
+	WpaEap
+	NotSupportedProto
+)
+
 type UserInputMessage struct {
 	args []string
 }
 
 type StatusMessage struct {
 	essid string
+}
+
+type WifiOption struct {
+	Essid     string
+	AuthSuite SecProto
 }
 
 var (

--- a/cmds/wifi/wifiCommsUtils.go
+++ b/cmds/wifi/wifiCommsUtils.go
@@ -27,6 +27,7 @@ type WifiOption struct {
 }
 
 var (
-	UserInputChannel = make(chan UserInputMessage)
-	StatusChannel    = make(chan StatusMessage)
+	StatusRequestChannel = make(chan bool)
+	UserInputChannel     = make(chan UserInputMessage)
+	StatusChannel        = make(chan StatusMessage)
 )

--- a/cmds/wifi/wifiServer.go
+++ b/cmds/wifi/wifiServer.go
@@ -12,14 +12,6 @@ import (
 	"net/http"
 )
 
-type SecProto int
-
-const (
-	NoEnc SecProto = iota
-	WpaPsk
-	WpaEap
-)
-
 const (
 	PortNum  = "8080"
 	HtmlPage = `
@@ -138,7 +130,7 @@ func userInputValidation(essid, pass, id string) ([]string, error) {
 
 func startServer() {
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		stubWifis := []WifiOptions{
+		stubWifis := []WifiOption{
 			{"stub1", NoEnc},
 			{"stub2", WpaPsk},
 			{"stub3", WpaEap},
@@ -167,14 +159,9 @@ func startServer() {
 	http.ListenAndServe(fmt.Sprintf(":%s", PortNum), nil)
 }
 
-type WifiOptions struct {
-	Essid     string
-	AuthSuite SecProto
-}
-
-func displayWifi(wr io.Writer, wifiOpts []WifiOptions, connectedEssid string) error {
+func displayWifi(wr io.Writer, wifiOpts []WifiOption, connectedEssid string) error {
 	wifiData := struct {
-		WifiOpts       []WifiOptions
+		WifiOpts       []WifiOption
 		ConnectedEssid string
 	}{wifiOpts, connectedEssid}
 

--- a/cmds/wifi/wifiServer_test.go
+++ b/cmds/wifi/wifiServer_test.go
@@ -64,7 +64,7 @@ var (
 	}
 )
 
-func TestWifiServerUserInputValidation(t *testing.T) {
+func TestUserInputValidation(t *testing.T) {
 	for _, test := range userInputValidationTestcases {
 		out, err := userInputValidation(test.essid, test.pass, test.id)
 		if !reflect.DeepEqual(err, test.err) || !reflect.DeepEqual(out, test.exp) {

--- a/cmds/wifi/wifiServer_test.go
+++ b/cmds/wifi/wifiServer_test.go
@@ -1,0 +1,76 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+type UserInputValidationTestcase struct {
+	name  string
+	essid string
+	pass  string
+	id    string
+	exp   []string
+	err   error
+}
+
+var (
+	userInputValidationTestcases = []UserInputValidationTestcase{
+		{
+			name:  "Essid, passphrase, Id",
+			essid: EssidStub,
+			pass:  PassStub,
+			id:    IdStub,
+			exp:   []string{EssidStub, PassStub, IdStub},
+			err:   nil,
+		},
+		{
+			name:  "Essid, passphrase",
+			essid: EssidStub,
+			pass:  PassStub,
+			id:    "",
+			exp:   []string{EssidStub, PassStub},
+			err:   nil,
+		},
+		{
+			name:  "Essid",
+			essid: EssidStub,
+			pass:  "",
+			id:    "",
+			exp:   []string{EssidStub},
+			err:   nil,
+		},
+		{
+			name:  "No Essid",
+			essid: "",
+			pass:  PassStub,
+			id:    IdStub,
+			exp:   nil,
+			err:   fmt.Errorf("Invalid user input"),
+		},
+		{
+			name:  "Essid, Id",
+			essid: EssidStub,
+			pass:  "",
+			id:    IdStub,
+			exp:   nil,
+			err:   fmt.Errorf("Invalid user input"),
+		},
+	}
+)
+
+func TestWifiServerUserInputValidation(t *testing.T) {
+	for _, test := range userInputValidationTestcases {
+		out, err := userInputValidation(test.essid, test.pass, test.id)
+		if !reflect.DeepEqual(err, test.err) || !reflect.DeepEqual(out, test.exp) {
+			t.Logf("TEST %v", test.name)
+			fncCall := fmt.Sprintf("userInputValidation(%v, %v, %v)", test.essid, test.pass, test.id)
+			t.Errorf("%s\ngot:[%v, %v]\nwant:[%v, %v]", fncCall, out, err, test.exp, test.err)
+		}
+	}
+}

--- a/cmds/wifi/wifi_test.go
+++ b/cmds/wifi/wifi_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"reflect"
@@ -109,14 +110,174 @@ func TestWifiErrors(t *testing.T) {
 	}
 }
 
-func TestWifiGenerateConfig(t *testing.T) {
+func TestGenerateConfig(t *testing.T) {
 	for _, test := range generateConfigTestcases {
 		out, err := generateConfig(test.args...)
 		if !reflect.DeepEqual(err, test.err) || !bytes.Equal(out, test.exp) {
 			t.Logf("TEST %v", test.name)
 			fncCall := fmt.Sprintf("genrateConfig(%v)", test.args)
 			t.Errorf("%s\ngot:[%v, %v]\nwant:[%v, %v]", fncCall, string(out), err, string(test.exp), test.err)
-
 		}
+	}
+}
+
+func TestCellRE(t *testing.T) {
+	testcases := []struct {
+		s   string
+		exp bool
+	}{
+		{"blahblahblah\n   Cell 01:", true},
+		{"\"Cell\"", false},
+		{"\"blah blah Cell blah blah\"", false},
+	}
+	for _, test := range testcases {
+		if out := CellRE.MatchString(test.s); out != test.exp {
+			t.Errorf("%s\ngot:%v\nwant:%v", test.s, out, test.exp)
+		}
+	}
+}
+
+func TestEssidRE(t *testing.T) {
+	testcases := []struct {
+		s   string
+		exp bool
+	}{
+		{"blahblahblah\n    ESSID:\"stub\"\n", true},
+		{"blahblahblah\n    ESSID:\"stub-stub\"\n", true},
+		{"blah blah ESSID blah", false},
+	}
+	for _, test := range testcases {
+		if out := EssidRE.MatchString(test.s); out != test.exp {
+			t.Errorf("%s\ngot:%v\nwant:%v", test.s, out, test.exp)
+		}
+	}
+}
+
+func TestEncKeyOptRE(t *testing.T) {
+	testcases := []struct {
+		s   string
+		exp bool
+	}{
+		{"blahblahblah\n      Encryption key:on\n", true},
+		{"blahblahblah\n      Encryption key:off\n", true},
+		{"blah blah Encryption key blah blah", false},
+		{"blah blah Encryption key:on  blah blah", false},
+		{"blah blah Encryption key:off blah blah", false},
+	}
+	for _, test := range testcases {
+		if out := EncKeyOptRE.MatchString(test.s); out != test.exp {
+			t.Errorf("%s\ngot:%v\nwant:%v", test.s, out, test.exp)
+		}
+	}
+}
+
+func TestWpa2RE(t *testing.T) {
+	testcases := []struct {
+		s   string
+		exp bool
+	}{
+		{"blahblahblah\n            IE: IEEE 802.11i/WPA2 Version 1\n", true},
+		{"blah blah IE: IEEE 802.11i/WPA2 Version 1", false},
+	}
+	for _, test := range testcases {
+		if out := Wpa2RE.MatchString(test.s); out != test.exp {
+			t.Errorf("%s\ngot:%v\nwant:%v", test.s, out, test.exp)
+		}
+	}
+}
+
+func TestAuthSuitesRE(t *testing.T) {
+	testcases := []struct {
+		s   string
+		exp bool
+	}{
+		{"blahblahblah\n            Authentication Suites (1) : 802.1x\n", true},
+		{"blahblahblah\n            Authentication Suites (1) : PSK\n", true},
+		{"blahblahblah\n            Authentication Suites (2) : blah, blah\n", true},
+		{"blahblahblah\n            Authentication Suites (1) : other protocol\n", true},
+		{"blah blah Authentication Suites : blah blah", false},
+	}
+	for _, test := range testcases {
+		if out := AuthSuitesRE.MatchString(test.s); out != test.exp {
+			t.Errorf("%s\ngot:%v\nwant:%v", test.s, out, test.exp)
+		}
+	}
+}
+
+func TestParseIwlistOutput(t *testing.T) {
+	var (
+		o        []byte
+		exp, out []WifiOption
+		err      error
+	)
+
+	// No WiFi present
+	o = nil
+	exp = nil
+	out = parseIwlistOut(o)
+	if !reflect.DeepEqual(out, exp) {
+		t.Errorf("\ngot:[%v]\nwant:[%v]", out, exp)
+	}
+
+	// Only 1 WiFi present
+	o = []byte(`
+wlan0    Scan completed :
+          Cell 01 - Address: 00:00:00:00:00:01
+                    Channel:001
+                    Frequency:5.58 GHz (Channel 001)
+                    Quality=1/2  Signal level=-23 dBm  
+                    Encryption key:on
+                    ESSID:"stub-wpa-eap-1"
+                    Bit Rates:36 Mb/s; 48 Mb/s; 54 Mb/s
+                    Mode:Master
+                    Extra:tsf=000000000000000000
+                    Extra: Last beacon: 1260ms ago
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : 802.1x
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+                    IE: Unknown: 000000000000000000
+`)
+	exp = []WifiOption{
+		{"stub-wpa-eap-1", WpaEap},
+	}
+	out = parseIwlistOut(o)
+	if !reflect.DeepEqual(out, exp) {
+		t.Errorf("\ngot:[%v]\nwant:[%v]", out, exp)
+	}
+
+	// Regular scenarios (many choices)
+	exp = []WifiOption{
+		{"stub-wpa-eap-1", WpaEap},
+		{"stub-rsa-1", NoEnc},
+		{"stub-wpa-psk-1", WpaPsk},
+		{"stub-rsa-2", NoEnc},
+		{"stub-wpa-psk-2", WpaPsk},
+	}
+	o, err = ioutil.ReadFile("iwlistStubOutput.txt")
+	if err != nil {
+		t.Errorf("error reading iwlistStubOutput.txt: %v", err)
+	}
+	out = parseIwlistOut(o)
+	if !reflect.DeepEqual(out, exp) {
+		t.Errorf("\ngot:[%v]\nwant:[%v]", out, exp)
+	}
+}
+
+func BenchmarkParseIwlistOutput(b *testing.B) {
+	// Set Up
+	o, err := ioutil.ReadFile("iwlistStubOutput.txt")
+	if err != nil {
+		b.Errorf("error reading iwlistStubOutput.txt: %v", err)
+	}
+	for i := 0; i < b.N; i++ {
+		parseIwlistOut(o)
 	}
 }

--- a/cmds/wifi/wifi_test.go
+++ b/cmds/wifi/wifi_test.go
@@ -280,73 +280,6 @@ wlan0    Scan completed :
 	}
 }
 
-func TestParseIwlistOutput2(t *testing.T) {
-	var (
-		o        []byte
-		exp, out []WifiOption
-		err      error
-	)
-
-	// No WiFi present
-	o = nil
-	exp = nil
-	out = parseIwlistOut2(o)
-	if !reflect.DeepEqual(out, exp) {
-		t.Errorf("\ngot:[%v]\nwant:[%v]", out, exp)
-	}
-
-	// Only 1 WiFi present
-	o = []byte(`
-wlan0    Scan completed :
-          Cell 01 - Address: 00:00:00:00:00:01
-                    Channel:001
-                    Frequency:5.58 GHz (Channel 001)
-                    Quality=1/2  Signal level=-23 dBm  
-                    Encryption key:on
-                    ESSID:"stub-wpa-eap-1"
-                    Bit Rates:36 Mb/s; 48 Mb/s; 54 Mb/s
-                    Mode:Master
-                    Extra:tsf=000000000000000000
-                    Extra: Last beacon: 1260ms ago
-                    IE: Unknown: 000000000000000000
-                    IE: Unknown: 000000000000000000
-                    IE: Unknown: 000000000000000000
-                    IE: IEEE 802.11i/WPA2 Version 1
-                        Group Cipher : CCMP
-                        Pairwise Ciphers (1) : CCMP
-                        Authentication Suites (1) : 802.1x
-                    IE: Unknown: 000000000000000000
-                    IE: Unknown: 000000000000000000
-                    IE: Unknown: 000000000000000000
-                    IE: Unknown: 000000000000000000
-                    IE: Unknown: 000000000000000000
-`)
-	exp = []WifiOption{
-		{"stub-wpa-eap-1", WpaEap},
-	}
-	out = parseIwlistOut2(o)
-	if !reflect.DeepEqual(out, exp) {
-		t.Errorf("\ngot:[%v]\nwant:[%v]", out, exp)
-	}
-
-	// Regular scenarios (many choices)
-	exp = []WifiOption{
-		{"stub-wpa-eap-1", WpaEap},
-		{"stub-rsa-1", NoEnc},
-		{"stub-wpa-psk-1", WpaPsk},
-		{"stub-rsa-2", NoEnc},
-		{"stub-wpa-psk-2", WpaPsk},
-	}
-	o, err = ioutil.ReadFile("iwlistStubOutput.txt")
-	if err != nil {
-		t.Errorf("error reading iwlistStubOutput.txt: %v", err)
-	}
-	out = parseIwlistOut2(o)
-	if !reflect.DeepEqual(out, exp) {
-		t.Errorf("\ngot:[%v]\nwant:[%v]", out, exp)
-	}
-}
-
 func BenchmarkParseIwlistOutput(b *testing.B) {
 	// Set Up
 	o, err := ioutil.ReadFile("iwlistStubOutput.txt")
@@ -355,16 +288,5 @@ func BenchmarkParseIwlistOutput(b *testing.B) {
 	}
 	for i := 0; i < b.N; i++ {
 		parseIwlistOut(o)
-	}
-}
-
-func BenchmarkParseIwlistOutput2(b *testing.B) {
-	// Set Up
-	o, err := ioutil.ReadFile("iwlistStubOutput.txt")
-	if err != nil {
-		b.Errorf("error reading iwlistStubOutput.txt: %v", err)
-	}
-	for i := 0; i < b.N; i++ {
-		parseIwlistOut2(o)
 	}
 }


### PR DESCRIPTION
Majority of this PR are test cases in `wifi_test.go` and a big `.txt` file to emulate the output of iwlist.

The **main new logic** of this PR is in the `parseIwlistOut(o []byte)` function in `wifi.go`