### PR TITLE
gang of four: allow u-root to start with 4 binaries not 5

### DIFF
--- a/pkg/uroot/builder/builder.go
+++ b/pkg/uroot/builder/builder.go
@@ -45,6 +45,11 @@ type Opts struct {
 	//
 	// BinaryDir must be specified.
 	BinaryDir string
+
+	// SkipBuildingInstallCommand indicates that we need not build
+	// installcommand; rather, the building of it will happen
+	// in the go command.
+	SkipBuildingInstallCommand bool
 }
 
 // Builder builds Go packages and adds the binaries to an initramfs.

--- a/pkg/uroot/builder/builder.go
+++ b/pkg/uroot/builder/builder.go
@@ -5,8 +5,6 @@
 package builder
 
 import (
-	"fmt"
-
 	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
 )
@@ -16,12 +14,6 @@ var (
 	Source  = SourceBuilder{}
 	Binary  = BinaryBuilder{}
 )
-
-var Builders = map[string]Builder{
-	"bb":     BusyBox,
-	"source": Source,
-	"binary": Binary,
-}
 
 // Opts are options passed to the Builder.Build function.
 type Opts struct {
@@ -45,11 +37,6 @@ type Opts struct {
 	//
 	// BinaryDir must be specified.
 	BinaryDir string
-
-	// SkipBuildingInstallCommand indicates that we need not build
-	// installcommand; rather, the building of it will happen
-	// in the go command.
-	SkipBuildingInstallCommand bool
 }
 
 // Builder builds Go packages and adds the binaries to an initramfs.
@@ -64,13 +51,4 @@ type Builder interface {
 	// DefaultBinaryDir is the initramfs' default directory for binaries
 	// built using this builder.
 	DefaultBinaryDir() string
-}
-
-// GetBuilder returns the Build function for the named build mode.
-func GetBuilder(name string) (Builder, error) {
-	build, ok := Builders[name]
-	if !ok {
-		return nil, fmt.Errorf("couldn't find builder %q", name)
-	}
-	return build, nil
 }

--- a/pkg/uroot/builder/source.go
+++ b/pkg/uroot/builder/source.go
@@ -83,8 +83,10 @@ func (SourceBuilder) Build(af *initramfs.Files, opts Opts) error {
 	if err := buildToolchain(opts); err != nil {
 		return err
 	}
-	if err := opts.Env.Build(installcommand, filepath.Join(opts.TempDir, opts.BinaryDir, "installcommand"), golang.BuildOpts{}); err != nil {
-		return err
+	if !opts.SkipBuildingInstallCommand {
+		if err := opts.Env.Build(installcommand, filepath.Join(opts.TempDir, opts.BinaryDir, "installcommand"), golang.BuildOpts{}); err != nil {
+			return err
+		}
 	}
 
 	// Add Go toolchain and installcommand to archive.

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -169,13 +169,6 @@ type Opts struct {
 	//
 	// This must be specified to have a default shell.
 	DefaultShell string
-
-	// SkipBuildingInstallCommand, if true, will cause us to not build
-	// an installcommand. This only makes sense if you are using the
-	// fourbins command in the u-root command, but that's your call.
-	// In operation, the default behavior is the one most people will want,
-	// i.e. the installcommand will be built.
-	SkipBuildingInstallCommand bool
 }
 
 // CreateInitramfs creates an initramfs built to opts' specifications.
@@ -207,11 +200,10 @@ func CreateInitramfs(logger *log.Logger, opts Opts) error {
 
 		// Build packages.
 		bOpts := builder.Opts{
-			Env:                        opts.Env,
-			Packages:                   cmds.Packages,
-			TempDir:                    builderTmpDir,
-			BinaryDir:                  cmds.TargetDir(),
-			SkipBuildingInstallCommand: opts.SkipBuildingInstallCommand,
+			Env:       opts.Env,
+			Packages:  cmds.Packages,
+			TempDir:   builderTmpDir,
+			BinaryDir: cmds.TargetDir(),
 		}
 		if err := cmds.Builder.Build(files, bOpts); err != nil {
 			return fmt.Errorf("error building %#v: %v", bOpts, err)

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -169,6 +169,13 @@ type Opts struct {
 	//
 	// This must be specified to have a default shell.
 	DefaultShell string
+
+	// SkipBuildingInstallCommand, if true, will cause us to not build
+	// an installcommand. This only makes sense if you are using the
+	// fourbins command in the u-root command, but that's your call.
+	// In operation, the default behavior is the one most people will want,
+	// i.e. the installcommand will be built.
+	SkipBuildingInstallCommand bool
 }
 
 // CreateInitramfs creates an initramfs built to opts' specifications.
@@ -200,10 +207,11 @@ func CreateInitramfs(logger *log.Logger, opts Opts) error {
 
 		// Build packages.
 		bOpts := builder.Opts{
-			Env:       opts.Env,
-			Packages:  cmds.Packages,
-			TempDir:   builderTmpDir,
-			BinaryDir: cmds.TargetDir(),
+			Env:                        opts.Env,
+			Packages:                   cmds.Packages,
+			TempDir:                    builderTmpDir,
+			BinaryDir:                  cmds.TargetDir(),
+			SkipBuildingInstallCommand: opts.SkipBuildingInstallCommand,
 		}
 		if err := cmds.Builder.Build(files, bOpts); err != nil {
 			return fmt.Errorf("error building %#v: %v", bOpts, err)


### PR DESCRIPTION
In our never ending quest to shrink the images, no matter what
it takes, this PR shows how we might do so.

The idea is to drop a file, zzzzinit.go, into go/src/cmd/build,
which is
1) the last init function run, and
2) the init function.

The function looks at os.Args[0] and, if it is /init, proceeds
to build installcommand, then runs /ubin/init, which gets built
and is then run.

So the go command is now init, with special behavior when it is
called as such.

The zzzzinit.go is not placed in the command directory unless
GOROOT is set, and the file does not already exist. It is removed
once u-root is run. If you run two u-root's at the same time one will fail.

Results:
With compiling installcommand on boot, it's dramatically slower, 13 seconds
vs 5 seconds

but it's also 35M vs 37.5M

And note the size of the savings is constant: installcommand is the same size
no matter what tools you include.

So some space constrained environments might find this useful. That said, I'm sure this
one needs some, um, self criticism sessions.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>