### PR TITLE
Add support for pxeboot to get DHCP configuration on IPv6.

### DIFF
--- a/cmds/dhclient/dhclient.go
+++ b/cmds/dhclient/dhclient.go
@@ -87,12 +87,12 @@ func main() {
 }
 
 func configureAll(ifs []netlink.Link) {
-	timeout := time.Duration(*timeout) * time.Second
+	packetTimeout := time.Duration(*timeout) * time.Second
 
-	ctx, cancel := context.WithTimeout(context.Background(), timeout*time.Duration(*retry))
+	ctx, cancel := context.WithTimeout(context.Background(), packetTimeout*time.Duration(*retry))
 	defer cancel()
 
-	r := dhclient.SendRequests(ifs, timeout, *retry, *ipv4, *ipv6)
+	r := dhclient.SendRequests(ifs, packetTimeout, *retry, *ipv4, *ipv6)
 
 	for {
 		select {

--- a/cmds/pxeboot/pxeboot.go
+++ b/cmds/pxeboot/pxeboot.go
@@ -108,7 +108,8 @@ func Boot(lease dhclient.Lease) error {
 	}
 	log.Printf("Boot URI: %s", uri)
 
-	// IP only makes sense for v4 anyway.
+	// IP only makes sense for v4 anyway, because the PXE probing of files
+	// uses a MAC address and an IPv4 address to look at files.
 	var ip net.IP
 	if p4, ok := lease.(*dhclient.Packet4); ok {
 		ip = p4.Lease().IP

--- a/cmds/pxeboot/pxeboot.go
+++ b/cmds/pxeboot/pxeboot.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -17,6 +18,7 @@ import (
 	"github.com/u-root/dhcp4/dhcp4client"
 	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/dhclient"
+	"github.com/u-root/u-root/pkg/dhcp6client"
 	"github.com/u-root/u-root/pkg/ipxe"
 	"github.com/u-root/u-root/pkg/pxe"
 	"github.com/vishvananda/netlink"
@@ -28,23 +30,118 @@ var (
 	debug   = func(string, ...interface{}) {}
 )
 
-func attemptDHCPLease(iface netlink.Link, timeout time.Duration, retry int) (*dhclient.Packet4, error) {
-	if _, err := dhclient.IfUp(iface.Attrs().Name); err != nil {
-		return nil, err
-	}
+const (
+	kDhcpTimeout = 30 * time.Second
+	kDhcpTries   = 5
+)
 
+func leaseAndConfigureV4(iface netlink.Link, leased chan bool) (*url.URL, net.IP, error) {
 	client, err := dhcp4client.New(iface,
-		dhcp4client.WithTimeout(timeout),
-		dhcp4client.WithRetry(retry))
+		dhcp4client.WithTimeout(kDhcpTimeout),
+		dhcp4client.WithRetry(kDhcpTries))
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
+	log.Printf("Attempting to get DHCPv4 lease on %s", iface.Attrs().Name)
 	p, err := client.Request()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return dhclient.NewPacket4(p), nil
+	packet := dhclient.NewPacket4(p)
+	uri, err := packet.Boot()
+	if err != nil {
+		log.Printf("Got DHCPv4 lease, but no valid PXE information.")
+		return nil, nil, err
+	}
+
+	_, ok := <-leased
+	if !ok {
+		return nil, nil, errors.New("another DHCP request offer was acepted")
+	}
+	close(leased)
+
+	log.Printf("Got DHCPv4 lease on %s", iface.Attrs().Name)
+	return uri, packet.Lease().IP, dhclient.Configure4(iface, packet.P)
+}
+
+func leaseAndConfigureV6(iface netlink.Link, leased chan bool) (*url.URL, net.IP, error) {
+	client, err := dhcp6client.New(iface,
+		dhcp6client.WithTimeout(kDhcpTimeout),
+		dhcp6client.WithRetry(kDhcpTries))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	log.Printf("Attempting to get DHCPv6 lease on %s", iface.Attrs().Name)
+	iana, p, err := client.RapidSolicit()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	packet := dhclient.NewPacket6(p, iana)
+	uri, _, err := packet.Boot()
+	if err != nil {
+		log.Printf("Got DHCPv6 lease, but no valid PXE information.")
+		return nil, nil, err
+	}
+
+	_, ok := <-leased
+	if !ok {
+		return nil, nil, errors.New("another DHCP request offer was acepted")
+	}
+	close(leased)
+
+	log.Printf("Got DHCPv6 lease on %s", iface.Attrs().Name)
+
+	return uri, packet.Lease().IP, dhclient.Configure6(iface, p, iana)
+}
+
+func leaseAndConfigure(iface netlink.Link) (*url.URL, net.IP, error) {
+	// leased has a message if no lease had been accepted. It is closed otherwise.
+	leased := make(chan bool, 1)
+	leased <- true
+
+	type dhcpResponse struct {
+		u   *url.URL
+		ip  net.IP
+		err error
+	}
+
+	response := make(chan dhcpResponse)
+
+	leaseFunctions := []func(iface netlink.Link, leased chan bool) (*url.URL, net.IP, error){
+		leaseAndConfigureV4,
+		leaseAndConfigureV6,
+	}
+
+	for _, f := range leaseFunctions {
+		f := f
+		go func() {
+			u, ip, err := f(iface, leased)
+			response <- dhcpResponse{
+				u:   u,
+				ip:  ip,
+				err: err,
+			}
+		}()
+	}
+
+	errCount := 0
+
+	for r := range response {
+		// If we got a lease, we are all set.
+		// Note that one go routine will leak, but eventually timeout.
+		if r.err != nil {
+			return r.u, r.ip, nil
+		}
+		errCount++
+		// All attempts failed, report to caller.
+		if errCount == len(leaseFunctions) {
+			return nil, nil, errors.New("unable to get DHCP lease on IPv4 nor IPv6")
+		}
+	}
+	return nil, nil, errors.New("BUG: unreachable code")
 }
 
 // getBootImage attempts to parse the file at uri as an ipxe config and returns
@@ -86,34 +183,15 @@ func Netboot() error {
 			continue
 		}
 
-		log.Printf("Attempting to get DHCP lease on %s", iface.Attrs().Name)
-		packet, err := attemptDHCPLease(iface, 30*time.Second, 5)
+		uri, ip, err := leaseAndConfigure(iface)
 		if err != nil {
-			log.Printf("No lease on %s: %v", iface.Attrs().Name, err)
-			continue
-		}
-		log.Printf("Got lease on %s", iface.Attrs().Name)
-		if err := dhclient.Configure4(iface, packet.P); err != nil {
-			log.Printf("shit: %v", err)
-			continue
-		}
-
-		// We may have to make this DHCPv6 and DHCPv4-specific anyway.
-		// Only tested with v4 right now; and assuming the uri points
-		// to a pxelinux.0.
-		//
-		// Or rather, we need to make this option-specific. DHCPv6 has
-		// options for passing a kernel and cmdline directly. v4
-		// usually just passes a pxelinux.0. But what about an initrd?
-		uri, err := packet.Boot()
-		if err != nil {
-			log.Printf("Got DHCP lease, but no valid PXE information.")
+			log.Printf("error while attempting DHCP on interface %v: %v", iface.Attrs().Name, err)
 			continue
 		}
 
 		log.Printf("Boot URI: %s", uri)
 
-		img, err := getBootImage(uri, iface.Attrs().HardwareAddr, packet.Lease().IP)
+		img, err := getBootImage(uri, iface.Attrs().HardwareAddr, ip)
 		if err != nil {
 			return err
 		}

--- a/cmds/pxeboot/pxeboot.go
+++ b/cmds/pxeboot/pxeboot.go
@@ -59,13 +59,14 @@ func Netboot(ctx context.Context, ifaceNames string) error {
 				log.Printf("Configured all interfaces.")
 				return fmt.Errorf("nothing bootable found")
 			}
-			if result.Err == nil {
-				if err := Boot(result.Lease); err != nil {
-					log.Printf("Failed to boot lease %v: %v", result.Lease, err)
-					continue
-				} else {
-					return nil
-				}
+			if result.Err != nil {
+				continue
+			}
+			if err := Boot(result.Lease); err != nil {
+				log.Printf("Failed to boot lease %v: %v", result.Lease, err)
+				continue
+			} else {
+				return nil
 			}
 		}
 	}

--- a/cmds/pxeboot/pxeboot.go
+++ b/cmds/pxeboot/pxeboot.go
@@ -14,80 +14,23 @@ import (
 	"os"
 	"path"
 	"regexp"
-	"sync"
 	"time"
 
-	"github.com/u-root/dhcp4/dhcp4client"
 	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/dhclient"
-	"github.com/u-root/u-root/pkg/dhcp6client"
 	"github.com/u-root/u-root/pkg/ipxe"
 	"github.com/u-root/u-root/pkg/pxe"
 	"github.com/vishvananda/netlink"
 )
 
 var (
-	verbose = flag.Bool("v", true, "print all kinds of things out, more than Chris wants")
-	dryRun  = flag.Bool("dry-run", false, "download kernel, but don't kexec it")
-	debug   = func(string, ...interface{}) {}
+	dryRun = flag.Bool("dry-run", false, "download kernel, but don't kexec it")
 )
 
 const (
 	dhcpTimeout = 15 * time.Second
 	dhcpTries   = 3
 )
-
-type Lease interface {
-	Configure() error
-	Boot() (*url.URL, error)
-	Link() netlink.Link
-}
-
-func lease4(iface netlink.Link) (Lease, error) {
-	client, err := dhcp4client.New(iface,
-		dhcp4client.WithTimeout(dhcpTimeout),
-		dhcp4client.WithRetry(dhcpTries))
-	if err != nil {
-		return nil, err
-	}
-
-	log.Printf("Attempting to get DHCPv4 lease on %s", iface.Attrs().Name)
-	p, err := client.Request()
-	if err != nil {
-		return nil, err
-	}
-
-	packet := dhclient.NewPacket4(iface, p)
-	if _, err := packet.Boot(); err != nil {
-		return nil, fmt.Errorf("valid DHCPv4 lease without PXE info: %v", err)
-	}
-
-	log.Printf("Got DHCPv4 lease on %s", iface.Attrs().Name)
-	return packet, nil
-}
-
-func lease6(iface netlink.Link) (Lease, error) {
-	client, err := dhcp6client.New(iface,
-		dhcp6client.WithTimeout(dhcpTimeout),
-		dhcp6client.WithRetry(dhcpTries))
-	if err != nil {
-		return nil, err
-	}
-
-	log.Printf("Attempting to get DHCPv6 lease on %s", iface.Attrs().Name)
-	iana, p, err := client.RapidSolicit()
-	if err != nil {
-		return nil, err
-	}
-
-	packet := dhclient.NewPacket6(iface, p, iana)
-	if _, err := packet.Boot(); err != nil {
-		return nil, fmt.Errorf("valid DHCPv6 lease without PXE info: %v", err)
-	}
-
-	log.Printf("Got DHCPv6 lease on %s", iface.Attrs().Name)
-	return packet, nil
-}
 
 // Netboot boots all interfaces matched by the regex in ifaceNames.
 func Netboot(ctx context.Context, ifaceNames string) error {
@@ -96,61 +39,33 @@ func Netboot(ctx context.Context, ifaceNames string) error {
 		return err
 	}
 
+	var filteredIfs []netlink.Link
 	ifregex := regexp.MustCompilePOSIX(ifaceNames)
-
-	// Yeah, this is a hack, until we can cancel all leases in progress.
-	leases := make(chan Lease, 3*len(ifs))
-	defer close(leases)
-
-	var wg sync.WaitGroup
-	defer wg.Wait()
-
 	for _, iface := range ifs {
-		if !ifregex.MatchString(iface.Attrs().Name) {
-			continue
+		if ifregex.MatchString(iface.Attrs().Name) {
+			filteredIfs = append(filteredIfs, iface)
 		}
-
-		wg.Add(1)
-		go func(iface netlink.Link) {
-			defer wg.Done()
-
-			debug("Bringing up interface %s...", iface.Attrs().Name)
-			if _, err := dhclient.IfUp(iface.Attrs().Name); err != nil {
-				log.Printf("Could not bring up interface %s: %v", iface.Attrs().Name, err)
-				return
-			}
-
-			wg.Add(1)
-			go func(iface netlink.Link) {
-				defer wg.Done()
-				lease, err := lease4(iface)
-				if err == nil {
-					leases <- lease
-				}
-			}(iface)
-
-			wg.Add(1)
-			go func(iface netlink.Link) {
-				defer wg.Done()
-				lease, err := lease6(iface)
-				if err == nil {
-					leases <- lease
-				}
-			}(iface)
-		}(iface)
 	}
+
+	r := dhclient.SendRequests(filteredIfs, dhcpTimeout, dhcpTries, true, true)
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 
-		case lease := <-leases:
-			if err := Boot(lease); err != nil {
-				log.Printf("Failed to boot lease %v: %v", lease, err)
-				continue
-			} else {
-				return nil
+		case result, ok := <-r:
+			if !ok {
+				log.Printf("Configured all interfaces.")
+				return fmt.Errorf("nothing bootable found")
+			}
+			if result.Err == nil {
+				if err := Boot(result.Lease); err != nil {
+					log.Printf("Failed to boot lease %v: %v", result.Lease, err)
+					continue
+				} else {
+					return nil
+				}
 			}
 		}
 	}
@@ -181,7 +96,7 @@ func getBootImage(uri *url.URL, mac net.HardwareAddr, ip net.IP) (*boot.LinuxIma
 	return label, nil
 }
 
-func Boot(lease Lease) error {
+func Boot(lease dhclient.Lease) error {
 	if err := lease.Configure(); err != nil {
 		return err
 	}
@@ -197,14 +112,14 @@ func Boot(lease Lease) error {
 	if p4, ok := lease.(*dhclient.Packet4); ok {
 		ip = p4.Lease().IP
 	}
-	img, err := getBootImage(uri, iface.Attrs().HardwareAddr, ip)
+	img, err := getBootImage(uri, lease.Link().Attrs().HardwareAddr, ip)
 	if err != nil {
 		return err
 	}
 	log.Printf("Got configuration: %s", img)
 
 	if *dryRun {
-		label.ExecutionInfo(log.New(os.Stderr, "", log.LstdFlags))
+		img.ExecutionInfo(log.New(os.Stderr, "", log.LstdFlags))
 		return nil
 	} else if err := img.Execute(); err != nil {
 		return fmt.Errorf("kexec of %v failed: %v", img, err)
@@ -216,9 +131,6 @@ func Boot(lease Lease) error {
 
 func main() {
 	flag.Parse()
-	if *verbose {
-		debug = log.Printf
-	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), dhcpTries*dhcpTimeout)
 	defer cancel()

--- a/integration/dhclient_test.go
+++ b/integration/dhclient_test.go
@@ -69,7 +69,7 @@ func TestDhclient(t *testing.T) {
 
 	t.Logf("Now we wait!")
 
-	if err := dhcpClient.Expect("err from done <nil>"); err != nil {
+	if err := dhcpClient.Expect("Configured eth0 with IPv4 DHCP Lease"); err != nil {
 		t.Error(err)
 	}
 

--- a/pkg/dhclient/dhclient.go
+++ b/pkg/dhclient/dhclient.go
@@ -49,7 +49,7 @@ func IfUp(ifname string) (netlink.Link, error) {
 
 // Configure4 adds IP addresses, routes, and DNS servers to the system.
 func Configure4(iface netlink.Link, packet *dhcp4.Packet) error {
-	p := NewPacket4(packet)
+	p := NewPacket4(iface, packet)
 
 	l := p.Lease()
 	if l == nil {
@@ -87,7 +87,7 @@ func Configure4(iface netlink.Link, packet *dhcp4.Packet) error {
 
 // Configure6 adds IPv6 addresses, routes, and DNS servers to the system.
 func Configure6(iface netlink.Link, packet *dhcp6.Packet, iana *dhcp6opts.IANA) error {
-	p := NewPacket6(packet, iana)
+	p := NewPacket6(iface, packet, iana)
 
 	l := p.Lease()
 	if l == nil {

--- a/pkg/dhclient/dhclient.go
+++ b/pkg/dhclient/dhclient.go
@@ -153,10 +153,6 @@ func lease4(iface netlink.Link, timeout time.Duration, retries int) (Lease, erro
 	}
 
 	packet := NewPacket4(iface, p)
-	if _, err := packet.Boot(); err != nil {
-		return nil, fmt.Errorf("valid DHCPv4 lease without PXE info: %v", err)
-	}
-
 	log.Printf("Got DHCPv4 lease on %s", iface.Attrs().Name)
 	return packet, nil
 }
@@ -176,10 +172,6 @@ func lease6(iface netlink.Link, timeout time.Duration, retries int) (Lease, erro
 	}
 
 	packet := NewPacket6(iface, p, iana)
-	if _, err := packet.Boot(); err != nil {
-		return nil, fmt.Errorf("valid DHCPv6 lease without PXE info: %v", err)
-	}
-
 	log.Printf("Got DHCPv6 lease on %s", iface.Attrs().Name)
 	return packet, nil
 }

--- a/pkg/dhclient/dhclient.go
+++ b/pkg/dhclient/dhclient.go
@@ -10,13 +10,18 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net"
+	"net/url"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/mdlayher/dhcp6"
 	"github.com/mdlayher/dhcp6/dhcp6opts"
 	"github.com/u-root/dhcp4"
+	"github.com/u-root/dhcp4/dhcp4client"
+	"github.com/u-root/u-root/pkg/dhcp6client"
 	"github.com/vishvananda/netlink"
 )
 
@@ -124,4 +129,107 @@ func WriteDNSSettings(ips []net.IP) error {
 		rc.WriteString(fmt.Sprintf("nameserver %s\n", ip))
 	}
 	return ioutil.WriteFile("/etc/resolv.conf", rc.Bytes(), 0644)
+}
+
+type Lease interface {
+	fmt.Stringer
+	Configure() error
+	Boot() (*url.URL, error)
+	Link() netlink.Link
+}
+
+func lease4(iface netlink.Link, timeout time.Duration, retries int) (Lease, error) {
+	client, err := dhcp4client.New(iface,
+		dhcp4client.WithTimeout(timeout),
+		dhcp4client.WithRetry(retries))
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Attempting to get DHCPv4 lease on %s", iface.Attrs().Name)
+	p, err := client.Request()
+	if err != nil {
+		return nil, err
+	}
+
+	packet := NewPacket4(iface, p)
+	if _, err := packet.Boot(); err != nil {
+		return nil, fmt.Errorf("valid DHCPv4 lease without PXE info: %v", err)
+	}
+
+	log.Printf("Got DHCPv4 lease on %s", iface.Attrs().Name)
+	return packet, nil
+}
+
+func lease6(iface netlink.Link, timeout time.Duration, retries int) (Lease, error) {
+	client, err := dhcp6client.New(iface,
+		dhcp6client.WithTimeout(timeout),
+		dhcp6client.WithRetry(retries))
+	if err != nil {
+		return nil, err
+	}
+
+	log.Printf("Attempting to get DHCPv6 lease on %s", iface.Attrs().Name)
+	iana, p, err := client.RapidSolicit()
+	if err != nil {
+		return nil, err
+	}
+
+	packet := NewPacket6(iface, p, iana)
+	if _, err := packet.Boot(); err != nil {
+		return nil, fmt.Errorf("valid DHCPv6 lease without PXE info: %v", err)
+	}
+
+	log.Printf("Got DHCPv6 lease on %s", iface.Attrs().Name)
+	return packet, nil
+}
+
+type Result struct {
+	Interface netlink.Link
+	Lease     Lease
+	Err       error
+}
+
+func SendRequests(ifs []netlink.Link, timeout time.Duration, retries int, ipv4, ipv6 bool) chan *Result {
+	// Yeah, this is a hack, until we can cancel all leases in progress.
+	r := make(chan *Result, 3*len(ifs))
+
+	var wg sync.WaitGroup
+	for _, iface := range ifs {
+		wg.Add(1)
+		go func(iface netlink.Link) {
+			defer wg.Done()
+
+			log.Printf("Bringing up interface %s...", iface.Attrs().Name)
+			if _, err := IfUp(iface.Attrs().Name); err != nil {
+				log.Printf("Could not bring up interface %s: %v", iface.Attrs().Name, err)
+				return
+			}
+
+			if ipv4 {
+				wg.Add(1)
+				go func(iface netlink.Link) {
+					defer wg.Done()
+					lease, err := lease4(iface, timeout, retries)
+					r <- &Result{iface, lease, err}
+				}(iface)
+			}
+
+			if ipv6 {
+				wg.Add(1)
+				go func(iface netlink.Link) {
+					defer wg.Done()
+					lease, err := lease6(iface, timeout, retries)
+					r <- &Result{iface, lease, err}
+				}(iface)
+			}
+		}(iface)
+	}
+
+	go func() {
+		wg.Wait()
+		close(r)
+	}()
+
+	return r
 }

--- a/pkg/dhclient/dhcp4.go
+++ b/pkg/dhclient/dhcp4.go
@@ -5,6 +5,7 @@
 package dhclient
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 
@@ -34,6 +35,10 @@ func (p *Packet4) Link() netlink.Link {
 // Configure configures interface using this packet.
 func (p *Packet4) Configure() error {
 	return Configure4(p.iface, p.P)
+}
+
+func (p *Packet4) String() string {
+	return fmt.Sprintf("IPv4 DHCP Lease IP %s", p.Lease())
 }
 
 // Lease returns the IPNet assigned.

--- a/pkg/dhclient/dhcp4.go
+++ b/pkg/dhclient/dhcp4.go
@@ -10,18 +10,30 @@ import (
 
 	"github.com/u-root/dhcp4"
 	"github.com/u-root/dhcp4/dhcp4opts"
+	"github.com/vishvananda/netlink"
 )
 
 // Packet4 implements convenience functions for DHCPv4 packets.
 type Packet4 struct {
-	P *dhcp4.Packet
+	iface netlink.Link
+	P     *dhcp4.Packet
 }
 
 // NewPacket4 wraps a DHCPv4 packet with some convenience methods.
-func NewPacket4(p *dhcp4.Packet) *Packet4 {
+func NewPacket4(iface netlink.Link, p *dhcp4.Packet) *Packet4 {
 	return &Packet4{
-		P: p,
+		iface: iface,
+		P:     p,
 	}
+}
+
+func (p *Packet4) Link() netlink.Link {
+	return p.iface
+}
+
+// Configure configures interface using this packet.
+func (p *Packet4) Configure() error {
+	return Configure4(p.iface, p.P)
 }
 
 // Lease returns the IPNet assigned.

--- a/pkg/dhclient/dhcp6.go
+++ b/pkg/dhclient/dhcp6.go
@@ -5,6 +5,7 @@
 package dhclient
 
 import (
+	"fmt"
 	"net"
 	"net/url"
 
@@ -36,6 +37,10 @@ func (p *Packet6) Link() netlink.Link {
 // Configure configures interface using this packet.
 func (p *Packet6) Configure() error {
 	return Configure6(p.iface, p.p, p.iana)
+}
+
+func (p *Packet6) String() string {
+	return fmt.Sprintf("IPv6 DHCP Lease IP %s", p.Lease().IP)
 }
 
 // Lease returns lease information assigned.

--- a/pkg/pxe/pxe.go
+++ b/pkg/pxe/pxe.go
@@ -274,9 +274,11 @@ func probeFiles(ethernetMac net.HardwareAddr, ip net.IP) []string {
 	files = append(files, fmt.Sprintf("01-%s", strings.ToLower(strings.Replace(ethernetMac.String(), ":", "-", -1))))
 
 	// IP address in upper case hex, chopping one letter off at a time.
-	ipf := strings.ToUpper(hex.EncodeToString(ip))
-	for n := len(ipf); n >= 1; n-- {
-		files = append(files, ipf[:n])
+	if ip != nil {
+		ipf := strings.ToUpper(hex.EncodeToString(ip))
+		for n := len(ipf); n >= 1; n-- {
+			files = append(files, ipf[:n])
+		}
 	}
 	files = append(files, "default")
 	return files

--- a/pkg/qemu/devices.go
+++ b/pkg/qemu/devices.go
@@ -72,7 +72,7 @@ func (rod ReadOnlyDirectory) Cmdline() []string {
 
 	// Expose the temp directory to QEMU as /dev/sda1
 	return []string{
-		"-drive", fmt.Sprintf("file=fat:ro:%s,if=none,id=tmpdir", rod.Dir),
+		"-drive", fmt.Sprintf("file=fat:rw:%s,if=none,id=tmpdir", rod.Dir),
 		"-device", "ich9-ahci,id=ahci",
 		"-device", "ide-drive,drive=tmpdir,bus=ahci.0",
 	}


### PR DESCRIPTION
This commit updates pxeboot to fire DHCP requests on IPv4 and IPv6 in
parallel. The first response response will be use as DHCP configuration
and the other will be discarded.

Signed-off-by: Luis Alberto Herrera <luisalberto@google.com>