### PR TITLE
Always add CGO_ENABLED when building the toolchain

### DIFF
--- a/cmds/init/init.go
+++ b/cmds/init/init.go
@@ -139,7 +139,7 @@ func main() {
 	for _, v := range cmdList {
 		debug("Let's try to run %v", v)
 		if _, err := os.Stat(v); os.IsNotExist(err) {
-			log.Printf("it's not there")
+			debug("it's not there")
 			continue
 		}
 

--- a/pkg/golang/build.go
+++ b/pkg/golang/build.go
@@ -59,7 +59,7 @@ type ListPackage struct {
 
 func (c Environ) goCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command(filepath.Join(c.GOROOT, "bin", "go"), args...)
-	cmd.Env = append(os.Environ(), c.Env()...)
+	cmd.Env = append(os.Environ(), append(c.Env(), "CGO_ENABLED=0")...)
 	return cmd
 }
 


### PR DESCRIPTION
This ensures that defaultCGO_ENABLED is set correctly.
This variable is created at runtime and for whatever
reason we were not getting it set correctly. It makes
sense to hardwire it here since the consequences of it
being wrong are so serious. dynamic mode has been broken
for some time now and we did not know, for example.

This fixes the problems people have had with both testramfs
and qemu using dynamic mode.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>