### PR TITLE
Require a blank line after the license

### DIFF
--- a/cmds/date/date_test.go
+++ b/cmds/date/date_test.go
@@ -1,7 +1,7 @@
 // Copyright 2012 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-//
+
 //  created by Manoel Vilela (manoel_vilela@engineer.com)
 
 package main

--- a/cmds/df/df.go
+++ b/cmds/df/df.go
@@ -1,7 +1,7 @@
 // Copyright 2015-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-//
+
 // df reports details of mounted filesystems
 //
 // Synopsis
@@ -16,7 +16,6 @@
 // Options
 //  -k: display values in KB (default)
 //  -m: dispaly values in MB
-//
 package main
 
 import (

--- a/cmds/pci/pci.go
+++ b/cmds/pci/pci.go
@@ -1,8 +1,8 @@
 // Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-//
-//     pci: show pci bus vendor ids and other info
+
+// pci: show pci bus vendor ids and other info
 //
 // Description:
 //     List the PCI bus, with names if possible.

--- a/cmds/rm/rm_test.go
+++ b/cmds/rm/rm_test.go
@@ -1,7 +1,7 @@
 // Copyright 2012 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-//
+
 //  created by Manoel Vilela (manoel_vilela@engineer.com)
 
 package main

--- a/cmds/which/which_test.go
+++ b/cmds/which/which_test.go
@@ -1,7 +1,7 @@
 // Copyright 2016 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-//
+
 // created by Rafael Campos Nunes <rafaelnunes@engineer.com>
 
 package main

--- a/pkg/pci/lookup_test.go
+++ b/pkg/pci/lookup_test.go
@@ -1,6 +1,7 @@
 // Copyright 2012-2017 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
 package pci
 
 import (

--- a/scripts/checklicenses/checklicenses.go
+++ b/scripts/checklicenses/checklicenses.go
@@ -24,12 +24,13 @@ const uroot = "$GOPATH/src/github.com/u-root/u-root"
 
 var oklicenses = []*regexp.Regexp{
 	regexp.MustCompile(
-	`^// Copyright [\d\-, ]+ the u-root Authors\. All rights reserved
+		`^// Copyright [\d\-, ]+ the u-root Authors\. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file\.
+
 `),
 	regexp.MustCompile(
-`^// Copyright [\d\-, ]+ Google LLC.
+		`^// Copyright [\d\-, ]+ Google LLC.
 //
 // Licensed under the Apache License, Version 2.0.*
 `),
@@ -116,7 +117,7 @@ outer:
 				break
 			}
 		}
-		if ! foundone {
+		if !foundone {
 			p := trimmedPath
 			if *absPath {
 				p = file


### PR DESCRIPTION
This is so they do not get mixed in with the godoc.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>