### PR TITLE
fix errors with testramfs and dynamic mode

### DIFF
--- a/scripts/testramfs/testramfs.go
+++ b/scripts/testramfs/testramfs.go
@@ -116,6 +116,7 @@ func main() {
 	cmd.C.SysProcAttr.Chroot = tempDir
 	cmd.C.SysProcAttr.Cloneflags = cloneFlags
 	cmd.C.SysProcAttr.Unshareflags = cloneFlags
+	cmd.C.Env = append(cmd.C.Env, "CGO_ENABLED=0")
 	if *interactive {
 		if err := cmd.Run(); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
If you are in github.com/u-root/u-root and do this
go run .
testramfs /tmp/initramfs.*cpio

you get this
rminnich@xcpu:~/gopath/src/github.com/u-root/u-root$ sudo ~/gopath/bin/testramfs  /tmp/initramfs.linux_amd64.cpio
exit
2019/02/05 14:27:29 Couldn't compile "init": error building go package in "/src/github.com/u-root/u-root/cmds/init": # net
/go/src/net/lookup_unix.go:80:24: undefined: cgoLookupHost
/go/src/net/lookup_unix.go:95:24: undefined: cgoLookupIP
/go/src/net/lookup_unix.go:107:23: undefined: cgoLookupPort
/go/src/net/lookup_unix.go:123:24: undefined: cgoLookupCNAME
/go/src/net/lookup_unix.go:323:23: undefined: cgoLookupPTR
, exit status 2
2019/02/05 14:27:29 exit status 1

This is because testramfs doesn't set CGO_ENABLED=0.

This PR fixes that problem.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>