### PR TITLE
cmds/ip: fix output for addr subcommand

### DIFF
--- a/cmds/ip/ops.go
+++ b/cmds/ip/ops.go
@@ -53,7 +53,7 @@ func showLinkAddresses(w io.Writer, link netlink.Link) error {
 			return fmt.Errorf("Can't figure out IP protocol version")
 		}
 
-		fmt.Fprintf(w, "    %s %s", inet, addr.Peer)
+		fmt.Fprintf(w, "    %s %s", inet, addr.IP)
 		if addr.Broadcast != nil {
 			fmt.Fprintf(w, " brd %s", addr.Broadcast)
 		}


### PR DESCRIPTION
Fixes https://github.com/u-root/u-root/issues/931

```
$ ./ip a
1: lo: <UP,LOOPBACK> mtu 65536 state UNKNOWN
    link/loopback 
    inet 127.0.0.1 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1 scope host 
       valid_lft forever preferred_lft forever
2: wlp2s0: <UP,BROADCAST,MULTICAST> mtu 1500 state UP
    link/ether 00:fa:ce:b0:0c:00
    inet 172.16.x.y brd 172.16.3.255 scope global wlp2s0
       valid_lft 6545sec preferred_lft 6545sec
    inet6 2620:[snip] scope global 
       valid_lft 603248sec preferred_lft 84510sec

```