### PR TITLE
cat: Fix arg counting

### DIFF
--- a/cmds/cat/cat.go
+++ b/cmds/cat/cat.go
@@ -48,7 +48,7 @@ func cat(w io.Writer, files []string) error {
 func main() {
 	flag.Parse()
 
-	if len(os.Args) == 1 {
+	if flag.NArg() == 0 {
 		if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {
 			log.Fatalf("error concatenating stdin to stdout: %v", err)
 		}


### PR DESCRIPTION
Subtle bug prevented using arguments on cat. For example, the following
did not print "hi":

    echo "hi" | cat -u

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>