### PR TITLE
cmds/ip: add ip link set (hardware) address

### DIFF
--- a/cmds/ip/ip.go
+++ b/cmds/ip/ip.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 	l "log"
 	"math"
+	"net"
 	"os"
 	"strings"
 
@@ -200,11 +201,25 @@ func linkshow() {
 	}
 }
 
+func setHardwareAddress(iface netlink.Link) {
+	cursor++
+	hwAddr, err := net.ParseMAC(arg[cursor])
+	if err != nil {
+		log.Fatalf("%v cant parse mac addr %v: %v", iface, hwAddr, err)
+	}
+	err = netlink.LinkSetHardwareAddr(iface, hwAddr)
+	if err != nil {
+		log.Fatalf("%v cant set mac addr %v: %v", iface, hwAddr, err)
+	}
+}
+
 func linkset() {
 	iface := dev()
 	cursor++
-	whatIWant = []string{"up", "down"}
+	whatIWant = []string{"address", "up", "down"}
 	switch one(arg[cursor], whatIWant) {
+	case "address":
+		setHardwareAddress(iface)
 	case "up":
 		if err := netlink.LinkSetUp(iface); err != nil {
 			log.Fatalf("%v can't make it up: %v", iface, err)


### PR DESCRIPTION
Provide the ability for u-root to modify the hardware (mac) address.

Follows the same structure as other 'ip link set' commands.

usage:
~/> ip link set eth1 address 00:00:00:02:01:01

results:
~/> ip link show
3: eth1: <UP,BROADCAST,MULTICAST> mtu 1500 state UP
    link/ether 00:00:00:00:00:01

error reporting:
~/> ip link set eth1 address 00:00:00:02:01:0h
ip: &{{3 1500 1000 eth1 00:00:00:02:01:01 up|broadcast|multicast
69699 0 0 <nil>  0xc42017c0e4 0 0xc420016680 ether <nil> up 0 0 0}}
cant parse mac addr : address 00:00:00:02:01:0h: invalid MAC address