### PR TITLE
Add comments for hosted mode; add tests to ensure it keeps working

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,6 +52,12 @@ workflows:
       - check_licenses:
           requires:
             - clean-code
+      - check_hosted_source:
+          requires:
+            - clean-code
+      - check_hosted_busybox:
+          requires:
+            - clean-code
 jobs:
   clean-code:
     docker:
@@ -457,3 +463,25 @@ jobs:
       - run:
           name: Check licenses
           command: go run scripts/checklicenses/checklicenses.go
+  check_hosted_source:
+    docker:
+      - image: circleci/golang:1.11
+    working_directory: /go/src/github.com/u-root/u-root
+    environment:
+      - CGO_ENABLED: 0
+    steps:
+      - checkout
+      - run:
+          name: Build hosted source initramfs with no defaultsh or init symlink, no base cpio
+          command: go run u-root.go -base=/dev/null -defaultsh="" -initcmd=""
+  check_hosted_busybox:
+    docker:
+      - image: circleci/golang:1.11
+    working_directory: /go/src/github.com/u-root/u-root
+    environment:
+      - CGO_ENABLED: 0
+    steps:
+      - checkout
+      - run:
+          name: Build hosted busybox initramfs with no defaultsh or init symlink, no base cpio
+          command: go run u-root.go -build=bb -base=/dev/null -defaultsh="" -initcmd=""

--- a/u-root.go
+++ b/u-root.go
@@ -227,12 +227,12 @@ func init() {
 
 	tmpDir = flag.String("tmpdir", "", "Temporary directory to put binaries in.")
 
-	base = flag.String("base", "", "Base archive to add files to. By default, this is a couple of directories like /bin, /etc, etc.")
+	base = flag.String("base", "", "Base archive to add files to. By default, this is a couple of directories like /bin, /etc, etc. u-root has a default internally supplied set of files; use base=/dev/null if you don't want any base files.")
 	useExistingInit = flag.Bool("useinit", false, "Use existing init from base archive (only if --base was specified).")
 	outputPath = flag.String("o", "", "Path to output initramfs file.")
 
-	initCmd = flag.String("initcmd", "init", "Symlink target for /init. Can be an absolute path or a u-root command name.")
-	defaultShell = flag.String("defaultsh", "elvish", "Default shell. Can be an absolute path or a u-root command name.")
+	initCmd = flag.String("initcmd", "init", "Symlink target for /init. Can be an absolute path or a u-root command name. Use initcmd=\"\" if you don't want the symlink.")
+	defaultShell = flag.String("defaultsh", "elvish", "Default shell. Can be an absolute path or a u-root command name. Use defaultsh=\"\" if you don't want the symlink.")
 
 	flag.Var(&extraFiles, "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be speficified multiple times.")
 }


### PR DESCRIPTION
It is possible to have an initramfs for "hosted" mode, i.e. a
mode in which u-root is installed onto an existing system
such as a chromebook.

In that case we should not create defaultsh and init symlinks,
or try to populate /dev, /usr, /lib, and so on.

This works today with the right commandline usage:
go run u-root.go -base=/dev/null -defaultsh="" -initcmd=""

Add a bit more cmdline documentation for 'hosted' mode,
and add two tests to make sure nobody breaks it by accident
in the future. NiChrome will be using this mode.

Kind of cool: I did not know this would even work but the command
needed no changes.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>