### PR TITLE
Fixing ssh pty error

### DIFF
--- a/cmds/sshd/sshd.go
+++ b/cmds/sshd/sshd.go
@@ -83,6 +83,9 @@ func newPTY(b []byte) (*pty.Pty, error) {
 		return nil, err
 	}
 	p, err := pty.New()
+	if err != nil {
+		return nil, err
+	}
 	ws, err := p.TTY.GetWinSize()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
sshd didn't use to check err when calling pty.New()
Added in an error and return in that case.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>