### PR TITLE
Keep installcommand source in source mode

### DIFF
--- a/pkg/uroot/source.go
+++ b/pkg/uroot/source.go
@@ -35,7 +35,6 @@ func SourceBuild(af ArchiveFiles, opts BuildOpts) error {
 		name := path.Base(pkg)
 		if name == "installcommand" {
 			installcommand = pkg
-			continue
 		}
 
 		// Add high-level packages' src files to archive.


### PR DESCRIPTION
A goal of source mode images is that they be able to recreate themselves.
Leave the installcommand source in the image so this capability
is not impossible (although it may have stopped working, no need to
make it worse).

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>