### PR TITLE
Fix Upspin SoS tab name

### DIFF
--- a/pkg/sos/html/upspin.html
+++ b/pkg/sos/html/upspin.html
@@ -1,5 +1,5 @@
 <head>
-  <title>Service of Services</title>
+  <title>Upspin</title>
   <link rel="stylesheet" href="css/stylesheet.css">
   <meta charset="utf-8">
   <script>


### PR DESCRIPTION
This addresses u-root/NiChrome issue #105.