### PR TITLE
pex: portable executables

### DIFF
--- a/pkg/loop/loop.go
+++ b/pkg/loop/loop.go
@@ -1,0 +1,44 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package loop
+
+import (
+	"github.com/u-root/u-root/pkg/mount"
+	"golang.org/x/sys/unix"
+)
+
+// Loop implements mount.Mount
+type Loop struct {
+	Dev     string
+	Source  string
+	Dir     string
+	FStype  string
+	Flags   uintptr
+	Data    string
+	Mounted bool
+}
+
+// New initializes a Loop struct and allocates a loodevice to it.
+func New(source, target, fstype string, flags uintptr, data string) (mount.Mounter, error) {
+	devicename, err := FindDevice()
+	if err != nil {
+		return nil, err
+	}
+	if err := SetFdFiles(devicename, source); err != nil {
+		return nil, err
+	}
+	l := &Loop{Dev: devicename, Dir: target, Source: source, FStype: fstype, Flags: flags, Data: data}
+	return l, nil
+}
+
+// Mount mounts the provided source file, with type fstype, and flags and data options
+// (which are usually 0 and ""), using any available loop device.
+func (l *Loop) Mount() error {
+	if err := unix.Mount(l.Dev, l.Dir, l.FStype, l.Flags, l.Data); err != nil {
+		return err
+	}
+	l.Mounted = true
+	return nil
+}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,0 +1,12 @@
+// Copyright 2012-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The mount package implements functions for mounting and unmounting
+// file systems and defines the mount interface.
+package mount
+
+type Mounter interface {
+	Mount() error
+	Unmount(flags int) error
+}

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// The mount package implements functions for mounting and unmounting
+// file systems and defines the mount interface.
 package mount
 
 import (

--- a/xcmds/pex/pex.go
+++ b/xcmds/pex/pex.go
@@ -1,0 +1,153 @@
+// Copyright 2012-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// pex builds a portable executable as a squashfs image.
+// It is intended to create files compatible with tinycore
+// tcz files.
+// This could have been a simple program but mksquashfs does not
+// preserve path information.
+// Yeah.
+//
+// Synopsis:
+//     pex [-d] -[output|o file]
+//
+// Description:
+//     pex makes portable executables in squashfs format compatible with
+//     tcz format. We don't build in the execution code, rather, we set it
+//     up so we can use the command itself.
+//
+// Options:
+//     debug|d: verbose
+//     output|o file: output file name (default /tmp/pex.tcz)
+//     test|t: run a test by loopback mounting the squashfs and using the first arg as a command to run in a chroot
+//
+// Example:
+//	pex -d -t /bin/bash /bin/cat /bin/ls /etc/hosts
+//	Will build and squashfs, mount it, and drop you into it running bash.
+//	You can use ls and cat on /etc/hosts.
+//	Simpler example:
+//	pex -d -t /bin/ls /etc/hosts
+//	will run ls and exit.
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+
+	flag "github.com/spf13/pflag"
+	"github.com/u-root/u-root/pkg/cpio"
+	"github.com/u-root/u-root/pkg/ldd"
+	"github.com/u-root/u-root/pkg/loop"
+)
+
+const usage = "pex [-d] [-f file] command..."
+
+var (
+	debug = flag.BoolP("debug", "d", false, "enable debug prints")
+	test  = flag.BoolP("test", "t", false, "run a test with the first argument")
+	v     = func(string, ...interface{}) {}
+	ofile = flag.StringP("output", "o", "/tmp/pex.tcz", "Output file")
+)
+
+func pex() error {
+	flag.Parse()
+	if *debug {
+		v = log.Printf
+	}
+	names := flag.Args()
+	if len(names) == 0 {
+		return fmt.Errorf(usage)
+	}
+
+	l, err := ldd.Ldd(names)
+	if err != nil {
+		return err
+	}
+
+	for _, dep := range l {
+		v("%s", dep.FullName)
+		names = append(names, dep.FullName)
+	}
+	// Now we need to make a template file hierarchy and put
+	// the stuff we want in there.
+	dir, err := ioutil.TempDir("", "pex")
+	if err != nil {
+		return err
+	}
+	if !*debug {
+		defer os.RemoveAll(dir)
+	}
+	archiver := cpio.InMemArchive()
+	for _, f := range names {
+		v("Process %v", f)
+		rec, err := cpio.GetRecord(f)
+		if err != nil {
+			return err
+		}
+		if err := archiver.WriteRecord(rec); err != nil {
+			return err
+		}
+	}
+	v("%v", archiver)
+	rr := archiver.Reader()
+	for {
+		r, err := rr.ReadRecord()
+		v("%v %v", r, err)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if err := cpio.CreateFileInRoot(r, dir); err != nil {
+			return err
+		}
+
+	}
+	c := exec.Command("mksquashfs", dir, *ofile)
+	o, err := c.CombinedOutput()
+	v("%v", string(o))
+	if err != nil {
+		return fmt.Errorf("%v: %v: %v", c.Args, string(o), err)
+	}
+
+	if !*test {
+		return nil
+	}
+	// We can just mount on our own temporary directory ..
+	m, err := loop.New(*ofile, dir, "squashfs", 0, "")
+	if err != nil {
+		return err
+	}
+	if err := m.Mount(); err != nil {
+		return err
+	}
+	c = exec.Command(names[0])
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	c.SysProcAttr = &syscall.SysProcAttr{
+		Chroot: dir,
+	}
+
+	err = c.Run()
+	if err != nil {
+		log.Printf("Running test: %v", err)
+	}
+	if err := m.Unmount(0); err != nil {
+		log.Printf("Unmounting and freeing %v: %v", m, err)
+	}
+
+	log.Printf("Done, your pex is in %v", *ofile)
+	return err
+}
+
+func main() {
+	if err := pex(); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
A portable executable is a squashfs containing a set of files,
.so's, and anything else you want to bring along. It is inspired
by tinycore packages and appimage. While appimages and
tinycore packages are a bit involved to build, pex makes
it easy.

Why we're doing this: we've had a lot of trouble bringing along binaries due to
shared library issues. For example, if we build the cgpt tool from chromeos
static, on debian, it core dumps. GNU and glibc are no longer friendly to
static linking.

pex is a program that builds portable executables that look like
tinycore tczs.

For example, we might want some random programs such as
/usr/bin/minicom and a few files such as /etc/minicom.d.
We can say this:

pex /usr/bin/minicom /etc/minicom.d

The command, its .so dependencies, and /etc/minicom.d
will be packaged into a squashfs that can be (we hope)
install via the tcz command.

You can test this easily:
pex -t /bin/bash

will build the squashfs, mount it, and drop you into bash:
rminnich@uroot:~/go/src/github.com/u-root/u-root/xcmds/pex$ sudo ./pex -t /bin/bash
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
bash-4.4# ls
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
'#main.go#'   pex   pex.go   shit
bash-4.4# exit
exit
2018/08/17 13:45:00 Done, your pex is in /tmp/pex.tcz

or you can even add a program for fun:
pex -t /bin/bash /bin/cat /etc/hosts
 sudo ./pex -t /bin/bash /bin/cat /etc/hosts
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
bash-4.4# cat /etc/hosts
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
127.0.0.1	localhost
127.0.1.1	uroot

::1     localhost ip6-localhost ip6-loopback
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
192.81.129.194	 linode
bash-4.4# exit
exit
2018/08/17 13:45:47 Done, your pex is in /tmp/pex.tcz

One remaining question is how to run a pex. I'm thinking
of pexe, which would take a pex and a command in it and just
run it; for we could just have a -c to pex, meaning, use the
file but don't build it, since pex can already run these files.

I took the opportunity to clean up the mount and loop packages.
It seemed a good time to create a Mounter interface.
Should Mounter distinguish Free and Unmount? Seems a bit of
overkill.

Comments welcome.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>