### PR TITLE
elvish: fix incorrect behavior of sh -c "command ...arg"

### DIFF
--- a/pkg/bb/cmd/main.go
+++ b/pkg/bb/cmd/main.go
@@ -28,6 +28,14 @@ func init() {
 		if len(os.Args) == 0 {
 			log.Fatal("Arg len is 0. This is impossible")
 		}
+		// This is a gross hack for elvish.
+		// If you do this:
+		// elvish -c "echo hi" # works
+		// sh -c "echo hi" # fails b/c it does not parse it.
+		if len(os.Args) == 1 && !filepath.IsAbs(os.Args[0]) {
+			os.Args = []string{"/bbin/elvish", "-c", os.Args[0]}
+			run()
+		}
 		if len(os.Args) == 1 {
 			// This might be a symlink, and have been invoked by an sshd.
 			// Let's try this: readlink until we get a terminal link.


### PR DESCRIPTION
Python and other programs do things like this:
sh -c "echo hi"
elvish, give this, runs a program named
echo\ hi
This is different than what happens when you do
elvish -c "echo hi"
which works.

I can't figure elvish behavior out and this nasty hack is simpler.

This gross hack applies when len(os.Args) is 1. If
os.Args[0] is not absolute, which only happens in this case,
run
elvis -c os.Args[0]

Don't attempt to parse os.Args[0]. That's not trivial.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>