### PR TITLE
Run dep ensure -vendor-only in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,9 +60,15 @@ jobs:
             chmod +x ./dep-linux-amd64
       - run:
           name: Check vendored dependencies
-          command:
-                  ./dep-linux-amd64 hash-inputs
-                  ./dep-linux-amd64 status
+          command: |
+            ./dep-linux-amd64 hash-inputs
+            ./dep-linux-amd64 status
+            ./dep-linux-amd64 ensure -vendor-only
+            if [[ -n "$(git status --porcelain vendor)" ]]; then
+              echo 'vendor/ is out-of-date: run `dep ensure -vendor-only` and then check in the changes'
+              git status --porcelain vendor
+              exit 1
+            fi
       - run:
           name: vet
           command: |


### PR DESCRIPTION
This will ensure that required packages are checked in and there is no diff in vendor after running dep ensure. The checks before this should check if `Gopkg.toml` has been updated based on what is in the code.

Resolves https://github.com/u-root/u-root/issues/813