### PR TITLE
bb: fix issues when the command is not a direct symlink to bb

### DIFF
--- a/pkg/bb/cmd/main.go
+++ b/pkg/bb/cmd/main.go
@@ -20,6 +20,12 @@ func run() {
 }
 
 func main() {
+	arg1 := os.Args[0]
+	for s, err := os.Readlink(arg1); err == nil && s != "bb"; s, err = os.Readlink(arg1) {
+		arg1 = s
+	}
+	os.Args[0] = arg1
+
 	run()
 }
 


### PR DESCRIPTION
Python and other programs do things like this:
sh -c "echo hi"

what you see as an error is that the command
echo hi

does not exist.

What's going on here?
It's a few steps.
When elvish runs /bin/sh, it calls exec ad the child gets argv like this:
["/bin/sh" "-c" "echo hi"]

That child is bb and from this name it needs to figure out which u-root command to run.
But sh is not a u-root command; it's a symlink to a u-root command.
bb looks at filepath.Base("/bin/sh"), fails to find sh, and runs the default handler.
The default handler attempts to do something reasonable with os.Args.
When the default handler sees len(os.Args) > 1, it calls run with with os.Args[1:]
so the sequence is this:
/bin/sh -c "echo hi"
calls run with
-c "echo hi"
and since that is 2 args and -c is not found then it calls run with os.Args[1:]
and that is
"echo hi"
and the special case for len(os.Args) == 1 tries to find
something to run.

What we do is change bb main to try to follow the symlink until it finds
the terminal one, which by definition points to bb (if we are here, it's because
the symlink pointed to bb: QED).
If the follow fails, which could mainly happen if someone is messing with the file system,
or the link is bb, we run with the last follow that worked.

This is working now for every case I've tried.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>