### PR TITLE
Add symlink regression test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,9 @@ workflows:
       - check_hosted_busybox:
           requires:
             - clean-code
+      - check_symlinks:
+          requires:
+            - clean-code
 jobs:
   clean-code:
     docker:
@@ -485,3 +488,14 @@ jobs:
       - run:
           name: Build hosted busybox initramfs with no defaultsh or init symlink, no base cpio
           command: go run u-root.go -build=bb -base=/dev/null -defaultsh="" -initcmd=""
+  check_symlinks:
+    docker:
+      - image: circleci/golang:1.11
+    working_directory: /go/src/github.com/u-root/u-root
+    environment:
+      - CGO_ENABLED: 0
+    steps:
+      - checkout
+      - run:
+          name: Symbol tests to ensure we do not break symlink handling
+          command: mkdir /tmp/usr && ln -s /tmp/usr/x /tmp/usr/y && go run u-root.go -build=bb -files /tmp/usr minimal


### PR DESCRIPTION
This test ensures we handle aspects of symlinks correctly.
The first test makes sure we DO NOT follow symlinks from -files <dir>.

Hopefully, as more symlink issues are found and fixed, we can grow
this regression test.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>