### PR TITLE
ip: Return nil instead of usage()

### DIFF
--- a/cmds/ip/ip.go
+++ b/cmds/ip/ip.go
@@ -171,8 +171,10 @@ func linkset() error {
 		if err := netlink.LinkSetDown(iface); err != nil {
 			return fmt.Errorf("%v can't make it down: %v", iface, err)
 		}
+	default:
+		return usage()
 	}
-	return usage()
+	return nil
 }
 
 func link() error {


### PR DESCRIPTION
Signed-off-by: Trevor Farrelly <trevorfarrelly@google.com>