### PR TITLE
Ignore bb directory while doing a dep ensure

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,5 @@
+ignored = ["github.com/u-root/u-root/bb*"]
+
 [[constraint]]
   branch = "master"
   name = "github.com/vishvananda/netlink"


### PR DESCRIPTION
I noticed this after building u-bmc. `dep ensure` was trying to vendor
u-bmc's packages because its intermediate files were stored in the
u-root directory.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>