### PR TITLE
Revert "initramfs: now that we follow symlinks, don't lstat."

### DIFF
--- a/pkg/uroot/initramfs/files.go
+++ b/pkg/uroot/initramfs/files.go
@@ -63,9 +63,9 @@ func (af *Files) AddFile(src string, dest string) error {
 
 	// We check if it's a directory first. If a directory already exists as
 	// a record or file, we want to include its children anyway.
-	sInfo, err := os.Stat(src)
+	sInfo, err := os.Lstat(src)
 	if err != nil {
-		return fmt.Errorf("Adding %q to archive failed because stat failed: %v", src, err)
+		return fmt.Errorf("Adding %q to archive failed because Lstat failed: %v", src, err)
 	}
 
 	// Recursively add children.


### PR DESCRIPTION
This change broke nichrome. Also, there's a lot of software
in various places that depends on things being symbolic links,
so following them can cause a different issue than this problem
fixed. We're going to need to figure out another way to solve
the problem.

This reverts commit 8ebf81a3bb98549c3c14b65068deacc3528a36ed.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>