### PR TITLE
kexec/multiboot: fix memory mapping

### DIFF
--- a/pkg/kexec/memory_linux.go
+++ b/pkg/kexec/memory_linux.go
@@ -359,11 +359,11 @@ func (m *Memory) ParseMemoryMap() error {
 type RangeType string
 
 const (
-	RangeRAM     RangeType = "System RAM"
-	RangeDefault           = "Default"
-	RangeNVACPI            = "ACPI Non-volatile Storage"
-	RangeACPI              = "ACPI Tables"
-	RangeNVS               = "Reserved"
+	RangeRAM      RangeType = "System RAM"
+	RangeDefault            = "Default"
+	RangeACPI               = "ACPI Tables"
+	RangeNVS                = "ACPI Non-volatile Storage"
+	RangeReserved           = "Reserved"
 )
 
 // Memory provides routines to work with physical memory ranges.

--- a/pkg/kexec/memory_linux_test.go
+++ b/pkg/kexec/memory_linux_test.go
@@ -43,21 +43,21 @@ func TestParseMemoryMap(t *testing.T) {
 	if err := create("0", 0, 50, RangeRAM); err != nil {
 		t.Fatal(err)
 	}
-	if err := create("1", 100, 150, RangeNVACPI); err != nil {
+	if err := create("1", 100, 150, RangeACPI); err != nil {
 		t.Fatal(err)
 	}
-	if err := create("2", 200, 250, RangeACPI); err != nil {
+	if err := create("2", 200, 250, RangeNVS); err != nil {
 		t.Fatal(err)
 	}
-	if err := create("3", 300, 350, RangeNVS); err != nil {
+	if err := create("3", 300, 350, RangeReserved); err != nil {
 		t.Fatal(err)
 	}
 
 	want := []TypedAddressRange{
 		{Range: Range{Start: 0, Size: 50}, Type: RangeRAM},
-		{Range: Range{Start: 100, Size: 50}, Type: RangeNVACPI},
-		{Range: Range{Start: 200, Size: 50}, Type: RangeACPI},
-		{Range: Range{Start: 300, Size: 50}, Type: RangeNVS},
+		{Range: Range{Start: 100, Size: 50}, Type: RangeACPI},
+		{Range: Range{Start: 200, Size: 50}, Type: RangeNVS},
+		{Range: Range{Start: 300, Size: 50}, Type: RangeReserved},
 	}
 
 	if err := mem.ParseMemoryMap(); err != nil {

--- a/pkg/multiboot/multiboot.go
+++ b/pkg/multiboot/multiboot.go
@@ -51,11 +51,11 @@ type Multiboot struct {
 }
 
 var rangeTypes = map[kexec.RangeType]uint32{
-	kexec.RangeRAM:     1,
-	kexec.RangeDefault: 2,
-	kexec.RangeNVACPI:  3,
-	kexec.RangeACPI:    3,
-	kexec.RangeNVS:     4,
+	kexec.RangeRAM:      1,
+	kexec.RangeDefault:  2,
+	kexec.RangeACPI:     3,
+	kexec.RangeNVS:      4,
+	kexec.RangeReserved: 2,
 }
 
 var sizeofMemoryMap = uint(binary.Size(MemoryMap{}))


### PR DESCRIPTION
modified kexec RangeType consts and multiboot rageTypes map for compatibity
with e280 memory mep.

modified kexec RangeType consts and multiboot rageTypes map for compatibity
with e280 memory map. Ranges found as "ACPI Non-volatile Storage" at firmware
memory map, needs to be mapped to type 4 in multiboot in order to work
properly with e820.
Changes are still compliant with multiboot spec.

Signed-off-by: Jens Drenhaus <jens.drenhaus@9elements.com>