### PR TITLE
De-couple bb mode from init and rush. Add standalone makebb tool.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@
 *.so
 *~
 
-bbsh
-u-root
+/bbsh
+/bb
+/u-root
 !vendor/github.com/u-root
 
 # Folders

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -198,6 +198,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e1a178092006f93c9de124c458d2eac8ad385d356d4328f475a9c1d49b661206"
+  inputs-digest = "64e3c851fe52e70b5458df7e0bff6ddda21bf06abe5af8fee42cd73dd386b425"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -157,7 +157,16 @@ func main() {
 	// run inito and then run our shell
 	// inito is always first and we set default flags for it.
 	cloneFlags := uintptr(syscall.CLONE_NEWPID)
-	cmdList := []string{"/inito", "/buildbin/uinit", "/buildbin/rush"}
+	cmdList := []string{
+		"/inito",
+		"/bbin/uinit",
+		"/buildbin/uinit",
+		"/bbin/sh",
+		"/bbin/rush",
+		"/buildbin/sh",
+		"/buildbin/rush",
+	}
+
 	noCmdFound := true
 	for _, v := range cmdList {
 		if _, err := os.Stat(v); !os.IsNotExist(err) {

--- a/pkg/bb/cmd/main.go
+++ b/pkg/bb/cmd/main.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/u-root/u-root/pkg/bb"
+)
+
+func run() {
+	name := filepath.Base(os.Args[0])
+	if err := bb.Run(name); err != nil {
+		log.Fatalf("%q: %v", name, err)
+	}
+}
+
+func main() {
+	run()
+}
+
+func init() {
+	bb.Register("bb", bb.Noop, func() {
+		if len(os.Args) <= 1 {
+			log.Fatalf("You need to specify which command to invoke.")
+		}
+		os.Args = os.Args[1:]
+		run()
+	})
+}

--- a/pkg/bb/register.go
+++ b/pkg/bb/register.go
@@ -1,0 +1,44 @@
+package bb
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ErrNotRegistered is returned by Run if the given command is not registered.
+var ErrNotRegistered = errors.New("command not registered")
+
+// Noop is a noop function.
+var Noop = func() {}
+
+type bbCmd struct {
+	init, main func()
+}
+
+var bbcmds = map[string]bbCmd{}
+
+// Register registers an init and main function for name.
+func Register(name string, init, main func()) {
+	if _, ok := bbcmds[name]; ok {
+		panic(fmt.Sprintf("cannot register two commands with name %q", name))
+	}
+	bbcmds[name] = bbCmd{
+		init: init,
+		main: main,
+	}
+}
+
+// Run runs the command with the given name.
+//
+// If the command's main exits without calling os.Exit, Run will exit with exit
+// code 0.
+func Run(name string) error {
+	if _, ok := bbcmds[name]; !ok {
+		return ErrNotRegistered
+	}
+	bbcmds[name].init()
+	bbcmds[name].main()
+	os.Exit(0)
+	return nil
+}

--- a/pkg/uroot/bb.go
+++ b/pkg/uroot/bb.go
@@ -123,13 +123,13 @@ func BBBuild(opts BuildOpts) (ArchiveFiles, error) {
 		}
 
 		// Add a symlink /bbin/{cmd} -> /bbin/bb to our initramfs.
-		if err := af.AddRecord(cpio.Symlink(filepath.Join("bbin", path.Base(pkg)), "/bbin/bb")); err != nil {
+		if err := af.AddRecord(cpio.Symlink(filepath.Join("bbin", path.Base(pkg)), "bb")); err != nil {
 			return ArchiveFiles{}, err
 		}
 	}
 
 	// Symlink from /init to busybox init.
-	if err := af.AddRecord(cpio.Symlink("init", "/bbin/init")); err != nil {
+	if err := af.AddRecord(cpio.Symlink("init", "bbin/init")); err != nil {
 		return ArchiveFiles{}, err
 	}
 	return af, nil

--- a/pkg/uroot/bb.go
+++ b/pkg/uroot/bb.go
@@ -413,7 +413,7 @@ func (b *bbBuilder) moveCommand(pkgPath string) error {
 						// name=
 						&ast.BasicLit{
 							Kind:  token.STRING,
-							Value: fmt.Sprintf("%#v", p.name),
+							Value: strconv.Quote(p.name),
 						},
 						// init=
 						ast.NewIdent("Init"),

--- a/pkg/uroot/bb_test.go
+++ b/pkg/uroot/bb_test.go
@@ -20,9 +20,12 @@ func TestBBBuild(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	opts := BuildOpts{
-		Env:      golang.Default(),
-		Packages: []string{"github.com/u-root/u-root/pkg/uroot/test/foo"},
-		TempDir:  dir,
+		Env: golang.Default(),
+		Packages: []string{
+			"github.com/u-root/u-root/pkg/uroot/test/foo",
+			"github.com/u-root/u-root/cmds/rush",
+		},
+		TempDir: dir,
 	}
 	af, err := BBBuild(opts)
 	if err != nil {
@@ -58,12 +61,7 @@ func TestPackageRewriteFile(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	opts := BuildOpts{
-		Env:     golang.Default(),
-		TempDir: dir,
-	}
-
-	p, err := getPackage(opts, "github.com/u-root/u-root/pkg/uroot/test/foo", importer.For("source", nil))
+	p, err := getPackage(golang.Default(), "github.com/u-root/u-root/pkg/uroot/test/foo", importer.For("source", nil))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,7 +125,7 @@ func TestPackageRewriteFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := opts.Env.BuildDir(d, filepath.Join(d, "foo"), golang.BuildOpts{}); err != nil {
+	if err := golang.Default().BuildDir(d, filepath.Join(d, "foo"), golang.BuildOpts{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/tools/makebb/.gitignore
+++ b/tools/makebb/.gitignore
@@ -1,0 +1,2 @@
+makebb
+bb

--- a/tools/makebb/makebb.go
+++ b/tools/makebb/makebb.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"path/filepath"
+
+	"github.com/u-root/u-root/pkg/golang"
+	"github.com/u-root/u-root/pkg/uroot"
+)
+
+var outputPath = flag.String("o", "bb", "Path to busybox binary")
+
+func main() {
+	flag.Parse()
+
+	env := golang.Default()
+	if env.CgoEnabled {
+		log.Printf("Disabling CGO for u-root...")
+		env.CgoEnabled = false
+	}
+	log.Printf("Build environment: %s", env)
+
+	pkgs := flag.Args()
+	var err error
+	if len(pkgs) == 0 {
+		pkgs, err = uroot.DefaultPackageImports(env)
+	} else {
+		pkgs, err = uroot.ResolvePackagePaths(env, pkgs)
+	}
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	o, err := filepath.Abs(*outputPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := uroot.BuildBusybox(env, pkgs, o); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
So far, you are forced to use rush and forced to use init as compiled into bb by default.

This will allow users to include a custom init and a custom default shell in bb mode. You can also choose not to include an init and not to include a shell in bb: init and rush are just two other normal bb programs.

This will also allow users to eventually write commands directly targeted at bb, by using a bb command that Registers them manually:

```go
bb.Register("my-own-command", func() {
    log.Printf("init stuff")
}, func() {
    log.Printf("main stuff")
})
```

rush and init both are just another command compiled into bb mode. No reason to be special.