### PR TITLE
rel paths: make installcommand use UROOT_ROOT, /init -> rel symlink

### DIFF
--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -31,18 +31,23 @@ var (
 	test     = flag.Bool("test", false, "Test mode: don't try to set control tty")
 	debug    = func(string, ...interface{}) {}
 	osInitGo = func() {}
-	cmdList  = []string{
-		"/inito",
-
-		"/bbin/uinit",
-		"/bin/uinit",
-		"/buildbin/uinit",
-
-		"/bin/defaultsh",
-	}
+	cmdList  []string
 	cmdCount int
 	envs     []string
 )
+
+func init() {
+	r := util.UrootPath
+	cmdList = []string{
+		r("/inito"),
+
+		r("/bbin/uinit"),
+		r("/bin/uinit"),
+		r("/buildbin/uinit"),
+
+		r("/bin/defaultsh"),
+	}
+}
 
 func main() {
 	flag.Parse()
@@ -146,6 +151,11 @@ func main() {
 			if err == nil {
 				v = s
 			}
+			// and, well, it might be a relative link.
+			// We must go deeper.
+			d, b := filepath.Split(v)
+			d = filepath.Base(d)
+			v = filepath.Join("/", os.Getenv("UROOT_ROOT"), d, b)
 		}
 
 		// inito is (optionally) created by the u-root command when the

--- a/cmds/installcommand/installcommand.go
+++ b/cmds/installcommand/installcommand.go
@@ -36,6 +36,7 @@ import (
 	"syscall"
 
 	"github.com/u-root/u-root/pkg/golang"
+	"github.com/u-root/u-root/pkg/uroot/util"
 )
 
 var (
@@ -45,6 +46,7 @@ var (
 
 	verbose = flag.Bool("v", false, "print all build commands")
 	debug   = func(string, ...interface{}) {}
+	r = util.UrootPath
 )
 
 type form struct {
@@ -130,7 +132,7 @@ func main() {
 	}
 
 	debug("Command name: %v\n", form.cmdName)
-	destFile := filepath.Join("/ubin", form.cmdName)
+	destFile := filepath.Join(r("/ubin"), form.cmdName)
 
 	// Is the command there? This covers a race condition
 	// in that some other process may have caused it to be
@@ -143,11 +145,11 @@ func main() {
 	}
 
 	env := golang.Default()
-	env.Context.GOROOT = "/go"
-	env.Context.GOPATH = "/"
+	env.Context.GOROOT = r("/go")
+	env.Context.GOPATH = r("/")
 
 	var srcDir string
-	err := filepath.Walk("/src", func(p string, fi os.FileInfo, err error) error {
+	err := filepath.Walk(r("/src"), func(p string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return nil
 		}

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -255,7 +255,7 @@ func TestCreateInitramfs(t *testing.T) {
 				hasFile{path: "bbin/bb"},
 				hasRecord{cpio.Symlink("bbin/init", "bb")},
 				hasRecord{cpio.Symlink("bbin/ls", "bb")},
-				hasRecord{cpio.Symlink("bin/defaultsh", "/bbin/ls")},
+				hasRecord{cpio.Symlink("bin/defaultsh", "../bbin/ls")},
 			},
 		},
 		{
@@ -304,7 +304,7 @@ func TestCreateInitramfs(t *testing.T) {
 			},
 			want: nil,
 			validators: []archiveValidator{
-				hasRecord{cpio.Symlink("init", "/bin/systemd")},
+				hasRecord{cpio.Symlink("init", "bin/systemd")},
 			},
 		},
 		{
@@ -343,13 +343,13 @@ func TestCreateInitramfs(t *testing.T) {
 			},
 			want: nil,
 			validators: []archiveValidator{
-				hasRecord{cpio.Symlink("init", "/bbin/init")},
+				hasRecord{cpio.Symlink("init", "bbin/init")},
 
 				// bb mode.
 				hasFile{path: "bbin/bb"},
 				hasRecord{cpio.Symlink("bbin/init", "bb")},
 				hasRecord{cpio.Symlink("bbin/ls", "bb")},
-				hasRecord{cpio.Symlink("bin/defaultsh", "/bbin/ls")},
+				hasRecord{cpio.Symlink("bin/defaultsh", "../bbin/ls")},
 
 				// binary mode.
 				hasFile{path: "bin/cp"},

--- a/pkg/uroot/util/urootpath.go
+++ b/pkg/uroot/util/urootpath.go
@@ -1,0 +1,25 @@
+// Copyright 2015-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var root = os.Getenv("UROOT_ROOT")
+
+// UrootPath returns the full path for a uroot file with
+// the UROOT_ROOT environment variable taken into account.
+// It returns a proper value if UROOT_ROOT is not set.
+// u-root was built to assume everything is rooted at /,
+// and in most cases that is still true.
+// But in hosted mode, e.g. on developer mode chromebooks,
+// it's far better if u-root can be rooted in /usr/local,
+// so successive kernel/root file system upgrades
+// do not wipe it out.
+func UrootPath(n ...string) string {
+	return filepath.Join("/", root, filepath.Join(n...))
+}

--- a/pkg/uroot/util/urootpath_test.go
+++ b/pkg/uroot/util/urootpath_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"testing"
+)
+
+func TestUrootPath(t *testing.T) {
+	var tests = []struct {
+		name      string
+		urootRoot string
+		out       string
+	}{
+		{"ubin/cat", "", "/ubin/cat"},
+		{"ubin/cat", "/", "/ubin/cat"},
+		{"ubin/cat", "usr/local", "/usr/local/ubin/cat"},
+	}
+
+	for _, tt := range tests {
+		root = tt.urootRoot
+		o := UrootPath(tt.name)
+		t.Logf("%v", tt)
+		if o != tt.out {
+			t.Errorf("%v: got %v, want %v", tt, o, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
installcommand now honors UROOT_ROOT. If UROOT_ROOT is set, then
variables such as GOROOT, GOPATH, and others needed by u-root,
will have UROOT_ROOT prepended.

pkg/uroot/uroot.go now creates init as a relative symlink, i.e.
it points to buildbin/init, not /buildbin/init.

To test this I do this:
go run u-root.go # build a dynamic u-root
mv /tmp/initramfs.linux_amd64.cpio /tmp/initramfs.linux_amd64.cpio.dynamic
go run u-root.go  -build=bb -files /tmp/initramfs.linux_amd64.cpio.dynamic:i.cpio -files /bin/bash # build a static u-root with the dynamic one inside it
sudo ./testramfs -i /tmp/initramfs.linux_amd64.cpio
bash-4.4# export UROOT_ROOT=/usr/local # we are now in the static u-root
bash-4.4# mkdir /usr/local
bash-4.4# cd /usr/local
bash-4.4# cpio i < /i.cpio
bash-4.4# ./init # Yep, run the u-root dynamic init
/usr/local# ./buildbin/ls # it builds ls
bin
buildbin
dev
etc
go
init
lib64
src
tcz
tmp
ubin
usr
var
/usr/local# ./ubin/ls # run the ls we just build dynamically

Note that our PATH is still not entirely right, working on that, but the "hosted" u-root
(hosted under u-root!) works.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>