### PR TITLE
allow rotating upspin keys from SoS page

### DIFF
--- a/cmds/upspin_sos/service.go
+++ b/cmds/upspin_sos/service.go
@@ -85,15 +85,16 @@ func (us UpspinService) setKeys(path string) error {
 	}
 	defer f.Close()
 	_, err = f.Readdir(1)
+	args := []string {"keygen", fmt.Sprintf("-secretseed=%v", us.Seed)}
 	// if the directory is populated, rotate the keys instead of generating new ones
+	// this method of appending args is ugly, but they have to be in this specific order:
+	// upspin keygen <-rotate> -secretseed=<seed> path
 	if err == nil {
-		keygen := exec.Command("upspin", "keygen", "-rotate", fmt.Sprintf("-secretseed=%v", us.Seed), path)
-		err = keygen.Run()
-	} else {
-		keygen := exec.Command("upspin", "keygen", fmt.Sprintf("-secretseed=%v", us.Seed), path)
-		err = keygen.Run()
+		args = append(args, "-rotate")
 	}
 
+	keygen := exec.Command("upspin", append(args, path)...)
+	err = keygen.Run()
 	if err != nil {
 		return err
 	}

--- a/cmds/upspin_sos/service.go
+++ b/cmds/upspin_sos/service.go
@@ -84,21 +84,15 @@ func (us UpspinService) setKeys(path string) error {
 		return err
 	}
 	defer f.Close()
-	_, err = f.Readdir(1)
 	args := []string{"keygen", fmt.Sprintf("-secretseed=%v", us.Seed)}
 	// if the directory is populated, rotate the keys instead of generating new ones
 	// this method of appending args is ugly, but they have to be in this specific order:
 	// upspin keygen <-rotate> -secretseed=<seed> path
-	if err == nil {
+	if _, err = f.Readdir(1); err == nil {
 		args = append(args, "-rotate")
 	}
 
-	keygen := exec.Command("upspin", append(args, path)...)
-	err = keygen.Run()
-	if err != nil {
-		return err
-	}
-	return nil
+	return exec.Command("upspin", append(args, path)...).Run()
 }
 
 func (us *UpspinService) Update() {

--- a/cmds/upspin_sos/service.go
+++ b/cmds/upspin_sos/service.go
@@ -85,7 +85,7 @@ func (us UpspinService) setKeys(path string) error {
 	}
 	defer f.Close()
 	_, err = f.Readdir(1)
-	args := []string {"keygen", fmt.Sprintf("-secretseed=%v", us.Seed)}
+	args := []string{"keygen", fmt.Sprintf("-secretseed=%v", us.Seed)}
 	// if the directory is populated, rotate the keys instead of generating new ones
 	// this method of appending args is ugly, but they have to be in this specific order:
 	// upspin keygen <-rotate> -secretseed=<seed> path


### PR DESCRIPTION
`upspin keygen` does not work if generated keys already exist, you need to run it with the `-rotate` flag to replace them. This adds this functionality to the Upspin SoS service.