### PR TITLE
dep: Remove extraneous warning

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,9 +1,5 @@
 [[constraint]]
   branch = "master"
-  name = "github.com/google/uuid"
-
-[[constraint]]
-  branch = "master"
   name = "github.com/vishvananda/netlink"
 
 [[constraint]]


### PR DESCRIPTION
We do not need the google/uuid package anymore.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>