### PR TITLE
tmp: create the /tmp in the cpio, not the installcommand

### DIFF
--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -129,9 +129,6 @@ func main() {
 		debug = log.Printf
 	}
 
-	// To compile something in Go, you need a /tmp directory, apparently.
-	os.Mkdir("/tmp", 0755)
-
 	debug("Command name: %v\n", form.cmdName)
 	destFile := filepath.Join("/ubin", form.cmdName)
 

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -50,6 +50,7 @@ var DefaultRamfs = []cpio.Record{
 	cpio.Directory("tcz", 0755),
 	cpio.Directory("etc", 0755),
 	cpio.Directory("dev", 0755),
+	cpio.Directory("tmp", 0777),
 	cpio.Directory("ubin", 0755),
 	cpio.Directory("usr", 0755),
 	cpio.Directory("usr/lib", 0755),


### PR DESCRIPTION
The creation of /tmp in the first program goes back
a long way, and now that we have a cpio which is the template
for /, we should put the /tmp in there.

Also, the mode needs to be 777 now.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>