### PR TITLE
checklicenses: allow for more than one license regexp

### DIFF
--- a/scripts/checklicenses/checklicenses.go
+++ b/scripts/checklicenses/checklicenses.go
@@ -22,12 +22,18 @@ var absPath = flag.Bool("a", false, "Print absolute paths")
 
 const uroot = "$GOPATH/src/github.com/u-root/u-root"
 
-// The first few lines of every go file is expected to contain this license.
-var license = regexp.MustCompile(
+var oklicenses = []*regexp.Regexp{
+	regexp.MustCompile(
 	`^// Copyright [\d\-, ]+ the u-root Authors\. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file\.
-`)
+`),
+	regexp.MustCompile(
+`^// Copyright [\d\-, ]+ Google Inc.
+//
+// Licensed under the Apache License, Version 2.0.*
+`),
+}
 
 type rule struct {
 	*regexp.Regexp
@@ -103,7 +109,14 @@ outer:
 		if err != nil {
 			log.Fatalln("cannot read", file, err)
 		}
-		if !license.Match(contents) {
+		var foundone bool
+		for _, l := range oklicenses {
+			if l.Match(contents) {
+				foundone = true
+				break
+			}
+		}
+		if ! foundone {
 			p := trimmedPath
 			if *absPath {
 				p = file


### PR DESCRIPTION
Some code imported from, e.g., gvisor, has a
different license and that needs to remain unchanged.

We now support an array of re's for the license check.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>