### PR TITLE
Fix ld.so glob for some musl-based Linux distros

### DIFF
--- a/pkg/ldd/ldso_linux.go
+++ b/pkg/ldd/ldso_linux.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 )
 
-const ldso = "/lib*/ld-linux-*.so.*"
+const ldso = "/lib*/ld-*.so.*"
 
 func LdSo() (string, error) {
 	n, err := filepath.Glob(ldso)


### PR DESCRIPTION
On Alpine Linux (amd64 arch) `ld.so` should resolve to `/lib/ld-musl-x86_64.so.1` which does not match glob `/lib*/ld-linux-*.so.*`.