### PR TITLE
Add basic Upspin frontend for future SoS integration

### DIFF
--- a/cmds/upspin/server.go
+++ b/cmds/upspin/server.go
@@ -1,0 +1,58 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	"github.com/u-root/u-root/pkg/sos"
+)
+
+const (
+	HtmlPage = `
+<head>
+</head>
+<body>
+  <h1>Upspin</h1>
+</body>
+`
+)
+
+var (
+	Port uint
+)
+
+type UpspinServer struct {
+	// TODO: Implement an Upspin client manager
+}
+
+func (us UpspinServer) displayUpspinHandle(w http.ResponseWriter, r *http.Request) {
+	tmpl := template.Must(template.New("upspin").Parse(HtmlPage))
+	tmpl.Execute(w, "")
+}
+
+func (us UpspinServer) buildRouter() *mux.Router {
+	r := mux.NewRouter()
+	r.HandleFunc("/", us.displayUpspinHandle).Methods("GET")
+	return r
+}
+
+func (us UpspinServer) Start() {
+	//defer us.service.Shutdown()
+	listener, port, err := sos.GetListener()
+	if err != nil {
+		log.Fatalf("error: %v", err)
+	}
+	Port = port
+	fmt.Println(sos.StartServiceServer(us.buildRouter(), "upspin", listener, Port))
+}
+
+func NewUpspinServer() *UpspinServer {
+	return &UpspinServer{}
+}

--- a/cmds/upspin/server.go
+++ b/cmds/upspin/server.go
@@ -44,7 +44,6 @@ func (us UpspinServer) buildRouter() *mux.Router {
 }
 
 func (us UpspinServer) Start() {
-	//defer us.service.Shutdown()
 	listener, port, err := sos.GetListener()
 	if err != nil {
 		log.Fatalf("error: %v", err)

--- a/cmds/upspin/upspin.go
+++ b/cmds/upspin/upspin.go
@@ -1,0 +1,14 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"log"
+	"os/exec"
+)
+
+func main() {
+	NewUpspinServer().Start()
+}

--- a/cmds/upspin/upspin.go
+++ b/cmds/upspin/upspin.go
@@ -4,11 +4,6 @@
 
 package main
 
-import (
-	"log"
-	"os/exec"
-)
-
 func main() {
 	NewUpspinServer().Start()
 }


### PR DESCRIPTION
Add an SoS server skeleton for Upspin integration in the future. These changes are for development of the [NiChrome project](https://github.com/u-root/NiChrome).

Upspin: https://upspin.io
Service of Services (SoS): u-root/cmds/sos, u-root/pkg/sos

Signed-off-by: Trevor Farrelly <trevorfarrelly@google.com>