### PR TITLE
 pkg/uroot & tools: add standalone build tools to facilitate bazel/buck rules.

### DIFF
--- a/pkg/golang/build.go
+++ b/pkg/golang/build.go
@@ -1,3 +1,7 @@
+// Copyright 2015-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package golang
 
 import (

--- a/pkg/uroot/cpio.go
+++ b/pkg/uroot/cpio.go
@@ -24,6 +24,9 @@ type CPIOArchiver struct {
 // If `path` is empty, a default path of /tmp/initramfs.GOOS_GOARCH.cpio is
 // used.
 func (ca CPIOArchiver) OpenWriter(path, goos, goarch string) (ArchiveWriter, error) {
+	if len(path) == 0 && len(goos) == 0 && len(goarch) == 0 {
+		return nil, fmt.Errorf("passed no path, GOOS, and GOARCH to CPIOArchiver.OpenWriter")
+	}
 	if len(path) == 0 {
 		path = fmt.Sprintf("/tmp/initramfs.%s_%s.cpio", goos, goarch)
 	}

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -153,6 +153,59 @@ func ResolvePackagePaths(env golang.Environ, pkgs []string) ([]string, error) {
 	return importPaths, nil
 }
 
+// ParseExtraFiles adds files from the extraFiles list to the archive, as
+// parsed from the following formats:
+//
+// - hostPath:archivePath adds the file from hostPath at the relative archivePath in the archive.
+// - justAPath is added to the archive under justAPath.
+//
+// ParseExtraFiles will also add ldd-listed dependencies if lddDeps is true.
+func ParseExtraFiles(archive ArchiveFiles, extraFiles []string, lddDeps bool) error {
+	var err error
+	// Add files from command line.
+	for _, file := range extraFiles {
+		var src, dst string
+		parts := strings.SplitN(file, ":", 2)
+		if len(parts) == 2 {
+			// treat the entry with the new src:dst syntax
+			src = filepath.Clean(parts[0])
+			dst = filepath.Clean(parts[1])
+		} else {
+			// plain old syntax
+			src = filepath.Clean(file)
+			dst = src
+			if filepath.IsAbs(dst) {
+				dst, err = filepath.Rel("/", dst)
+				if err != nil {
+					return fmt.Errorf("cannot make path relative to /: %v: %v", dst, err)
+				}
+			}
+		}
+		src, err := filepath.Abs(src)
+		if err != nil {
+			return fmt.Errorf("couldn't find absolute path for %q: %v", src, err)
+		}
+		if err := archive.AddFile(src, dst); err != nil {
+			return fmt.Errorf("couldn't add %q to archive: %v", file, err)
+		}
+
+		if lddDeps {
+			// Pull dependencies in the case of binaries. If `path` is not
+			// a binary, `libs` will just be empty.
+			libs, err := ldd.List([]string{src})
+			if err != nil {
+				return fmt.Errorf("couldn't list ldd dependencies for %q: %v", file, err)
+			}
+			for _, lib := range libs {
+				if err := archive.AddFile(lib, lib[1:]); err != nil {
+					return fmt.Errorf("couldn't add %q to archive: %v", lib, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
 // CreateInitramfs creates an initramfs built to `opts`' specifications.
 func CreateInitramfs(opts Opts) error {
 	if _, err := os.Stat(opts.TempDir); os.IsNotExist(err) {
@@ -197,45 +250,8 @@ func CreateInitramfs(opts Opts) error {
 		DefaultRecords:  DefaultRamfs,
 	}
 
-	var err error
-	// Add files from command line.
-	for _, file := range opts.ExtraFiles {
-		var src, dst string
-		parts := strings.SplitN(file, ":", 2)
-		if len(parts) == 2 {
-			// treat the entry with the new src:dst syntax
-			src = filepath.Clean(parts[0])
-			dst = filepath.Clean(parts[1])
-		} else {
-			// plain old syntax
-			src = filepath.Clean(file)
-			dst = src
-			if filepath.IsAbs(dst) {
-				dst, err = filepath.Rel("/", dst)
-				if err != nil {
-					return fmt.Errorf("cannot make path relative to /: %v: %v", dst, err)
-				}
-			}
-		}
-		src, err := filepath.Abs(src)
-		if err != nil {
-			return fmt.Errorf("couldn't find absolute path for %q: %v", src, err)
-		}
-		if err := archive.AddFile(src, dst); err != nil {
-			return fmt.Errorf("couldn't add %q to archive: %v", file, err)
-		}
-
-		// Pull dependencies in the case of binaries. If `path` is not
-		// a binary, `libs` will just be empty.
-		libs, err := ldd.List([]string{src})
-		if err != nil {
-			return fmt.Errorf("couldn't list ldd dependencies for %q: %v", file, err)
-		}
-		for _, lib := range libs {
-			if err := archive.AddFile(lib, lib[1:]); err != nil {
-				return fmt.Errorf("couldn't add %q to archive: %v", lib, err)
-			}
-		}
+	if err := ParseExtraFiles(archive.ArchiveFiles, opts.ExtraFiles, true); err != nil {
+		return err
 	}
 
 	// Finally, write the archive.

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,4 @@
+# Ignore binaries (files without extensions)
+*
+!*.*
+!*/

--- a/tools/makebb/makebb.go
+++ b/tools/makebb/makebb.go
@@ -1,3 +1,8 @@
+// Copyright 2015-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// makebb compiles many Go commands into one bb-style binary.
 package main
 
 import (

--- a/tools/makebbmain/main.go
+++ b/tools/makebbmain/main.go
@@ -1,0 +1,34 @@
+// Copyright 2015-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// makebbmain creates a bb main.go source file.
+package main
+
+import (
+	"flag"
+	"go/importer"
+	"log"
+
+	"github.com/u-root/u-root/pkg/golang"
+	"github.com/u-root/u-root/pkg/uroot"
+)
+
+var (
+	template  = flag.String("template", "github.com/u-root/u-root/pkg/bb/cmd", "bb main.go template package")
+	outputDir = flag.String("o", "", "output directory")
+)
+
+func main() {
+	flag.Parse()
+	if flag.NArg() == 0 {
+		log.Fatalf("must list bb packages as arguments")
+	}
+
+	env := golang.Default()
+	importer := importer.For("source", nil)
+
+	if err := uroot.CreateBBMainSource(env, importer, *template, flag.Args(), *outputDir); err != nil {
+		log.Fatalf("failed to create bb source file: %v", err)
+	}
+}

--- a/tools/mkinitramfs/main.go
+++ b/tools/mkinitramfs/main.go
@@ -1,0 +1,50 @@
+// Copyright 2015-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// mkinitramfs creates a u-root initramfs given the list of files on the
+// command line.
+package mkinitramfs
+
+import (
+	"flag"
+	"log"
+
+	"github.com/u-root/u-root/pkg/cpio"
+	"github.com/u-root/u-root/pkg/uroot"
+)
+
+var (
+	outputFile = flag.String("o", "initramfs.cpio", "Initramfs output file")
+)
+
+func main() {
+	flag.Parse()
+
+	if flag.NArg() == 0 {
+		log.Fatalf("must specify at least one file to include in initramfs")
+	}
+	archiver := uroot.CPIOArchiver{
+		RecordFormat: cpio.Newc,
+	}
+
+	// Open the target initramfs file.
+	w, err := archiver.OpenWriter(*outputFile, "", "")
+	if err != nil {
+		log.Fatalf("failed to open cpio archive %q: %v", *outputFile, err)
+	}
+
+	files := uroot.NewArchiveFiles()
+	archive := uroot.ArchiveOpts{
+		ArchiveFiles:   files,
+		OutputFile:     w,
+		DefaultRecords: uroot.DefaultRamfs,
+	}
+	if err := uroot.ParseExtraFiles(archive.ArchiveFiles, flag.Args(), false); err != nil {
+		log.Fatalf("failed to parse file names %v: %v", flag.Args(), err)
+	}
+
+	if err := archive.Write(); err != nil {
+		log.Fatalf("failed to write archive %q: %v", *outputFile, err)
+	}
+}

--- a/tools/rewriteast/main.go
+++ b/tools/rewriteast/main.go
@@ -1,0 +1,32 @@
+// Copyright 2015-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// rewriteast rewrites a Go command to be bb-compatible.
+package main
+
+import (
+	"flag"
+	"go/importer"
+	"log"
+
+	"github.com/u-root/u-root/pkg/golang"
+	"github.com/u-root/u-root/pkg/uroot"
+)
+
+var (
+	pkg    = flag.String("pkg", "", "Go package path to rewrite")
+	dest   = flag.String("dest", "", "Destination directory for rewritten package files")
+	bbPath = flag.String("bbpath", "", "bb package Go import path")
+)
+
+func main() {
+	flag.Parse()
+
+	env := golang.Default()
+	importer := importer.For("source", nil)
+
+	if err := uroot.RewritePackage(env, *pkg, *dest, *bbPath, importer); err != nil {
+		log.Fatalf("failed to rewrite package %v: %v", *pkg, err)
+	}
+}


### PR DESCRIPTION
This is not intended to replace the u-root utility. It refactors some of pkg/uroot such that most of the standalone utilities are just single function calls. 