### PR TITLE
Add printing for network operations

### DIFF
--- a/pkg/strace/socket.go
+++ b/pkg/strace/socket.go
@@ -200,10 +200,10 @@ func sockAddr(t *Tracer, addr Addr, length uint32) string {
 		}
 
 		if family == unix.AF_UNIX {
-			return fmt.Sprintf("%#x {Family: %s, Addr: %q}", addr, familyStr, string(fa.Addr))
+			return fmt.Sprintf("%#x {Family: %s, Addr: %q}", addr, familyStr, fa.Addr)
 		}
 
-		return fmt.Sprintf("%#x {Family: %s, Addr: %v, Port: %d}", addr, familyStr, fa.Addr, fa.Port)
+		return fmt.Sprintf("%#x {Family: %s, Addr: %#02x, Port: %d}", addr, familyStr, []byte(fa.Addr), fa.Port)
 	case unix.AF_NETLINK:
 		//sa, err := netlink.ExtractSockAddr(b)
 		//if err != nil {


### PR DESCRIPTION
So now, for example, with
telnet localhost 2448
you see things like

telnet(18797) E connect(0x3, 0x55efe8c7a1f0 {Family: AF_INET, Addr: 0x7f000001, Port: 2448}, 0x10)
telnet(18797) X connect(0x3, 0x55efe8c7a1f0 {Family: AF_INET, Addr: 0x7f000001, Port: 2448}, 0x10) = {0xffffffffffffff91} (452.745µs)

It's not complete but it's better. And you can see how long it wasted on that connect :-)

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>