### PR TITLE
pox: POrtable eXecutables

### DIFF
--- a/pkg/loop/loop.go
+++ b/pkg/loop/loop.go
@@ -1,0 +1,44 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package loop
+
+import (
+	"github.com/u-root/u-root/pkg/mount"
+	"golang.org/x/sys/unix"
+)
+
+// Loop implements mount.Mount
+type Loop struct {
+	Dev     string
+	Source  string
+	Dir     string
+	FStype  string
+	Flags   uintptr
+	Data    string
+	Mounted bool
+}
+
+// New initializes a Loop struct and allocates a loodevice to it.
+func New(source, target, fstype string, flags uintptr, data string) (mount.Mounter, error) {
+	devicename, err := FindDevice()
+	if err != nil {
+		return nil, err
+	}
+	if err := SetFdFiles(devicename, source); err != nil {
+		return nil, err
+	}
+	l := &Loop{Dev: devicename, Dir: target, Source: source, FStype: fstype, Flags: flags, Data: data}
+	return l, nil
+}
+
+// Mount mounts the provided source file, with type fstype, and flags and data options
+// (which are usually 0 and ""), using any available loop device.
+func (l *Loop) Mount() error {
+	if err := unix.Mount(l.Dev, l.Dir, l.FStype, l.Flags, l.Data); err != nil {
+		return err
+	}
+	l.Mounted = true
+	return nil
+}

