### PR TITLE
[bb] check if symlink instead of whether resolved filename is "bb"

### DIFF
--- a/pkg/bb/cmd/main.go
+++ b/pkg/bb/cmd/main.go
@@ -19,9 +19,17 @@ func run() {
 	}
 }
 
+func isSymlink(f string) bool {
+	s, err := os.Stat(f)
+	if err != nil {
+		return false
+	}
+	return (s.Mode() & os.ModeSymlink) == os.ModeSymlink
+}
+
 func main() {
 	arg1 := os.Args[0]
-	for s, err := os.Readlink(arg1); err == nil && filepath.Base(s) != "bb"; s, err = os.Readlink(arg1) {
+	for s, err := os.Readlink(arg1); err == nil && isSymlink(s); s, err = os.Readlink(arg1) {
 		arg1 = s
 	}
 	os.Args[0] = arg1
@@ -39,7 +47,7 @@ func init() {
 			// Let's try this: readlink until we get a terminal link.
 			// If the final link is "", then forget it.
 			var arg1 string
-			for s, err := os.Readlink(os.Args[0]); err == nil && filepath.Base(s) != "bb"; s, err = os.Readlink(arg1) {
+			for s, err := os.Readlink(os.Args[0]); err == nil && isSymlink(s); s, err = os.Readlink(arg1) {
 				arg1 = s
 			}
 			if arg1 == "" {


### PR DESCRIPTION
The logic of resolving symlinks until we encounter "bb" introduced in
aaa8821 also broke a use cases when the
binary generated with makebb is not named "bb" after all. This can be
easily acheved by calling makebb with -o switch.

```
$ go build
$ ./makebb -o test ../../cmds/{ls,df}
$ ln -s test ls
lrwxrwxrwx 1 lsiudut lsiudut       4 Jan 30 11:18 ls -> test
-rwxr-xr-x 1 lsiudut lsiudut 8929697 Jan 30 11:14 makebb
-rw-r--r-- 1 lsiudut lsiudut    1112 Jan 30 11:12 makebb.go
-rwxr-xr-x 1 lsiudut lsiudut 2290720 Jan 30 11:18 test
$ ./ls
2019/01/30 11:18:10 os.Args is [test]: you need to specify which command to invoke.
```

I propose to check if resolved path is a symlink and continue traversal if it is. If
not - assume that this is our final bb binary.

This is repost of PR 1115 which went into merge/sign hell.

Signed-off-by: Lukasz Siudut <lsiudut@gmail.com>