### PR TITLE
getPackage now returns an error if ParseDir fails

### DIFF
--- a/pkg/uroot/bb.go
+++ b/pkg/uroot/bb.go
@@ -316,7 +316,7 @@ func getPackage(env golang.Environ, importPath string, importer types.Importer) 
 	}, parser.ParseComments)
 	if err != nil {
 		log.Printf("can't parsedir %q: %v", p.Dir, err)
-		return nil, nil
+		return nil, err
 	}
 
 	pp := &Package{


### PR DESCRIPTION
`getPackage` was not returning an error if `ParseDir` fails. Now it does