--- a/pkg/loop/loop_linux.go
+++ b/pkg/loop/loop_linux.go
@@ -1,0 +1,26 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package loop
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+const forceUnmount = syscall.MNT_FORCE | syscall.MNT_DETACH
+
+// Unmount unmounts and frees a loop. If it is mounted, it will try to unmount it.
+// If the unmount fails, we try to free it anyway, after trying a more
+// forceful unmount. We don't log errors, but we do return a concatentation
+// of whatever errors occur.
+func (l *Loop) Unmount(flags int) error {
+	if l.Mounted {
+		if err := unix.Unmount(l.Dir, flags); err != nil {
+			unix.Unmount(l.Dir, flags|forceUnmount)
+		}
+	}
+	return ClearFdFile(l.Dev)
+}

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,0 +1,12 @@
+// Copyright 2012-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The mount package implements functions for mounting and unmounting
+// file systems and defines the mount interface.
+package mount
+
+type Mounter interface {
+	Mount() error
+	Unmount(flags int) error
+}

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// The mount package implements functions for mounting and unmounting
+// file systems and defines the mount interface.
 package mount
 
 import (

--- a/xcmds/pox/pox.go
+++ b/xcmds/pox/pox.go
@@ -1,0 +1,162 @@
+// Copyright 2012-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// pox builds a portable executable as a squashfs image.
+// It is intended to create files compatible with tinycore
+// tcz files.
+// This could have been a simple program but mksquashfs does not
+// preserve path information.
+// Yeah.
+//
+// Synopsis:
+//     pox [-d] -[output|o file]
+//
+// Description:
+//     pox makes portable executables in squashfs format compatible with
+//     tcz format. We don't build in the execution code, rather, we set it
+//     up so we can use the command itself.
+//
+// Options:
+//     debug|d: verbose
+//     output|o file: output file name (default /tmp/pox.tcz)
+//     test|t: run a test by loopback mounting the squashfs and using the first arg as a command to run in a chroot
+//
+// Example:
+//	pox -d -t /bin/bash /bin/cat /bin/ls /etc/hosts
+//	Will build and squashfs, mount it, and drop you into it running bash.
+//	You can use ls and cat on /etc/hosts.
+//	Simpler example:
+//	pox -d -t /bin/ls /etc/hosts
+//	will run ls and exit.
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"syscall"
+
+	flag "github.com/spf13/pflag"
+	"github.com/u-root/u-root/pkg/cpio"
+	"github.com/u-root/u-root/pkg/ldd"
+	"github.com/u-root/u-root/pkg/loop"
+)
+
+const usage = "pox [-d] [-f file] command..."
+
+var (
+	debug  = flag.BoolP("debug", "d", false, "enable debug prints")
+	test   = flag.BoolP("test", "t", false, "run a test with the first argument")
+	create = flag.BoolP("create", "c", true, "create it")
+	v      = func(string, ...interface{}) {}
+	ofile  = flag.StringP("output", "o", "/tmp/pox.tcz", "Output file")
+)
+
+func pox() error {
+	flag.Parse()
+	if *debug {
+		v = log.Printf
+	}
+	names := flag.Args()
+	if len(names) == 0 {
+		return fmt.Errorf(usage)
+	}
+
+	if *create {
+		l, err := ldd.Ldd(names)
+		if err != nil {
+			return err
+		}
+
+		for _, dep := range l {
+			v("%s", dep.FullName)
+			names = append(names, dep.FullName)
+		}
+		// Now we need to make a template file hierarchy and put
+		// the stuff we want in there.
+		dir, err := ioutil.TempDir("", "pox")
+		if err != nil {
+			return err
+		}
+		if !*debug {
+			defer os.RemoveAll(dir)
+		}
+		archiver := cpio.InMemArchive()
+		for _, f := range names {
+			v("Process %v", f)
+			rec, err := cpio.GetRecord(f)
+			if err != nil {
+				return err
+			}
+			if err := archiver.WriteRecord(rec); err != nil {
+				return err
+			}
+		}
+		v("%v", archiver)
+		rr := archiver.Reader()
+		for {
+			r, err := rr.ReadRecord()
+			v("%v %v", r, err)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			if err := cpio.CreateFileInRoot(r, dir); err != nil {
+				return err
+			}
+
+		}
+		c := exec.Command("mksquashfs", dir, *ofile, "-noappend")
+		o, err := c.CombinedOutput()
+		v("%v", string(o))
+		if err != nil {
+			return fmt.Errorf("%v: %v: %v", c.Args, string(o), err)
+		}
+	}
+
+	if !*test {
+		return nil
+	}
+	dir, err := ioutil.TempDir("", "pox")
+	if err != nil {
+		return err
+	}
+	if !*debug {
+		defer os.RemoveAll(dir)
+	}
+	m, err := loop.New(*ofile, dir, "squashfs", 0, "")
+	if err != nil {
+		return err
+	}
+	if err := m.Mount(); err != nil {
+		return err
+	}
+	c := exec.Command(names[0])
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	c.SysProcAttr = &syscall.SysProcAttr{
+		Chroot: dir,
+	}
+
+	err = c.Run()
+	if err != nil {
+		log.Printf("Running test: %v", err)
+	}
+	if err := m.Unmount(0); err != nil {
+		v("Unmounting and freeing %v: %v", m, err)
+	}
+
+	v("Done, your pox is in %v", *ofile)
+	return err
+}
+
+func main() {
+	if err := pox(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/xcmds/pox/pox_test.go
+++ b/xcmds/pox/pox_test.go
@@ -1,0 +1,91 @@
+// Copyright 2017-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
+)
+
+var (
+	uskip = len("2018/08/10 21:20:42 ")
+)
+
+func TestSimple(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("Must be root for this test")
+	}
+
+	tmpDir, err := ioutil.TempDir("", "pox")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	var tests = []struct {
+		args   []string
+		name   string
+		status int
+		out    string
+		skip   int
+		stdin  *testutil.FakeStdin
+	}{
+		//		  -c, --create          create it (default true)
+		//  -d, --debug           enable debug prints
+		//  -o, --output string   Output file (default "/tmp/pox.tcz")
+		//  -t, --test            run a test with the first argument
+		{
+			args:   []string{"-o", "/tmp/x/a/g/c/d/e/f/g", "bin/bash"},
+			name:   "Bad executable",
+			status: 1,
+			out:    "open bin/bash: no such file or directory\n",
+			skip:   uskip,
+		},
+		{
+			args:   []string{"-o", "/tmp/x/a/g/c/d/e/f/g", "/bin/bash"},
+			name:   "Bad output file",
+			status: 1,
+			out:    "/tmp/x/a/g/c/d/e/f/g -noappend]: Could not stat destination file: Not a directory\n: exit status 1\n",
+			skip:   uskip + len("[mksquashfs /tmp/pox373051153 "), // the tempname varies so skip it.
+		},
+		{
+			args:  []string{"-t", "/bin/bash"},
+			name:  "shellexit",
+			out:   "shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory\n",
+			skip:  0,
+			stdin: testutil.NewFakeStdin("exit"),
+		},
+	}
+
+	// Table-driven testing
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := testutil.Command(t, tt.args...)
+			// ignore the error, we deal with it via process status,
+			// and most of these commands are supposed to get an error.
+			out, _ := c.CombinedOutput()
+			status := c.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+			if tt.status != status {
+				t.Errorf("err got: %v want %v", status, tt.status)
+			}
+			if len(out) < tt.skip {
+				t.Errorf("err got: %v wanted at least %d bytes", string(out), tt.skip)
+				return
+			}
+			m := string(out[tt.skip:])
+			if m != tt.out {
+				t.Errorf("got:'%q'(%d bytes) want:'%q'(%d bytes)", m, len(m), tt.out, len(tt.out))
+			}
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	testutil.Run(m, main)
+}


