### PR TITLE
cpio: Limit inode cache lifetime

### DIFF
--- a/cmds/cpio/cpio.go
+++ b/cmds/cpio/cpio.go
@@ -83,11 +83,12 @@ func main() {
 
 	case "o":
 		rw := archiver.Writer(os.Stdout)
+		cr := cpio.NewRecorder()
 		scanner := bufio.NewScanner(os.Stdin)
 
 		for scanner.Scan() {
 			name := scanner.Text()
-			rec, err := cpio.GetRecord(name)
+			rec, err := cr.GetRecord(name)
 			if err != nil {
 				log.Fatalf("Getting record of %q failed: %v", name, err)
 			}

--- a/pkg/uroot/initramfs/files.go
+++ b/pkg/uroot/initramfs/files.go
@@ -189,6 +189,7 @@ func (af *Files) fillInParents() {
 func (af *Files) WriteTo(w Writer) error {
 	// Add parent directories when not added specifically.
 	af.fillInParents()
+	cr := cpio.NewRecorder()
 
 	// Reproducible builds: Files should be added to the archive in the
 	// same order.
@@ -199,7 +200,7 @@ func (af *Files) WriteTo(w Writer) error {
 			}
 		}
 		if src, ok := af.Files[path]; ok {
-			if err := writeFile(w, src, path); err != nil {
+			if err := writeFile(w, cr, src, path); err != nil {
 				return err
 			}
 		}
@@ -211,8 +212,8 @@ func (af *Files) WriteTo(w Writer) error {
 // archive `w` at path `dest`.
 //
 // If `src` is a directory, its children will be added to the archive as well.
-func writeFile(w Writer, src, dest string) error {
-	record, err := cpio.GetRecord(src)
+func writeFile(w Writer, r *cpio.Recorder, src, dest string) error {
+	record, err := r.GetRecord(src)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Make CPIO record writer inode counter into its own object to ensure that
the inode cache is flushed between cpio creations.

Fixes #1171 