### PR TITLE
symlinks: handle them differently for -files commands

### DIFF
--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -371,7 +371,7 @@ func ParseExtraFiles(logger *log.Logger, archive *initramfs.Files, extraFiles []
 		if err != nil {
 			return fmt.Errorf("couldn't find absolute path for %q: %v", src, err)
 		}
-		if err := archive.AddFile(src, dst); err != nil {
+		if err := archive.AddFileNoFollow(src, dst); err != nil {
 			return fmt.Errorf("couldn't add %q to archive: %v", file, err)
 		}
 
@@ -384,7 +384,7 @@ func ParseExtraFiles(logger *log.Logger, archive *initramfs.Files, extraFiles []
 				continue
 			}
 			for _, lib := range libs {
-				if err := archive.AddFile(lib, lib[1:]); err != nil {
+				if err := archive.AddFileNoFollow(lib, lib[1:]); err != nil {
 					logger.Printf("WARNING: couldn't add ldd dependencies for %q: %v", lib, err)
 				}
 			}


### PR DESCRIPTION
We've had issues with some build systems using symlinks.
Further, some distros drop extraneous symlinks into the
Go source tree.

Change u-root behavior as follows:
for /go and /bbin and friends, always follow symlinks.
There should never be symlinks in those trees anyway.

For -files, do not follow symlinks. Following symlinks
causes really problematical behavior that's not always obvius.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>