### PR TITLE
pkg/uroot/bb: avoid having to fix import statements.

### DIFF
--- a/pkg/bb/cmd/main.go
+++ b/pkg/bb/cmd/main.go
@@ -11,7 +11,7 @@ import (
 func run() {
 	name := filepath.Base(os.Args[0])
 	if err := bb.Run(name); err != nil {
-		log.Fatalf("%q: %v", name, err)
+		log.Fatalf("%s: %v", name, err)
 	}
 }
 
@@ -20,11 +20,14 @@ func main() {
 }
 
 func init() {
-	bb.Register("bb", bb.Noop, func() {
+	m := func() {
 		if len(os.Args) <= 1 {
 			log.Fatalf("You need to specify which command to invoke.")
 		}
+		// Use argv[1] as the name.
 		os.Args = os.Args[1:]
 		run()
-	})
+	}
+	bb.Register("bb", bb.Noop, m)
+	bb.RegisterDefault(bb.Noop, m)
 }

--- a/pkg/bb/register.go
+++ b/pkg/bb/register.go
@@ -16,14 +16,24 @@ type bbCmd struct {
 	init, main func()
 }
 
-var bbcmds = map[string]bbCmd{}
+var bbCmds = map[string]bbCmd{}
+
+var defaultCmd *bbCmd
 
 // Register registers an init and main function for name.
 func Register(name string, init, main func()) {
-	if _, ok := bbcmds[name]; ok {
+	if _, ok := bbCmds[name]; ok {
 		panic(fmt.Sprintf("cannot register two commands with name %q", name))
 	}
-	bbcmds[name] = bbCmd{
+	bbCmds[name] = bbCmd{
+		init: init,
+		main: main,
+	}
+}
+
+// RegisterDefault registers a default init and main function.
+func RegisterDefault(init, main func()) {
+	defaultCmd = &bbCmd{
 		init: init,
 		main: main,
 	}
@@ -34,11 +44,17 @@ func Register(name string, init, main func()) {
 // If the command's main exits without calling os.Exit, Run will exit with exit
 // code 0.
 func Run(name string) error {
-	if _, ok := bbcmds[name]; !ok {
+	var cmd *bbCmd
+	if c, ok := bbCmds[name]; ok {
+		cmd = &c
+	} else if defaultCmd != nil {
+		cmd = defaultCmd
+	} else {
 		return ErrNotRegistered
 	}
-	bbcmds[name].init()
-	bbcmds[name].main()
+	cmd.init()
+	cmd.main()
 	os.Exit(0)
+	// Unreachable.
 	return nil
 }

--- a/pkg/uroot/bb_test.go
+++ b/pkg/uroot/bb_test.go
@@ -2,7 +2,6 @@ package uroot
 
 import (
 	"go/ast"
-	"go/importer"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -61,75 +60,12 @@ func TestPackageRewriteFile(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 
-	p, err := NewPackageFromEnv(golang.Default(), "github.com/u-root/u-root/pkg/uroot/test/foo", importer.For("source", nil))
-	if err != nil {
+	bin := filepath.Join(dir, "foo")
+	if err := BuildBusybox(golang.Default(), []string{"github.com/u-root/u-root/pkg/uroot/test/foo"}, bin); err != nil {
 		t.Fatal(err)
 	}
 
-	f := findFile(p.ast.Files, "foo.go")
-	if f == nil {
-		t.Fatalf("file not found in files: %v", p.ast.Files)
-	}
-
-	// This init holds all variable initializations.
-	varInit := &ast.FuncDecl{
-		Name: p.nextInit(),
-		Type: &ast.FuncType{
-			Params:  &ast.FieldList{},
-			Results: nil,
-		},
-		Body: &ast.BlockStmt{},
-	}
-
-	hasMain := p.rewriteFile(f)
-	if !hasMain {
-		t.Fatalf("foo.go should have main")
-	}
-
-	// Add variable initializations to Init0 in the right order.
-	for _, initStmt := range p.typeInfo.InitOrder {
-		a, ok := p.initAssigns[initStmt.Rhs]
-		if !ok {
-			t.Fatalf("couldn't find init assignment %s", initStmt)
-		}
-		varInit.Body.List = append(varInit.Body.List, a)
-	}
-
-	f.Decls = append(f.Decls, varInit)
-
-	// Change the package name back to main.
-	f.Name = ast.NewIdent("main")
-
-	// Add init.
-	f.Decls = append(f.Decls, p.init)
-	f.Decls = append(f.Decls, &ast.FuncDecl{
-		Name: ast.NewIdent("main"),
-		Type: &ast.FuncType{
-			Params:  &ast.FieldList{},
-			Results: nil,
-		},
-		Body: &ast.BlockStmt{
-			List: []ast.Stmt{
-				&ast.ExprStmt{X: &ast.CallExpr{Fun: ast.NewIdent("Init")}},
-				&ast.ExprStmt{X: &ast.CallExpr{Fun: ast.NewIdent("Main")}},
-			},
-		},
-	})
-
-	d, err := ioutil.TempDir("", "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := writeFile(filepath.Join(d, "foo.go"), p.fset, f); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := golang.Default().BuildDir(d, filepath.Join(d, "foo"), golang.BuildOpts{}); err != nil {
-		t.Fatal(err)
-	}
-
-	cmd := exec.Command(filepath.Join(d, "foo"))
+	cmd := exec.Command(bin)
 	o, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("foo failed: %v %v", string(o), err)


### PR DESCRIPTION
This way, we don't have to make the Go toolchain guess what imports may
be missing, and we only rewrite statements within each file.