### PR TITLE
init: fix environment handling

### DIFF
--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -40,7 +40,7 @@ var (
 		"/buildbin/rush",
 	}
 	cmdCount int
-	envs     = os.Environ()
+	envs     []string
 )
 
 func main() {
@@ -80,6 +80,7 @@ func main() {
 		}
 	}
 
+	envs = os.Environ()
 	debug("envs %v", envs)
 	os.Setenv("GOBIN", "/buildbin")
 	a = append(a, "-o", "/buildbin/installcommand", filepath.Join(util.CmdsPath, "installcommand"))


### PR DESCRIPTION
Environment has to be set in main() not via an initializer,
possibly due to something in the os package.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>