### PR TITLE
u-root: create relative links, not absolute

### DIFF
--- a/pkg/uroot/builder/source.go
+++ b/pkg/uroot/builder/source.go
@@ -106,9 +106,7 @@ func (sb SourceBuilder) Build(af *initramfs.Files, opts Opts) error {
 		if name != "installcommand" {
 			// Add a symlink to installcommand. This means source mode can
 			// work with any init.
-			if err := af.AddRecord(cpio.Symlink(
-				path.Join(opts.BinaryDir, name),
-				path.Join("/", opts.BinaryDir, "installcommand"))); err != nil {
+			if err := af.AddRecord(cpio.Symlink(path.Join(opts.BinaryDir, name), "installcommand")); err != nil {
 				return err
 			}
 		}

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -356,8 +356,8 @@ func TestCreateInitramfs(t *testing.T) {
 				hasFile{path: "bin/dd"},
 
 				// source mode.
-				hasRecord{cpio.Symlink("buildbin/cat", "/buildbin/installcommand")},
-				hasRecord{cpio.Symlink("buildbin/chroot", "/buildbin/installcommand")},
+				hasRecord{cpio.Symlink("buildbin/cat", "installcommand")},
+				hasRecord{cpio.Symlink("buildbin/chroot", "installcommand")},
 				hasFile{path: "buildbin/installcommand"},
 				hasFile{path: "src/github.com/u-root/u-root/cmds/cat/cat.go"},
 				hasFile{path: "src/github.com/u-root/u-root/cmds/chroot/chroot.go"},


### PR DESCRIPTION
For hosted mode on a chromebook turns out we need to allow
relative symlinks in buildbin. The links are now, e.g.,
/buildbin/cat -> installcommand
instead of
/buildbin/cat -> /buildbin/installcommand

This seems to work, save I can not create relative link
for defaultsh, i.e.
/bin/defaultsh -> ../buildbin/elvish

fails. That fix can come later I guess.

How I miss plan 9 union mounts. None of this nonsense would be
needed.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>