### PR TITLE
root file system create: setup with empty umask

### DIFF
--- a/pkg/uroot/util/root.go
+++ b/pkg/uroot/util/root.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 
 	"github.com/u-root/u-root/pkg/cmdline"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -199,6 +200,9 @@ func GoBin() string {
 }
 
 func create(namespace []Creator) {
+	// Clear umask bits so that we get stuff like ptmx right.
+	m := unix.Umask(0)
+	defer unix.Umask(m)
 	for _, c := range namespace {
 		if err := c.Create(); err != nil {
 			log.Printf("Error creating %s: %v", c, err)


### PR DESCRIPTION
Before setting up a root file system, set umask
to 0 and restore it when done. This is essential
for any environment in which "not UID 0" will be
used.

Fixes NiChrome 0.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>