### PR TITLE
Fixed linter warnings

### DIFF
--- a/pkg/gzip/file_test.go
+++ b/pkg/gzip/file_test.go
@@ -59,7 +59,7 @@ func TestFile_CheckPath(t *testing.T) {
 		fields  fields
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -84,7 +84,7 @@ func TestFile_CheckOutputPath(t *testing.T) {
 		fields  fields
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -169,7 +169,7 @@ func TestFile_Cleanup(t *testing.T) {
 		fields  fields
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -194,7 +194,7 @@ func TestFile_Process(t *testing.T) {
 		fields  fields
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/gzip/file_test.go
+++ b/pkg/gzip/file_test.go
@@ -186,13 +186,12 @@ func TestFile_Process(t *testing.T) {
 		Path    string
 		Options *Options
 	}
+	// TODO: Add test cases.
 	tests := []struct {
 		name    string
 		fields  fields
 		wantErr bool
-	}{
-	// TODO: Add test cases.
-	}
+	}{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &File{

--- a/pkg/gzip/file_test.go
+++ b/pkg/gzip/file_test.go
@@ -54,13 +54,12 @@ func TestFile_CheckPath(t *testing.T) {
 		Path    string
 		Options *Options
 	}
+	// TODO: Add test cases.
 	tests := []struct {
 		name    string
 		fields  fields
 		wantErr bool
-	}{
-	// TODO: Add test cases.
-	}
+	}{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &File{
@@ -79,13 +78,12 @@ func TestFile_CheckOutputPath(t *testing.T) {
 		Path    string
 		Options *Options
 	}
+	// TODO: Add test cases.
 	tests := []struct {
 		name    string
 		fields  fields
 		wantErr bool
-	}{
-	// TODO: Add test cases.
-	}
+	}{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &File{
@@ -164,13 +162,12 @@ func TestFile_Cleanup(t *testing.T) {
 		Path    string
 		Options *Options
 	}
+	// TODO: Add test cases.
 	tests := []struct {
 		name    string
 		fields  fields
 		wantErr bool
-	}{
-	// TODO: Add test cases.
-	}
+	}{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &File{

--- a/pkg/gzip/options_test.go
+++ b/pkg/gzip/options_test.go
@@ -28,14 +28,13 @@ func TestOptions_ParseArgs(t *testing.T) {
 		args    []string
 		cmdLine *flag.FlagSet
 	}
+	// TODO: Add test cases.
 	tests := []struct {
 		name    string
 		fields  fields
 		args    args
 		wantErr bool
-	}{
-	// TODO: Add test cases.
-	}
+	}{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := &Options{

--- a/pkg/gzip/options_test.go
+++ b/pkg/gzip/options_test.go
@@ -34,7 +34,7 @@ func TestOptions_ParseArgs(t *testing.T) {
 		args    args
 		wantErr bool
 	}{
-		// TODO: Add test cases.
+	// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
I just ran `gofmt -w *.go` under `pkg/gzip` to solve the CI failures at http://github.com/u-root/u-root/pull/740