### PR TITLE
Add a /bin/sh link to elvish for busybox mode

### DIFF
--- a/pkg/bb/cmd/main.go
+++ b/pkg/bb/cmd/main.go
@@ -25,8 +25,21 @@ func main() {
 
 func init() {
 	m := func() {
-		if len(os.Args) <= 1 {
-			log.Fatalf("You need to specify which command to invoke.")
+		if len(os.Args) == 0 {
+			log.Fatal("Arg len is 0. This is impossible")
+		}
+		if len(os.Args) == 1 {
+			// This might be a symlink, and have been invoked by an sshd.
+			// Let's try this: readlink until we get a terminal link.
+			// If the final link is "", then forget it.
+			var arg1 string
+			for s, err := os.Readlink(os.Args[0]); err == nil && s != "bb"; s, err = os.Readlink(arg1) {
+				arg1 = s
+			}
+			if arg1 == "" {
+				log.Fatalf("os.Args is %v: you need to specify which command to invoke.", os.Args)
+			}
+			os.Args = append(os.Args, arg1)
 		}
 		// Use argv[1] as the name.
 		os.Args = os.Args[1:]

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -230,6 +230,9 @@ func CreateInitramfs(logger logger.Logger, opts Opts) error {
 			if err := archive.AddRecord(cpio.Symlink("bin/defaultsh", filepath.Join("..", rtarget))); err != nil {
 				return err
 			}
+			if err := archive.AddRecord(cpio.Symlink("bin/sh", filepath.Join("..", rtarget))); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -207,6 +207,7 @@ func TestCreateInitramfs(t *testing.T) {
 				itest.HasRecord{cpio.Symlink("bbin/init", "bb")},
 				itest.HasRecord{cpio.Symlink("bbin/ls", "bb")},
 				itest.HasRecord{cpio.Symlink("bin/defaultsh", "../bbin/ls")},
+				itest.HasRecord{cpio.Symlink("bin/sh", "../bbin/ls")},
 			},
 		},
 		{
@@ -309,6 +310,7 @@ func TestCreateInitramfs(t *testing.T) {
 				itest.HasRecord{cpio.Symlink("bbin/init", "bb")},
 				itest.HasRecord{cpio.Symlink("bbin/ls", "bb")},
 				itest.HasRecord{cpio.Symlink("bin/defaultsh", "../bbin/ls")},
+				itest.HasRecord{cpio.Symlink("bin/sh", "../bbin/ls")},
 
 				// binary mode.
 				itest.HasFile{"bin/cp"},


### PR DESCRIPTION
The defaultsh link is a problem for things like sshd as it is so non-standard.
/bin/sh is a symlink now on everything and we might as well use that convention.

bb mode will now deal with any number of symlinks.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>