### PR TITLE
multiboot: Use absolute path of the running bb binary to extract trampoline.

### DIFF
--- a/cmds/kexec/kexec_linux.go
+++ b/cmds/kexec/kexec_linux.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	flag "github.com/spf13/pflag"
 
@@ -86,7 +87,15 @@ func (f file) Load(path, cmdLine string) error {
 
 func (mb mboot) Load(path, cmdLine string) error {
 	// Trampoline should be a part of current binary.
-	m := multiboot.New(path, cmdLine, os.Args[0], mb.modules)
+	p, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("Cannot find current executable path: %v", err)
+	}
+	trampoline, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return fmt.Errorf("Cannot eval symlinks for %v: %v", p, err)
+	}
+	m := multiboot.New(path, cmdLine, trampoline, mb.modules)
 	if err := m.Load(mb.debug); err != nil {
 		return fmt.Errorf("Load failed: %v", err)
 	}

--- a/integration/multiboot_test.go
+++ b/integration/multiboot_test.go
@@ -24,7 +24,7 @@ func TestMultiboot(t *testing.T) {
 			"github.com/u-root/u-root/cmds/kexec",
 		},
 		Uinit: []string{
-			`/bbin/kexec -l /kernel -e -d --module="/kernel foo=bar" --module="/bbin/bb"`,
+			`kexec -l /kernel -e -d --module="/kernel foo=bar" --module="/bbin/bb"`,
 		},
 		SerialOutput: &serial,
 	})


### PR DESCRIPTION
Use absolute path of the running bb binary
to extract trampoline.

Signed-off-by: Max Shegai <max.shegai@gmail.com>