### PR DESCRIPTION
A portable executable is a squashfs containing a set of files,
.so's, and anything else you want to bring along. It is inspired
by tinycore packages and appimage. While appimages and
tinycore packages are a bit involved to build, pex makes
it easy.

Why we're doing this: we've had a lot of trouble bringing along binaries due to
shared library issues. For example, if we build the cgpt tool from chromeos
static, on debian, it core dumps. GNU and glibc are no longer friendly to
static linking.

pex is a program that builds portable executables that look like
tinycore tczs.

For example, we might want some random programs such as
/usr/bin/minicom and a few files such as /etc/minicom.d.
We can say this:

pex /usr/bin/minicom /etc/minicom.d

The command, its .so dependencies, and /etc/minicom.d
will be packaged into a squashfs that can be (we hope)
install via the tcz command.

You can test this easily:
pex -t /bin/bash

will build the squashfs, mount it, and drop you into bash:
rminnich@uroot:~/go/src/github.com/u-root/u-root/xcmds/pex$ sudo ./pex -t /bin/bash
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
bash-4.4# ls
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
'#main.go#'   pex   pex.go   shit
bash-4.4# exit
exit
2018/08/17 13:45:00 Done, your pex is in /tmp/pex.tcz

or you can even add a program for fun:
pex -t /bin/bash /bin/cat /etc/hosts
sudo ./pex -t /bin/bash /bin/cat /etc/hosts
shell-init: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
bash-4.4# cat /etc/hosts
job-working-directory: error retrieving current directory: getcwd: cannot access parent directories: No such file or directory
127.0.0.1       localhost
127.0.1.1       uroot

::1     localhost ip6-localhost ip6-loopback
ff02::1 ip6-allnodes
ff02::2 ip6-allrouters
192.81.129.194   linode
bash-4.4# exit
exit
2018/08/17 13:45:47 Done, your pex is in /tmp/pex.tcz

One remaining question is how to run a pex. I'm thinking
of pexe, which would take a pex and a command in it and just
run it; for we could just have a -c to pex, meaning, use the
file but don't build it, since pex can already run these files.

I took the opportunity to clean up the mount and loop packages.
It seemed a good time to create a Mounter interface.
Should Mounter distinguish Free and Unmount? Seems a bit of
overkill.

Comments welcome.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>