### PR TITLE
dhclient: printf formatting changes

### DIFF
--- a/cmds/dhclient/dhclient.go
+++ b/cmds/dhclient/dhclient.go
@@ -71,7 +71,7 @@ func ifup(ifname string) (netlink.Link, error) {
 		}
 		time.Sleep(1 * time.Second)
 	}
-	return nil, fmt.Errorf("Link %v still down after %d seconds", ifname, linkUpAttempt)
+	return nil, fmt.Errorf("Link %v still down after %s", ifname, linkUpAttempt)
 }
 
 func dhclient4(iface netlink.Link, timeout time.Duration, retry int, numRenewals int) error {
@@ -218,5 +218,5 @@ func main() {
 	if nif == 0 {
 		log.Fatalf("No interfaces match %v\n", ifName)
 	}
-	fmt.Printf("%d dhclient attempts were sent", nif)
+	fmt.Printf("%d dhclient attempts were sent\n", nif)
 }


### PR DESCRIPTION
change 1: change "%d" to "%s" for time print stmt
change 2: append newline at end of final print stmt

outcomes:

before: link "eth1" still down after 30000000000 seconds
after: link "eth1" still down after 30s

before: 3 dhclient attempts were sent%
after: 3 dhclient attempts were sent

Signed-off-by: Lincoln Thurlow <lincoln@isi.edu>