### PR TITLE
kmodule_linux: add ProbeOpts.IgnoreProcMods parameter

### DIFF
--- a/pkg/kmodule/kmodule_linux.go
+++ b/pkg/kmodule/kmodule_linux.go
@@ -82,6 +82,7 @@ type ProbeOpts struct {
 	DryRunCB func(string)
 	RootDir  string
 	KVer     string
+	IgnoreProcMods bool
 }
 
 // Probe loads the given kernel module and its dependencies.
@@ -194,10 +195,12 @@ func genDeps(opts ProbeOpts) (depMap, error) {
 		return nil, err
 	}
 
-	fm, err := os.Open("/proc/modules")
-	if err == nil {
-		defer fm.Close()
-		genLoadedMods(fm, deps)
+	if !opts.IgnoreProcMods {
+		fm, err := os.Open("/proc/modules")
+		if err == nil {
+			defer fm.Close()
+			genLoadedMods(fm, deps)
+		}
 	}
 
 	return deps, nil


### PR DESCRIPTION
Unconditionally parsing /proc/modules for preloaded (and subsequently
skipped) kernel modules breaks use-cases where DryRunCB is used for
kernel module dependency gathering.
Add a new ProbeOpts.IgnoreProcMods parameter, which allows the caller to
explicitly disable this behaviour.

Signed-off-by: David Disseldorp <ddiss@suse.de>