### PR TITLE
Be friendlier to bazel-like build systems.

### DIFF
--- a/pkg/golang/build.go
+++ b/pkg/golang/build.go
@@ -14,20 +14,69 @@ import (
 	"strings"
 )
 
-type Environ struct {
+// Package is the basic information a build system should provide about a Go
+// package.
+type Package struct {
+	Name       string
+	Dir        string
+	ImportPath string
+	GoFiles    []string
+	IsCommand  bool
+}
+
+// Environ is the shared toolchain interface for all build systems building Go
+// packages.
+//
+// This is to have a common denominator between the standard Go toolchain and
+// build systems such as bazel, buck, or blaze.
+type Environ interface {
+	// Package retrieves information about a package by its Go import path.
+	Package(importPath string) (*Package, error)
+}
+
+// PuppetEnviron is an Environ that can be used with the u-root busybox build
+// system by build systems that don't use the standard Go toolchain, such as
+// blaze, bazel, or buck.
+type PuppetEnviron struct {
+	packages map[string]*Package
+}
+
+var _ Environ = &PuppetEnviron{}
+
+// NewPuppetEnviron returns a new puppet toolchain environment.
+func NewPuppetEnviron(pkgs map[string]*Package) *PuppetEnviron {
+	return &PuppetEnviron{
+		packages: pkgs,
+	}
+}
+
+// Package implements Environ.Package.
+func (p *PuppetEnviron) Package(importPath string) (*Package, error) {
+	pkg, ok := p.packages[importPath]
+	if ok {
+		return pkg, nil
+	}
+	return nil, fmt.Errorf("build system did not pass enough information to find package %v", importPath)
+}
+
+// StandardGoEnviron gives a Go API to interact with the standard Go toolchain
+// and implements Environ.
+type StandardGoEnviron struct {
 	build.Context
 }
 
+var _ Environ = &StandardGoEnviron{}
+
 // Default is the default build environment comprised of the default GOPATH,
 // GOROOT, GOOS, GOARCH, and CGO_ENABLED values.
-func Default() Environ {
-	return Environ{Context: build.Default}
+func Default() *StandardGoEnviron {
+	return &StandardGoEnviron{Context: build.Default}
 }
 
 // PackageByPath retrieves information about a package by its file system path.
 //
 // `path` is assumed to be the directory containing the package.
-func (c Environ) PackageByPath(path string) (*build.Package, error) {
+func (c *StandardGoEnviron) PackageByPath(path string) (*build.Package, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, err
@@ -35,9 +84,24 @@ func (c Environ) PackageByPath(path string) (*build.Package, error) {
 	return c.Context.ImportDir(abs, 0)
 }
 
-// Package retrieves information about a package by its Go import path.
-func (c Environ) Package(importPath string) (*build.Package, error) {
+// GoPackage retrieves information about a package by its Go import path.
+func (c *StandardGoEnviron) GoPackage(importPath string) (*build.Package, error) {
 	return c.Context.Import(importPath, "", 0)
+}
+
+// Package implements Environ.Package.
+func (c *StandardGoEnviron) Package(importPath string) (*Package, error) {
+	p, err := c.GoPackage(importPath)
+	if err != nil {
+		return nil, err
+	}
+	return &Package{
+		Name:       p.Name,
+		Dir:        p.Dir,
+		ImportPath: p.ImportPath,
+		GoFiles:    p.GoFiles,
+		IsCommand:  p.IsCommand(),
+	}, nil
 }
 
 // ListPackage matches a subset of the JSON output of the `go list -json`
@@ -57,14 +121,14 @@ type ListPackage struct {
 	ImportPath string
 }
 
-func (c Environ) goCmd(args ...string) *exec.Cmd {
+func (c StandardGoEnviron) goCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command(filepath.Join(c.GOROOT, "bin", "go"), args...)
 	cmd.Env = append(os.Environ(), c.Env()...)
 	return cmd
 }
 
 // Deps lists all dependencies of the package given by `importPath`.
-func (c Environ) Deps(importPath string) (*ListPackage, error) {
+func (c StandardGoEnviron) Deps(importPath string) (*ListPackage, error) {
 	// The output of this is almost the same as build.Import, except for
 	// the dependencies.
 	cmd := c.goCmd("list", "-json", importPath)
@@ -80,7 +144,7 @@ func (c Environ) Deps(importPath string) (*ListPackage, error) {
 	return &p, nil
 }
 
-func (c Environ) Env() []string {
+func (c StandardGoEnviron) Env() []string {
 	var env []string
 	if c.GOARCH != "" {
 		env = append(env, fmt.Sprintf("GOARCH=%s", c.GOARCH))
@@ -102,19 +166,20 @@ func (c Environ) Env() []string {
 	return env
 }
 
-func (c Environ) String() string {
+// String implements fmt.Stringer.
+func (c StandardGoEnviron) String() string {
 	return strings.Join(c.Env(), " ")
 }
 
 // Optional arguments to Environ.Build.
 type BuildOpts struct {
-	// ExtraArgs to `go build`.
+	// ExtraArgs are extra arguments to pass to `go build`.
 	ExtraArgs []string
 }
 
 // Build compiles the package given by `importPath`, writing the build object
 // to `binaryPath`.
-func (c Environ) Build(importPath string, binaryPath string, opts BuildOpts) error {
+func (c StandardGoEnviron) Build(importPath string, binaryPath string, opts BuildOpts) error {
 	p, err := c.Package(importPath)
 	if err != nil {
 		return err
@@ -125,7 +190,7 @@ func (c Environ) Build(importPath string, binaryPath string, opts BuildOpts) err
 
 // BuildDir compiles the package in the directory `dirPath`, writing the build
 // object to `binaryPath`.
-func (c Environ) BuildDir(dirPath string, binaryPath string, opts BuildOpts) error {
+func (c StandardGoEnviron) BuildDir(dirPath string, binaryPath string, opts BuildOpts) error {
 	args := []string{
 		"build",
 		"-a", // Force rebuilding of packages.

--- a/pkg/uroot/bb.go
+++ b/pkg/uroot/bb.go
@@ -38,7 +38,7 @@ var skip = map[string]struct{}{
 //
 // pkgs is a list of Go import paths. If nil is returned, binaryPath will hold
 // the busybox-style binary.
-func BuildBusybox(env golang.Environ, pkgs []string, binaryPath string) error {
+func BuildBusybox(env *golang.StandardGoEnviron, pkgs []string, binaryPath string) error {
 	urootPkg, err := env.Package("github.com/u-root/u-root")
 	if err != nil {
 		return err
@@ -316,7 +316,7 @@ func getPackage(env golang.Environ, importPath string, importer types.Importer) 
 	}
 
 	name := filepath.Base(p.Dir)
-	if !p.IsCommand() {
+	if !p.IsCommand {
 		return nil, fmt.Errorf("package %q is not a command and cannot be included in bb", name)
 	}
 

--- a/pkg/uroot/bb.go
+++ b/pkg/uroot/bb.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"fmt"
 	"go/ast"
-	"go/build"
 	"go/format"
 	"go/importer"
 	"go/parser"
@@ -158,7 +157,6 @@ func BBBuild(af ArchiveFiles, opts BuildOpts) error {
 type Package struct {
 	name string
 
-	pkg         *build.Package
 	fset        *token.FileSet
 	ast         *ast.Package
 	typeInfo    types.Info
@@ -339,7 +337,6 @@ func getPackage(env golang.Environ, importPath string, importer types.Importer) 
 
 	pp := &Package{
 		name: name,
-		pkg:  p,
 		fset: fset,
 		ast:  pars[p.Name],
 		typeInfo: types.Info{
@@ -378,7 +375,7 @@ func getPackage(env golang.Environ, importPath string, importer types.Importer) 
 		// We only need global declarations' types.
 		IgnoreFuncBodies: true,
 	}
-	tpkg, err := conf.Check(pp.pkg.ImportPath, pp.fset, pp.sortedFiles, &pp.typeInfo)
+	tpkg, err := conf.Check(p.ImportPath, pp.fset, pp.sortedFiles, &pp.typeInfo)
 	if err != nil {
 		return nil, fmt.Errorf("type checking failed: %v", err)
 	}

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -84,7 +84,7 @@ type Commands struct {
 // Opts are the arguments to CreateInitramfs.
 type Opts struct {
 	// Env is the build environment (OS, arch, etc).
-	Env golang.Environ
+	Env *golang.StandardGoEnviron
 
 	// Commands specify packages to build using a specific builder.
 	Commands []Commands
@@ -120,7 +120,7 @@ type Opts struct {
 }
 
 // resolvePackagePath finds import paths for a single import path or directory string
-func resolvePackagePath(env golang.Environ, pkg string) ([]string, error) {
+func resolvePackagePath(env *golang.StandardGoEnviron, pkg string) ([]string, error) {
 	// Search the current working directory, as well GOROOT and GOPATHs
 	prefixes := append([]string{""}, env.SrcDirs()...)
 	// Resolve file system paths to package import paths.
@@ -158,7 +158,7 @@ func resolvePackagePath(env golang.Environ, pkg string) ([]string, error) {
 //   Paths to Go package directories; e.g. $GOPATH/src/github.com/u-root/u-root/cmds/ls
 //   Globs of package imports, e.g. github.com/u-root/u-root/cmds/*
 //   Globs of paths to Go package directories; e.g. ./cmds/*
-func ResolvePackagePaths(env golang.Environ, pkgs []string) ([]string, error) {
+func ResolvePackagePaths(env *golang.StandardGoEnviron, pkgs []string) ([]string, error) {
 	var importPaths []string
 	for _, pkg := range pkgs {
 		paths, err := resolvePackagePath(env, pkg)
@@ -281,7 +281,7 @@ func CreateInitramfs(opts Opts) error {
 // BuildOpts are arguments to the Build function.
 type BuildOpts struct {
 	// Env is the Go environment to use to compile and link packages.
-	Env golang.Environ
+	Env *golang.StandardGoEnviron
 
 	// Packages are the Go package import paths to compile.
 	//
@@ -387,7 +387,7 @@ func GetArchiver(name string) (Archiver, error) {
 }
 
 // DefaultPackageImports returns a list of default u-root packages to include.
-func DefaultPackageImports(env golang.Environ) ([]string, error) {
+func DefaultPackageImports(env *golang.StandardGoEnviron) ([]string, error) {
 	// Find u-root directory.
 	urootPkg, err := env.Package("github.com/u-root/u-root")
 	if err != nil {


### PR DESCRIPTION
This is so getPackage can be called with a golang.Environ that corresponds to a bazel-like build system. This is the first step in making RewritePackage and CreateBBMainSource usable with bazel-like build systems.

Next is a types.Importer implementation that looks at compiled Go files in {bazel,buck,blaze}-bin/...