### PR TITLE
sos: add HTMLPath function; remove /etc/sos/html hardcodes

### DIFF
--- a/cmds/wifi/server.go
+++ b/cmds/wifi/server.go
@@ -255,7 +255,7 @@ func (ws WifiServer) buildRouter() *mux.Router {
 	r.HandleFunc("/", ws.displayStateHandle).Methods("GET")
 	r.HandleFunc("/refresh", ws.refreshHandle).Methods("POST")
 	r.HandleFunc("/connect", ws.connectHandle).Methods("POST")
-	r.PathPrefix("/css/").Handler(http.StripPrefix("/css/", http.FileServer(http.Dir("/etc/sos/html/css"))))
+	r.PathPrefix("/css/").Handler(http.StripPrefix("/css/", http.FileServer(http.Dir(sos.HTMLPath("css")))))
 	return r
 }
 

--- a/pkg/sos/server_test.go
+++ b/pkg/sos/server_test.go
@@ -10,10 +10,29 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"path/filepath"
 	"reflect"
 	"sync"
 	"testing"
 )
+
+func TestSOSHtmlPath(t *testing.T) {
+	var tests = []struct {
+		paths  []string
+		result string
+	}{
+		{paths: []string{""}, result: *htmlRoot},
+		{paths: []string{"css"}, result: filepath.Join(*htmlRoot, "css")},
+		{paths: []string{"html", "wifi.html"}, result: filepath.Join(*htmlRoot, "html/wifi.html")},
+		{paths: []string{"html/wifi.html"}, result: filepath.Join(*htmlRoot, "html/wifi.html")},
+	}
+
+	for _, test := range tests {
+		if p := HTMLPath(test.paths...); p != test.result {
+			t.Errorf("%v: want %v, got %v", test, test.result, p)
+		}
+	}
+}
 
 func TestRegisterHandle(t *testing.T) {
 	// Set up


### PR DESCRIPTION
Also, add a switch, soshtml, so that on tests, one
can use a different root for finding html.

Hence any command using this package can be invoked with
a different root, e.g.
wifi -soshtml ~/go/src/github.com/u*/u*/pkg/sos/html

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>