### PR TITLE
Remove all the shell attempts from init

### DIFF
--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -39,14 +39,6 @@ var (
 		"/buildbin/uinit",
 
 		"/bin/defaultsh",
-
-		"/bbin/sh",
-		"/bin/sh",
-		"/buildbin/sh",
-
-		"/bbin/rush",
-		"/bin/rush",
-		"/buildbin/rush",
 	}
 	cmdCount int
 	envs     []string


### PR DESCRIPTION
We now have the defaultsh symlink
so just use that.

I'm not a real fan of this symlink magic, because it always
starts with one symlink and ends up here:
(google etc alternatives)

So if we could do something else I could worry less. 
But, assuming it's here to stay, and a correctly formed u-root
/ always has defaultsh, then we might as well just try to run
that one thing. 

All these choices are making testramfs a pain.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>