### PR TITLE
scp should not return absolute path names

### DIFF
--- a/cmds/scp/scp.go
+++ b/cmds/scp/scp.go
@@ -23,6 +23,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path"
 )
 
 const (
@@ -35,8 +36,8 @@ var (
 	_        = flag.Bool("v", false, "Ignored")
 )
 
-func scpSingleSource(w io.Writer, r io.Reader, path string) error {
-	f, err := os.Open(path)
+func scpSingleSource(w io.Writer, r io.Reader, pth string) error {
+	f, err := os.Open(pth)
 	if err != nil {
 		return err
 	}
@@ -45,7 +46,8 @@ func scpSingleSource(w io.Writer, r io.Reader, path string) error {
 	if err != nil {
 		return err
 	}
-	w.Write([]byte(fmt.Sprintf("C0%o %d %s\n", s.Mode(), s.Size(), path)))
+	filename := path.Base(pth)
+	w.Write([]byte(fmt.Sprintf("C0%o %d %s\n", s.Mode(), s.Size(), filename)))
 	if response(r) != SUCCESS {
 		return fmt.Errorf("response was not success")
 	}

--- a/cmds/scp/scp_test.go
+++ b/cmds/scp/scp_test.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 )
 
@@ -29,7 +30,7 @@ func TestScpSource(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
-	expected := []byte(fmt.Sprintf("C0600 19 %s\ndummy-file-contents", tf.Name()))
+	expected := []byte(fmt.Sprintf("C0600 19 %s\ndummy-file-contents", path.Base(tf.Name())))
 	expected = append(expected, 0)
 	if string(expected) != w.String() {
 		t.Fatalf("Got: %v\nExpected: %v", w.Bytes(), expected)


### PR DESCRIPTION
Return only base name to be compliant with openssh's scp.

Signed-off-by: Christian Svensson <bluecmd@google.com>