### PR TITLE
ExtraBuildEnv/ExtraArgs for qemu and tests

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -91,6 +91,9 @@ type Options struct {
 
 	// Network is the VM's network.
 	Network *qemu.Network
+
+	// Extra environment variables to set when building (used by u-bmc)
+	ExtraBuildEnv []string
 }
 
 func last(s string) string {


### PR DESCRIPTION
u-bmc needs to pass a lot of parameters to qemu due to the nature of
ARM boards. Furthermore, u-bmc has a slightly more complex build system
than u-root and needs to pass some extra environment variables.

For ExtraBuildEnv nothing is using that particular value in u-root, but
as the same Options struct is passed around in u-bmc it would be nice to
add it to that structure.

Signed-off-by: Christian Svensson <bluecmd@google.com>