### PR TITLE
all: rewrite testutil to use main() directly; clean up tests.

### DIFF
--- a/cmds/chmod/chmod.go
+++ b/cmds/chmod/chmod.go
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Change modifier bits of a file.
+// Chmod changes modifier bits of a file.
 //
 // Synopsis:
-//     chmod MODE FILE...
+//     chmod [-R] [--reference=file] [MODE] FILE...
 //
-// Desription:
+// Description:
 //     MODE is a three character octal value.
 package main
 
@@ -18,87 +18,119 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 )
 
-var (
+type flags struct {
 	recursive bool
 	reference string
-)
+}
 
-func init() {
-	flag.BoolVar(&recursive,
+func (f *flags) registerFlags(flag *flag.FlagSet) {
+	flag.BoolVar(&f.recursive,
 		"R",
 		false,
 		"do changes recursively")
 
-	flag.BoolVar(&recursive,
+	flag.BoolVar(&f.recursive,
 		"recursive",
 		false,
 		"do changes recursively")
 
-	flag.StringVar(&reference,
+	flag.StringVar(&f.reference,
 		"reference",
 		"",
 		"use mode from reference file")
 }
 
 func main() {
+	f := flags{}
+	f.registerFlags(flag.CommandLine)
 	flag.Parse()
-	if len(flag.Args()) < 1 {
+
+	if flag.NArg() < 1 {
 		fmt.Fprintf(os.Stderr, "Usage of %s: [mode] filepath\n", os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	if len(flag.Args()) < 2 && reference == "" {
+	if flag.NArg() < 2 && len(f.reference) == 0 {
 		fmt.Fprintf(os.Stderr, "Usage of %s: [mode] filepath\n", os.Args[0])
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
-	var mode os.FileMode
-	var fileList []string
+	if err := chmodMain(f, flag.Args()); err != nil {
+		log.Fatal(err)
+	}
+}
 
-	if reference != "" {
-		fi, err := os.Stat(reference)
+func chmodMain(f flags, args []string) error {
+	if len(f.reference) > 0 {
+		fi, err := os.Stat(f.reference)
 		if err != nil {
-			log.Fatalf("bad reference file: %v", err)
-
+			return fmt.Errorf("bad reference file %q: %v", f.reference, err)
 		}
-		mode = fi.Mode()
-		fileList = flag.Args()
-	} else {
-		modeString := flag.Args()[0]
-		octval, err := strconv.ParseUint(modeString, 8, 32)
-		if err != nil {
-			log.Fatalf("Unable to decode mode %q. Please use an octal value: %v", modeString, err)
-		} else if octval > 0777 {
-			log.Fatalf("Invalid octal value %0o. Value should be less than or equal to 0777.", octval)
-		}
-		mode = os.FileMode(octval)
-		fileList = flag.Args()[1:]
+		return doChmod(f.recursive, fi.Mode(), args)
 	}
 
-	var exitError bool
+	modeString := args[0]
+	octval, err := strconv.ParseUint(modeString, 8, 32)
+	if err != nil {
+		return fmt.Errorf("unable to decode mode %q: must use an octal value: %v", modeString, err)
+	} else if octval > 0777 {
+		return fmt.Errorf("invalid octal value %0o: value should be less than or equal to 0777", octval)
+	}
+	return doChmod(f.recursive, os.FileMode(octval), args[1:])
+}
+
+type errors []error
+
+func (e *errors) Add(f error) {
+	if f != nil {
+		*e = append(*e, f)
+	}
+}
+
+func (e errors) AnyError() error {
+	if e == nil {
+		return nil
+	}
+	// Only return e if any of the errors are non-nil.
+	for _, f := range e {
+		if f != nil {
+			return e
+		}
+	}
+	return nil
+}
+
+func (e errors) Error() string {
+	s := make([]string, 0, len(e))
+	for _, f := range e {
+		if f != nil {
+			s = append(s, f.Error())
+		}
+	}
+
+	// Only one error? Just return that one.
+	if len(s) == 1 {
+		return s[0]
+	}
+	return fmt.Sprintf("multiple errors: %s", strings.Join(s, "; "))
+}
+
+func doChmod(recursive bool, mode os.FileMode, fileList []string) error {
+	var e errors
 	for _, name := range fileList {
 		if recursive {
-			err := filepath.Walk(name, func(path string,
-				info os.FileInfo,
-				err error) error {
+			e.Add(filepath.Walk(name, func(path string, info os.FileInfo, _ error) error {
 				return os.Chmod(path, mode)
-			})
-			if err != nil {
-				log.Printf("%v", err)
-				exitError = true
-			}
+			}))
 		} else {
-			if err := os.Chmod(name, mode); err != nil {
-				log.Printf("%v", err)
-				exitError = true
-			}
+			e.Add(os.Chmod(name, mode))
 		}
 	}
-	if exitError {
-		os.Exit(1)
-	}
+
+	return e.AnyError()
 }

--- a/cmds/chmod/chmod_test.go
+++ b/cmds/chmod/chmod_test.go
@@ -9,56 +9,132 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
-var (
-	testPath = "."
-)
-
-func run(c *exec.Cmd) (string, string, error) {
-	var o, e bytes.Buffer
-	c.Stdout, c.Stderr = &o, &e
-	err := c.Run()
-	return o.String(), e.String(), err
-}
-
-func TestChmodSimple(t *testing.T) {
-	// Temporary directories.
-	tempDir, err := ioutil.TempDir("", "TestChmodSimple")
+func TestChmod(t *testing.T) {
+	tempDir, err := ioutil.TempDir("", "chmod")
 	if err != nil {
-		t.Fatalf("cannot create temporary directory: %v", err)
+		t.Fatal(err)
 	}
 	defer os.RemoveAll(tempDir)
 
-	f, err := ioutil.TempFile(tempDir, "BLAH1")
+	// Set up single file for simple test.
+	f, err := ioutil.TempFile(tempDir, "chmod-tmp-test")
 	if err != nil {
-		t.Fatalf("cannot create temporary file: %v", err)
+		t.Fatal(err)
 	}
 	defer f.Close()
 
-	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
+	// Set up single file for simple test.
+	f2, err := ioutil.TempFile(tempDir, "chmod-tmp-test")
 	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
+		t.Fatal(err)
+	}
+	defer f2.Close()
+
+	file0544, err := ioutil.TempFile(tempDir, "file0544")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file0544.Close()
+	if err := os.Chmod(file0544.Name(), 0544); err != nil {
+		t.Fatal(err)
 	}
 
-	for _, perm := range []os.FileMode{0777, 0644} {
-		// Set permissions using chmod.
-		c := exec.Command(testpath, fmt.Sprintf("%0o", perm), f.Name())
-		c.Run()
+	// Set up complicated directory structure for recursive test.
+	recDir, err := ioutil.TempDir(tempDir, "recursive")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		// Check that it worked.
-		info, err := os.Stat(f.Name())
-		if err != nil {
-			t.Fatalf("stat(%q) failed: %v", f.Name(), err)
+	recursives := []string{recDir}
+	for _, dir := range []string{
+		"L1_A",
+		"L1_B",
+		"L1_C",
+		filepath.Join("L1_A", "L2_A"),
+		filepath.Join("L1_A", "L2_B"),
+		filepath.Join("L1_A", "L2_C"),
+		filepath.Join("L1_B", "L2_A"),
+		filepath.Join("L1_B", "L2_B"),
+		filepath.Join("L1_B", "L2_C"),
+		filepath.Join("L1_C", "L2_A"),
+		filepath.Join("L1_C", "L2_B"),
+		filepath.Join("L1_C", "L2_C"),
+	} {
+		dir = filepath.Join(recDir, dir)
+		if err := os.MkdirAll(dir, os.FileMode(0700)); err != nil {
+			t.Fatalf("cannot create test directory: %v", err)
 		}
-		if got := info.Mode().Perm(); got != perm {
-			t.Errorf("Wrong file permissions on %q: got %0o, want %0o", f.Name(), got, perm)
-		}
+		recursives = append(recursives, dir)
+	}
+
+	for i, tt := range []struct {
+		args   []string
+		stderr string
+
+		// fileList is the list of files that wantMode should be set on
+		// after calling chmod.
+		fileList []string
+		wantMode os.FileMode
+	}{
+		{
+			args:     []string{"0777", f.Name()},
+			fileList: []string{f.Name()},
+			wantMode: 0777,
+		},
+		{
+			args:     []string{"0644", f.Name()},
+			fileList: []string{f.Name()},
+			wantMode: 0644,
+		},
+		{
+			args:     []string{"-R", "0707", recDir},
+			fileList: recursives,
+			wantMode: 0707,
+		},
+		{
+			args:     []string{"-R", "0770", recDir},
+			fileList: recursives,
+			wantMode: 0770,
+		},
+		{
+			args:     []string{"--reference", file0544.Name(), f2.Name()},
+			fileList: []string{f2.Name()},
+			wantMode: 0544,
+		},
+		{
+			args:   []string{"01777", f.Name()},
+			stderr: "invalid octal value 1777: value should be less than or equal to 0777",
+		},
+		{
+			args:   []string{"0abas", f.Name()},
+			stderr: "unable to decode mode \"0abas\": must use an octal value: strconv.ParseUint: parsing \"0abas\": invalid syntax",
+		},
+		{
+			args:   []string{"0777", "blah1234"},
+			stderr: "chmod blah1234: no such file or directory",
+		},
+	} {
+		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
+			cmd := testutil.Command(t, tt.args...)
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			cmd.Run()
+
+			if e := stderr.String(); !strings.Contains(e, tt.stderr) {
+				t.Errorf("chmod(%v) = %v, stderr %v", tt.args, e, tt.stderr)
+			}
+
+			for _, file := range tt.fileList {
+				checkPath(t, file, tt.wantMode)
+			}
+		})
 	}
 }
 
@@ -72,180 +148,12 @@ func checkPath(t *testing.T, path string, want os.FileMode) {
 			path, got, want)
 	}
 }
-func TestChmodRecursive(t *testing.T) {
-	// Temporary directories.
-	tempDir, err := ioutil.TempDir("", "TestChmodRecursive")
-	if err != nil {
-		t.Fatalf("cannot create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
 
-	var targetFiles []string
-	var targetDirectories []string
-	for _, dir := range []string{"L1_A", "L1_B", "L1_C",
-		filepath.Join("L1_A", "L2_A"),
-		filepath.Join("L1_A", "L2_B"),
-		filepath.Join("L1_A", "L2_C"),
-		filepath.Join("L1_B", "L2_A"),
-		filepath.Join("L1_B", "L2_B"),
-		filepath.Join("L1_B", "L2_C"),
-		filepath.Join("L1_C", "L2_A"),
-		filepath.Join("L1_C", "L2_B"),
-		filepath.Join("L1_C", "L2_C"),
-	} {
-		dir = filepath.Join(tempDir, dir)
-		err := os.Mkdir(dir, os.FileMode(0700))
-		if err != nil {
-			t.Fatalf("cannot create test directory: %v", err)
-		}
-		targetDirectories = append(targetDirectories, dir)
-		targetFile, err := os.Create(filepath.Join(dir, "X"))
-		if err != nil {
-			t.Fatalf("cannot create temporary file: %v", err)
-		}
-		targetFiles = append(targetFiles, targetFile.Name())
-
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
 	}
 
-	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
-	for _, perm := range []os.FileMode{0707, 0770} {
-		// Set target file permissions using chmod.
-		c := exec.Command(testpath,
-			"-R",
-			fmt.Sprintf("%0o", perm),
-			tempDir)
-		c.Run()
-
-		// Check that it worked.
-		for _, dir := range targetDirectories {
-			checkPath(t, dir, perm)
-		}
-	}
-}
-
-func TestChmodReference(t *testing.T) {
-	// Temporary directories.
-	tempDir, err := ioutil.TempDir("", "TestChmodReference")
-	if err != nil {
-		t.Fatalf("cannot create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	sourceFile, err := ioutil.TempFile(tempDir, "BLAH1")
-	if err != nil {
-		t.Fatalf("cannot create temporary file: %v", err)
-	}
-	defer sourceFile.Close()
-
-	targetFile, err := ioutil.TempFile(tempDir, "BLAH2")
-	if err != nil {
-		t.Fatalf("cannot create temporary file: %v", err)
-	}
-	defer targetFile.Close()
-
-	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
-	for _, perm := range []os.FileMode{0777, 0644} {
-		os.Chmod(sourceFile.Name(), perm)
-
-		// Set target file permissions using chmod.
-		c := exec.Command(testpath,
-			"--reference",
-			sourceFile.Name(),
-			targetFile.Name())
-		c.Run()
-
-		// Check that it worked.
-		info, err := os.Stat(targetFile.Name())
-		if err != nil {
-			t.Fatalf("stat(%q) failed: %v", targetFile.Name(), err)
-		}
-		if got := info.Mode().Perm(); got != perm {
-			t.Fatalf("Wrong file permissions on file %q: got %0o, want %0o",
-				targetFile.Name(), got, perm)
-		}
-	}
-}
-
-func TestInvocationErrors(t *testing.T) {
-	tempDir, err := ioutil.TempDir("", "TestInvocationErrors")
-	if err != nil {
-		t.Fatalf("cannot create temporary directory: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	f, err := ioutil.TempFile(tempDir, "BLAH1")
-	if err != nil {
-		t.Fatalf("cannot create temporary file: %v", err)
-	}
-	defer f.Close()
-
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
-	for _, v := range []struct {
-		args     []string
-		want     string
-		skipTo   int
-		skipFrom int
-	}{
-
-		{
-			args:     []string{f.Name()},
-			want:     "Usage",
-			skipTo:   0,
-			skipFrom: len("Usage"),
-		},
-		{
-			args:     []string{""},
-			want:     "Usage",
-			skipTo:   0,
-			skipFrom: len("Usage"),
-		},
-		{
-			args:     []string{"01777", f.Name()},
-			want:     "Invalid octal value 1777. Value should be less than or equal to 0777.\n",
-			skipTo:   20,
-			skipFrom: -1,
-		},
-		{
-			args:     []string{"0abas", f.Name()},
-			want:     "Unable to decode mode \"0abas\". Please use an octal value: strconv.ParseUint: parsing \"0abas\": invalid syntax\n",
-			skipTo:   20,
-			skipFrom: -1,
-		},
-		{
-			args:     []string{"0777", "blah1234"},
-			want:     "chmod blah1234: no such file or directory\n",
-			skipTo:   20,
-			skipFrom: -1,
-		},
-	} {
-		cmd := exec.Command(testpath, v.args...)
-		_, stderr, err := run(cmd)
-		if v.skipFrom == -1 {
-			v.skipFrom = len(stderr)
-		}
-		// Ignore the date and time because we're using Log.Fatalf
-		if got := stderr[v.skipTo:v.skipFrom]; got != v.want {
-			t.Errorf("Chmod for %q failed: got %q, want %q", v.args, got, v.want)
-		}
-		if err == nil {
-			t.Errorf("Chmod for %q failed: got nil want err", v.args)
-		}
-	}
+	os.Exit(m.Run())
 }

--- a/cmds/dhclient/dhclient_test.go
+++ b/cmds/dhclient/dhclient_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -28,11 +27,8 @@ var tests = []struct {
 }
 
 func TestDhclient(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
 	for _, tt := range tests {
-		out, err := exec.Command(execPath, tt.isIPv4, tt.test, tt.iface).CombinedOutput()
+		out, err := testutil.Command(t, tt.isIPv4, tt.test, tt.iface).CombinedOutput()
 		if err == nil {
 			t.Errorf("%v: got nil, want err", tt)
 		}
@@ -40,4 +36,13 @@ func TestDhclient(t *testing.T) {
 			t.Errorf("expected:\n%s\ngot:\n%s", tt.out, string(out))
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/dirname/dirname_test.go
+++ b/cmds/dirname/dirname_test.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
@@ -30,12 +29,9 @@ var dirnameTests = []test{
 }
 
 func TestDirName(t *testing.T) {
-	tmpDir, dirname := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
 	// Table-driven testing
 	for _, tt := range dirnameTests {
-		c := exec.Command(dirname, tt.args...)
+		c := testutil.Command(t, tt.args...)
 		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 		c.Stdout, c.Stderr = stdout, stderr
 		err := c.Run()
@@ -53,4 +49,13 @@ func TestDirName(t *testing.T) {
 		}
 
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/false/false_test.go
+++ b/cmds/false/false_test.go
@@ -6,28 +6,27 @@ package main
 
 import (
 	"os"
-	"os/exec"
-	"syscall"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-// Ensure 1 is returned.
 func TestFalse(t *testing.T) {
-	tmpDir, falsePath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
-	out, err := exec.Command(falsePath).CombinedOutput()
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatal("Expected an exit error result")
-	}
-	retCode := exitErr.Sys().(syscall.WaitStatus).ExitStatus()
-	if retCode != 1 {
-		t.Fatalf("Expected 1 as the return code; got %v", retCode)
+	// Ensure 1 is returned.
+	out, err := testutil.Command(t).CombinedOutput()
+	if err := testutil.IsExitCode(err, 1); err != nil {
+		t.Error(err)
 	}
 	if len(out) != 0 {
 		t.Fatalf("Expected no output; got %#v", string(out))
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/fmap/fmap_test.go
+++ b/cmds/fmap/fmap_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -59,14 +58,12 @@ Mixed:        3 (50.0%)
 
 // Table driven testing
 func TestFmap(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
 	for _, tt := range tests {
-		out, err := exec.Command(execPath, tt.cmd, testFlash).CombinedOutput()
+		out, err := testutil.Command(t, tt.cmd, testFlash).CombinedOutput()
 		if err != nil {
 			t.Error(err)
 		}
+
 		// Filter out null characters which may be present in fmap strings.
 		out = bytes.Replace(out, []byte{0}, []byte{}, -1)
 		if string(out) != tt.out {
@@ -76,11 +73,14 @@ func TestFmap(t *testing.T) {
 }
 
 func TestJson(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "fmap_json")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	jsonFile := filepath.Join(tmpDir, "tmp.json")
-	if err := exec.Command(execPath, "jget", jsonFile, testFlash).Run(); err != nil {
+	if err := testutil.Command(t, "jget", jsonFile, testFlash).Run(); err != nil {
 		t.Fatal(err)
 	}
 	got, err := ioutil.ReadFile(jsonFile)
@@ -128,4 +128,13 @@ func TestJson(t *testing.T) {
 	if string(got) != want {
 		t.Errorf("want:%s; got:%s", string(want), got)
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/grep/grep_test.go
+++ b/cmds/grep/grep_test.go
@@ -6,63 +6,74 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"syscall"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
 // GrepTest is a table-driven which spawns grep with a variety of options and inputs.
 // We need to look at any output data, as well as exit status for things like the -q switch.
 func TestGrep(t *testing.T) {
-	var tab = []struct {
-		i string
-		o string
-		s int
-		a []string
-	}{
-		// BEWARE: the IO package seems to want this to be newline terminated.
-		// If you just use hix with no newline the test will fail. Yuck.
-		{"hix\n", "hix\n", 0, []string{"."}},
-		{"hix\n", "", 0, []string{"-q", "."}},
-		{"hix\n", "", 1, []string{"-q", "hox"}},
-	}
-
-	tmpDir, err := ioutil.TempDir("", "TestGrep")
+	tmpDir, err := ioutil.TempDir("", "grep")
 	if err != nil {
-		t.Fatal("TempDir failed: ", err)
+		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	testgreppath := filepath.Join(tmpDir, "testgrep.exe")
-	out, err := exec.Command("go", "build", "-o", testgreppath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/grep: %v\n%s", testgreppath, err, string(out))
+	for i, tt := range []struct {
+		in       string
+		out      string
+		exitCode int
+		args     []string
+	}{
+		// BEWARE: the IO package seems to want this to be newline terminated.
+		// If you just use hix with no newline the test will fail. Yuck.
+		// TODO: Then don't use the IO package.
+		//
+		// TODO: yeesh. more, and better test cases.
+		{
+			in:       "hix\n",
+			out:      "hix\n",
+			exitCode: 0,
+			args:     []string{"."},
+		},
+		{
+			in:       "hix\n",
+			out:      "",
+			exitCode: 0,
+			args:     []string{"-q", "."},
+		},
+		{
+			in:       "hix\n",
+			out:      "",
+			exitCode: 1,
+			args:     []string{"-q", "hox"},
+		},
+	} {
+		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
+			c := testutil.Command(t, tt.args...)
+			c.Stdin = bytes.NewReader([]byte(tt.in))
+
+			o, err := c.CombinedOutput()
+			if err := testutil.IsExitCode(err, tt.exitCode); err != nil {
+				t.Fatal(err)
+			}
+
+			if string(o) != tt.out {
+				t.Errorf("grep %v < %v = %v, want %v", tt.args, tt.in, string(o), tt.out)
+			}
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
 	}
 
-	t.Logf("Built %v for test", testgreppath)
-	for _, v := range tab {
-		t.Logf("Run %v args %v", testgreppath, v)
-		c := exec.Command(testgreppath, v.a...)
-		c.Stdin = bytes.NewReader([]byte(v.i))
-		o, err := c.CombinedOutput()
-		s := c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-
-		if s != v.s {
-			t.Errorf("Grep %v < %v > %v: want (exit: %v), got (exit %v)", v.a, v.i, v.o, v.s, s)
-			continue
-		}
-
-		if err != nil && s != v.s {
-			t.Errorf("Grep %v < %v > %v: want nil, got %v", v.a, v.i, v.o, err)
-			continue
-		}
-		if string(o) != v.o {
-			t.Errorf("Grep %v < %v: want '%v', got '%v'", v.a, v.i, v.o, string(o))
-			continue
-		}
-		t.Logf("Grep %v < %v: %v", v.a, v.i, v.o)
-	}
+	os.Exit(m.Run())
 }

--- a/cmds/hexdump/hexdump_test.go
+++ b/cmds/hexdump/hexdump_test.go
@@ -7,31 +7,25 @@ package main
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-var tests = []struct {
-	in  []byte
-	out []byte
-}{
-	{
-		in: []byte("abcdefghijklmnopqrstuvwxyz"),
-		out: []byte(
-			`00000000  61 62 63 64 65 66 67 68  69 6a 6b 6c 6d 6e 6f 70  |abcdefghijklmnop|
+func TestHexdump(t *testing.T) {
+	for _, tt := range []struct {
+		in  []byte
+		out []byte
+	}{
+		{
+			in: []byte("abcdefghijklmnopqrstuvwxyz"),
+			out: []byte(
+				`00000000  61 62 63 64 65 66 67 68  69 6a 6b 6c 6d 6e 6f 70  |abcdefghijklmnop|
 00000010  71 72 73 74 75 76 77 78  79 7a                    |qrstuvwxyz|
 `),
-	},
-}
-
-func TestHexdump(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
-	for _, tt := range tests {
-		cmd := exec.Command(execPath)
+		},
+	} {
+		cmd := testutil.Command(t)
 		cmd.Stdin = bytes.NewReader(tt.in)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -42,4 +36,13 @@ func TestHexdump(t *testing.T) {
 			t.Errorf("want=%#v; got=%#v", tt.out, tt)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/id/id_test.go
+++ b/cmds/id/id_test.go
@@ -1,57 +1,49 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-var (
-	remove          = true
-	testpath        = "."
-	logPrefixLength = len("2009/11/10 23:00:00 ")
-)
+var logPrefixLength = len("2009/11/10 23:00:00 ")
 
-type test struct {
-	opt []string
-	out string
-}
-
-// Run the command, with the optional args, and return a string
-// for stdout, stderr, and an error.
-func run(c *exec.Cmd) (string, string, error) {
-	var o, e bytes.Buffer
-	c.Stdout, c.Stderr = &o, &e
-	err := c.Run()
-	return o.String(), e.String(), err
-}
-
-// Test incorrect invocation of id
 func TestInvocation(t *testing.T) {
-	tempDir, idPath := testutil.CompileInTempDir(t)
-
-	if remove {
-		defer os.RemoveAll(tempDir)
-	}
-
-	var tests = []test{
+	for _, test := range []struct {
+		opt []string
+		out string
+	}{
 		{opt: []string{"-n"}, out: "id: cannot print only names in default format\n"},
 		{opt: []string{"-G", "-g"}, out: "id: cannot print \"only\" of more than one choice\n"},
 		{opt: []string{"-G", "-u"}, out: "id: cannot print \"only\" of more than one choice\n"},
 		{opt: []string{"-g", "-u"}, out: "id: cannot print \"only\" of more than one choice\n"},
 		{opt: []string{"-g", "-u", "-G"}, out: "id: cannot print \"only\" of more than one choice\n"},
-	}
+	} {
+		c := testutil.Command(t, test.opt...)
+		stderr := &bytes.Buffer{}
+		c.Stderr = stderr
+		// TODO: expect the exit status to be 1.
+		c.Run()
 
-	for _, test := range tests {
-		c := exec.Command(idPath, test.opt...)
-		_, e, _ := run(c)
-
+		e := stderr.String()
 		// Ignore the date and time because we're using Log.Fatalf
 		if e[logPrefixLength:] != test.out {
 			t.Errorf("id for '%v' failed: got '%s', want '%s'", test.opt, e, test.out)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/kill/kill_test.go
+++ b/cmds/kill/kill_test.go
@@ -10,100 +10,74 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
-// Run the command, with the optional args, and return a string
-// for stdout, stderr, and an error.
-func run(c *exec.Cmd) (string, string, error) {
-	var o, e bytes.Buffer
-	c.Stdout, c.Stderr = &o, &e
-	err := c.Run()
-	return o.String(), e.String(), err
-}
-
 func TestKillProcess(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "KillTest")
+	tmpDir, err := ioutil.TempDir("", "kill")
 	if err != nil {
-		t.Fatal("TempDir failed: ", err)
+		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
-
-	killtestpath := filepath.Join(tmpDir, "killtest.exe")
-	o, e, err := run(exec.Command("go", "build", "-o", killtestpath, "."))
-	if err != nil {
-		t.Fatalf("go build -o %s cmds/kill: %v, %s", killtestpath, err, o+":"+e)
-	}
-
-	t.Logf("Built %v for test", killtestpath)
 
 	// Re-exec the test binary itself to emulate "sleep 1".
 	cmd := exec.Command("/bin/sleep", "10")
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("Failed to start test process: %v, output %s", err, string(e))
+		t.Fatalf("Failed to start test process: %v", err)
 	}
 
 	// from the orignal. hokey .1 second wait for the process to start. Racy.
 	time.Sleep(100 * time.Millisecond)
 
-	if o, e, err = run(exec.Command(killtestpath, "-9", fmt.Sprintf("%d", cmd.Process.Pid))); err != nil {
+	if err := testutil.Command(t, "-9", fmt.Sprintf("%d", cmd.Process.Pid)).Run(); err != nil {
 		t.Errorf("Could not spawn first kill: %v", err)
 	}
 
-	t.Logf("Ran kill: output :%s:, extra info :%v", o, e)
-	if err = cmd.Wait(); err == nil {
+	if err := cmd.Wait(); err == nil {
 		t.Errorf("Test process succeeded, but expected to fail")
-	}
-
-	// now this is a little weird. We're going to try to kill it again.
-	// Arguably, this should be done in another test, but finding a process
-	// you just "know" does not exist is tricky. What PID do you use?
-	// So we just kill the one we just killed; it should get an error.
-	// If not, something's wrong.
-	if _, _, err = run(exec.Command(killtestpath, "-9", fmt.Sprintf("%d", cmd.Process.Pid))); err == nil {
-		t.Fatalf("Second kill: got nil, want error")
 	}
 }
 
 func TestBadInvocations(t *testing.T) {
-	var (
-		tab = []struct {
-			a   []string
-			err string
-		}{
-			{a: []string{"-1w34"}, err: "1w34 is not a valid signal\n"},
-			{a: []string{"-s"}, err: eUsage + "\n"},
-			{a: []string{"-s", "a"}, err: "a is not a valid signal\n"},
-			{a: []string{"a"}, err: "Some processes could not be killed: [a: arguments must be process or job IDS]\n"},
-			{a: []string{"--signal"}, err: eUsage + "\n"},
-			{a: []string{"--signal", "a"}, err: "a is not a valid signal\n"},
-			{a: []string{"-1", "a"}, err: "Some processes could not be killed: [a: arguments must be process or job IDS]\n"},
-		}
-	)
-
-	tmpDir, err := ioutil.TempDir("", "KillTest")
+	tmpDir, err := ioutil.TempDir("", "kill")
 	if err != nil {
-		t.Fatal("TempDir failed: ", err)
+		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
 
-	killtestpath := filepath.Join(tmpDir, "killtest.exe")
-	o, e, err := run(exec.Command("go", "build", "-o", killtestpath, "."))
-	if err != nil {
-		t.Fatalf("go build -o %s cmds/kill: %v, %s", killtestpath, err, o+":"+e)
-	}
-
-	t.Logf("Built %v for test", killtestpath)
-	for _, v := range tab {
-		o, e, err := run(exec.Command(killtestpath, v.a...))
-		t.Logf("%v: %s %s %v", v.a, o, e, err)
-		if e != v.err {
-			t.Errorf("Kill for '%v' failed: got '%s', want '%s'", v.a, e, v.err)
+	for _, v := range []struct {
+		args []string
+		err  string
+	}{
+		{args: []string{"-1w34"}, err: "1w34 is not a valid signal\n"},
+		{args: []string{"-s"}, err: eUsage + "\n"},
+		{args: []string{"-s", "a"}, err: "a is not a valid signal\n"},
+		{args: []string{"a"}, err: "Some processes could not be killed: [a: arguments must be process or job IDS]\n"},
+		{args: []string{"--signal"}, err: eUsage + "\n"},
+		{args: []string{"--signal", "a"}, err: "a is not a valid signal\n"},
+		{args: []string{"-1", "a"}, err: "Some processes could not be killed: [a: arguments must be process or job IDS]\n"},
+	} {
+		cmd := testutil.Command(t, v.args...)
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if e := stderr.String(); e != v.err {
+			t.Errorf("kill %v failed: got %s, want %s", v.args, e, v.err)
 		}
 		if err == nil {
-			t.Errorf("Kill for '%v' failed: got nil, want err", v.a)
+			t.Errorf("kill %v failed: got nil, want err", v.args)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/ls/ls_test.go
+++ b/cmds/ls/ls_test.go
@@ -5,75 +5,83 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-var tests = []struct {
-	flags []string
-	out   string
-}{
-	{
-		flags: []string{},
-		out: `d1
+func TestLS(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create some files.
+	os.Create(filepath.Join(tmpDir, "f1"))
+	os.Create(filepath.Join(tmpDir, "f2"))
+	os.Create(filepath.Join(tmpDir, "f3\nline 2"))
+	os.Create(filepath.Join(tmpDir, ".f4"))
+	os.Mkdir(filepath.Join(tmpDir, "d1"), 0740)
+	os.Create(filepath.Join(tmpDir, "d1/f4"))
+
+	// Table-driven testing
+	for _, tt := range []struct {
+		args []string
+		out  string
+		wd   string
+	}{
+		{
+			args: []string{},
+			wd:   tmpDir,
+			out: `d1
 f1
 f2
 f3?line 2
 `,
-	}, {
-		flags: []string{"-Q"},
-		out: `"d1"
+		}, {
+			args: []string{"-Q"},
+			wd:   tmpDir,
+			out: `"d1"
 "f1"
 "f2"
 "f3\nline 2"
 `,
-	}, {
-		flags: []string{"-R"},
-		out: `d1
+		}, {
+			args: []string{"-R"},
+			wd:   tmpDir,
+			out: `d1
 d1/f4
 f1
 f2
 f3?line 2
 `,
-	}, {
-		flags: []string{"-a"},
-		out: `.
+		}, {
+			args: []string{"-a"},
+			wd:   tmpDir,
+			out: `.
 .f4
 d1
 f1
 f2
 f3?line 2
 `,
-	},
-}
-
-func TestLs(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
-	// Create an empty directory.
-	testDir := filepath.Join(tmpDir, "testDir")
-	os.Mkdir(testDir, 0700)
-
-	// Create some files.
-	os.Create(filepath.Join(testDir, "f1"))
-	os.Create(filepath.Join(testDir, "f2"))
-	os.Create(filepath.Join(testDir, "f3\nline 2"))
-	os.Create(filepath.Join(testDir, ".f4"))
-	os.Mkdir(filepath.Join(testDir, "d1"), 0740)
-	os.Create(filepath.Join(testDir, "d1/f4"))
-
-	// Table-driven testing
-	for _, tt := range tests {
-		c := exec.Command(execPath, tt.flags...)
-		t.Logf("Dir is %v", testDir)
-		c.Dir = testDir
+		}, {
+			args: []string{tmpDir},
+			wd:   filepath.Join(tmpDir, "d1"),
+			out: `d1
+f1
+f2
+f3?line 2
+`,
+		},
+	} {
+		c := testutil.Command(t, tt.args...)
+		c.Dir = tt.wd
 		out, err := c.Output()
-		t.Logf("out :%v err: %v", out, err)
 		if err != nil {
 			t.Error(err)
 		}
@@ -81,4 +89,13 @@ func TestLs(t *testing.T) {
 			t.Errorf("got:\n%s\nwant:\n%s", string(out), tt.out)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/mkfifo/mkfifo_test.go
+++ b/cmds/mkfifo/mkfifo_test.go
@@ -6,8 +6,8 @@ package main
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,55 +15,51 @@ import (
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-type test struct {
-	name   string
-	flags  []string
-	stdErr string
-}
-
 func TestMkfifo(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "mkfifo")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	// used later in testing
 	testDir := filepath.Join(tmpDir, "mkfifoDir")
-	err := os.Mkdir(testDir, 0700)
-	if err != nil {
+	if err := os.Mkdir(testDir, 0700); err != nil {
 		t.Error(err)
 	}
 
-	var tests = []test{
+	for _, tt := range []struct {
+		name   string
+		flags  []string
+		stderr string
+	}{
 		{
 			name:   "no path or mode, error",
 			flags:  []string{},
-			stdErr: "please provide a path, or multiple, to create a fifo",
+			stderr: "please provide a path, or multiple, to create a fifo",
 		},
 		{
 			name:   "single path",
 			flags:  []string{filepath.Join(testDir, "testfifo")},
-			stdErr: "",
+			stderr: "",
 		},
 		{
 			name:   "duplicate path",
 			flags:  []string{filepath.Join(testDir, "testfifo1"), filepath.Join(testDir, "testfifo1")},
-			stdErr: "file exists",
+			stderr: "file exists",
 		},
-	}
-
-	for _, tt := range tests {
-		var out, stdErr bytes.Buffer
-		cmd := exec.Command(execPath, tt.flags...)
-		cmd.Stdout = &out
-		cmd.Stderr = &stdErr
+	} {
+		var stderr bytes.Buffer
+		cmd := testutil.Command(t, tt.flags...)
+		cmd.Stderr = &stderr
 		err := cmd.Run()
 
-		if err != nil && !strings.Contains(stdErr.String(), tt.stdErr) {
-			t.Errorf("expected %v got %v", tt.stdErr, stdErr.String())
+		if err != nil && !strings.Contains(stderr.String(), tt.stderr) {
+			t.Errorf("expected %v got %v", tt.stderr, stderr.String())
 		}
 
 		for _, path := range tt.flags {
 			testFile, err := os.Stat(path)
-
 			if err != nil {
 				t.Errorf("Unable to stat file %s", path)
 			}
@@ -74,4 +70,13 @@ func TestMkfifo(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/sort/sort_test.go
+++ b/cmds/sort/sort_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -16,55 +15,85 @@ import (
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-type test struct {
+type sortTest struct {
+	name  string
 	flags []string
 	in    string
 	out   string
 }
 
-var sortTests = []test{
-	// empty
-	{[]string{}, "", ""},
-	// already sorted, in == out
-	{[]string{}, "a\nb\nc\n", "a\nb\nc\n"},
-	// sort letters
-	{[]string{}, "c\na\nb\n", "a\nb\nc\n"},
-	// sort lexicographic
-	{[]string{}, "abc \nab\na bc\n", "a bc\nab\nabc \n"},
-	// sort without terminating newline
-	{[]string{}, "a\nb\nc", "a\nb\nc\n"},
-	// sort with utf-8 characters
-	{[]string{}, "γ\nα\nβ\n", "α\nβ\nγ\n"},
-	// reverse sort
-	{[]string{"-r"}, "c\na\nb\n", "c\nb\na\n"},
-	// reverse sort without terminating newline
-	{[]string{"-r"}, "a\nb\nc", "c\nb\na\n"},
+var tests = []sortTest{
+	{
+		name:  "empty",
+		flags: []string{},
+		in:    "",
+		out:   "",
+	},
+	{
+		name:  "already sorted, in == out",
+		flags: []string{},
+		in:    "a\nb\nc\n",
+		out:   "a\nb\nc\n",
+	},
+	{
+		name:  "sort letters",
+		flags: []string{},
+		in:    "c\na\nb\n",
+		out:   "a\nb\nc\n",
+	},
+	{
+		name:  "sort lexicographic",
+		flags: []string{},
+		in:    "abc \nab\na bc\n",
+		out:   "a bc\nab\nabc \n",
+	},
+	{
+		name:  "sort without terminating newline",
+		flags: []string{},
+		in:    "a\nb\nc",
+		out:   "a\nb\nc\n",
+	},
+	{
+		name:  "sort with utf-8 characters",
+		flags: []string{},
+		in:    "γ\nα\nβ\n",
+		out:   "α\nβ\nγ\n",
+	},
+	{
+		name:  "reverse sort",
+		flags: []string{"-r"},
+		in:    "c\na\nb\n",
+		out:   "c\nb\na\n",
+	},
+	{
+		name:  "reverse sort without terminating newline",
+		flags: []string{"-r"},
+		in:    "a\nb\nc",
+		out:   "c\nb\na\n",
+	},
 }
 
 // sort < in > out
 func TestSortWithPipes(t *testing.T) {
-	tmpDir, sortPath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
-	// Table-driven testing
-	for _, tt := range sortTests {
-		cmd := exec.Command(sortPath, tt.flags...)
-		cmd.Stdin = strings.NewReader(tt.in)
-		var out bytes.Buffer
-		cmd.Stdout = &out
-		if err := cmd.Run(); err != nil {
-			t.Errorf("sort(%#v): %v", tt.in, err)
-		}
-		if out.String() != tt.out {
-			t.Errorf("sort(%#v) = %#v; want %#v", tt.in,
-				out.String(), tt.out)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := testutil.Command(t, tt.flags...)
+			cmd.Stdin = strings.NewReader(tt.in)
+			var out bytes.Buffer
+			cmd.Stdout = &out
+			if err := cmd.Run(); err != nil {
+				t.Errorf("sort(%#v): %v", tt.in, err)
+			}
+			if out.String() != tt.out {
+				t.Errorf("sort(%#v) = %#v; want %#v", tt.in,
+					out.String(), tt.out)
+			}
+		})
 	}
 }
 
 // Helper function to create input files, run sort and compare the output.
-func sortWithFiles(t *testing.T, tt test, tmpDir string, sortPath string,
-	inFiles []string, outFile string) {
+func sortWithFiles(t *testing.T, tt sortTest, tmpDir string, inFiles []string, outFile string) {
 	// Create input files
 	inPaths := make([]string, len(inFiles))
 	for i, inFile := range inFiles {
@@ -76,12 +105,10 @@ func sortWithFiles(t *testing.T, tt test, tmpDir string, sortPath string,
 	}
 	outPath := filepath.Join(tmpDir, outFile)
 
-	args := append(append(append([]string{}, tt.flags...), "-o",
-		outPath), inPaths...)
-	out, err := exec.Command(sortPath, args...).CombinedOutput()
+	args := append(append(tt.flags, "-o", outPath), inPaths...)
+	out, err := testutil.Command(t, args...).CombinedOutput()
 	if err != nil {
-		t.Errorf("sort %s: %v\n%s", strings.Join(args, " "),
-			err, out)
+		t.Errorf("sort %s: %v\n%s", strings.Join(args, " "), err, out)
 		return
 	}
 
@@ -91,46 +118,73 @@ func sortWithFiles(t *testing.T, tt test, tmpDir string, sortPath string,
 		return
 	}
 	if string(out) != tt.out {
-		t.Errorf("sort %s = %#v; want %#v", strings.Join(args, " "),
-			string(out), tt.out)
+		t.Errorf("sort %s = %#v; want %#v", strings.Join(args, " "), string(out), tt.out)
 	}
 }
 
 // sort -o in out
 func TestSortWithFiles(t *testing.T) {
-	tmpDir, sortPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "sort_files")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
-	// Table-driven testing
-	for _, tt := range sortTests {
-		sortWithFiles(t, tt, tmpDir, sortPath, []string{"in"}, "out")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortWithFiles(t, tt, tmpDir, []string{"in"}, "out")
+		})
 	}
 }
 
 // sort -o file file
 func TestInplaceSort(t *testing.T) {
-	tmpDir, sortPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "sort_files")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
-	// Table-driven testing
-	for _, tt := range sortTests {
-		sortWithFiles(t, tt, tmpDir, sortPath, []string{"file"}, "file")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sortWithFiles(t, tt, tmpDir, []string{"file"}, "file")
+		})
 	}
 }
 
 // sort -o out in1 in2 in3 in4
 func TestMultipleFileInputs(t *testing.T) {
-	tmpDir, sortPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "sort_files")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
-	tt := test{[]string{}, "a\nb\nc\n",
-		"a\na\na\na\nb\nb\nb\nb\nc\nc\nc\nc\n"}
-	sortWithFiles(t, tt, tmpDir, sortPath,
+	tt := sortTest{
+		name:  "multiple ins",
+		flags: []string{},
+		in:    "a\nb\nc\n",
+		out:   "a\na\na\na\nb\nb\nb\nb\nc\nc\nc\nc\n",
+	}
+	sortWithFiles(t, tt, tmpDir,
 		[]string{"in1", "in2", "in3", "in4"}, "out")
 
 	// Run the test again without newline terminators.
-	tt = test{[]string{}, "a\nb\nc",
-		"a\na\na\na\nb\nb\nb\nb\nc\nc\nc\nc\n"}
-	sortWithFiles(t, tt, tmpDir, sortPath,
+	tt = sortTest{
+		name:  "multiple ins with terminators",
+		flags: []string{},
+		in:    "a\nb\nc",
+		out:   "a\na\na\na\nb\nb\nb\nb\nc\nc\nc\nc\n",
+	}
+	sortWithFiles(t, tt, tmpDir,
 		[]string{"in1", "in2", "in3", "in4"}, "out")
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/truncate/truncate_test.go
+++ b/cmds/truncate/truncate_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -102,8 +101,10 @@ var truncateTests = []struct {
 
 // TestTruncate implements a table-driven test.
 func TestTruncate(t *testing.T) {
-	// Compile truncate.
-	tmpDir, truncatePath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "truncate")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	for i, test := range truncateTests {
@@ -116,8 +117,7 @@ func TestTruncate(t *testing.T) {
 			}
 		}
 		// Execute truncate.go
-		args := append(append([]string{}, test.flags...), testfile)
-		cmd := exec.Command(truncatePath, args...)
+		cmd := testutil.Command(t, append(test.flags, testfile)...)
 		err := cmd.Run()
 		if err != nil {
 			if test.ret == 0 {
@@ -138,4 +138,13 @@ func TestTruncate(t *testing.T) {
 			t.Fatalf("Expected that %s has size: %d, but it has size: %d\n", testfile, test.size, s)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/uniq/uniq_test.go
+++ b/cmds/uniq/uniq_test.go
@@ -6,33 +6,18 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"syscall"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
 func TestUniq(t *testing.T) {
 	var (
 		input1 string = "test\ntest\ngo\ngo\ngo\ncoool\ncoool\ncool\nlegaal\ntest\n"
 		input2 string = "u-root\nuniq\nron\nron\nteam\nbinaries\ntest\n\n\n\n\n\n"
-		tab           = []struct {
-			i string
-			o string
-			s int
-			a []string
-		}{
-			{input1, "test\ngo\ncoool\ncool\nlegaal\ntest\n", 0, nil},
-			{input1, "2\ttest\n3\tgo\n2\tcoool\n1\tcool\n1\tlegaal\n1\ttest\n", 0, []string{"-c"}},
-			{input1, "cool\nlegaal\ntest\n", 0, []string{"-u"}},
-			{input1, "test\ngo\ncoool\n", 0, []string{"-d"}},
-			{input2, "u-root\nuniq\nron\nteam\nbinaries\ntest\n\n", 0, nil},
-			{input2, "1\tu-root\n1\tuniq\n2\tron\n1\tteam\n1\tbinaries\n1\ttest\n5\t\n", 0, []string{"-c"}},
-			{input2, "u-root\nuniq\nteam\nbinaries\ntest\n", 0, []string{"-u"}},
-			{input2, "ron\n\n", 0, []string{"-d"}},
-		}
 	)
 
 	tmpDir, err := ioutil.TempDir("", "UniqTest")
@@ -41,32 +26,42 @@ func TestUniq(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	uniqtestpath := filepath.Join(tmpDir, "uniqtest.exe")
-	out, err := exec.Command("go", "build", "-o", uniqtestpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/uniq: %v\n%s", uniqtestpath, err, string(out))
+	for i, tt := range []struct {
+		in       string
+		out      string
+		exitCode int
+		args     []string
+	}{
+		{input1, "test\ngo\ncoool\ncool\nlegaal\ntest\n", 0, nil},
+		{input1, "2\ttest\n3\tgo\n2\tcoool\n1\tcool\n1\tlegaal\n1\ttest\n", 0, []string{"-c"}},
+		{input1, "cool\nlegaal\ntest\n", 0, []string{"-u"}},
+		{input1, "test\ngo\ncoool\n", 0, []string{"-d"}},
+		{input2, "u-root\nuniq\nron\nteam\nbinaries\ntest\n\n", 0, nil},
+		{input2, "1\tu-root\n1\tuniq\n2\tron\n1\tteam\n1\tbinaries\n1\ttest\n5\t\n", 0, []string{"-c"}},
+		{input2, "u-root\nuniq\nteam\nbinaries\ntest\n", 0, []string{"-u"}},
+		{input2, "ron\n\n", 0, []string{"-d"}},
+	} {
+		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
+			c := testutil.Command(t, tt.args...)
+			c.Stdin = bytes.NewReader([]byte(tt.in))
+
+			o, err := c.CombinedOutput()
+			if err := testutil.IsExitCode(err, tt.exitCode); err != nil {
+				t.Fatal(err)
+			}
+
+			if string(o) != tt.out {
+				t.Errorf("uniq %v < %v: got %v, want %v", tt.args, tt.in, string(o), tt.out)
+			}
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
 	}
 
-	t.Logf("Built %v for test", uniqtestpath)
-	for _, v := range tab {
-		c := exec.Command(uniqtestpath, v.a...)
-		c.Stdin = bytes.NewReader([]byte(v.i))
-		o, err := c.CombinedOutput()
-		s := c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-
-		if s != v.s {
-			t.Errorf("Uniq %v < %v > %v: want (exit: %v), got (exit %v)", v.a, v.i, v.o, v.s, s)
-			continue
-		}
-
-		if err != nil && s != v.s {
-			t.Errorf("Uniq %v < %v > %v: want nil, got %v", v.a, v.i, v.o, err)
-			continue
-		}
-		if string(o) != v.o {
-			t.Errorf("Uniq %v < %v: want '%v', got '%v'", v.a, v.i, v.o, string(o))
-			continue
-		}
-		t.Logf("Uniq %v < %v: %v", v.a, v.i, v.o)
-	}
+	os.Exit(m.Run())
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -5,39 +5,53 @@
 package testutil
 
 import (
-	"io/ioutil"
+	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 )
 
-// CompileInTempDir creates a temp directory and compiles the main package of
-// the current directory. Remember to delete the directory after the test:
-//
-//     defer os.RemoveAll(tmpDir)
-//
-// The first argument of the environment variable EXECPATH overrides execPath.
-func CompileInTempDir(t testing.TB) (tmpDir string, execPath string) {
-	// Create temp directory
-	tmpDir, err := ioutil.TempDir("", "Test")
-	if err != nil {
-		t.Fatal("TempDir failed: ", err)
-	}
-
+func Command(t testing.TB, args ...string) *exec.Cmd {
 	// Skip compilation if EXECPATH is set.
-	execPath = os.Getenv("EXECPATH")
-	if execPath != "" {
-		execPath = strings.SplitN(execPath, " ", 2)[0]
-		return
+	execPath := os.Getenv("EXECPATH")
+	if len(execPath) > 0 {
+		exe := strings.Split(os.Getenv("EXECPATH"), " ")
+		return exec.Command(exe[0], append(exe[1:], args...)...)
 	}
 
-	// Compile the program
-	execPath = filepath.Join(tmpDir, "exec")
-	out, err := exec.Command("go", "build", "-o", execPath).CombinedOutput()
+	execPath, err := os.Executable()
 	if err != nil {
-		t.Fatalf("Failed to build: %v\n%s", err, string(out))
+		t.Errorf("on strange system: cannot find executable path? %v", err)
 	}
-	return
+	c := exec.Command(execPath, args...)
+	c.Env = append(c.Env, "UROOT_CALL_MAIN=1")
+	return c
+}
+
+func IsExitCode(err error, exitCode int) error {
+	if err == nil {
+		if exitCode != 0 {
+			return fmt.Errorf("got code 0, want %d", exitCode)
+		}
+		return nil
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		return fmt.Errorf("encountered error other than ExitError: %#v", err)
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return fmt.Errorf("sys() is not a syscall WaitStatus: %v", err)
+	}
+	if es := ws.ExitStatus(); es != exitCode {
+		return fmt.Errorf("got exit status %d, want %d", es, exitCode)
+	}
+	return nil
+}
+
+func CallMain() bool {
+	return len(os.Getenv("UROOT_CALL_MAIN")) > 0
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -55,7 +55,7 @@ func Command(t testing.TB, args ...string) *exec.Cmd {
 	}
 
 	c := exec.Command(execPath, args...)
-	c.Env = append(c.Env, "UROOT_CALL_MAIN=1")
+	c.Env = append(c.Env, append(os.Environ(), "UROOT_CALL_MAIN=1")...)
 	return c
 }
 


### PR DESCRIPTION
This implements @rjoleary's suggestion from #721.

Eliminates the use of the go compiler in tests.