### PR TITLE
ps: additional paths now work

### DIFF
--- a/cmds/ps/ps.go
+++ b/cmds/ps/ps.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2017 the u-root Authors. All rights reserved
+// Copyright 2013-2018 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
Suppose you have a lot of hosts' /proc mounted in /tmp/netproc/*
You would do this
UROOT_PSPATH=/proc:/tmp/netproc/* ps aux | grep dnsmasq

You see:
     PID     PGRP      SID TTY             STAT         TIME  COMMAND
a22/1996     1995     1995 ?               S        00:00:00  dnsmasq
    2069     2068     2068 ?               S        00:00:00  dnsmasq

you might even export UROOT_PSPATH so you always see what you want to see.

The path can have more than 2 elements, of course. The code assumes the first
path element is the local one.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>