### PR TITLE
xcmds/sshd: add support for host keys

### DIFF
--- a/xcmds/sshd/sshd.go
+++ b/xcmds/sshd/sshd.go
@@ -20,8 +20,9 @@ import (
 )
 
 var (
-	pubKeyFile = flag.StringP("pubkeyfile", "k", "key.pub", "file for public key")
-	port       = flag.StringP("port", "p", "2222", "default port")
+	hostKeyFile = flag.StringP("hostkeyfile", "h", "/etc/ssh_host_rsa_key", "file for host key")
+	pubKeyFile  = flag.StringP("pubkeyfile", "k", "key.pub", "file for public key")
+	port        = flag.StringP("port", "p", "2222", "default port")
 )
 
 func setWinsize(f *os.File, w, h int) {
@@ -41,7 +42,8 @@ func handler(s ssh.Session) {
 		cmd.Env = append(cmd.Env, fmt.Sprintf("TERM=%s", ptyReq.Term))
 		f, err := pty.Start(cmd)
 		if err != nil {
-			panic(err)
+			log.Print(err)
+			return
 		}
 		go func() {
 			for win := range winCh {
@@ -55,7 +57,8 @@ func handler(s ssh.Session) {
 	} else {
 		cmd.Stdin, cmd.Stdout, cmd.Stderr = s, s, s
 		if err := cmd.Run(); err != nil {
-			panic(err)
+			log.Print(err)
+			return
 		}
 	}
 }
@@ -87,6 +90,7 @@ func main() {
 		Handler: handler,
 	}
 
+	server.SetOption(ssh.HostKeyFile(*hostKeyFile))
 	log.Println("starting ssh server on port " + *port)
 	log.Fatal(server.ListenAndServe())
 }


### PR DESCRIPTION
Right now it only takes one key, but it's not clear we want
more. We might in figure glob /etc/ssh for keys and add them
all. It just doesn't seem necessary.

This gets rid of all warnings from ssh to this daemon.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>