### PR TITLE
dmesg: require root for test. fixes #1160

### DIFF
--- a/cmds/dmesg/dmesg_test.go
+++ b/cmds/dmesg/dmesg_test.go
@@ -5,13 +5,17 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
-// TODO(https://github.com/u-root/u-root/issues/1160): This test has been disabled
-func testDmesg(t *testing.T) {
+func TestDmesg(t *testing.T) {
+	if uid := os.Getuid(); uid != 0 {
+		t.Skipf("test requires root on CircleCI, your uid is %d", uid)
+	}
+
 	cmd := testutil.Command(t)
 	out, err := cmd.Output()
 	if err != nil || len(out) == 0 {


### PR DESCRIPTION
Kind of sucks, because only CircleCI requires root access for that. Oh
well.