### PR TITLE
Fix rsdp with Go 1.11, and imply early exit of kmesg read if RSDP poi…

### DIFF
--- a/cmds/rsdp/rsdp.go
+++ b/cmds/rsdp/rsdp.go
@@ -60,7 +60,7 @@ func getRSDP(path string) (string, error) {
 		case res := <-channel:
 			if strings.Contains(res, "RSDP") {
 				returnValue = strings.Split(res, " ")[2]
-				exit = 0
+				exit = 1
 			}
 
 		case <-time.After(1 * time.Second):


### PR DESCRIPTION
…nter value is found. This is a mandatory patch to make work Ubuntu 16.04 installer
booting on Winterfell node, otherwise the installer kernel is unable to properly
detect IRQ mapping