### PR TITLE
u-root: default to CGO_ENABLED=0 unless CGO_ENABLED is set to 1

### DIFF
--- a/pkg/golang/build.go
+++ b/pkg/golang/build.go
@@ -95,7 +95,7 @@ func (c Environ) Env() []string {
 		env = append(env, fmt.Sprintf("GOPATH=%s", c.GOPATH))
 	}
 	var cgo int8
-	if c.CgoEnabled {
+	if os.Getenv("CGO_ENABLED") == "1" {
 		cgo = 1
 	}
 	env = append(env, fmt.Sprintf("CGO_ENABLED=%d", cgo))


### PR DESCRIPTION
To get a properly working dynamic u-root, we're required people to set
CGO_ENABLED=0

People are forgetting to do this, and if the compiler toolchain we have is
capable of building with cgo, it defaults to building our dynamic toolchain
with cgo, defaulting to it being enabled.

Breakage ensues with all kinds of errors, kernel panics,
and failed demos (I just had this at FOSDEM).

With this change, we only set CGO_ENABLED=1 if the user has set
CGO_ENABLED=1
in the environment.

Hence, they can still get cgo if they want it, but we default to
more reasonable behavior.

IOW, we want to set default behavior not by what the go toolchains
capabilities are but to a reasonable value of what we want.

Tested on qemu and testramfs and fixes observed calamities users
have had.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>