### PR TITLE
Do not serve cached index

### DIFF
--- a/cmds/srvfiles/srvfiles.go
+++ b/cmds/srvfiles/srvfiles.go
@@ -25,7 +25,29 @@ var (
 	dir  = flag.String("d", ".", "directory to serve")
 )
 
+var cacheHeaders = []string{
+	"ETag",
+	"If-Modified-Since",
+	"If-None-Match",
+	"If-Range",
+	"If-Unmodified-Since",
+}
+
+func maxAgeHandler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+
+		for _, v := range cacheHeaders {
+			if r.Header.Get(v) != "" {
+				r.Header.Del(v)
+			}
+		}
+
+		h.ServeHTTP(w, r)
+	})
+}
+
 func main() {
 	flag.Parse()
-	log.Fatal(http.ListenAndServe(*host+":"+*port, http.FileServer(http.Dir(*dir))))
+	http.Handle("/", maxAgeHandler(http.FileServer(http.Dir(*dir))))
+	log.Fatal(http.ListenAndServe(*host+":"+*port, nil))
 }


### PR DESCRIPTION
This will strip any caching headers from the client (probably a browser in this case) and have the server always serve the file/directory. Caching is hard and this would have the downside of always serving up a static file which may have not changed. 

I tested that this works with the test case outlined by @rjoleary in https://github.com/u-root/u-root/issues/808 .