### PR TITLE
(Experimental) Support Wifi Scanning from 1 browser tab

### DIFF
--- a/cmds/wifi/wifiCommsUtils.go
+++ b/cmds/wifi/wifiCommsUtils.go
@@ -13,21 +13,22 @@ const (
 	NotSupportedProto
 )
 
-type UserInputMessage struct {
-	args []string
-}
-
-type StatusMessage struct {
-	essid string
-}
-
 type WifiOption struct {
 	Essid     string
 	AuthSuite SecProto
 }
 
+type UserInputMessage struct {
+	args []string
+}
+
+type State struct {
+	nearbyWifis []WifiOption
+	curEssid    string
+}
+
 var (
 	StatusRequestChannel = make(chan bool)
 	UserInputChannel     = make(chan UserInputMessage)
-	StatusChannel        = make(chan StatusMessage)
+	StateChannel         = make(chan State)
 )

--- a/cmds/wifi/wifiServer.go
+++ b/cmds/wifi/wifiServer.go
@@ -42,24 +42,23 @@ function replaceWithConnecting(elem) {
     connectingTxt = document.createTextNode("Connecting...")
     elem.style.display = "none"
     elem.parentNode.appendChild(connectingTxt);
-	disableOtherButton(elem)
+	disableOtherButtons(elem)
 }
 
 function sendRefresh(elem) {
 	elem.setAttribute("disabled", "true")
 	elem.setAttribute("value","Refreshing")
-	disableOtherButton(elem)
+	disableOtherButtons(elem)
 	fetch("http://localhost:8080/refresh").then(_ => window.location.reload())
 }
 
-function disableOtherButton(elem) {
+function disableOtherButtons(elem) {
     btns = document.getElementsByClassName("btn");
-	var i;
-    for (i = 0; i < btns.length; i++) {
-    	if (btns[i] === elem) {
+    for (let btn of btns) {
+    	if (btn === elem) {
     		continue;
     	}
-    	btns[i].setAttribute("disabled", "true")
+    	btn.setAttribute("disabled", "true")
     }	
 }
 


### PR DESCRIPTION
2+ browser tabs will encounter the following problems:
- If they all press Refresh at the same time, then only 1 of them can go through, the other ones are going to fail due to that one going through hogging the up the WiFi scanning resources.
- If a tap updates its state after the refresh, nothing about this update is reflected on the other tabs. That is, there will be some inconsistencies between the tabs.

However, for a one-user system, there aren't any use cases where a user needs more than 1 tab to connect to the WiFi. If he/she is not most up to date to the state of the server, they can just hit Refresh.