### PR TITLE
pkg/uroot: fix the -files rename case

### DIFF
--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -384,6 +384,12 @@ func ParseExtraFiles(logger logger.Logger, archive *initramfs.Files, extraFiles 
 				continue
 			}
 			for _, lib := range libs {
+				// N.B.: we already added information about the src.
+				// Don't add it twice. We have to do this check here in
+				// case we're renaming the src to a different dest.
+				if lib == src {
+					continue
+				}
 				if err := archive.AddFileNoFollow(lib, lib[1:]); err != nil {
 					logger.Printf("WARNING: couldn't add ldd dependencies for %q: %v", lib, err)
 				}


### PR DESCRIPTION
We recently changed lddfiles to return all the files, including
the source. This is arguably far more convenient for lddfiles
package users but caused a problem for uroot.

This change resolves the problem: when we're adding files
from ldd, we don't add the file we ran ldd on, since we
previously added it anyway.

Hence, if we do something like this:
go run u-root.go -build=bb -files /bin/date:d -files /etc/hosts:h

the right set of files is added, as well as the right set of libraries.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>