### PR TITLE
cmds/grep: added -i for case insensitive matching

### DIFF
--- a/cmds/grep/grep.go
+++ b/cmds/grep/grep.go
@@ -31,6 +31,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 type grepResult struct {
@@ -49,15 +50,16 @@ type oneGrep struct {
 }
 
 var (
-	match       = flag.Bool("v", true, "Print only non-matching lines")
-	recursive   = flag.Bool("r", false, "recursive")
-	noshowmatch = flag.Bool("l", false, "list only files")
-	quiet       = flag.Bool("q", false, "Don't print matches; exit on first match")
-	count       = flag.Bool("c", false, "Just show counts")
-	showname    bool
-	allGrep     = make(chan *oneGrep)
-	nGrep       int
-	matchCount  int
+	match           = flag.Bool("v", true, "Print only non-matching lines")
+	recursive       = flag.Bool("r", false, "recursive")
+	noshowmatch     = flag.Bool("l", false, "list only files")
+	quiet           = flag.Bool("q", false, "Don't print matches; exit on first match")
+	count           = flag.Bool("c", false, "Just show counts")
+	caseinsensitive = flag.Bool("i", false, "case-insensitive matching")
+	showname        bool
+	allGrep         = make(chan *oneGrep)
+	nGrep           int
+	matchCount      int
 )
 
 // grep reads data from the os.File embedded in grepCommand.
@@ -116,6 +118,9 @@ func main() {
 	a := flag.Args()
 	if len(a) > 0 {
 		r = a[0]
+	}
+	if *caseinsensitive && !strings.HasPrefix(r, "(?i)") {
+		r = "(?i)" + r
 	}
 	re := regexp.MustCompile(r)
 	// very special case, just stdin ...

--- a/cmds/grep/grep_test.go
+++ b/cmds/grep/grep_test.go
@@ -26,7 +26,9 @@ func TestGrep(t *testing.T) {
 		// If you just use hix with no newline the test will fail. Yuck.
 		{"hix\n", "hix\n", 0, []string{"."}},
 		{"hix\n", "", 0, []string{"-q", "."}},
-		{"hix\n", "", 1, []string{"-q", "hox"}},
+		{"hix\n", "hix\n", 0, []string{"-i", "hix"}},
+		{"hix\n", "", 0, []string{"-i", "hox"}},
+		{"HiX\n", "HiX\n", 0, []string{"-i", "hix"}},
 	}
 
 	tmpDir, err := ioutil.TempDir("", "TestGrep")
@@ -44,7 +46,7 @@ func TestGrep(t *testing.T) {
 			continue
 		}
 		if string(o) != v.o {
-			t.Errorf("Grep %v < %v: want '%v', got '%v'", v.a, v.i, v.o, string(o))
+			t.Errorf("Grep %v != %v: want '%v', got '%v'", v.a, v.i, v.o, string(o))
 			continue
 		}
 	}


### PR DESCRIPTION
Case insensitive matching can be already achieved by prepending `(?i)` to the pattern, but `-i` is compatible with mainstream `grep` implementations.