### PR TITLE
Implements Upspin service backend

### DIFF
--- a/cmds/upspin_sos/server.go
+++ b/cmds/upspin_sos/server.go
@@ -138,7 +138,7 @@ const (
 )
 
 type UpspinServer struct {
-	service *DummyUpspinService
+	service *UpspinService
 }
 
 var (
@@ -178,6 +178,7 @@ func (us *UpspinServer) submitHandle(w http.ResponseWriter, r *http.Request) {
 }
 
 func (us *UpspinServer) displayStateHandle(w http.ResponseWriter, r *http.Request) {
+	us.service.Update()
 	upspinData := struct {
 		Configured bool
 		User       string
@@ -215,7 +216,7 @@ func (us *UpspinServer) Start() {
 	fmt.Println(sos.StartServiceServer(us.buildRouter(), "upspin", listener, Port))
 }
 
-func NewUpspinServer(service *DummyUpspinService) *UpspinServer {
+func NewUpspinServer(service *UpspinService) *UpspinServer {
 	return &UpspinServer{
 		service: service,
 	}

--- a/cmds/upspin_sos/service.go
+++ b/cmds/upspin_sos/service.go
@@ -4,6 +4,20 @@
 
 package main
 
+import (
+	"fmt"
+	"os"
+	"strings"
+	"regexp"
+	"io/ioutil"
+)
+
+var (
+	upspinConfigDir	= fmt.Sprintf("%v/upspin/config", os.Getenv("HOME"))
+)
+
+
+
 type DummyUpspinService struct {
 	Configured bool
 	User       string
@@ -11,11 +25,9 @@ type DummyUpspinService struct {
 	Store      string
 	Seed       string
 }
-
 func (us *DummyUpspinService) ToggleFlag() {
 	us.Configured = !us.Configured
 }
-
 func (us *DummyUpspinService) SetConfig(new UpspinAcctJsonMsg) error {
 	us.User = new.User
 	us.Dir = new.Dir
@@ -23,13 +35,72 @@ func (us *DummyUpspinService) SetConfig(new UpspinAcctJsonMsg) error {
 	us.Seed = new.Seed
 	return nil
 }
-
 func NewDummyUpspinService() (*DummyUpspinService, error) {
 	return &DummyUpspinService{
 		Configured: false,
 		User:       "",
 		Dir:        "",
 		Store:      "",
+		Seed:       "",
+	}, nil
+}
+
+
+
+type UpspinService struct  {
+	Configured bool
+	User       string
+	Dir        string
+	Store      string
+	Seed       string
+}
+
+func getFileData(path string) map[string]string {
+	userData := make(map[string]string)
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		// start in unconfigured mode using empty map
+		return userData
+	}
+	// parse file data into map using regex
+	reg, err := regexp.Compile("(: )(.*,|)")
+	for _, s := range strings.Split(string(b), "\n") {
+		keyval := reg.Split(s, -1)
+		if len(keyval) == 2 {
+			userData[keyval[0]] = keyval[1]
+		}
+	}
+	return userData
+}
+
+func (us *UpspinService) SetConfig(new UpspinAcctJsonMsg) error {
+	us.User = new.User
+	us.Dir = new.Dir
+	us.Store = new.Store
+	us.Seed = new.Seed
+	return nil
+}
+
+func (us *UpspinService) Update() {
+	data := getFileData(upspinConfigDir)
+	us.Configured = true
+	us.User       = data["username"]
+	us.Dir        = data["dirserver"]
+	us.Store      = data["storeserver"]
+	us.Seed       = ""
+}
+
+func (us *UpspinService) ToggleFlag() {
+	us.Configured = !us.Configured
+}
+
+func NewUpspinService() (*UpspinService, error) {
+	data := getFileData(upspinConfigDir)
+	return &UpspinService{
+		Configured: true,
+		User:       data["username"],
+		Dir:        data["dirserver"],
+		Store:      data["storeserver"],
 		Seed:       "",
 	}, nil
 }

--- a/cmds/upspin_sos/service.go
+++ b/cmds/upspin_sos/service.go
@@ -48,7 +48,7 @@ func getFileData(path string) map[string]string {
 
 func (us UpspinService) setFileData(path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 1000); err != nil {
+		if err := os.MkdirAll(path, 0777); err != nil {
 			return err
 		}
 	}
@@ -69,11 +69,14 @@ func (us UpspinService) setFileData(path string) error {
 
 func (us UpspinService) setKeys(path string) error {
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err := os.MkdirAll(path, 1000); err != nil {
+		if err := os.MkdirAll(path, 0777); err != nil {
 			return err
 		}
 	}
-	// TODO: upspin keygen is acting up. Removing for now
+	err := exec.Command("upspin", "keygen", fmt.Sprintf("-secretseed=%v", us.Seed), path).Start()
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmds/upspin_sos/upspin_sos.go
+++ b/cmds/upspin_sos/upspin_sos.go
@@ -9,7 +9,7 @@ import (
 )
 
 func main() {
-	service, err := NewDummyUpspinService()
+	service, err := NewUpspinService()
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Writes entered config data to $HOME/upspin/config, and calls `upspin keygen` with the entered seed, writing keys to $HOME/.ssh/yourusername@email.com.