### PR TITLE
Avoid error when probing module

### DIFF
--- a/pkg/kmodule/kmodule_linux_test.go
+++ b/pkg/kmodule/kmodule_linux_test.go
@@ -1,0 +1,34 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kmodule
+
+import (
+	"bytes"
+	"path"
+	"testing"
+)
+
+var procModsMock = `hid_generic 16384 0 - Live 0x0000000000000000
+usbhid 49152 0 - Live 0x0000000000000000
+ccm 20480 6 - Live 0x0000000000000000
+`
+
+func TestGenLoadedMods(t *testing.T) {
+	m := depMap{
+		"/lib/modules/6.6.6-generic/kernel/drivers/hid/hid-generic.ko":   &dependency{},
+		"/lib/modules/6.6.6-generic/kernel/drivers/hid/usbhid/usbhid.ko": &dependency{},
+		"/lib/modules/6.6.6-generic/kernel/crypto/ccm.ko":                &dependency{},
+	}
+	br := bytes.NewBufferString(procModsMock)
+	err := genLoadedMods(br, m)
+	if err != nil {
+		t.Fatalf("fail to genLoadedMods: %v\n", err)
+	}
+	for mod, d := range m {
+		if d.state != loaded {
+			t.Fatalf("mod %q should have been loaded", path.Base(mod))
+		}
+	}
+}


### PR DESCRIPTION
The current implementation of Probe tries to load the module first
without checking if it's loaded or if it has dependencies to load first.
In the case of trying to load a module that has dependencies, this
fails by design and the returned error is used to properly load the
module.

This patch introduces parsing /proc/modules to find loaded modules and
removes the logic of special error handling.

Signed-off-by: Nikolas Sepos <nikolas.sepos@gmail.com>