### PR TITLE
Stop relying on go build in tests.

### DIFF
--- a/cmds/chmod/chmod.go
+++ b/cmds/chmod/chmod.go
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Change modifier bits of a file.
+// Chmod changes modifier bits of a file.
 //
 // Synopsis:
-//     chmod MODE FILE...
+//     chmod [-R] [--reference=file] [MODE] FILE...
 //
-// Desription:
+// Description:
 //     MODE is a three character octal value.
 package main
 
@@ -18,25 +18,32 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
-var (
+type flags struct {
 	recursive bool
 	reference string
-)
+}
+
+var f = flags{}
 
 func init() {
-	flag.BoolVar(&recursive,
+	f.registerFlags(flag.CommandLine)
+}
+
+func (f flags) registerFlags(flag *flag.FlagSet) {
+	flag.BoolVar(&f.recursive,
 		"R",
 		false,
 		"do changes recursively")
 
-	flag.BoolVar(&recursive,
+	flag.BoolVar(&f.recursive,
 		"recursive",
 		false,
 		"do changes recursively")
 
-	flag.StringVar(&reference,
+	flag.StringVar(&f.reference,
 		"reference",
 		"",
 		"use mode from reference file")
@@ -44,61 +51,89 @@ func init() {
 
 func main() {
 	flag.Parse()
-	if len(flag.Args()) < 1 {
+	if flag.NArg() < 1 {
 		fmt.Fprintf(os.Stderr, "Usage of %s: [mode] filepath\n", os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	if len(flag.Args()) < 2 && reference == "" {
+	if flag.NArg() < 2 && len(f.reference) == 0 {
 		fmt.Fprintf(os.Stderr, "Usage of %s: [mode] filepath\n", os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	var mode os.FileMode
-	var fileList []string
+	if err := chmodMain(f, flag.Args()); err != nil {
+		log.Fatal(err)
+	}
+}
 
-	if reference != "" {
-		fi, err := os.Stat(reference)
+func chmodMain(f flags, args []string) error {
+	if len(f.reference) > 0 {
+		fi, err := os.Stat(f.reference)
 		if err != nil {
-			log.Fatalf("bad reference file: %v", err)
-
+			return fmt.Errorf("bad reference file %q: %v", f.reference, err)
 		}
-		mode = fi.Mode()
-		fileList = flag.Args()
-	} else {
-		modeString := flag.Args()[0]
-		octval, err := strconv.ParseUint(modeString, 8, 32)
-		if err != nil {
-			log.Fatalf("Unable to decode mode %q. Please use an octal value: %v", modeString, err)
-		} else if octval > 0777 {
-			log.Fatalf("Invalid octal value %0o. Value should be less than or equal to 0777.", octval)
-		}
-		mode = os.FileMode(octval)
-		fileList = flag.Args()[1:]
+		return doChmod(f.recursive, fi.Mode(), args)
 	}
 
-	var exitError bool
+	modeString := args[0]
+	octval, err := strconv.ParseUint(modeString, 8, 32)
+	if err != nil {
+		return fmt.Errorf("unable to decode mode %q: must use an octal value: %v", modeString, err)
+	} else if octval > 0777 {
+		return fmt.Errorf("invalid octal value %0o: value should be less than or equal to 0777", octval)
+	}
+	return doChmod(f.recursive, os.FileMode(octval), args[1:])
+}
+
+type errors []error
+
+func (e *errors) Add(f error) {
+	if f != nil {
+		*e = append(*e, f)
+	}
+}
+
+func (e errors) AnyError() error {
+	if e == nil {
+		return nil
+	}
+	// Only return e if any of the errors are non-nil.
+	for _, f := range e {
+		if f != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+func (e errors) Error() string {
+	s := make([]string, 0, len(e))
+	for _, f := range e {
+		if f != nil {
+			s = append(s, f.Error())
+		}
+	}
+
+	// Only one error? Just return that one.
+	if len(s) == 1 {
+		return s[0]
+	}
+	return fmt.Sprintf("multiple errors: %s", strings.Join(s, "; "))
+}
+
+func doChmod(recursive bool, mode os.FileMode, fileList []string) error {
+	var e errors
 	for _, name := range fileList {
 		if recursive {
-			err := filepath.Walk(name, func(path string,
-				info os.FileInfo,
-				err error) error {
+			e.Add(filepath.Walk(name, func(path string, info os.FileInfo, _ error) error {
 				return os.Chmod(path, mode)
-			})
-			if err != nil {
-				log.Printf("%v", err)
-				exitError = true
-			}
+			}))
 		} else {
-			if err := os.Chmod(name, mode); err != nil {
-				log.Printf("%v", err)
-				exitError = true
-			}
+			e.Add(os.Chmod(name, mode))
 		}
 	}
-	if exitError {
-		os.Exit(1)
-	}
+
+	return e.AnyError()
 }

--- a/cmds/chmod/chmod_test.go
+++ b/cmds/chmod/chmod_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,50 +13,153 @@ import (
 	"testing"
 )
 
-var (
-	testPath = "."
-)
-
-func run(c *exec.Cmd) (string, string, error) {
-	var o, e bytes.Buffer
-	c.Stdout, c.Stderr = &o, &e
-	err := c.Run()
-	return o.String(), e.String(), err
+func runChmodBinary(f flags, args []string) error {
+	var a []string
+	if f.recursive {
+		a = append(a, "-R")
+	}
+	if len(f.reference) > 0 {
+		a = append(a, "--reference", f.reference)
+	}
+	a = append(a, args...)
+	c := exec.Command(os.Getenv("EXECPATH"), a...)
+	c.Stdout, c.Stderr = os.Stdout, os.Stderr
+	return c.Run()
 }
 
-func TestChmodSimple(t *testing.T) {
-	// Temporary directories.
-	tempDir, err := ioutil.TempDir("", "TestChmodSimple")
+func TestChmod(t *testing.T) {
+	chmod := chmodMain
+	// If EXECPATH is set, test this implementation against the binary
+	// given by EXECPATH.
+	if len(os.Getenv("EXECPATH")) != 0 {
+		chmod = runChmodBinary
+	}
+
+	tempDir, err := ioutil.TempDir("", "chmod")
 	if err != nil {
-		t.Fatalf("cannot create temporary directory: %v", err)
+		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	f, err := ioutil.TempFile(tempDir, "BLAH1")
+	// Set up single file for simple test.
+	f, err := ioutil.TempFile(tempDir, "chmod-tmp-test")
 	if err != nil {
-		t.Fatalf("cannot create temporary file: %v", err)
+		t.Fatal(err)
 	}
 	defer f.Close()
 
-	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
+	// Set up single file for simple test.
+	f2, err := ioutil.TempFile(tempDir, "chmod-tmp-test")
 	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
+		t.Fatal(err)
+	}
+	defer f2.Close()
+
+	file0544, err := ioutil.TempFile(tempDir, "file0544")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file0544.Close()
+	if err := os.Chmod(file0544.Name(), 0544); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, perm := range []os.FileMode{0777, 0644} {
-		// Set permissions using chmod.
-		c := exec.Command(testpath, fmt.Sprintf("%0o", perm), f.Name())
-		c.Run()
+	// Set up complicated directory structure for recursive test.
+	recDir, err := ioutil.TempDir(tempDir, "recursive")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		// Check that it worked.
-		info, err := os.Stat(f.Name())
-		if err != nil {
-			t.Fatalf("stat(%q) failed: %v", f.Name(), err)
+	recursives := []string{recDir}
+	for _, dir := range []string{
+		"L1_A",
+		"L1_B",
+		"L1_C",
+		filepath.Join("L1_A", "L2_A"),
+		filepath.Join("L1_A", "L2_B"),
+		filepath.Join("L1_A", "L2_C"),
+		filepath.Join("L1_B", "L2_A"),
+		filepath.Join("L1_B", "L2_B"),
+		filepath.Join("L1_B", "L2_C"),
+		filepath.Join("L1_C", "L2_A"),
+		filepath.Join("L1_C", "L2_B"),
+		filepath.Join("L1_C", "L2_C"),
+	} {
+		dir = filepath.Join(recDir, dir)
+		if err := os.MkdirAll(dir, os.FileMode(0700)); err != nil {
+			t.Fatalf("cannot create test directory: %v", err)
 		}
-		if got := info.Mode().Perm(); got != perm {
-			t.Errorf("Wrong file permissions on %q: got %0o, want %0o", f.Name(), got, perm)
+		recursives = append(recursives, dir)
+	}
+
+	for _, tt := range []struct {
+		flags flags
+		args  []string
+		want  error
+
+		// fileList is the list of files that wantMode should be set on
+		// after calling chmod.
+		fileList []string
+		wantMode os.FileMode
+	}{
+		{
+			args:     []string{"0777", f.Name()},
+			want:     nil,
+			fileList: []string{f.Name()},
+			wantMode: 0777,
+		},
+		{
+			args:     []string{"0644", f.Name()},
+			want:     nil,
+			fileList: []string{f.Name()},
+			wantMode: 0644,
+		},
+		{
+			args: []string{"0707", recDir},
+			want: nil,
+			flags: flags{
+				recursive: true,
+			},
+			fileList: recursives,
+			wantMode: 0707,
+		},
+		{
+			args: []string{"0770", recDir},
+			want: nil,
+			flags: flags{
+				recursive: true,
+			},
+			fileList: recursives,
+			wantMode: 0770,
+		},
+		{
+			args: []string{f2.Name()},
+			want: nil,
+			flags: flags{
+				reference: file0544.Name(),
+			},
+			fileList: []string{f2.Name()},
+			wantMode: 0544,
+		},
+		{
+			args: []string{"01777", f.Name()},
+			want: fmt.Errorf("invalid octal value 1777: value should be less than or equal to 0777"),
+		},
+		{
+			args: []string{"0abas", f.Name()},
+			want: fmt.Errorf("unable to decode mode \"0abas\": must use an octal value: strconv.ParseUint: parsing \"0abas\": invalid syntax"),
+		},
+		{
+			args: []string{"0777", "blah1234"},
+			want: fmt.Errorf("chmod blah1234: no such file or directory"),
+		},
+	} {
+		if err := chmod(tt.flags, tt.args); err != tt.want && (err == nil || tt.want == nil || err.Error() != tt.want.Error()) {
+			t.Errorf("chmod(%#v, %v) = %v, want %v", tt.flags, tt.args, err, tt.want)
+		}
+
+		for _, file := range tt.fileList {
+			checkPath(t, file, tt.wantMode)
 		}
 	}
 }
@@ -70,182 +172,5 @@ func checkPath(t *testing.T, path string, want os.FileMode) {
 	if got := info.Mode().Perm(); got != want {
 		t.Fatalf("Wrong file permissions on file %q: got %0o, want %0o",
 			path, got, want)
-	}
-}
-func TestChmodRecursive(t *testing.T) {
-	// Temporary directories.
-	tempDir, err := ioutil.TempDir("", "TestChmodRecursive")
-	if err != nil {
-		t.Fatalf("cannot create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	var targetFiles []string
-	var targetDirectories []string
-	for _, dir := range []string{"L1_A", "L1_B", "L1_C",
-		filepath.Join("L1_A", "L2_A"),
-		filepath.Join("L1_A", "L2_B"),
-		filepath.Join("L1_A", "L2_C"),
-		filepath.Join("L1_B", "L2_A"),
-		filepath.Join("L1_B", "L2_B"),
-		filepath.Join("L1_B", "L2_C"),
-		filepath.Join("L1_C", "L2_A"),
-		filepath.Join("L1_C", "L2_B"),
-		filepath.Join("L1_C", "L2_C"),
-	} {
-		dir = filepath.Join(tempDir, dir)
-		err := os.Mkdir(dir, os.FileMode(0700))
-		if err != nil {
-			t.Fatalf("cannot create test directory: %v", err)
-		}
-		targetDirectories = append(targetDirectories, dir)
-		targetFile, err := os.Create(filepath.Join(dir, "X"))
-		if err != nil {
-			t.Fatalf("cannot create temporary file: %v", err)
-		}
-		targetFiles = append(targetFiles, targetFile.Name())
-
-	}
-
-	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
-	for _, perm := range []os.FileMode{0707, 0770} {
-		// Set target file permissions using chmod.
-		c := exec.Command(testpath,
-			"-R",
-			fmt.Sprintf("%0o", perm),
-			tempDir)
-		c.Run()
-
-		// Check that it worked.
-		for _, dir := range targetDirectories {
-			checkPath(t, dir, perm)
-		}
-	}
-}
-
-func TestChmodReference(t *testing.T) {
-	// Temporary directories.
-	tempDir, err := ioutil.TempDir("", "TestChmodReference")
-	if err != nil {
-		t.Fatalf("cannot create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	sourceFile, err := ioutil.TempFile(tempDir, "BLAH1")
-	if err != nil {
-		t.Fatalf("cannot create temporary file: %v", err)
-	}
-	defer sourceFile.Close()
-
-	targetFile, err := ioutil.TempFile(tempDir, "BLAH2")
-	if err != nil {
-		t.Fatalf("cannot create temporary file: %v", err)
-	}
-	defer targetFile.Close()
-
-	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
-	for _, perm := range []os.FileMode{0777, 0644} {
-		os.Chmod(sourceFile.Name(), perm)
-
-		// Set target file permissions using chmod.
-		c := exec.Command(testpath,
-			"--reference",
-			sourceFile.Name(),
-			targetFile.Name())
-		c.Run()
-
-		// Check that it worked.
-		info, err := os.Stat(targetFile.Name())
-		if err != nil {
-			t.Fatalf("stat(%q) failed: %v", targetFile.Name(), err)
-		}
-		if got := info.Mode().Perm(); got != perm {
-			t.Fatalf("Wrong file permissions on file %q: got %0o, want %0o",
-				targetFile.Name(), got, perm)
-		}
-	}
-}
-
-func TestInvocationErrors(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "TestInvocationErrors")
-	if err != nil {
-		t.Fatalf("cannot create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	f, err := ioutil.TempFile(tempDir, "BLAH1")
-	if err != nil {
-		t.Fatalf("cannot create temporary file: %v", err)
-	}
-	defer f.Close()
-
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
-	for _, v := range []struct {
-		args     []string
-		want     string
-		skipTo   int
-		skipFrom int
-	}{
-
-		{
-			args:     []string{f.Name()},
-			want:     "Usage",
-			skipTo:   0,
-			skipFrom: len("Usage"),
-		},
-		{
-			args:     []string{""},
-			want:     "Usage",
-			skipTo:   0,
-			skipFrom: len("Usage"),
-		},
-		{
-			args:     []string{"01777", f.Name()},
-			want:     "Invalid octal value 1777. Value should be less than or equal to 0777.\n",
-			skipTo:   20,
-			skipFrom: -1,
-		},
-		{
-			args:     []string{"0abas", f.Name()},
-			want:     "Unable to decode mode \"0abas\". Please use an octal value: strconv.ParseUint: parsing \"0abas\": invalid syntax\n",
-			skipTo:   20,
-			skipFrom: -1,
-		},
-		{
-			args:     []string{"0777", "blah1234"},
-			want:     "chmod blah1234: no such file or directory\n",
-			skipTo:   20,
-			skipFrom: -1,
-		},
-	} {
-		cmd := exec.Command(testpath, v.args...)
-		_, stderr, err := run(cmd)
-		if v.skipFrom == -1 {
-			v.skipFrom = len(stderr)
-		}
-		// Ignore the date and time because we're using Log.Fatalf
-		if got := stderr[v.skipTo:v.skipFrom]; got != v.want {
-			t.Errorf("Chmod for %q failed: got %q, want %q", v.args, got, v.want)
-		}
-		if err == nil {
-			t.Errorf("Chmod for %q failed: got nil want err", v.args)
-		}
 	}
 }


### PR DESCRIPTION
Our current way of using pkg/testutil, which compiles each command on the fly, is totally incompatible with Go binaries built by Bazel. To be able to use u-root inside google3, we've got to clean up all of that stuff and get rid of pkg/testutil.

Attached is an example of such a cleanup.