### PR TITLE
multiboot: add ACPITable function

### DIFF
--- a/pkg/acpi/ibft.go
+++ b/pkg/acpi/ibft.go
@@ -58,7 +58,10 @@ type acpiIBFTHeader struct {
 	Reserved   [24]byte `offset:"24" desc:"Reserved"`
 }
 
-var rawIBTFHeader = "IBFT\x00\x08\x00\x001\x00ACPIXXACPISUCK1234567890abcdef01234567"
+var (
+	rawIBTFHeader = "IBFT\x00\x08\x00\x001\x00ACPIXXACPISUCK1234567890abcdef01234567"
+	_             = Tabler(&IBFT{})
+)
 
 // acpiIBFTStructHeader defines the common components of the structure headers.
 // In the standard, IBM made the flags common, even though the values

--- a/pkg/multiboot/multiboot.go
+++ b/pkg/multiboot/multiboot.go
@@ -165,6 +165,14 @@ func (m *Multiboot) Load(debug bool) error {
 // been nice.  Multiboot1 only mentions the APM table, which is
 // surprising; I had no idea it was that old.
 func (m *Multiboot) ACPI(n string) error {
+	xtra, err := acpi.RawFromFile(n)
+	if err != nil {
+		return err
+	}
+	return m.ACPITable(xtra)
+}
+
+func (m *Multiboot) ACPITable(t ...acpi.Tabler) error {
 	// NewSDT won't work on some linux kernels that limit reading
 	// above 1m. So we have to read the rsdp, which seems ok; then cons up
 	// a new SDT from scratch, since there is not one in /sys.
@@ -186,13 +194,9 @@ func (m *Multiboot) ACPI(n string) error {
 	if err != nil {
 		return err
 	}
-	xtra, err := acpi.RawFromFile(n)
-	if err != nil {
-		return err
-	}
-	rr = append(rr, xtra)
+	rr = append(rr, t...)
 
-	log.Printf("Calling SDT Marshal with %d tables", rr)
+	log.Printf("Calling SDT Marshal with %d tables", len(rr))
 	b, err := s.MarshalAll(rr...)
 	if err != nil {
 		return err


### PR DESCRIPTION
For esxiboot or other programs that will create a Tabler,
we need a function to take a tabler, not a pathname.

Another nice result is that we can now add any number of tables
to the ACPI table for multiboot. We can even add 0 tables and just
force a remarshaling if we so desire.