### PR TITLE
ldd package: also follow symlinks for the commands

### DIFF
--- a/cmds/lddfiles/lddfiles.go
+++ b/cmds/lddfiles/lddfiles.go
@@ -32,9 +32,6 @@ func main() {
 		log.Fatalf("ldd: %v", err)
 	}
 
-	for _, arg := range os.Args[1:] {
-		fmt.Printf("%s\n", arg)
-	}
 	for _, dep := range l {
 		fmt.Printf("%s\n", dep.FullName)
 	}

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -110,6 +110,11 @@ func Ldd(names []string) ([]*FileInfo, error) {
 		libs    []*FileInfo
 	)
 	for _, n := range names {
+		if err := follow(n, list); err != nil {
+			return nil, err
+		}
+	}
+	for _, n := range names {
 		r, err := os.Open(n)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
On many linux systems, /bin/xyz can be a link to, e.g.,
/etc/alternatives/xyz, and from the to /bin/someotherthing.

We considered the following:
if /bin/xxx is a link to /etc/alternatives/xxx, and then to /bin/zzz,
create /bin/xxx as a file, contents /bin/zzz

The problem is that it can often by extremely useful to see the
alternatives structure:
/bin/nc -> /etc/alternatives/nc -> /bin/nc.openbsd

so you know which nc you're getting (in this case the openbds version).
It seems easy to produce this information and it is useful,
so we now produce output like this:

/lib/x86_64-linux-gnu/ld-2.27.so
/lib64/ld-linux-x86-64.so.2
/lib/x86_64-linux-gnu/librt.so.1
/lib/x86_64-linux-gnu/librt-2.27.so
/lib/x86_64-linux-gnu/libpthread.so.0
/lib/x86_64-linux-gnu/libbsd.so.0
/lib/x86_64-linux-gnu/libbsd.so.0.8.7
/lib/x86_64-linux-gnu/libc.so.6
/lib/x86_64-linux-gnu/libresolv.so.2
/lib/x86_64-linux-gnu/libresolv-2.27.so
/lib/x86_64-linux-gnu/libc-2.27.so
/lib/x86_64-linux-gnu/libpthread-2.27.so
/bin/nc
/etc/alternatives/nc
/bin/nc.openbsd

so that in the eventual cpio, we can see the actual program we got.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>