### PR TITLE
ps: fix bug when /proc is not mounted

### DIFF
--- a/cmds/ps/ps_linux.go
+++ b/cmds/ps/ps_linux.go
@@ -223,6 +223,9 @@ func (pT *ProcessTable) LoadTable() error {
 	if err != nil {
 		return err
 	}
+	if len(list) == 0 {
+		return fmt.Errorf("No processes in /proc.")
+	}
 
 	for _, dir := range list {
 		// Filter out files and directories which are not numbers.


### PR DESCRIPTION
I debated just having it print nothing but that's kinda
counterintuitive.

Testing this would add another test that requires we run as root.
Maybe we should anyway.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>