### PR TITLE
Eliminate go compiler in tests

### DIFF
--- a/cmds/chmod/chmod_test.go
+++ b/cmds/chmod/chmod_test.go
@@ -223,13 +223,5 @@ func TestInvocationErrors(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/chmod/chmod_test.go
+++ b/cmds/chmod/chmod_test.go
@@ -223,10 +223,13 @@ func TestInvocationErrors(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/chmod/chmod_test.go
+++ b/cmds/chmod/chmod_test.go
@@ -12,10 +12,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"testing"
-)
 
-var (
-	testPath = "."
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
 func run(c *exec.Cmd) (string, string, error) {
@@ -39,16 +37,9 @@ func TestChmodSimple(t *testing.T) {
 	}
 	defer f.Close()
 
-	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
 	for _, perm := range []os.FileMode{0777, 0644} {
 		// Set permissions using chmod.
-		c := exec.Command(testpath, fmt.Sprintf("%0o", perm), f.Name())
+		c := testutil.Command(t, fmt.Sprintf("%0o", perm), f.Name())
 		c.Run()
 
 		// Check that it worked.
@@ -108,15 +99,9 @@ func TestChmodRecursive(t *testing.T) {
 	}
 
 	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
 	for _, perm := range []os.FileMode{0707, 0770} {
 		// Set target file permissions using chmod.
-		c := exec.Command(testpath,
+		c := testutil.Command(t,
 			"-R",
 			fmt.Sprintf("%0o", perm),
 			tempDir)
@@ -149,18 +134,11 @@ func TestChmodReference(t *testing.T) {
 	}
 	defer targetFile.Close()
 
-	// Build chmod binary.
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
-
 	for _, perm := range []os.FileMode{0777, 0644} {
 		os.Chmod(sourceFile.Name(), perm)
 
 		// Set target file permissions using chmod.
-		c := exec.Command(testpath,
+		c := testutil.Command(t,
 			"--reference",
 			sourceFile.Name(),
 			targetFile.Name())
@@ -190,12 +168,6 @@ func TestInvocationErrors(t *testing.T) {
 		t.Fatalf("cannot create temporary file: %v", err)
 	}
 	defer f.Close()
-
-	testpath := filepath.Join(tempDir, "testchmod.exe")
-	out, err := exec.Command("go", "build", "-o", testpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/chmod: %v\n%s", testpath, err, string(out))
-	}
 
 	for _, v := range []struct {
 		args     []string
@@ -235,7 +207,7 @@ func TestInvocationErrors(t *testing.T) {
 			skipFrom: -1,
 		},
 	} {
-		cmd := exec.Command(testpath, v.args...)
+		cmd := testutil.Command(t, v.args...)
 		_, stderr, err := run(cmd)
 		if v.skipFrom == -1 {
 			v.skipFrom = len(stderr)
@@ -248,4 +220,13 @@ func TestInvocationErrors(t *testing.T) {
 			t.Errorf("Chmod for %q failed: got nil want err", v.args)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/comm/comm_test.go
+++ b/cmds/comm/comm_test.go
@@ -82,10 +82,13 @@ func TestComm(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/comm/comm_test.go
+++ b/cmds/comm/comm_test.go
@@ -82,13 +82,5 @@ func TestComm(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/dd/dd_test.go
+++ b/cmds/dd/dd_test.go
@@ -203,10 +203,13 @@ func BenchmarkDd(b *testing.B) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/dd/dd_test.go
+++ b/cmds/dd/dd_test.go
@@ -100,11 +100,11 @@ func TestDd(t *testing.T) {
 			compare: stdoutEqual,
 		},
 		{
-			name:    "1 GiB zeroed file in 1024 1KiB blocks",
-			flags:   []string{"bs=1048576", "count=1024", "if=/dev/zero"},
+			name:    "512 MiB zeroed file in 1024 1KiB blocks",
+			flags:   []string{"bs=524288", "count=1024", "if=/dev/zero"},
 			stdin:   "",
 			stdout:  []byte("\x00"),
-			count:   1024 * 1024 * 1024,
+			count:   1024 * 1024 * 512,
 			compare: byteCount,
 		},
 	}

--- a/cmds/dd/dd_test.go
+++ b/cmds/dd/dd_test.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"testing"
 
@@ -203,13 +202,5 @@ func BenchmarkDd(b *testing.B) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/dhclient/dhclient_test.go
+++ b/cmds/dhclient/dhclient_test.go
@@ -39,10 +39,13 @@ func TestDhclient(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/dhclient/dhclient_test.go
+++ b/cmds/dhclient/dhclient_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"os"
-	"os/exec"
 	"strings"
 	"testing"
 
@@ -28,11 +27,8 @@ var tests = []struct {
 }
 
 func TestDhclient(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
 	for _, tt := range tests {
-		out, err := exec.Command(execPath, tt.isIPv4, tt.test, tt.iface).CombinedOutput()
+		out, err := testutil.Command(t, tt.isIPv4, tt.test, tt.iface).CombinedOutput()
 		if err == nil {
 			t.Errorf("%v: got nil, want err", tt)
 		}
@@ -40,4 +36,13 @@ func TestDhclient(t *testing.T) {
 			t.Errorf("expected:\n%s\ngot:\n%s", tt.out, string(out))
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/dhclient/dhclient_test.go
+++ b/cmds/dhclient/dhclient_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -39,13 +38,5 @@ func TestDhclient(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/dirname/dirname_test.go
+++ b/cmds/dirname/dirname_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
@@ -52,13 +51,5 @@ func TestDirName(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/dirname/dirname_test.go
+++ b/cmds/dirname/dirname_test.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
@@ -30,12 +29,9 @@ var dirnameTests = []test{
 }
 
 func TestDirName(t *testing.T) {
-	tmpDir, dirname := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
 	// Table-driven testing
 	for _, tt := range dirnameTests {
-		c := exec.Command(dirname, tt.args...)
+		c := testutil.Command(t, tt.args...)
 		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 		c.Stdout, c.Stderr = stdout, stderr
 		err := c.Run()
@@ -53,4 +49,13 @@ func TestDirName(t *testing.T) {
 		}
 
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/dirname/dirname_test.go
+++ b/cmds/dirname/dirname_test.go
@@ -52,10 +52,13 @@ func TestDirName(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/false/false_test.go
+++ b/cmds/false/false_test.go
@@ -23,10 +23,13 @@ func TestFalse(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/false/false_test.go
+++ b/cmds/false/false_test.go
@@ -6,28 +6,27 @@ package main
 
 import (
 	"os"
-	"os/exec"
-	"syscall"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-// Ensure 1 is returned.
 func TestFalse(t *testing.T) {
-	tmpDir, falsePath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
-	out, err := exec.Command(falsePath).CombinedOutput()
-	exitErr, ok := err.(*exec.ExitError)
-	if !ok {
-		t.Fatal("Expected an exit error result")
-	}
-	retCode := exitErr.Sys().(syscall.WaitStatus).ExitStatus()
-	if retCode != 1 {
-		t.Fatalf("Expected 1 as the return code; got %v", retCode)
+	// Ensure 1 is returned.
+	out, err := testutil.Command(t).CombinedOutput()
+	if err := testutil.IsExitCode(err, 1); err != nil {
+		t.Error(err)
 	}
 	if len(out) != 0 {
 		t.Fatalf("Expected no output; got %#v", string(out))
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/false/false_test.go
+++ b/cmds/false/false_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
@@ -23,13 +22,5 @@ func TestFalse(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/fmap/fmap_test.go
+++ b/cmds/fmap/fmap_test.go
@@ -131,10 +131,13 @@ func TestJson(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/fmap/fmap_test.go
+++ b/cmds/fmap/fmap_test.go
@@ -131,13 +131,5 @@ func TestJson(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/fmap/fmap_test.go
+++ b/cmds/fmap/fmap_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -59,14 +58,12 @@ Mixed:        3 (50.0%)
 
 // Table driven testing
 func TestFmap(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
 	for _, tt := range tests {
-		out, err := exec.Command(execPath, tt.cmd, testFlash).CombinedOutput()
+		out, err := testutil.Command(t, tt.cmd, testFlash).CombinedOutput()
 		if err != nil {
 			t.Error(err)
 		}
+
 		// Filter out null characters which may be present in fmap strings.
 		out = bytes.Replace(out, []byte{0}, []byte{}, -1)
 		if string(out) != tt.out {
@@ -76,11 +73,14 @@ func TestFmap(t *testing.T) {
 }
 
 func TestJson(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "fmap_json")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	jsonFile := filepath.Join(tmpDir, "tmp.json")
-	if err := exec.Command(execPath, "jget", jsonFile, testFlash).Run(); err != nil {
+	if err := testutil.Command(t, "jget", jsonFile, testFlash).Run(); err != nil {
 		t.Fatal(err)
 	}
 	got, err := ioutil.ReadFile(jsonFile)
@@ -128,4 +128,13 @@ func TestJson(t *testing.T) {
 	if string(got) != want {
 		t.Errorf("want:%s; got:%s", string(want), got)
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/grep/grep_test.go
+++ b/cmds/grep/grep_test.go
@@ -8,10 +8,9 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"syscall"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
 // GrepTest is a table-driven which spawns grep with a variety of options and inputs.
@@ -36,33 +35,26 @@ func TestGrep(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	testgreppath := filepath.Join(tmpDir, "testgrep.exe")
-	out, err := exec.Command("go", "build", "-o", testgreppath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/grep: %v\n%s", testgreppath, err, string(out))
-	}
-
-	t.Logf("Built %v for test", testgreppath)
 	for _, v := range tab {
-		t.Logf("Run %v args %v", testgreppath, v)
-		c := exec.Command(testgreppath, v.a...)
+		c := testutil.Command(t, v.a...)
 		c.Stdin = bytes.NewReader([]byte(v.i))
 		o, err := c.CombinedOutput()
-		s := c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-
-		if s != v.s {
-			t.Errorf("Grep %v < %v > %v: want (exit: %v), got (exit %v)", v.a, v.i, v.o, v.s, s)
-			continue
-		}
-
-		if err != nil && s != v.s {
-			t.Errorf("Grep %v < %v > %v: want nil, got %v", v.a, v.i, v.o, err)
+		if err := testutil.IsExitCode(err, v.s); err != nil {
+			t.Error(err)
 			continue
 		}
 		if string(o) != v.o {
 			t.Errorf("Grep %v < %v: want '%v', got '%v'", v.a, v.i, v.o, string(o))
 			continue
 		}
-		t.Logf("Grep %v < %v: %v", v.a, v.i, v.o)
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/grep/grep_test.go
+++ b/cmds/grep/grep_test.go
@@ -51,10 +51,13 @@ func TestGrep(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/grep/grep_test.go
+++ b/cmds/grep/grep_test.go
@@ -51,13 +51,5 @@ func TestGrep(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/hexdump/hexdump_test.go
+++ b/cmds/hexdump/hexdump_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bytes"
-	"os"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
@@ -41,13 +40,5 @@ func TestHexdump(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/hexdump/hexdump_test.go
+++ b/cmds/hexdump/hexdump_test.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"os"
-	"os/exec"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
@@ -27,11 +26,8 @@ var tests = []struct {
 }
 
 func TestHexdump(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
-	defer os.RemoveAll(tmpDir)
-
 	for _, tt := range tests {
-		cmd := exec.Command(execPath)
+		cmd := testutil.Command(t)
 		cmd.Stdin = bytes.NewReader(tt.in)
 		out, err := cmd.CombinedOutput()
 		if err != nil {
@@ -42,4 +38,13 @@ func TestHexdump(t *testing.T) {
 			t.Errorf("want=%#v; got=%#v", tt.out, tt)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/hexdump/hexdump_test.go
+++ b/cmds/hexdump/hexdump_test.go
@@ -41,10 +41,13 @@ func TestHexdump(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/id/id_test.go
+++ b/cmds/id/id_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"os"
 	"os/exec"
 	"testing"
 
@@ -49,13 +48,5 @@ func TestInvocation(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/id/id_test.go
+++ b/cmds/id/id_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 var (
-	remove          = true
-	testpath        = "."
 	logPrefixLength = len("2009/11/10 23:00:00 ")
 )
 
@@ -31,12 +29,6 @@ func run(c *exec.Cmd) (string, string, error) {
 
 // Test incorrect invocation of id
 func TestInvocation(t *testing.T) {
-	tempDir, idPath := testutil.CompileInTempDir(t)
-
-	if remove {
-		defer os.RemoveAll(tempDir)
-	}
-
 	var tests = []test{
 		{opt: []string{"-n"}, out: "id: cannot print only names in default format\n"},
 		{opt: []string{"-G", "-g"}, out: "id: cannot print \"only\" of more than one choice\n"},
@@ -46,7 +38,7 @@ func TestInvocation(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		c := exec.Command(idPath, test.opt...)
+		c := testutil.Command(t, test.opt...)
 		_, e, _ := run(c)
 
 		// Ignore the date and time because we're using Log.Fatalf
@@ -54,4 +46,13 @@ func TestInvocation(t *testing.T) {
 			t.Errorf("id for '%v' failed: got '%s', want '%s'", test.opt, e, test.out)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/id/id_test.go
+++ b/cmds/id/id_test.go
@@ -49,10 +49,13 @@ func TestInvocation(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/kill/kill_test.go
+++ b/cmds/kill/kill_test.go
@@ -93,13 +93,5 @@ func TestBadInvocations(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/kill/kill_test.go
+++ b/cmds/kill/kill_test.go
@@ -10,9 +10,10 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
 // Run the command, with the optional args, and return a string
@@ -31,29 +32,20 @@ func TestKillProcess(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	killtestpath := filepath.Join(tmpDir, "killtest.exe")
-	o, e, err := run(exec.Command("go", "build", "-o", killtestpath, "."))
-	if err != nil {
-		t.Fatalf("go build -o %s cmds/kill: %v, %s", killtestpath, err, o+":"+e)
-	}
-
-	t.Logf("Built %v for test", killtestpath)
-
 	// Re-exec the test binary itself to emulate "sleep 1".
 	cmd := exec.Command("/bin/sleep", "10")
 	if err := cmd.Start(); err != nil {
-		t.Fatalf("Failed to start test process: %v, output %s", err, string(e))
+		t.Fatalf("Failed to start test process: %v", err)
 	}
 
 	// from the orignal. hokey .1 second wait for the process to start. Racy.
 	time.Sleep(100 * time.Millisecond)
 
-	if o, e, err = run(exec.Command(killtestpath, "-9", fmt.Sprintf("%d", cmd.Process.Pid))); err != nil {
+	if _, _, err := run(testutil.Command(t, "-9", fmt.Sprintf("%d", cmd.Process.Pid))); err != nil {
 		t.Errorf("Could not spawn first kill: %v", err)
 	}
 
-	t.Logf("Ran kill: output :%s:, extra info :%v", o, e)
-	if err = cmd.Wait(); err == nil {
+	if err := cmd.Wait(); err == nil {
 		t.Errorf("Test process succeeded, but expected to fail")
 	}
 
@@ -62,7 +54,7 @@ func TestKillProcess(t *testing.T) {
 	// you just "know" does not exist is tricky. What PID do you use?
 	// So we just kill the one we just killed; it should get an error.
 	// If not, something's wrong.
-	if _, _, err = run(exec.Command(killtestpath, "-9", fmt.Sprintf("%d", cmd.Process.Pid))); err == nil {
+	if _, _, err := run(testutil.Command(t, "-9", fmt.Sprintf("%d", cmd.Process.Pid))); err == nil {
 		t.Fatalf("Second kill: got nil, want error")
 	}
 }
@@ -89,16 +81,8 @@ func TestBadInvocations(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	killtestpath := filepath.Join(tmpDir, "killtest.exe")
-	o, e, err := run(exec.Command("go", "build", "-o", killtestpath, "."))
-	if err != nil {
-		t.Fatalf("go build -o %s cmds/kill: %v, %s", killtestpath, err, o+":"+e)
-	}
-
-	t.Logf("Built %v for test", killtestpath)
 	for _, v := range tab {
-		o, e, err := run(exec.Command(killtestpath, v.a...))
-		t.Logf("%v: %s %s %v", v.a, o, e, err)
+		_, e, err := run(testutil.Command(t, v.a...))
 		if e != v.err {
 			t.Errorf("Kill for '%v' failed: got '%s', want '%s'", v.a, e, v.err)
 		}
@@ -106,4 +90,13 @@ func TestBadInvocations(t *testing.T) {
 			t.Errorf("Kill for '%v' failed: got nil, want err", v.a)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/kill/kill_test.go
+++ b/cmds/kill/kill_test.go
@@ -93,10 +93,13 @@ func TestBadInvocations(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/ls/ls_test.go
+++ b/cmds/ls/ls_test.go
@@ -5,8 +5,8 @@
 package main
 
 import (
+	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -52,7 +52,10 @@ f3?line 2
 }
 
 func TestLs(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	// Create an empty directory.
@@ -69,11 +72,9 @@ func TestLs(t *testing.T) {
 
 	// Table-driven testing
 	for _, tt := range tests {
-		c := exec.Command(execPath, tt.flags...)
-		t.Logf("Dir is %v", testDir)
+		c := testutil.Command(t, tt.flags...)
 		c.Dir = testDir
 		out, err := c.Output()
-		t.Logf("out :%v err: %v", out, err)
 		if err != nil {
 			t.Error(err)
 		}
@@ -81,4 +82,13 @@ func TestLs(t *testing.T) {
 			t.Errorf("got:\n%s\nwant:\n%s", string(out), tt.out)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/ls/ls_test.go
+++ b/cmds/ls/ls_test.go
@@ -85,13 +85,5 @@ func TestLs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/ls/ls_test.go
+++ b/cmds/ls/ls_test.go
@@ -85,10 +85,13 @@ func TestLs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/mkdir/mkdir_test.go
+++ b/cmds/mkdir/mkdir_test.go
@@ -253,13 +253,5 @@ func TestMkdirPermission(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/mkdir/mkdir_test.go
+++ b/cmds/mkdir/mkdir_test.go
@@ -253,10 +253,13 @@ func TestMkdirPermission(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/mkdir/mkdir_test.go
+++ b/cmds/mkdir/mkdir_test.go
@@ -151,14 +151,17 @@ func removeCreatedFiles(tmpDir string) {
 
 func TestMkdirErrors(t *testing.T) {
 	// Set Up
-	tmpDir, execPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 	syscall.Umask(umaskDefault)
 
 	// Error Tests
 	for _, test := range errorTestCases {
 		removeCreatedFiles(tmpDir)
-		c := exec.Command(execPath, test.args...)
+		c := testutil.Command(t, test.args...)
 		execStmt := fmt.Sprintf("exec(mkdir %s)", strings.Trim(fmt.Sprint(test.args), "[]"))
 		c.Dir = tmpDir
 		_, e, err := run(c)
@@ -179,14 +182,17 @@ func TestMkdirErrors(t *testing.T) {
 
 func TestMkdirRegular(t *testing.T) {
 	// Set Up
-	tmpDir, execPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 	syscall.Umask(umaskDefault)
 
 	// Regular Tests
 	for _, test := range regularTestCases {
 		removeCreatedFiles(tmpDir)
-		c := exec.Command(execPath, test.args...)
+		c := testutil.Command(t, test.args...)
 		execStmt := fmt.Sprintf("exec(mkdir %s)", strings.Trim(fmt.Sprint(test.args), "[]"))
 		c.Dir = tmpDir
 		_, e, err := run(c)
@@ -210,14 +216,17 @@ func TestMkdirRegular(t *testing.T) {
 
 func TestMkdirPermission(t *testing.T) {
 	// Set Up
-	tmpDir, execPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 	syscall.Umask(umaskDefault)
 
 	// Permission Tests
 	for _, test := range permTestCases {
 		removeCreatedFiles(tmpDir)
-		c := exec.Command(execPath, test.args...)
+		c := testutil.Command(t, test.args...)
 		execStmt := fmt.Sprintf("exec(mkdir %s)", strings.Trim(fmt.Sprint(test.args), "[]"))
 		c.Dir = tmpDir
 		_, e, err := run(c)
@@ -241,4 +250,13 @@ func TestMkdirPermission(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/mkfifo/mkfifo_test.go
+++ b/cmds/mkfifo/mkfifo_test.go
@@ -79,13 +79,5 @@ func TestMkfifo(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/mkfifo/mkfifo_test.go
+++ b/cmds/mkfifo/mkfifo_test.go
@@ -6,8 +6,8 @@ package main
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,13 +22,15 @@ type test struct {
 }
 
 func TestMkfifo(t *testing.T) {
-	tmpDir, execPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	// used later in testing
 	testDir := filepath.Join(tmpDir, "mkfifoDir")
-	err := os.Mkdir(testDir, 0700)
-	if err != nil {
+	if err := os.Mkdir(testDir, 0700); err != nil {
 		t.Error(err)
 	}
 
@@ -52,7 +54,7 @@ func TestMkfifo(t *testing.T) {
 
 	for _, tt := range tests {
 		var out, stdErr bytes.Buffer
-		cmd := exec.Command(execPath, tt.flags...)
+		cmd := testutil.Command(t, tt.flags...)
 		cmd.Stdout = &out
 		cmd.Stderr = &stdErr
 		err := cmd.Run()
@@ -74,4 +76,13 @@ func TestMkfifo(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/mkfifo/mkfifo_test.go
+++ b/cmds/mkfifo/mkfifo_test.go
@@ -79,10 +79,13 @@ func TestMkfifo(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/mknod/mknod_test.go
+++ b/cmds/mknod/mknod_test.go
@@ -85,10 +85,13 @@ func TestInvocationErrors(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/mknod/mknod_test.go
+++ b/cmds/mknod/mknod_test.go
@@ -16,12 +16,6 @@ import (
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-var (
-	testPath = "."
-	// if true removeAll the testPath on the end
-	remove = true
-)
-
 type test struct {
 	args    []string
 	expects string
@@ -85,13 +79,5 @@ func TestInvocationErrors(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/readlink/readlink_test.go
+++ b/cmds/readlink/readlink_test.go
@@ -136,10 +136,13 @@ func TestReadlink(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/readlink/readlink_test.go
+++ b/cmds/readlink/readlink_test.go
@@ -136,13 +136,5 @@ func TestReadlink(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/rush/rush_test.go
+++ b/cmds/rush/rush_test.go
@@ -73,10 +73,13 @@ func TestRush(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/rush/rush_test.go
+++ b/cmds/rush/rush_test.go
@@ -73,13 +73,5 @@ func TestRush(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/sort/sort_test.go
+++ b/cmds/sort/sort_test.go
@@ -145,10 +145,13 @@ func TestMultipleFileInputs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/sort/sort_test.go
+++ b/cmds/sort/sort_test.go
@@ -145,13 +145,5 @@ func TestMultipleFileInputs(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/sort/sort_test.go
+++ b/cmds/sort/sort_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -43,12 +42,15 @@ var sortTests = []test{
 
 // sort < in > out
 func TestSortWithPipes(t *testing.T) {
-	tmpDir, sortPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	// Table-driven testing
 	for _, tt := range sortTests {
-		cmd := exec.Command(sortPath, tt.flags...)
+		cmd := testutil.Command(t, tt.flags...)
 		cmd.Stdin = strings.NewReader(tt.in)
 		var out bytes.Buffer
 		cmd.Stdout = &out
@@ -63,7 +65,7 @@ func TestSortWithPipes(t *testing.T) {
 }
 
 // Helper function to create input files, run sort and compare the output.
-func sortWithFiles(t *testing.T, tt test, tmpDir string, sortPath string,
+func sortWithFiles(t *testing.T, tt test, tmpDir string,
 	inFiles []string, outFile string) {
 	// Create input files
 	inPaths := make([]string, len(inFiles))
@@ -76,12 +78,10 @@ func sortWithFiles(t *testing.T, tt test, tmpDir string, sortPath string,
 	}
 	outPath := filepath.Join(tmpDir, outFile)
 
-	args := append(append(append([]string{}, tt.flags...), "-o",
-		outPath), inPaths...)
-	out, err := exec.Command(sortPath, args...).CombinedOutput()
+	args := append(append(tt.flags, "-o", outPath), inPaths...)
+	out, err := testutil.Command(t, args...).CombinedOutput()
 	if err != nil {
-		t.Errorf("sort %s: %v\n%s", strings.Join(args, " "),
-			err, out)
+		t.Errorf("sort %s: %v\n%s", strings.Join(args, " "), err, out)
 		return
 	}
 
@@ -98,39 +98,57 @@ func sortWithFiles(t *testing.T, tt test, tmpDir string, sortPath string,
 
 // sort -o in out
 func TestSortWithFiles(t *testing.T) {
-	tmpDir, sortPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	// Table-driven testing
 	for _, tt := range sortTests {
-		sortWithFiles(t, tt, tmpDir, sortPath, []string{"in"}, "out")
+		sortWithFiles(t, tt, tmpDir, []string{"in"}, "out")
 	}
 }
 
 // sort -o file file
 func TestInplaceSort(t *testing.T) {
-	tmpDir, sortPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	// Table-driven testing
 	for _, tt := range sortTests {
-		sortWithFiles(t, tt, tmpDir, sortPath, []string{"file"}, "file")
+		sortWithFiles(t, tt, tmpDir, []string{"file"}, "file")
 	}
 }
 
 // sort -o out in1 in2 in3 in4
 func TestMultipleFileInputs(t *testing.T) {
-	tmpDir, sortPath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "ls")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	tt := test{[]string{}, "a\nb\nc\n",
 		"a\na\na\na\nb\nb\nb\nb\nc\nc\nc\nc\n"}
-	sortWithFiles(t, tt, tmpDir, sortPath,
+	sortWithFiles(t, tt, tmpDir,
 		[]string{"in1", "in2", "in3", "in4"}, "out")
 
 	// Run the test again without newline terminators.
 	tt = test{[]string{}, "a\nb\nc",
 		"a\na\na\na\nb\nb\nb\nb\nc\nc\nc\nc\n"}
-	sortWithFiles(t, tt, tmpDir, sortPath,
+	sortWithFiles(t, tt, tmpDir,
 		[]string{"in1", "in2", "in3", "in4"}, "out")
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/truncate/truncate_test.go
+++ b/cmds/truncate/truncate_test.go
@@ -141,10 +141,13 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/truncate/truncate_test.go
+++ b/cmds/truncate/truncate_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -102,8 +101,10 @@ var truncateTests = []struct {
 
 // TestTruncate implements a table-driven test.
 func TestTruncate(t *testing.T) {
-	// Compile truncate.
-	tmpDir, truncatePath := testutil.CompileInTempDir(t)
+	tmpDir, err := ioutil.TempDir("", "truncate")
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	for i, test := range truncateTests {
@@ -116,8 +117,7 @@ func TestTruncate(t *testing.T) {
 			}
 		}
 		// Execute truncate.go
-		args := append(append([]string{}, test.flags...), testfile)
-		cmd := exec.Command(truncatePath, args...)
+		cmd := testutil.Command(t, append(test.flags, testfile)...)
 		err := cmd.Run()
 		if err != nil {
 			if test.ret == 0 {
@@ -138,4 +138,13 @@ func TestTruncate(t *testing.T) {
 			t.Fatalf("Expected that %s has size: %d, but it has size: %d\n", testfile, test.size, s)
 		}
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/truncate/truncate_test.go
+++ b/cmds/truncate/truncate_test.go
@@ -141,13 +141,5 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/uniq/uniq_test.go
+++ b/cmds/uniq/uniq_test.go
@@ -8,10 +8,9 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"syscall"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
 func TestUniq(t *testing.T) {
@@ -41,32 +40,26 @@ func TestUniq(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	uniqtestpath := filepath.Join(tmpDir, "uniqtest.exe")
-	out, err := exec.Command("go", "build", "-o", uniqtestpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/uniq: %v\n%s", uniqtestpath, err, string(out))
-	}
-
-	t.Logf("Built %v for test", uniqtestpath)
 	for _, v := range tab {
-		c := exec.Command(uniqtestpath, v.a...)
+		c := testutil.Command(t, v.a...)
 		c.Stdin = bytes.NewReader([]byte(v.i))
 		o, err := c.CombinedOutput()
-		s := c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-
-		if s != v.s {
-			t.Errorf("Uniq %v < %v > %v: want (exit: %v), got (exit %v)", v.a, v.i, v.o, v.s, s)
-			continue
-		}
-
-		if err != nil && s != v.s {
-			t.Errorf("Uniq %v < %v > %v: want nil, got %v", v.a, v.i, v.o, err)
+		if err := testutil.IsExitCode(err, v.s); err != nil {
+			t.Error(err)
 			continue
 		}
 		if string(o) != v.o {
 			t.Errorf("Uniq %v < %v: want '%v', got '%v'", v.a, v.i, v.o, string(o))
 			continue
 		}
-		t.Logf("Uniq %v < %v: %v", v.a, v.i, v.o)
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/uniq/uniq_test.go
+++ b/cmds/uniq/uniq_test.go
@@ -56,13 +56,5 @@ func TestUniq(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/uniq/uniq_test.go
+++ b/cmds/uniq/uniq_test.go
@@ -56,10 +56,13 @@ func TestUniq(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/validate/validate_test.go
+++ b/cmds/validate/validate_test.go
@@ -101,10 +101,13 @@ ff02::2 ip6-allrouters
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/validate/validate_test.go
+++ b/cmds/validate/validate_test.go
@@ -7,10 +7,11 @@ package main
 import (
 	"io/ioutil"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"syscall"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
 type file struct {
@@ -46,19 +47,12 @@ ff02::2 ip6-allrouters
 		t.Fatalf("Can't set up data file: %v", err)
 	}
 
-	validatetestpath := filepath.Join(tmpDir, "validatetest.exe")
-	out, err := exec.Command("go", "build", "-o", validatetestpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/validate: %v\n%s", validatetestpath, err, string(out))
-	}
-
-	t.Logf("Built %v for test", validatetestpath)
 	for _, v := range tests {
 		if err := ioutil.WriteFile(filepath.Join(tmpDir, v.name), v.val, 0444); err != nil {
 			t.Fatalf("Can't set up hash file: %v", err)
 		}
 
-		c := exec.Command(validatetestpath, filepath.Join(tmpDir, v.name), filepath.Join(tmpDir, "hosts"))
+		c := testutil.Command(t, filepath.Join(tmpDir, v.name), filepath.Join(tmpDir, "hosts"))
 		ep, err := c.StderrPipe()
 		if err != nil {
 			t.Fatalf("Can't start StderrPipe: %v", err)
@@ -104,4 +98,13 @@ ff02::2 ip6-allrouters
 
 		t.Logf("Validate %v hosts %v: %v", v.a, v.name, string(o))
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/validate/validate_test.go
+++ b/cmds/validate/validate_test.go
@@ -101,13 +101,5 @@ ff02::2 ip6-allrouters
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/wc/wc_test.go
+++ b/cmds/wc/wc_test.go
@@ -47,13 +47,5 @@ func TestWc(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/wc/wc_test.go
+++ b/cmds/wc/wc_test.go
@@ -47,10 +47,13 @@ func TestWc(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/cmds/wc/wc_test.go
+++ b/cmds/wc/wc_test.go
@@ -8,13 +8,11 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"syscall"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
 )
 
-//
 func TestWc(t *testing.T) {
 	var tab = []struct {
 		i string
@@ -33,32 +31,26 @@ func TestWc(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	testwcpath := filepath.Join(tmpDir, "testwc.exe")
-	out, err := exec.Command("go", "build", "-o", testwcpath, ".").CombinedOutput()
-	if err != nil {
-		t.Fatalf("go build -o %v cmds/wc: %v\n%s", testwcpath, err, string(out))
-	}
-
-	t.Logf("Built %v for test", testwcpath)
 	for _, v := range tab {
-		c := exec.Command(testwcpath, v.a...)
+		c := testutil.Command(t, v.a...)
 		c.Stdin = bytes.NewReader([]byte(v.i))
 		o, err := c.CombinedOutput()
-		s := c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
-
-		if s != v.s {
-			t.Errorf("Wc %v < %v > %v: want (exit: %v), got (exit %v)", v.a, v.i, v.o, v.s, s)
-			continue
-		}
-
-		if err != nil && s != v.s {
-			t.Errorf("Wc %v < %v > %v: want nil, got %v", v.a, v.i, v.o, err)
+		if err := testutil.IsExitCode(err, v.s); err != nil {
+			t.Error(err)
 			continue
 		}
 		if string(o) != v.o {
 			t.Errorf("Wc %v < %v: want '%v', got '%v'", v.a, v.i, v.o, string(o))
 			continue
 		}
-		t.Logf("[ok] Wc %v < %v: %v", v.a, v.i, v.o)
 	}
+}
+
+func TestMain(m *testing.M) {
+	if testutil.CallMain() {
+		main()
+		os.Exit(0)
+	}
+
+	os.Exit(m.Run())
 }

--- a/cmds/wget/wget_test.go
+++ b/cmds/wget/wget_test.go
@@ -12,7 +12,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -146,13 +145,5 @@ func TestWget(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	remover, callMain := testutil.PrepareMain()
-	if callMain {
-		main()
-		remover()
-		os.Exit(0)
-	}
-	code := m.Run()
-	remover()
-	os.Exit(code)
+	testutil.Run(m, main)
 }

--- a/cmds/wget/wget_test.go
+++ b/cmds/wget/wget_test.go
@@ -146,10 +146,13 @@ func TestWget(t *testing.T) {
 }
 
 func TestMain(m *testing.M) {
-	if testutil.CallMain() {
+	remover, callMain := testutil.PrepareMain()
+	if callMain {
 		main()
+		remover()
 		os.Exit(0)
 	}
-
-	os.Exit(m.Run())
+	code := m.Run()
+	remover()
+	os.Exit(code)
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -5,39 +5,82 @@
 package testutil
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+
+	"github.com/u-root/u-root/pkg/golang"
 )
 
-// CompileInTempDir creates a temp directory and compiles the main package of
-// the current directory. Remember to delete the directory after the test:
-//
-//     defer os.RemoveAll(tmpDir)
-//
-// The first argument of the environment variable EXECPATH overrides execPath.
-func CompileInTempDir(t testing.TB) (tmpDir string, execPath string) {
-	// Create temp directory
-	tmpDir, err := ioutil.TempDir("", "Test")
-	if err != nil {
-		t.Fatal("TempDir failed: ", err)
-	}
+var binary string
 
+func Command(t testing.TB, args ...string) *exec.Cmd {
 	// Skip compilation if EXECPATH is set.
-	execPath = os.Getenv("EXECPATH")
-	if execPath != "" {
-		execPath = strings.SplitN(execPath, " ", 2)[0]
-		return
+	execPath := os.Getenv("EXECPATH")
+	if len(execPath) > 0 {
+		exe := strings.Split(os.Getenv("EXECPATH"), " ")
+		return exec.Command(exe[0], append(exe[1:], args...)...)
 	}
 
-	// Compile the program
-	execPath = filepath.Join(tmpDir, "exec")
-	out, err := exec.Command("go", "build", "-o", execPath).CombinedOutput()
-	if err != nil {
-		t.Fatalf("Failed to build: %v\n%s", err, string(out))
+	execPath, err := os.Executable()
+	if err != nil || len(os.Getenv("UROOT_TEST_BUILD")) > 0 {
+		if len(binary) > 0 {
+			return exec.Command(binary, args...)
+		}
+		// We can't find ourselves? Probably FreeBSD or something. Try to go
+		// build the command.
+		//
+		// This is NOT build-system-independent, and hence the fallback.
+		tmpDir, err := ioutil.TempDir("", "uroot-build")
+		if err != nil {
+			t.Fatal(err)
+		}
+		wd, err := os.Getwd()
+		if err != nil {
+			t.Fatal(err)
+		}
+		execPath = filepath.Join(tmpDir, "binary")
+		// Build the stuff.
+		if err := golang.Default().BuildDir(wd, execPath, golang.BuildOpts{}); err != nil {
+			t.Fatal(err)
+		}
+		// Cache dat.
+		binary = execPath
+		return exec.Command(execPath, args...)
 	}
-	return
+
+	c := exec.Command(execPath, args...)
+	c.Env = append(c.Env, append(os.Environ(), "UROOT_CALL_MAIN=1")...)
+	return c
+}
+
+func IsExitCode(err error, exitCode int) error {
+	if err == nil {
+		if exitCode != 0 {
+			return fmt.Errorf("got code 0, want %d", exitCode)
+		}
+		return nil
+	}
+
+	exitErr, ok := err.(*exec.ExitError)
+	if !ok {
+		return fmt.Errorf("encountered error other than ExitError: %#v", err)
+	}
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return fmt.Errorf("sys() is not a syscall WaitStatus: %v", err)
+	}
+	if es := ws.ExitStatus(); es != exitCode {
+		return fmt.Errorf("got exit status %d, want %d", es, exitCode)
+	}
+	return nil
+}
+
+func CallMain() bool {
+	return len(os.Getenv("UROOT_CALL_MAIN")) > 0
 }


### PR DESCRIPTION
This implements @rjoleary's suggestion from #721.

Eliminates the use of the go compiler in all tests. This makes u-root build-system-independent.