### PR TITLE
[WIP] Swapout netlink package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -75,7 +75,7 @@
   branch = "master"
   name = "github.com/jsimonetti/rtnetlink"
   packages = ["."]
-  revision = "9c928e1cf777fc0f98eef3ad8d078e628ca8a5fb"
+  revision = "00c3908f53782802e518ee7b06882e6feeab88a3"
 
 [[projects]]
   name = "github.com/klauspost/compress"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,82 +3,63 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:4d3dc52be088499ee1b86a009bf217aa398f3337121584fee4763989862f063b"
   name = "github.com/anmitsu/go-shlex"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "648efa622239a2f6ff949fed78ee37b48d499ba4"
 
 [[projects]]
-  digest = "1:e6c88dab8edc42242a2035bba3a869993ff08a3e245a445ea75f436e1bb27c33"
   name = "github.com/beevik/ntp"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "62c80a04de2086884d8296004b6d74ee1846c582"
   version = "v0.2.0"
 
 [[projects]]
-  digest = "1:b7ffca49e9cfd3dfb04a8e0a59347708c6f78f68476a32c5e0a0edca5d1b258c"
   name = "github.com/dustin/go-humanize"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "9f541cc9db5d55bce703bd99987c9d5cb8eea45e"
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:e8301df5b11c8c13927a26a88ee7ec65410024f75c0fc3c8e6421aa6833808ac"
   name = "github.com/gliderlabs/ssh"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "cbabf541443203944eeedf87d8bb92e2924170b5"
 
 [[projects]]
-  digest = "1:3c04690dd1d3fad9a36c492c32863fad91bcf822fd95d5c4cae97be1e9abc361"
   name = "github.com/go-test/deep"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "6592d9cc0a499ad2d5f574fde80a2b5c5cc3b4f5"
   version = "v1.0.1"
 
 [[projects]]
-  digest = "1:28c6f29a00fc674ce801a4e8e10eacdbb49dbe2eea79a2b3d60b405cc0bd2b2d"
   name = "github.com/google/go-tpm"
   packages = [
     "tpm",
     "tpmutil",
-    "tpmutil/tbs",
+    "tpmutil/tbs"
   ]
-  pruneopts = "NUT"
   revision = "ed7874b59abd5749750978becf34e4b094126de2"
   version = "v0.1.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:b4205462c2dfe9a2ad718107012129c98e5ef82ae2bbd19e21f1a8230e30711e"
   name = "github.com/google/goexpect"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "ebfe2174586a5f4f9ec8b504e19cc9faf16dc7bc"
 
 [[projects]]
   branch = "master"
-  digest = "1:5b66c432b11dc4996e583c298c03a3120c9f2e1c68d05b72adceff13595892c3"
   name = "github.com/google/goterm"
   packages = ["term"]
-  pruneopts = "NUT"
   revision = "ce302be1d1149d49ed520b8f0d9c956b2663b3d6"
 
 [[projects]]
-  digest = "1:f03d1f27dee54a6f51200778991db9b7a91e9d9cc42395ba813fc9efc490a9a2"
   name = "github.com/gorilla/mux"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c5c6c98bc25355028a63748a498942a6398ccd22"
   version = "v1.7.1"
 
 [[projects]]
   branch = "master"
-  digest = "1:f55ffe028761947faf43bcb08ce942f8f7730b251a5c282b96b6f40c47daed7b"
   name = "github.com/insomniacslk/dhcp"
   packages = [
     "dhcpv4",
@@ -86,133 +67,213 @@
     "dhcpv6",
     "dhcpv6/nclient6",
     "iana",
-    "rfc1035label",
+    "rfc1035label"
   ]
-  pruneopts = "NUT"
   revision = "b88ad4b870e4c440db756d101fe448f47a487dd8"
 
 [[projects]]
-  digest = "1:cbf515e2ef22155a1ccaa9e6d8c86f7c84cc7f95f13341d06649492bf8e5d9d5"
+  branch = "master"
+  name = "github.com/jsimonetti/rtnetlink"
+  packages = ["."]
+  revision = "9c928e1cf777fc0f98eef3ad8d078e628ca8a5fb"
+
+[[projects]]
   name = "github.com/klauspost/compress"
   packages = ["flate"]
-  pruneopts = "NUT"
   revision = "30be6041bed523c18e269a700ebd9c2ea9328574"
   version = "v1.4.1"
 
 [[projects]]
-  digest = "1:f44ca3e400a23dc9cf76a09d71891da95193c0c7da2008205f8f20154f49b22d"
   name = "github.com/klauspost/cpuid"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "e7e905edc00ea8827e58662220139109efea09db"
   version = "v1.2.0"
 
 [[projects]]
-  digest = "1:f3f3545a30b934b75ad9cf9c7e9543f84f1d1aee3e534f6d01ab1776fa519fb9"
   name = "github.com/klauspost/pgzip"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "083b1c3f84dd6486588802e5ce295de3a7f41a8b"
   version = "v1.2.1"
 
 [[projects]]
-  digest = "1:563fcc691498b68d6236cb0f9f224e5214d89c4588922bc1d307279f7bde6de6"
   name = "github.com/kr/pty"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "521317be5ebc228a0f0ede099fa2a0b5ece22e49"
   version = "v1.1.4"
 
 [[projects]]
-  digest = "1:85edcc76fa95b8b312642905b56284f4fe5c42d8becb219481adba7e97d4f5c5"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "c2a7a6ca930a4cd0bc33a3f298eb71960732a3a7"
   version = "v0.0.7"
 
 [[projects]]
-  digest = "1:70ef8268170621826f8c111ac1674afe75136f526f449453b4a6631c6dba1946"
   name = "github.com/mattn/go-runewidth"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "3ee7d812e62a0804a7d0a324e0249ca2db3476d3"
   version = "v0.0.4"
 
 [[projects]]
   branch = "master"
-  digest = "1:88810ec115324c260951440d11f030e4bfe451cd888720481e1ddc037a5c8678"
   name = "github.com/mdlayher/ethernet"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "5b5fc417d966b71d3781b0d5860413e9fae947c1"
 
 [[projects]]
   branch = "master"
-  digest = "1:82baf000055f2497bdf17392c4e70f10f910490de2f0ebac885acbd031f822f3"
+  name = "github.com/mdlayher/netlink"
+  packages = [
+    ".",
+    "nlenc"
+  ]
+  revision = "11939a169225a13c54d4099899357e2a67577fee"
+
+[[projects]]
+  branch = "master"
   name = "github.com/mdlayher/raw"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "b0647ab7d8b35d5b8b734462042628e5af82f7f4"
 
 [[projects]]
   branch = "master"
-  digest = "1:6022d8987643a603f69616699ba517019b353c0f6fd521372d465f3acbf081d5"
   name = "github.com/nsf/termbox-go"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "288510b9734e30e7966ec2f22b87c5f8e67345e3"
 
 [[projects]]
   branch = "master"
-  digest = "1:22ffe7a0e80f54e5a5ee408e2f6a4717ee8c5c3ecd94530963d1362efa178df5"
   name = "github.com/rck/unit"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "16d9ed3d60d943bbb0ed704264795a2541457601"
 
 [[projects]]
-  digest = "1:9d8420bbf131d1618bde6530af37c3799340d3762cc47210c1d9532a4c3a2779"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
   version = "v1.0.3"
 
 [[projects]]
   branch = "master"
-  digest = "1:7964b3b34b74b6c7dfbd5775d8bb82bef69e9729f4c7d341a9b73b0820b5c41a"
   name = "github.com/u-root/dhcp4"
   packages = [
     ".",
     "dhcp4opts",
-    "dhcp4server",
+    "dhcp4server"
   ]
-  pruneopts = "NUT"
   revision = "03363dc71ec82763595440b4b2c3e5f69f47a4e0"
 
 [[projects]]
   branch = "master"
-  digest = "1:2c6c98c684af5b5981082d8049fd9e7a02c1923374db65cb09c70de8f758e820"
+  name = "github.com/u-root/u-root"
+  packages = [
+    "cmds/elvish/build",
+    "cmds/elvish/edit",
+    "cmds/elvish/edit/completion",
+    "cmds/elvish/edit/eddefs",
+    "cmds/elvish/edit/highlight",
+    "cmds/elvish/edit/history",
+    "cmds/elvish/edit/lastcmd",
+    "cmds/elvish/edit/location",
+    "cmds/elvish/edit/prompt",
+    "cmds/elvish/edit/tty",
+    "cmds/elvish/edit/ui",
+    "cmds/elvish/eval",
+    "cmds/elvish/eval/bundled",
+    "cmds/elvish/eval/vals",
+    "cmds/elvish/eval/vars",
+    "cmds/elvish/getopt",
+    "cmds/elvish/glob",
+    "cmds/elvish/hash",
+    "cmds/elvish/hashmap",
+    "cmds/elvish/parse",
+    "cmds/elvish/parse/parseutil",
+    "cmds/elvish/program",
+    "cmds/elvish/program/shell",
+    "cmds/elvish/runtime",
+    "cmds/elvish/store",
+    "cmds/elvish/store/storedefs",
+    "cmds/elvish/sys",
+    "cmds/elvish/tt",
+    "cmds/elvish/util",
+    "cmds/elvish/vector",
+    "cmds/man/data",
+    "pkg/abi",
+    "pkg/acpi",
+    "pkg/bb",
+    "pkg/binary",
+    "pkg/boot",
+    "pkg/bzimage",
+    "pkg/cmdline",
+    "pkg/complete",
+    "pkg/cp",
+    "pkg/cpio",
+    "pkg/dhclient",
+    "pkg/diskboot",
+    "pkg/dt",
+    "pkg/find",
+    "pkg/forth",
+    "pkg/golang",
+    "pkg/gpt",
+    "pkg/gzip",
+    "pkg/io",
+    "pkg/ipxe",
+    "pkg/kexec",
+    "pkg/kmodule",
+    "pkg/ldd",
+    "pkg/less",
+    "pkg/lineio",
+    "pkg/lockfile",
+    "pkg/loop",
+    "pkg/ls",
+    "pkg/mount",
+    "pkg/multiboot",
+    "pkg/multiboot/internal/trampoline",
+    "pkg/null",
+    "pkg/pci",
+    "pkg/pty",
+    "pkg/pxe",
+    "pkg/qemu",
+    "pkg/rand",
+    "pkg/rtc",
+    "pkg/sh",
+    "pkg/sortedmap",
+    "pkg/sos",
+    "pkg/strace",
+    "pkg/tar",
+    "pkg/termios",
+    "pkg/testutil",
+    "pkg/ubinary",
+    "pkg/uio",
+    "pkg/uroot",
+    "pkg/uroot/builder",
+    "pkg/uroot/builder/bb",
+    "pkg/uroot/initramfs",
+    "pkg/uroot/initramfs/test",
+    "pkg/uroot/logger",
+    "pkg/uroot/util",
+    "pkg/wifi",
+    "pkg/wpa/passphrase",
+    "pkg/zimage"
+  ]
+  revision = "d6d5e43c7bdb9105bbee6d95e8e9f79360fb94c9"
+
+[[projects]]
+  branch = "master"
   name = "github.com/vishvananda/netlink"
   packages = [
     ".",
-    "nl",
+    "nl"
   ]
-  pruneopts = "NUT"
   revision = "f504738125a57f35f87fc30fb69b8df75237ccde"
 
 [[projects]]
   branch = "master"
-  digest = "1:2a1bbe57bb2602803e0f142d88453b0d9fec89e496aaa2cd8807bcae2e05a4a7"
   name = "github.com/vishvananda/netns"
   packages = ["."]
-  pruneopts = "NUT"
   revision = "13995c7128ccc8e51e9a6bd2b551020a27180abd"
 
 [[projects]]
   branch = "master"
-  digest = "1:69458fde745988d318e90cd314cb26e139a50eb160ce9169a92574d57a8854f1"
   name = "golang.org/x/crypto"
   packages = [
     "cast5",
@@ -232,39 +293,33 @@
     "poly1305",
     "ripemd160",
     "sha3",
-    "ssh",
+    "ssh"
   ]
-  pruneopts = "NUT"
   revision = "38d8ce5564a5b71b2e3a00553993f1b9a7ae852f"
 
 [[projects]]
   branch = "master"
-  digest = "1:cd54f1899e8e8769b9bc7c4922fc44c8c62a54cf63753b228b9c59d42e7ea0e5"
   name = "golang.org/x/net"
   packages = [
     "bpf",
     "internal/iana",
     "internal/socket",
-    "ipv4",
+    "ipv4"
   ]
-  pruneopts = "NUT"
   revision = "eb5bcb51f2a31c7d5141d810b70815c05d9c9146"
 
 [[projects]]
   branch = "master"
-  digest = "1:a26ebff2301ac8a4c8cedfec085e8190b035a7eec6b5614b7501f4714138a679"
   name = "golang.org/x/sys"
   packages = [
     "cpu",
     "unix",
-    "windows",
+    "windows"
   ]
-  pruneopts = "NUT"
-  revision = "4b34438f7a67ee5f45cc6132e2bad873a20324e9"
+  revision = "0ad05ae3009d6413d3363aa09b350b2ec37daf09"
 
 [[projects]]
   branch = "master"
-  digest = "1:797d26136f04e8b3731c21e7ed71cd881d95325f46d81f8a6bc24b1c80cb0e8a"
   name = "golang.org/x/tools"
   packages = [
     "go/ast/astutil",
@@ -277,67 +332,28 @@
     "internal/fastwalk",
     "internal/gopathwalk",
     "internal/module",
-    "internal/semver",
+    "internal/semver"
   ]
-  pruneopts = "NUT"
   revision = "0fdf0c73855bae8482c5d3907a9e06f33ff70a10"
 
 [[projects]]
-  digest = "1:8061e1ede5067e386972621147c69c9183d3dc3215056465206fc4202b3a15e7"
   name = "google.golang.org/grpc"
   packages = ["codes"]
-  pruneopts = "NUT"
   revision = "3507fb8e1a5ad030303c106fef3a47c9fdad16ad"
   version = "v1.19.1"
 
 [[projects]]
-  digest = "1:6889c82820f81a4fc7c707b5ac38e06da0486865ae513b0c33c38bf3b3fc46da"
   name = "pack.ag/tftp"
   packages = [
     ".",
-    "netascii",
+    "netascii"
   ]
-  pruneopts = "NUT"
   revision = "d0fca786a8ea95ad4515bb83b2c34a11ec6a3fc0"
   version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  input-imports = [
-    "github.com/beevik/ntp",
-    "github.com/dustin/go-humanize",
-    "github.com/gliderlabs/ssh",
-    "github.com/go-test/deep",
-    "github.com/google/go-tpm/tpm",
-    "github.com/google/goexpect",
-    "github.com/gorilla/mux",
-    "github.com/insomniacslk/dhcp/dhcpv4",
-    "github.com/insomniacslk/dhcp/dhcpv4/nclient4",
-    "github.com/insomniacslk/dhcp/dhcpv6",
-    "github.com/insomniacslk/dhcp/dhcpv6/nclient6",
-    "github.com/klauspost/pgzip",
-    "github.com/kr/pty",
-    "github.com/mattn/go-isatty",
-    "github.com/nsf/termbox-go",
-    "github.com/rck/unit",
-    "github.com/spf13/pflag",
-    "github.com/u-root/dhcp4/dhcp4server",
-    "github.com/vishvananda/netlink",
-    "golang.org/x/crypto/ed25519",
-    "golang.org/x/crypto/md4",
-    "golang.org/x/crypto/openpgp",
-    "golang.org/x/crypto/openpgp/errors",
-    "golang.org/x/crypto/openpgp/packet",
-    "golang.org/x/crypto/pbkdf2",
-    "golang.org/x/crypto/ripemd160",
-    "golang.org/x/crypto/sha3",
-    "golang.org/x/crypto/ssh",
-    "golang.org/x/sys/unix",
-    "golang.org/x/sys/windows",
-    "golang.org/x/tools/go/ast/astutil",
-    "golang.org/x/tools/imports",
-    "pack.ag/tftp",
-  ]
+  inputs-digest = "70f9b275b63642ca0263eb81ee5b9ead324072d8ed1f1274a507dbeb437764ba"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmds/ip/ops.go
+++ b/cmds/ip/ops.go
@@ -22,10 +22,10 @@ func showLinks(w io.Writer, withAddresses bool) error {
 
 	for _, l := range ifaces {
 		fmt.Fprintf(w, "%d: %s: <%s> mtu %d state %s\n", l.Index, l.Attributes.Name,
-			strings.Replace(strings.ToUpper(fmt.Sprintf("%x", l.Flags)), "|", ",", -1),
-			l.Attributes.MTU, strings.ToUpper(string(l.Attributes.OperationalState)))
+			linkFlags(l.Flags),
+			l.Attributes.MTU, linkStates[l.Attributes.OperationalState])
 
-		fmt.Fprintf(w, "    link/%x %s\n", l.Type, l.Attributes.Address)
+		fmt.Fprintf(w, "    link/%s %s\n", encapType(l.Type), l.Attributes.Address)
 
 		if withAddresses {
 			showLinkAddresses(w, &net.Interface{Index: int(l.Index)})

--- a/cmds/ip/ops.go
+++ b/cmds/ip/ops.go
@@ -92,7 +92,7 @@ func showNeighbours(w io.Writer, withAddresses bool) error {
 		return err
 	}
 	for _, iface := range ifaces {
-		neighs, err := neighList(&iface, 0)
+		neighs, err := neighList(&iface, unix.AF_INET)
 		if err != nil {
 			return fmt.Errorf("Can't list neighbours? %v", err)
 		}

--- a/cmds/ip/ops.go
+++ b/cmds/ip/ops.go
@@ -51,11 +51,11 @@ func showLinkAddresses(w io.Writer, link *net.Interface) error {
 			return fmt.Errorf("Can't figure out IP protocol version")
 		}
 
-		fmt.Fprintf(w, "    %s %s", inet, addr.Attributes.Address)
+		fmt.Fprintf(w, "    %s %s/%d", inet, addr.Attributes.Address, addr.PrefixLength)
 		if addr.Attributes.Broadcast != nil {
 			fmt.Fprintf(w, " brd %s", addr.Attributes.Broadcast)
 		}
-		fmt.Fprintf(w, " scope %s %s\n", addrScopes[addr.Scope], addr.Attributes.Label)
+		fmt.Fprintf(w, " scope %s %s %s\n", addrScopes[addr.Scope], addrFlags(addr.Attributes.Flags), addr.Attributes.Label)
 
 		var validLft, preferredLft string
 		if addr.Attributes.CacheInfo.Prefered == math.MaxUint32 {

--- a/cmds/ip/ops.go
+++ b/cmds/ip/ops.go
@@ -11,41 +11,38 @@ import (
 	"net"
 	"strings"
 
-	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 )
 
 func showLinks(w io.Writer, withAddresses bool) error {
-	ifaces, err := netlink.LinkList()
+	ifaces, err := linkList()
 	if err != nil {
 		return fmt.Errorf("Can't enumerate interfaces? %v", err)
 	}
 
-	for _, v := range ifaces {
-		l := v.Attrs()
+	for _, l := range ifaces {
+		fmt.Fprintf(w, "%d: %s: <%s> mtu %d state %s\n", l.Index, l.Attributes.Name,
+			strings.Replace(strings.ToUpper(fmt.Sprintf("%x", l.Flags)), "|", ",", -1),
+			l.Attributes.MTU, strings.ToUpper(string(l.Attributes.OperationalState)))
 
-		fmt.Fprintf(w, "%d: %s: <%s> mtu %d state %s\n", l.Index, l.Name,
-			strings.Replace(strings.ToUpper(fmt.Sprintf("%s", l.Flags)), "|", ",", -1),
-			l.MTU, strings.ToUpper(l.OperState.String()))
-
-		fmt.Fprintf(w, "    link/%s %s\n", l.EncapType, l.HardwareAddr)
+		fmt.Fprintf(w, "    link/%x %s\n", l.Type, l.Attributes.Address)
 
 		if withAddresses {
-			showLinkAddresses(w, v)
+			showLinkAddresses(w, &net.Interface{Index: int(l.Index)})
 		}
 	}
 	return nil
 }
 
-func showLinkAddresses(w io.Writer, link netlink.Link) error {
-	addrs, err := netlink.AddrList(link, netlink.FAMILY_ALL)
+func showLinkAddresses(w io.Writer, link *net.Interface) error {
+	addrs, err := addrList(link, unix.AF_UNSPEC)
 	if err != nil {
 		return fmt.Errorf("Can't enumerate addresses: %v", err)
 	}
 
 	for _, addr := range addrs {
-
 		var inet string
-		switch len(addr.IPNet.IP) {
+		switch len(addr.Attributes.Address) {
 		case 4:
 			inet = "inet"
 		case 16:
@@ -54,42 +51,29 @@ func showLinkAddresses(w io.Writer, link netlink.Link) error {
 			return fmt.Errorf("Can't figure out IP protocol version")
 		}
 
-		fmt.Fprintf(w, "    %s %s", inet, addr.IP)
-		if addr.Broadcast != nil {
-			fmt.Fprintf(w, " brd %s", addr.Broadcast)
+		fmt.Fprintf(w, "    %s %s", inet, addr.Attributes.Address)
+		if addr.Attributes.Broadcast != nil {
+			fmt.Fprintf(w, " brd %s", addr.Attributes.Broadcast)
 		}
-		fmt.Fprintf(w, " scope %s %s\n", addrScopes[netlink.Scope(addr.Scope)], addr.Label)
+		fmt.Fprintf(w, " scope %s %s\n", addrScopes[addr.Scope], addr.Attributes.Label)
 
 		var validLft, preferredLft string
-		// TODO: fix vishnavanda/netlink. *Lft should be uint32, not int.
-		if uint32(addr.PreferedLft) == math.MaxUint32 {
+		if addr.Attributes.CacheInfo.Prefered == math.MaxUint32 {
 			preferredLft = "forever"
 		} else {
-			preferredLft = fmt.Sprintf("%dsec", addr.PreferedLft)
+			preferredLft = fmt.Sprintf("%dsec", addr.Attributes.CacheInfo.Prefered)
 		}
-		if uint32(addr.ValidLft) == math.MaxUint32 {
+		if addr.Attributes.CacheInfo.Valid == math.MaxUint32 {
 			validLft = "forever"
 		} else {
-			validLft = fmt.Sprintf("%dsec", addr.ValidLft)
+			validLft = fmt.Sprintf("%dsec", addr.Attributes.CacheInfo.Valid)
 		}
 		fmt.Fprintf(w, "       valid_lft %s preferred_lft %s\n", validLft, preferredLft)
 	}
 	return nil
 }
 
-var neighStates = map[int]string{
-	netlink.NUD_NONE:       "NONE",
-	netlink.NUD_INCOMPLETE: "INCOMPLETE",
-	netlink.NUD_REACHABLE:  "REACHABLE",
-	netlink.NUD_STALE:      "STALE",
-	netlink.NUD_DELAY:      "DELAY",
-	netlink.NUD_PROBE:      "PROBE",
-	netlink.NUD_FAILED:     "FAILED",
-	netlink.NUD_NOARP:      "NOARP",
-	netlink.NUD_PERMANENT:  "PERMANENT",
-}
-
-func getState(state int) string {
+func getState(state uint16) string {
 	ret := make([]string, 0)
 	for st, name := range neighStates {
 		if state&st != 0 {
@@ -108,20 +92,20 @@ func showNeighbours(w io.Writer, withAddresses bool) error {
 		return err
 	}
 	for _, iface := range ifaces {
-		neighs, err := netlink.NeighList(iface.Index, 0)
+		neighs, err := neighList(&iface, 0)
 		if err != nil {
 			return fmt.Errorf("Can't list neighbours? %v", err)
 		}
 
 		for _, v := range neighs {
-			if v.State&netlink.NUD_NOARP != 0 {
+			if v.State&NUD_NOARP != 0 {
 				continue
 			}
-			entry := fmt.Sprintf("%s dev %s", v.IP.String(), iface.Name)
-			if v.HardwareAddr != nil {
-				entry += fmt.Sprintf(" lladdr %s", v.HardwareAddr)
+			entry := fmt.Sprintf("%s dev %s", v.Attributes.Address.String(), iface.Name)
+			if v.Attributes.LLAddress != nil {
+				entry += fmt.Sprintf(" lladdr %s", v.Attributes.LLAddress)
 			}
-			if v.Flags&netlink.NTF_ROUTER != 0 {
+			if v.Flags&unix.NTF_ROUTER != 0 {
 				entry += " router"
 			}
 			entry += " " + getState(v.State)

--- a/cmds/ip/rtnetlink.go
+++ b/cmds/ip/rtnetlink.go
@@ -131,8 +131,33 @@ func routeAdd(iface *net.Interface, dst net.IPNet, gw net.IP) error {
 	return nil
 }
 
-func neighList(iface *net.Interface, family uint8) ([]rtnetlink.NeighMessage, error) {
-	return nil, nil
+func neighList(iface *net.Interface, family uint16) ([]rtnetlink.NeighMessage, error) {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	msg, err := conn.Neigh.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var neigh []rtnetlink.NeighMessage
+	for _, v := range msg {
+		add := true
+		if iface != nil && v.Index != uint32(iface.Index) {
+			add = false
+		}
+		if family != 0 && v.Family != family {
+			add = false
+		}
+		if add {
+			neigh = append(neigh, v)
+		}
+	}
+
+	return neigh, nil
 }
 
 var flagNames = map[int]string{

--- a/cmds/ip/rtnetlink.go
+++ b/cmds/ip/rtnetlink.go
@@ -1,10 +1,191 @@
 package main
 
 import (
+	"fmt"
 	"net"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/jsimonetti/rtnetlink"
 )
+
+func addrAdd(iface *net.Interface, addr *net.IPNet) error {
+	return nil
+}
+
+func addrDel(iface *net.Interface, addr *net.IPNet) error {
+	return nil
+}
+
+func addrList(link *net.Interface, family uint8) ([]rtnetlink.AddressMessage, error) {
+	return nil, nil
+}
+
+func linkList() ([]rtnetlink.LinkMessage, error) {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	msg, err := conn.Link.List()
+	if err != nil {
+		return nil, err
+	}
+
+	// Cycle through to make sure the msg.Attributes is not nil
+	// as we might access this later on
+	for i := 0; i < len(msg); i++ {
+		if msg[i].Attributes == nil {
+			msg[i].Attributes = &rtnetlink.LinkAttributes{}
+		}
+	}
+	return msg, nil
+}
+
+func linkSetHardwareAddr(iface *net.Interface, hwAddr net.HardwareAddr) error {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	msg, err := conn.Link.Get(uint32(iface.Index))
+	if err != nil {
+		return err
+	}
+
+	err = conn.Link.Set(&rtnetlink.LinkMessage{
+		Family: msg.Family,
+		Type:   msg.Type,
+		Index:  uint32(iface.Index),
+		Flags:  msg.Flags,
+		Change: msg.Change,
+		Attributes: &rtnetlink.LinkAttributes{
+			Address: hwAddr,
+		},
+	})
+
+	return err
+}
+
+func linkSetUp(iface *net.Interface) error {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	msg, err := conn.Link.Get(uint32(iface.Index))
+	if err != nil {
+		return err
+	}
+
+	state := msg.Attributes.OperationalState
+	// If the link is already up, return immediately
+	if state == rtnetlink.OperStateUp || state == rtnetlink.OperStateUnknown {
+		return nil
+	}
+
+	err = conn.Link.Set(&rtnetlink.LinkMessage{
+		Family: msg.Family,
+		Type:   msg.Type,
+		Index:  uint32(iface.Index),
+		Flags:  unix.IFF_UP,
+		Change: unix.IFF_UP,
+	})
+
+	return err
+}
+
+func linkSetDown(iface *net.Interface) error {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	msg, err := conn.Link.Get(uint32(iface.Index))
+	if err != nil {
+		return err
+	}
+
+	state := msg.Attributes.OperationalState
+	// If the link is already down, return immediately
+	if state == rtnetlink.OperStateDown {
+		return nil
+	}
+
+	err = conn.Link.Set(&rtnetlink.LinkMessage{
+		Family: msg.Family,
+		Type:   msg.Type,
+		Index:  uint32(iface.Index),
+		Flags:  0x0,
+		Change: 0x1,
+	})
+
+	return err
+}
+
+func routeAdd(iface *net.Interface, dst net.IPNet, gw net.IP) error {
+	return nil
+}
+
+func neighList(iface *net.Interface, family uint8) ([]rtnetlink.NeighMessage, error) {
+	return nil, nil
+}
+
+var flagNames = map[int]string{
+	unix.IFF_UP:          "UP",
+	unix.IFF_BROADCAST:   "BROADCAST",
+	unix.IFF_POINTOPOINT: "POINTTOPOINT",
+	unix.IFF_LOOPBACK:    "LOOPBACK",
+	unix.IFF_LOWER_UP:    "LOWER_UP",
+	unix.IFF_NOARP:       "NOARP",
+	unix.IFF_MULTICAST:   "MULTICAST",
+}
+
+func linkFlags(f uint32) string {
+	s := ""
+	for i, name := range flagNames {
+		if f&uint32(i) != 0 {
+			if s != "" {
+				s += ","
+			}
+			s += name
+		}
+	}
+	if s == "" {
+		s = "0"
+	}
+	return s
+}
+
+func encapType(t uint16) string {
+	switch t {
+	case 0:
+		return "generic"
+	case unix.ARPHRD_ETHER:
+		return "ether"
+	case unix.ARPHRD_ATM:
+		return "atm"
+	case unix.ARPHRD_PPP:
+		return "ppp"
+	case unix.ARPHRD_TUNNEL:
+		return "ipip"
+	case unix.ARPHRD_TUNNEL6:
+		return "tunnel6"
+	case unix.ARPHRD_LOOPBACK:
+		return "loopback"
+	case unix.ARPHRD_SIT:
+		return "sit"
+	case unix.ARPHRD_IPGRE:
+		return "gre"
+	case unix.ARPHRD_NETLINK:
+		return "netlink"
+	}
+	return fmt.Sprintf("unknown%d", t)
+}
 
 // TODO: add these constants to golang.org/x/sys/unix
 const (
@@ -31,45 +212,12 @@ var neighStates = map[uint16]string{
 	NUD_PERMANENT:  "PERMANENT",
 }
 
-func addrAdd(iface *net.Interface, addr *net.IPNet) error {
-	return nil
-}
-
-func addrDel(iface *net.Interface, addr *net.IPNet) error {
-	return nil
-}
-
-func addrList(link *net.Interface, family uint8) ([]rtnetlink.AddressMessage, error) {
-	return nil, nil
-}
-
-func linkList() ([]rtnetlink.LinkMessage, error) {
-	var list []rtnetlink.LinkMessage
-
-	for i := 0; i < len(list); i++ {
-		if list[i].Attributes == nil {
-			list[i].Attributes = &rtnetlink.LinkAttributes{}
-		}
-	}
-	return nil, nil
-}
-
-func linkSetHardwareAddr(iface *net.Interface, hwAddr net.HardwareAddr) error {
-	return nil
-}
-
-func linkSetUp(iface *net.Interface) error {
-	return nil
-}
-
-func linkSetDown(iface *net.Interface) error {
-	return nil
-}
-
-func routeAdd(iface *net.Interface, dst net.IPNet, gw net.IP) error {
-	return nil
-}
-
-func neighList(iface *net.Interface, family uint8) ([]rtnetlink.NeighMessage, error) {
-	return nil, nil
+var linkStates = map[rtnetlink.OperationalState]string{
+	rtnetlink.OperStateUnknown:        "unknown",
+	rtnetlink.OperStateNotPresent:     "not-present",
+	rtnetlink.OperStateDown:           "down",
+	rtnetlink.OperStateLowerLayerDown: "lower-layer-down",
+	rtnetlink.OperStateTesting:        "testing",
+	rtnetlink.OperStateDormant:        "dormant",
+	rtnetlink.OperStateUp:             "up",
 }

--- a/cmds/ip/rtnetlink.go
+++ b/cmds/ip/rtnetlink.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"net"
+
+	"github.com/jsimonetti/rtnetlink"
+)
+
+// TODO: add these constants to golang.org/x/sys/unix
+const (
+	NUD_NONE       uint16 = 0x00
+	NUD_INCOMPLETE uint16 = 0x01
+	NUD_REACHABLE  uint16 = 0x02
+	NUD_STALE      uint16 = 0x04
+	NUD_DELAY      uint16 = 0x08
+	NUD_PROBE      uint16 = 0x10
+	NUD_FAILED     uint16 = 0x20
+	NUD_NOARP      uint16 = 0x40
+	NUD_PERMANENT  uint16 = 0x80
+)
+
+var neighStates = map[uint16]string{
+	NUD_NONE:       "NONE",
+	NUD_INCOMPLETE: "INCOMPLETE",
+	NUD_REACHABLE:  "REACHABLE",
+	NUD_STALE:      "STALE",
+	NUD_DELAY:      "DELAY",
+	NUD_PROBE:      "PROBE",
+	NUD_FAILED:     "FAILED",
+	NUD_NOARP:      "NOARP",
+	NUD_PERMANENT:  "PERMANENT",
+}
+
+func addrAdd(iface *net.Interface, addr *net.IPNet) error {
+	return nil
+}
+
+func addrDel(iface *net.Interface, addr *net.IPNet) error {
+	return nil
+}
+
+func addrList(link *net.Interface, family uint8) ([]rtnetlink.AddressMessage, error) {
+	return nil, nil
+}
+
+func linkList() ([]rtnetlink.LinkMessage, error) {
+	var list []rtnetlink.LinkMessage
+
+	for i := 0; i < len(list); i++ {
+		if list[i].Attributes == nil {
+			list[i].Attributes = &rtnetlink.LinkAttributes{}
+		}
+	}
+	return nil, nil
+}
+
+func linkSetHardwareAddr(iface *net.Interface, hwAddr net.HardwareAddr) error {
+	return nil
+}
+
+func linkSetUp(iface *net.Interface) error {
+	return nil
+}
+
+func linkSetDown(iface *net.Interface) error {
+	return nil
+}
+
+func routeAdd(iface *net.Interface, dst net.IPNet, gw net.IP) error {
+	return nil
+}
+
+func neighList(iface *net.Interface, family uint8) ([]rtnetlink.NeighMessage, error) {
+	return nil, nil
+}

--- a/cmds/ip/rtnetlink.go
+++ b/cmds/ip/rtnetlink.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/binary"
+	"errors"
 	"fmt"
 	"net"
 
@@ -10,15 +12,100 @@ import (
 )
 
 func addrAdd(iface *net.Interface, addr *net.IPNet) error {
-	return nil
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	family := unix.AF_INET6
+	if addr.IP.To4() != nil {
+		family = unix.AF_INET
+	}
+	ones, _ := addr.Mask.Size()
+
+	brd, err := broadcastAddr(addr)
+	if err != nil {
+		return err
+	}
+
+	err = conn.Address.New(&rtnetlink.AddressMessage{
+		Family:       uint8(family),
+		PrefixLength: uint8(ones),
+		Scope:        unix.RT_SCOPE_UNIVERSE,
+		Index:        uint32(iface.Index),
+		Attributes: rtnetlink.AddressAttributes{
+			Address:   addr.IP,
+			Local:     addr.IP,
+			Broadcast: brd,
+		},
+	})
+
+	return err
 }
 
 func addrDel(iface *net.Interface, addr *net.IPNet) error {
-	return nil
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	family := unix.AF_INET6
+	if addr.IP.To4() != nil {
+		family = unix.AF_INET
+	}
+	ones, _ := addr.Mask.Size()
+
+	req := &rtnetlink.AddressMessage{}
+
+	msg, err := addrList(iface, uint8(family))
+	for _, v := range msg {
+		if v.PrefixLength == uint8(ones) && v.Attributes.Address.Equal(addr.IP) {
+			req = &rtnetlink.AddressMessage{
+				Family:       uint8(family),
+				PrefixLength: uint8(ones),
+				Index:        uint32(iface.Index),
+				Attributes: rtnetlink.AddressAttributes{
+					Address:   addr.IP,
+					Broadcast: v.Attributes.Broadcast,
+				},
+			}
+		}
+	}
+
+	err = conn.Address.Delete(req)
+
+	return err
 }
 
-func addrList(link *net.Interface, family uint8) ([]rtnetlink.AddressMessage, error) {
-	return nil, nil
+func addrList(iface *net.Interface, family uint8) ([]rtnetlink.AddressMessage, error) {
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	msg, err := conn.Address.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var addr []rtnetlink.AddressMessage
+	for _, v := range msg {
+		add := true
+		if iface != nil && v.Index != uint32(iface.Index) {
+			add = false
+		}
+		if family != 0 && v.Family != family {
+			add = false
+		}
+		if add {
+			addr = append(addr, v)
+		}
+	}
+
+	return addr, nil
 }
 
 func linkList() ([]rtnetlink.LinkMessage, error) {
@@ -128,7 +215,31 @@ func linkSetDown(iface *net.Interface) error {
 }
 
 func routeAdd(iface *net.Interface, dst net.IPNet, gw net.IP) error {
-	return nil
+	conn, err := rtnetlink.Dial(nil)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	attr := rtnetlink.RouteAttributes{
+		Dst:      dst.IP,
+		OutIface: uint32(iface.Index),
+	}
+	if gw == nil {
+		attr.Gateway = gw
+	}
+
+	// TODO: fix this code
+	err = conn.Route.Add(&rtnetlink.RouteMessage{
+		Family:     unix.AF_INET,
+		Table:      unix.RT_TABLE_MAIN,
+		Protocol:   unix.RTPROT_BOOT,
+		Scope:      unix.RT_SCOPE_LINK,
+		Type:       unix.RTN_UNICAST,
+		Attributes: attr,
+	})
+
+	return err
 }
 
 func neighList(iface *net.Interface, family uint16) ([]rtnetlink.NeighMessage, error) {
@@ -158,6 +269,37 @@ func neighList(iface *net.Interface, family uint16) ([]rtnetlink.NeighMessage, e
 	}
 
 	return neigh, nil
+}
+
+var addrFlagNames = map[int]string{
+	unix.IFA_F_SECONDARY:      "secondary",
+	unix.IFA_F_NODAD:          "nodad",
+	unix.IFA_F_OPTIMISTIC:     "optimistic",
+	unix.IFA_F_DADFAILED:      "dadfailed",
+	unix.IFA_F_HOMEADDRESS:    "homeaddress",
+	unix.IFA_F_DEPRECATED:     "deprecated",
+	unix.IFA_F_TENTATIVE:      "tentative",
+	unix.IFA_F_PERMANENT:      "permanent",
+	unix.IFA_F_MANAGETEMPADDR: "managetempaddr",
+	unix.IFA_F_NOPREFIXROUTE:  "noprefixroute",
+	unix.IFA_F_MCAUTOJOIN:     "mcautojoin",
+	unix.IFA_F_STABLE_PRIVACY: "stable-privacy",
+}
+
+func addrFlags(f uint32) string {
+	s := ""
+	for i, name := range addrFlagNames {
+		if f&uint32(i) != 0 {
+			if s != "" {
+				s += ","
+			}
+			s += name
+		}
+	}
+	if s == "" {
+		s = "0"
+	}
+	return s
 }
 
 var flagNames = map[int]string{
@@ -245,4 +387,14 @@ var linkStates = map[rtnetlink.OperationalState]string{
 	rtnetlink.OperStateTesting:        "testing",
 	rtnetlink.OperStateDormant:        "dormant",
 	rtnetlink.OperStateUp:             "up",
+}
+
+// TODO: fix this to work for ipv6 too
+func broadcastAddr(n *net.IPNet) (net.IP, error) {
+	if n.IP.To4() == nil {
+		return net.IP{}, errors.New("does not support IPv6 addresses.")
+	}
+	ip := make(net.IP, len(n.IP.To4()))
+	binary.BigEndian.PutUint32(ip, binary.BigEndian.Uint32(n.IP.To4())|^binary.BigEndian.Uint32(net.IP(n.Mask).To4()))
+	return ip, nil
 }

--- a/cmds/ip/rtnetlink.go
+++ b/cmds/ip/rtnetlink.go
@@ -228,14 +228,15 @@ func routeAdd(iface *net.Interface, dst net.IPNet, gw net.IP) error {
 	if gw == nil {
 		attr.Gateway = gw
 	}
+	ones, _ := dst.Mask.Size()
 
-	// TODO: fix this code
 	err = conn.Route.Add(&rtnetlink.RouteMessage{
 		Family:     unix.AF_INET,
 		Table:      unix.RT_TABLE_MAIN,
 		Protocol:   unix.RTPROT_BOOT,
 		Scope:      unix.RT_SCOPE_LINK,
 		Type:       unix.RTN_UNICAST,
+		DstLength:  uint8(ones),
 		Attributes: attr,
 	})
 

--- a/vendor/github.com/jsimonetti/rtnetlink/LICENSE.md
+++ b/vendor/github.com/jsimonetti/rtnetlink/LICENSE.md
@@ -1,0 +1,10 @@
+MIT License
+===========
+
+Copyright (C) 2016 Jeroen Simonetti
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jsimonetti/rtnetlink/address.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/address.go
@@ -1,0 +1,268 @@
+package rtnetlink
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nlenc"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	// errInvalidaddressMessage is returned when a AddressMessage is malformed.
+	errInvalidAddressMessage = errors.New("rtnetlink AddressMessage is invalid or too short")
+
+	// errInvalidAddressMessageAttr is returned when link attributes are malformed.
+	errInvalidAddressMessageAttr = errors.New("rtnetlink AddressMessage has a wrong attribute data length")
+)
+
+var _ Message = &AddressMessage{}
+
+// A AddressMessage is a route netlink address message.
+type AddressMessage struct {
+	// Address family (current AFInet or AFInet6)
+	Family uint8
+
+	// Prefix length
+	PrefixLength uint8
+
+	// Contains address flags
+	Flags uint8
+
+	// Address Scope
+	Scope uint8
+
+	// Interface index
+	Index uint32
+
+	// Attributes List
+	Attributes AddressAttributes
+}
+
+// MarshalBinary marshals a AddressMessage into a byte slice.
+func (m *AddressMessage) MarshalBinary() ([]byte, error) {
+	b := make([]byte, unix.SizeofIfAddrmsg)
+
+	b[0] = m.Family
+	b[1] = m.PrefixLength
+	b[2] = m.Flags
+	b[3] = m.Scope
+	nlenc.PutUint32(b[4:8], m.Index)
+
+	a, err := m.Attributes.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(b, a...), nil
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a AddressMessage.
+func (m *AddressMessage) UnmarshalBinary(b []byte) error {
+	l := len(b)
+	if l < unix.SizeofIfAddrmsg {
+		return errInvalidAddressMessage
+	}
+
+	m.Family = uint8(b[0])
+	m.PrefixLength = uint8(b[1])
+	m.Flags = uint8(b[2])
+	m.Scope = uint8(b[3])
+	m.Index = nlenc.Uint32(b[4:8])
+
+	if l > unix.SizeofIfAddrmsg {
+		m.Attributes = AddressAttributes{}
+		err := m.Attributes.UnmarshalBinary(b[unix.SizeofIfAddrmsg:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// rtMessage is an empty method to sattisfy the Message interface.
+func (*AddressMessage) rtMessage() {}
+
+// AddressService is used to retrieve rtnetlink family information.
+type AddressService struct {
+	c *Conn
+}
+
+// New creates a new address using the AddressMessage information.
+func (a *AddressService) New(req *AddressMessage) error {
+	flags := netlink.Request | netlink.Create | netlink.Acknowledge | netlink.Excl
+	_, err := a.c.Execute(req, unix.RTM_NEWADDR, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete removes an address by ip and interface index.
+func (a *AddressService) Delete(address net.IP, index uint32) error {
+	req := &AddressMessage{
+		Index: index,
+		Attributes: AddressAttributes{
+			Address: address,
+		},
+	}
+
+	flags := netlink.Request | netlink.Acknowledge
+	_, err := a.c.Execute(req, unix.RTM_DELADDR, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// List retrieves all addresses.
+func (a *AddressService) List() ([]AddressMessage, error) {
+	req := &AddressMessage{}
+
+	flags := netlink.Request | netlink.Dump
+	msgs, err := a.c.Execute(req, unix.RTM_GETADDR, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	addresses := make([]AddressMessage, 0, len(msgs))
+	for _, m := range msgs {
+		address := (m).(*AddressMessage)
+		addresses = append(addresses, *address)
+	}
+	return addresses, nil
+}
+
+// AddressAttributes contains all attributes for an interface.
+type AddressAttributes struct {
+	Address   net.IP // Interface Ip address
+	Local     net.IP // Local Ip address
+	Label     string
+	Broadcast net.IP    // Broadcast Ip address
+	Anycast   net.IP    // Anycast Ip address
+	CacheInfo CacheInfo // Address information
+	Multicast net.IP    // Multicast Ip address
+	Flags     uint32    // Address flags
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a AddressMessage.
+func (a *AddressAttributes) UnmarshalBinary(b []byte) error {
+	attrs, err := netlink.UnmarshalAttributes(b)
+	if err != nil {
+		return err
+	}
+	for _, attr := range attrs {
+		switch attr.Type {
+		case unix.IFA_UNSPEC:
+			//unused attribute
+		case unix.IFA_ADDRESS:
+			if len(attr.Data) != 4 && len(attr.Data) != 16 {
+				return errInvalidAddressMessageAttr
+			}
+			a.Address = attr.Data
+		case unix.IFA_LOCAL:
+			if len(attr.Data) != 4 {
+				return errInvalidAddressMessageAttr
+			}
+			a.Local = attr.Data
+		case unix.IFA_LABEL:
+			a.Label = nlenc.String(attr.Data)
+		case unix.IFA_BROADCAST:
+			if len(attr.Data) != 4 {
+				return errInvalidAddressMessageAttr
+			}
+			a.Broadcast = attr.Data
+		case unix.IFA_ANYCAST:
+			if len(attr.Data) != 4 && len(attr.Data) != 16 {
+				return errInvalidAddressMessageAttr
+			}
+			a.Anycast = attr.Data
+		case unix.IFA_CACHEINFO:
+			if len(attr.Data) != 16 {
+				return errInvalidAddressMessageAttr
+			}
+			err := a.CacheInfo.UnmarshalBinary(attr.Data)
+			if err != nil {
+				return err
+			}
+		case unix.IFA_MULTICAST:
+			if len(attr.Data) != 4 && len(attr.Data) != 16 {
+				return errInvalidAddressMessageAttr
+			}
+			a.Multicast = attr.Data
+		case unix.IFA_FLAGS:
+			if len(attr.Data) != 4 {
+				return errInvalidAddressMessageAttr
+			}
+			a.Flags = nlenc.Uint32(attr.Data)
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary marshals a AddressAttributes into a byte slice.
+func (a *AddressAttributes) MarshalBinary() ([]byte, error) {
+	attrs := []netlink.Attribute{
+		{
+			Type: unix.IFA_UNSPEC,
+			Data: nlenc.Uint16Bytes(0),
+		},
+		{
+			Type: unix.IFA_ADDRESS,
+			Data: a.Address,
+		},
+		{
+			Type: unix.IFA_BROADCAST,
+			Data: a.Broadcast,
+		},
+		{
+			Type: unix.IFA_ANYCAST,
+			Data: a.Anycast,
+		},
+		{
+			Type: unix.IFA_MULTICAST,
+			Data: a.Multicast,
+		},
+		{
+			Type: unix.IFA_FLAGS,
+			Data: nlenc.Uint32Bytes(a.Flags),
+		},
+	}
+
+	if a.Local != nil {
+		attrs = append(attrs, netlink.Attribute{
+			Type: unix.IFA_LOCAL,
+			Data: a.Local,
+		})
+	}
+
+	return netlink.MarshalAttributes(attrs)
+}
+
+// CacheInfo contains address information
+type CacheInfo struct {
+	Prefered uint32
+	Valid    uint32
+	Created  uint32
+	Updated  uint32
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a LinkMessage.
+func (c *CacheInfo) UnmarshalBinary(b []byte) error {
+	if len(b) != 16 {
+		return fmt.Errorf("incorrect size, want: 16, got: %d", len(b))
+	}
+
+	c.Prefered = nlenc.Uint32(b[0:4])
+	c.Valid = nlenc.Uint32(b[4:8])
+	c.Created = nlenc.Uint32(b[8:12])
+	c.Updated = nlenc.Uint32(b[12:16])
+
+	return nil
+}

--- a/vendor/github.com/jsimonetti/rtnetlink/address.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/address.go
@@ -22,7 +22,7 @@ var _ Message = &AddressMessage{}
 
 // A AddressMessage is a route netlink address message.
 type AddressMessage struct {
-	// Address family (current AFInet or AFInet6)
+	// Address family (current unix.AF_INET or unix.AF_INET6)
 	Family uint8
 
 	// Prefix length
@@ -102,15 +102,8 @@ func (a *AddressService) New(req *AddressMessage) error {
 	return nil
 }
 
-// Delete removes an address by ip and interface index.
-func (a *AddressService) Delete(address net.IP, index uint32) error {
-	req := &AddressMessage{
-		Index: index,
-		Attributes: AddressAttributes{
-			Address: address,
-		},
-	}
-
+// Delete removes an address using the AddressMessage information.
+func (a *AddressService) Delete(req *AddressMessage) error {
 	flags := netlink.Request | netlink.Acknowledge
 	_, err := a.c.Execute(req, unix.RTM_DELADDR, flags)
 	if err != nil {

--- a/vendor/github.com/jsimonetti/rtnetlink/conn.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/conn.go
@@ -1,0 +1,195 @@
+package rtnetlink
+
+import (
+	"encoding"
+
+	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/unix"
+)
+
+// A Conn is a route netlink connection. A Conn can be used to send and
+// receive route netlink messages to and from netlink.
+type Conn struct {
+	c       conn
+	Link    *LinkService
+	Address *AddressService
+	Route   *RouteService
+	Neigh   *NeighService
+}
+
+var _ conn = &netlink.Conn{}
+
+// A conn is a netlink connection, which can be swapped for tests.
+type conn interface {
+	Close() error
+	Send(m netlink.Message) (netlink.Message, error)
+	Receive() ([]netlink.Message, error)
+	Execute(m netlink.Message) ([]netlink.Message, error)
+}
+
+// Dial dials a route netlink connection.  Config specifies optional
+// configuration for the underlying netlink connection.  If config is
+// nil, a default configuration will be used.
+func Dial(config *netlink.Config) (*Conn, error) {
+	c, err := netlink.Dial(unix.NETLINK_ROUTE, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return newConn(c), nil
+}
+
+// newConn creates a Conn that wraps an existing *netlink.Conn for
+// rtnetlink communications. It is used for testing.
+func newConn(c conn) *Conn {
+	rtc := &Conn{
+		c: c,
+	}
+
+	rtc.Link = &LinkService{c: rtc}
+	rtc.Address = &AddressService{c: rtc}
+	rtc.Route = &RouteService{c: rtc}
+	rtc.Neigh = &NeighService{c: rtc}
+
+	return rtc
+}
+
+// Close closes the connection.
+func (c *Conn) Close() error {
+	return c.c.Close()
+}
+
+// Send sends a single Message to netlink, wrapping it in a netlink.Message
+// using the specified generic netlink family and flags.  On success, Send
+// returns a copy of the netlink.Message with all parameters populated, for
+// later validation.
+func (c *Conn) Send(m Message, family uint16, flags netlink.HeaderFlags) (netlink.Message, error) {
+	nm := netlink.Message{
+		Header: netlink.Header{
+			Type:  netlink.HeaderType(family),
+			Flags: flags,
+		},
+	}
+
+	mb, err := m.MarshalBinary()
+	if err != nil {
+		return netlink.Message{}, err
+	}
+	nm.Data = mb
+	reqnm, err := c.c.Send(nm)
+	if err != nil {
+		return netlink.Message{}, err
+	}
+
+	return reqnm, nil
+}
+
+// Receive receives one or more Messages from netlink.  The netlink.Messages
+// used to wrap each Message are available for later validation.
+func (c *Conn) Receive() ([]Message, []netlink.Message, error) {
+	msgs, err := c.c.Receive()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rtmsgs, err := unpackMessages(msgs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return rtmsgs, msgs, nil
+}
+
+// Execute sends a single Message to netlink using Send, receives one or more
+// replies using Receive, and then checks the validity of the replies against
+// the request using netlink.Validate.
+//
+// Execute acquires a lock for the duration of the function call which blocks
+// concurrent calls to Send and Receive, in order to ensure consistency between
+// generic netlink request/reply messages.
+//
+// See the documentation of Send, Receive, and netlink.Validate for details
+// about each function.
+func (c *Conn) Execute(m Message, family uint16, flags netlink.HeaderFlags) ([]Message, error) {
+	nm, err := packMessage(m, family, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, err := c.c.Execute(nm)
+	if err != nil {
+		return nil, err
+	}
+
+	return unpackMessages(msgs)
+}
+
+//Message is the interface used for passing around different kinds of rtnetlink messages
+type Message interface {
+	encoding.BinaryMarshaler
+	encoding.BinaryUnmarshaler
+	rtMessage()
+}
+
+// packMessage packs a rtnetlink Message into a netlink.Message with the
+// appropriate rtnetlink family and netlink flags.
+func packMessage(m Message, family uint16, flags netlink.HeaderFlags) (netlink.Message, error) {
+	nm := netlink.Message{
+		Header: netlink.Header{
+			Type:  netlink.HeaderType(family),
+			Flags: flags,
+		},
+	}
+
+	mb, err := m.MarshalBinary()
+	if err != nil {
+		return netlink.Message{}, err
+	}
+	nm.Data = mb
+
+	return nm, nil
+}
+
+// unpackMessages unpacks rtnetlink Messages from a slice of netlink.Messages.
+func unpackMessages(msgs []netlink.Message) ([]Message, error) {
+	lmsgs := make([]Message, 0, len(msgs))
+
+	for _, nm := range msgs {
+		var m Message
+		switch nm.Header.Type {
+		case unix.RTM_GETLINK:
+			fallthrough
+		case unix.RTM_NEWLINK:
+			fallthrough
+		case unix.RTM_DELLINK:
+			m = &LinkMessage{}
+		case unix.RTM_GETADDR:
+			fallthrough
+		case unix.RTM_NEWADDR:
+			fallthrough
+		case unix.RTM_DELADDR:
+			m = &AddressMessage{}
+		case unix.RTM_GETROUTE:
+			fallthrough
+		case unix.RTM_NEWROUTE:
+			fallthrough
+		case unix.RTM_DELROUTE:
+			m = &RouteMessage{}
+		case unix.RTM_GETNEIGH:
+			fallthrough
+		case unix.RTM_NEWNEIGH:
+			fallthrough
+		case unix.RTM_DELNEIGH:
+			m = &NeighMessage{}
+		default:
+			continue
+		}
+
+		if err := (m).UnmarshalBinary(nm.Data); err != nil {
+			return nil, err
+		}
+		lmsgs = append(lmsgs, m)
+	}
+
+	return lmsgs, nil
+}

--- a/vendor/github.com/jsimonetti/rtnetlink/conn.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/conn.go
@@ -157,29 +157,13 @@ func unpackMessages(msgs []netlink.Message) ([]Message, error) {
 	for _, nm := range msgs {
 		var m Message
 		switch nm.Header.Type {
-		case unix.RTM_GETLINK:
-			fallthrough
-		case unix.RTM_NEWLINK:
-			fallthrough
-		case unix.RTM_DELLINK:
+		case unix.RTM_GETLINK, unix.RTM_NEWLINK, unix.RTM_DELLINK:
 			m = &LinkMessage{}
-		case unix.RTM_GETADDR:
-			fallthrough
-		case unix.RTM_NEWADDR:
-			fallthrough
-		case unix.RTM_DELADDR:
+		case unix.RTM_GETADDR, unix.RTM_NEWADDR, unix.RTM_DELADDR:
 			m = &AddressMessage{}
-		case unix.RTM_GETROUTE:
-			fallthrough
-		case unix.RTM_NEWROUTE:
-			fallthrough
-		case unix.RTM_DELROUTE:
+		case unix.RTM_GETROUTE, unix.RTM_NEWROUTE, unix.RTM_DELROUTE:
 			m = &RouteMessage{}
-		case unix.RTM_GETNEIGH:
-			fallthrough
-		case unix.RTM_NEWNEIGH:
-			fallthrough
-		case unix.RTM_DELNEIGH:
+		case unix.RTM_GETNEIGH, unix.RTM_NEWNEIGH, unix.RTM_DELNEIGH:
 			m = &NeighMessage{}
 		default:
 			continue

--- a/vendor/github.com/jsimonetti/rtnetlink/doc.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/doc.go
@@ -1,0 +1,5 @@
+// Package rtnetlink allows the kernel's routing tables to be read and altered.
+// Network routes, IP addresses, Link parameters, Neighbor setups, Queueing disciplines,
+// Traffic classes and Packet classifiers may all be controlled.
+// It is based on netlink messages.
+package rtnetlink

--- a/vendor/github.com/jsimonetti/rtnetlink/fuzz.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/fuzz.go
@@ -1,0 +1,62 @@
+// +build gofuzz
+
+package rtnetlink
+
+func Fuzz(data []byte) int {
+	//return fuzzLinkMessage(data)
+	//return fuzzAddressMessage(data)
+	//return fuzzRouteMessage(data)
+	return fuzzNeighMessage(data)
+}
+
+func fuzzLinkMessage(data []byte) int {
+	m := &LinkMessage{}
+	if err := (m).UnmarshalBinary(data); err != nil {
+		return 0
+	}
+
+	if _, err := m.MarshalBinary(); err != nil {
+		panic(err)
+	}
+
+	return 1
+}
+
+func fuzzAddressMessage(data []byte) int {
+	m := &AddressMessage{}
+	if err := (m).UnmarshalBinary(data); err != nil {
+		return 0
+	}
+
+	if _, err := m.MarshalBinary(); err != nil {
+		panic(err)
+	}
+
+	return 1
+}
+
+func fuzzRouteMessage(data []byte) int {
+	m := &RouteMessage{}
+	if err := (m).UnmarshalBinary(data); err != nil {
+		return 0
+	}
+
+	if _, err := m.MarshalBinary(); err != nil {
+		panic(err)
+	}
+
+	return 1
+}
+
+func fuzzNeighMessage(data []byte) int {
+	m := &NeighMessage{}
+	if err := (m).UnmarshalBinary(data); err != nil {
+		return 0
+	}
+
+	if _, err := m.MarshalBinary(); err != nil {
+		panic(err)
+	}
+
+	return 1
+}

--- a/vendor/github.com/jsimonetti/rtnetlink/link.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/link.go
@@ -1,0 +1,467 @@
+package rtnetlink
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nlenc"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	// errInvalidLinkMessage is returned when a LinkMessage is malformed.
+	errInvalidLinkMessage = errors.New("rtnetlink LinkMessage is invalid or too short")
+
+	// errInvalidLinkMessageAttr is returned when link attributes are malformed.
+	errInvalidLinkMessageAttr = errors.New("rtnetlink LinkMessage has a wrong attribute data length")
+)
+
+var _ Message = &LinkMessage{}
+
+// A LinkMessage is a route netlink link message.
+type LinkMessage struct {
+	// Always set to AF_UNSPEC (0)
+	Family uint16
+
+	// Device Type
+	Type uint16
+
+	// Unique interface index, using a nonzero value with
+	// NewLink will instruct the kernel to create a
+	// device with the given index (kernel 3.7+ required)
+	Index uint32
+
+	// Contains device flags, see netdevice(7)
+	Flags uint32
+
+	// Change Flags, specifies which flags will be affected by the Flags field
+	Change uint32
+
+	// Attributes List
+	Attributes *LinkAttributes
+}
+
+// MarshalBinary marshals a LinkMessage into a byte slice.
+func (m *LinkMessage) MarshalBinary() ([]byte, error) {
+	b := make([]byte, unix.SizeofIfInfomsg)
+
+	b[0] = 0 //Family
+	b[1] = 0 //reserved
+	nlenc.PutUint16(b[2:4], m.Type)
+	nlenc.PutUint32(b[4:8], m.Index)
+	nlenc.PutUint32(b[8:12], m.Flags)
+	nlenc.PutUint32(b[12:16], m.Change)
+
+	if m.Attributes != nil {
+		a, err := m.Attributes.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		return append(b, a...), nil
+	}
+
+	return b, nil
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a LinkMessage.
+func (m *LinkMessage) UnmarshalBinary(b []byte) error {
+	l := len(b)
+	if l < unix.SizeofIfInfomsg {
+		return errInvalidLinkMessage
+	}
+
+	m.Family = nlenc.Uint16(b[0:2])
+	m.Type = nlenc.Uint16(b[2:4])
+	m.Index = nlenc.Uint32(b[4:8])
+	m.Flags = nlenc.Uint32(b[8:12])
+	m.Change = nlenc.Uint32(b[12:16])
+
+	if l > unix.SizeofIfInfomsg {
+		m.Attributes = &LinkAttributes{}
+		err := m.Attributes.UnmarshalBinary(b[16:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// rtMessage is an empty method to sattisfy the Message interface.
+func (*LinkMessage) rtMessage() {}
+
+// LinkService is used to retrieve rtnetlink family information.
+type LinkService struct {
+	c *Conn
+}
+
+// New creates a new interface using the LinkMessage information.
+func (l *LinkService) New(req *LinkMessage) error {
+	flags := netlink.Request | netlink.Create | netlink.Acknowledge | netlink.Excl
+	_, err := l.c.Execute(req, unix.RTM_NEWLINK, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete removes an interface by index.
+func (l *LinkService) Delete(index uint32) error {
+	req := &LinkMessage{
+		Index: index,
+	}
+
+	flags := netlink.Request | netlink.Acknowledge
+	_, err := l.c.Execute(req, unix.RTM_DELLINK, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Get retrieves interface information by index.
+func (l *LinkService) Get(index uint32) (LinkMessage, error) {
+	req := &LinkMessage{
+		Index: index,
+	}
+
+	flags := netlink.Request | netlink.DumpFiltered
+	msg, err := l.c.Execute(req, unix.RTM_GETLINK, flags)
+	if err != nil {
+		return LinkMessage{}, err
+	}
+
+	if len(msg) != 1 {
+		return LinkMessage{}, fmt.Errorf("too many/little matches, expected 1")
+	}
+
+	link := (msg[0]).(*LinkMessage)
+	return *link, nil
+}
+
+// Set sets interface attributes according to the LinkMessage information.
+func (l *LinkService) Set(req *LinkMessage) error {
+	flags := netlink.Request | netlink.Acknowledge
+	_, err := l.c.Execute(req, unix.RTM_SETLINK, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// List retrieves all interfaces.
+func (l *LinkService) List() ([]LinkMessage, error) {
+	req := &LinkMessage{}
+
+	flags := netlink.Request | netlink.Dump
+	msgs, err := l.c.Execute(req, unix.RTM_GETLINK, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	links := make([]LinkMessage, 0, len(msgs))
+	for _, m := range msgs {
+		link := (m).(*LinkMessage)
+		links = append(links, *link)
+	}
+
+	return links, nil
+}
+
+// LinkAttributes contains all attributes for an interface.
+type LinkAttributes struct {
+	Address          net.HardwareAddr // Interface L2 address
+	Broadcast        net.HardwareAddr // L2 broadcast address
+	Name             string           // Device name
+	MTU              uint32           // MTU of the device
+	Type             uint32           // Link type
+	QueueDisc        string           // Queueing discipline
+	OperationalState OperationalState // Interface operation state
+	Stats            *LinkStats       // Interface Statistics
+	Info             *LinkInfo        // Detailed Interface Information
+}
+
+// OperationalState represents an interface's operational state.
+type OperationalState uint8
+
+// Constants that represent operational state of an interface
+//
+// Adapted from https://elixir.bootlin.com/linux/v4.19.2/source/include/uapi/linux/if.h#L166
+const (
+	OperStateUnknown        OperationalState = iota // status could not be determined
+	OperStateNotPresent                             // down, due to some missing component (typically hardware)
+	OperStateDown                                   // down, either administratively or due to a fault
+	OperStateLowerLayerDown                         // down, due to lower-layer interfaces
+	OperStateTesting                                // operationally down, in some test mode
+	OperStateDormant                                // down, waiting for some external event
+	OperStateUp                                     // interface is in a state to send and receive packets
+)
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a LinkMessage.
+func (a *LinkAttributes) UnmarshalBinary(b []byte) error {
+	attrs, err := netlink.UnmarshalAttributes(b)
+	if err != nil {
+		return err
+	}
+
+	for _, attr := range attrs {
+		switch attr.Type {
+		case unix.IFLA_UNSPEC:
+			//unused attribute
+		case unix.IFLA_ADDRESS:
+			l := len(attr.Data)
+			if l < 4 || l > 32 {
+				return errInvalidLinkMessageAttr
+			}
+			a.Address = attr.Data
+		case unix.IFLA_BROADCAST:
+			l := len(attr.Data)
+			if l < 4 || l > 32 {
+				return errInvalidLinkMessageAttr
+			}
+			a.Broadcast = attr.Data
+		case unix.IFLA_IFNAME:
+			a.Name = nlenc.String(attr.Data)
+		case unix.IFLA_MTU:
+			if len(attr.Data) != 4 {
+				return errInvalidLinkMessageAttr
+			}
+			a.MTU = nlenc.Uint32(attr.Data)
+		case unix.IFLA_LINK:
+			if len(attr.Data) != 4 {
+				return errInvalidLinkMessageAttr
+			}
+			a.Type = nlenc.Uint32(attr.Data)
+		case unix.IFLA_QDISC:
+			a.QueueDisc = nlenc.String(attr.Data)
+		case unix.IFLA_OPERSTATE:
+			if len(attr.Data) != 1 {
+				return errInvalidLinkMessageAttr
+			}
+			a.OperationalState = OperationalState(nlenc.Uint8(attr.Data))
+		case unix.IFLA_STATS:
+			a.Stats = &LinkStats{}
+			err := a.Stats.UnmarshalBinary(attr.Data)
+			if err != nil {
+				return err
+			}
+		case unix.IFLA_LINKINFO:
+			a.Info = &LinkInfo{}
+			err := a.Info.UnmarshalBinary(attr.Data)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary marshals a LinkAttributes into a byte slice.
+func (a *LinkAttributes) MarshalBinary() ([]byte, error) {
+	attrs := []netlink.Attribute{
+		{
+			Type: unix.IFLA_UNSPEC,
+			Data: nlenc.Uint16Bytes(0),
+		},
+		{
+			Type: unix.IFLA_IFNAME,
+			Data: nlenc.Bytes(a.Name),
+		},
+		{
+			Type: unix.IFLA_MTU,
+			Data: nlenc.Uint32Bytes(a.MTU),
+		},
+		{
+			Type: unix.IFLA_LINK,
+			Data: nlenc.Uint32Bytes(a.Type),
+		},
+		{
+			Type: unix.IFLA_QDISC,
+			Data: nlenc.Bytes(a.QueueDisc),
+		},
+	}
+
+	if len(a.Address) != 0 {
+		attrs = append(attrs, netlink.Attribute{
+			Type: unix.IFLA_ADDRESS,
+			Data: a.Address,
+		})
+	}
+
+	if len(a.Broadcast) != 0 {
+		attrs = append(attrs, netlink.Attribute{
+			Type: unix.IFLA_BROADCAST,
+			Data: a.Broadcast,
+		})
+	}
+
+	if a.OperationalState != OperStateUnknown {
+		attrs = append(attrs, netlink.Attribute{
+			Type: unix.IFLA_OPERSTATE,
+			Data: nlenc.Uint8Bytes(uint8(a.OperationalState)),
+		})
+	}
+
+	if a.Info != nil {
+		info, err := a.Info.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		attrs = append(attrs, netlink.Attribute{
+			Type: unix.IFLA_LINKINFO,
+			Data: info,
+		})
+	}
+
+	return netlink.MarshalAttributes(attrs)
+}
+
+//LinkStats contains packet statistics
+type LinkStats struct {
+	RXPackets  uint32 // total packets received
+	TXPackets  uint32 // total packets transmitted
+	RXBytes    uint32 // total bytes received
+	TXBytes    uint32 // total bytes transmitted
+	RXErrors   uint32 // bad packets received
+	TXErrors   uint32 // packet transmit problems
+	RXDropped  uint32 // no space in linux buffers
+	TXDropped  uint32 // no space available in linux
+	Multicast  uint32 // multicast packets received
+	Collisions uint32
+
+	// detailed rx_errors:
+	RXLengthErrors uint32
+	RXOverErrors   uint32 // receiver ring buff overflow
+	RXCRCErrors    uint32 // recved pkt with crc error
+	RXFrameErrors  uint32 // recv'd frame alignment error
+	RXFIFOErrors   uint32 // recv'r fifo overrun
+	RXMissedErrors uint32 // receiver missed packet
+
+	// detailed tx_errors
+	TXAbortedErrors   uint32
+	TXCarrierErrors   uint32
+	TXFIFOErrors      uint32
+	TXHeartbeatErrors uint32
+	TXWindowErrors    uint32
+
+	// for cslip etc
+	RXCompressed uint32
+	TXCompressed uint32
+
+	RXNoHandler uint32 // dropped, no handler found
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a LinkMessage.
+func (a *LinkStats) UnmarshalBinary(b []byte) error {
+	l := len(b)
+	if l != 92 && l != 96 {
+		return fmt.Errorf("incorrect size, want: 92 or 96")
+	}
+
+	a.RXPackets = nlenc.Uint32(b[0:4])
+	a.TXPackets = nlenc.Uint32(b[4:8])
+	a.RXBytes = nlenc.Uint32(b[8:12])
+	a.TXBytes = nlenc.Uint32(b[12:16])
+	a.RXErrors = nlenc.Uint32(b[16:20])
+	a.TXErrors = nlenc.Uint32(b[20:24])
+	a.RXDropped = nlenc.Uint32(b[24:28])
+	a.TXDropped = nlenc.Uint32(b[28:32])
+	a.Multicast = nlenc.Uint32(b[32:36])
+	a.Collisions = nlenc.Uint32(b[36:40])
+
+	a.RXLengthErrors = nlenc.Uint32(b[40:44])
+	a.RXOverErrors = nlenc.Uint32(b[44:48])
+	a.RXCRCErrors = nlenc.Uint32(b[48:52])
+	a.RXFrameErrors = nlenc.Uint32(b[52:56])
+	a.RXFIFOErrors = nlenc.Uint32(b[56:60])
+	a.RXMissedErrors = nlenc.Uint32(b[60:64])
+
+	a.TXAbortedErrors = nlenc.Uint32(b[64:68])
+	a.TXCarrierErrors = nlenc.Uint32(b[68:72])
+	a.TXFIFOErrors = nlenc.Uint32(b[72:76])
+	a.TXHeartbeatErrors = nlenc.Uint32(b[76:80])
+	a.TXWindowErrors = nlenc.Uint32(b[80:84])
+
+	a.RXCompressed = nlenc.Uint32(b[84:88])
+	a.TXCompressed = nlenc.Uint32(b[88:92])
+
+	if l == 96 {
+		a.RXNoHandler = nlenc.Uint32(b[92:96])
+	}
+
+	return nil
+}
+
+const (
+	iflaInfoKind      = 0x1
+	iflaInfoData      = 0x2
+	iflaInfoSlaveKind = 0x3
+	iflaInfoSlaveData = 0x4
+)
+
+// LinkInfo contains data for specific network types
+type LinkInfo struct {
+	Kind      string // Driver name
+	Data      []byte // Driver specific configuration stored as nested Netlink messages
+	SlaveKind string // Slave driver name
+	SlaveData []byte // Slave driver specific configuration
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a LinkInfo.
+func (i *LinkInfo) UnmarshalBinary(b []byte) error {
+	attrs, err := netlink.UnmarshalAttributes(b)
+	if err != nil {
+		return err
+	}
+
+	for _, attr := range attrs {
+		switch attr.Type {
+		case iflaInfoKind:
+			i.Kind = nlenc.String(attr.Data)
+		case iflaInfoSlaveKind:
+			i.SlaveKind = nlenc.String(attr.Data)
+		case iflaInfoData:
+			i.Data = attr.Data
+		case iflaInfoSlaveData:
+			i.SlaveData = attr.Data
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary marshals a LinkInfo into a byte slice.
+func (i *LinkInfo) MarshalBinary() ([]byte, error) {
+	attrs := []netlink.Attribute{
+		{
+			Type: iflaInfoKind,
+			Data: nlenc.Bytes(i.Kind),
+		},
+		{
+			Type: iflaInfoData,
+			Data: i.Data,
+		},
+	}
+
+	if len(i.SlaveData) > 0 {
+		attrs = append(attrs,
+			netlink.Attribute{
+				Type: iflaInfoSlaveKind,
+				Data: nlenc.Bytes(i.SlaveKind),
+			},
+			netlink.Attribute{
+				Type: iflaInfoSlaveData,
+				Data: i.SlaveData,
+			},
+		)
+	}
+
+	return netlink.MarshalAttributes(attrs)
+}

--- a/vendor/github.com/jsimonetti/rtnetlink/neigh.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/neigh.go
@@ -1,0 +1,231 @@
+package rtnetlink
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nlenc"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	// errInvalidNeighMessage is returned when a LinkMessage is malformed.
+	errInvalidNeighMessage = errors.New("rtnetlink NeighMessage is invalid or too short")
+
+	// errInvalidNeighMessageAttr is returned when neigh attributes are malformed.
+	errInvalidNeighMessageAttr = errors.New("rtnetlink NeighMessage has a wrong attribute data length")
+)
+
+var _ Message = &NeighMessage{}
+
+// A NeighMessage is a route netlink neighbor message.
+type NeighMessage struct {
+	// Always set to AF_UNSPEC (0)
+	Family uint16
+
+	// Unique interface index
+	Index uint32
+
+	// Neighbor State is a bitmask of neighbor states (see rtnetlink(7))
+	State uint16
+
+	// Neighbor flags
+	Flags uint8
+
+	// Neighbor type
+	Type uint8
+
+	// Attributes List
+	Attributes *NeighAttributes
+}
+
+// MarshalBinary marshals a NeighMessage into a byte slice.
+func (m *NeighMessage) MarshalBinary() ([]byte, error) {
+	b := make([]byte, unix.SizeofNdMsg)
+
+	nlenc.PutUint16(b[0:2], m.Family)
+	// bytes 3 and 4 are padding
+	nlenc.PutUint32(b[4:8], m.Index)
+	nlenc.PutUint16(b[8:10], m.State)
+	b[10] = m.Flags
+	b[11] = m.Type
+
+	if m.Attributes != nil {
+		a, err := m.Attributes.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		return append(b, a...), nil
+	}
+	return b, nil
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a NeighMessage.
+func (m *NeighMessage) UnmarshalBinary(b []byte) error {
+	l := len(b)
+	if l < unix.SizeofNdMsg {
+		return errInvalidNeighMessage
+	}
+
+	m.Family = nlenc.Uint16(b[0:2])
+	m.Index = nlenc.Uint32(b[4:8])
+	m.State = nlenc.Uint16(b[8:10])
+	m.Flags = b[10]
+	m.Type = b[11]
+
+	if l > unix.SizeofNdMsg {
+		m.Attributes = &NeighAttributes{}
+		err := m.Attributes.UnmarshalBinary(b[unix.SizeofNdMsg:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// rtMessage is an empty method to sattisfy the Message interface.
+func (*NeighMessage) rtMessage() {}
+
+// NeighService is used to retrieve rtnetlink family information.
+type NeighService struct {
+	c *Conn
+}
+
+// New creates a new interface using the LinkMessage information.
+func (l *NeighService) New(req *NeighMessage) error {
+	flags := netlink.Request | netlink.Create | netlink.Acknowledge | netlink.Excl
+	_, err := l.c.Execute(req, unix.RTM_NEWNEIGH, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete removes an neighbor entry by index.
+func (l *NeighService) Delete(index uint32) error {
+	req := &NeighMessage{}
+
+	flags := netlink.Request | netlink.Acknowledge
+	_, err := l.c.Execute(req, unix.RTM_DELNEIGH, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// List retrieves all neighbors.
+func (l *NeighService) List() ([]NeighMessage, error) {
+	req := &NeighMessage{}
+
+	flags := netlink.Request | netlink.Dump
+	msgs, err := l.c.Execute(req, unix.RTM_GETNEIGH, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	neighs := make([]NeighMessage, 0, len(msgs))
+	for _, m := range msgs {
+		neigh := (m).(*NeighMessage)
+		neighs = append(neighs, *neigh)
+	}
+
+	return neighs, nil
+}
+
+// NeighCacheInfo contains neigh information
+type NeighCacheInfo struct {
+	Confirmed uint32
+	Used      uint32
+	Updated   uint32
+	RefCount  uint32
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a NeighMessage.
+func (n *NeighCacheInfo) UnmarshalBinary(b []byte) error {
+	if len(b) != 16 {
+		return fmt.Errorf("incorrect size, want: 16, got: %d", len(b))
+	}
+
+	n.Confirmed = nlenc.Uint32(b[0:4])
+	n.Used = nlenc.Uint32(b[4:8])
+	n.Updated = nlenc.Uint32(b[8:12])
+	n.RefCount = nlenc.Uint32(b[12:16])
+
+	return nil
+}
+
+// NeighAttributes contains all attributes for a neighbor.
+type NeighAttributes struct {
+	Address   net.IP           // a neighbor cache n/w layer destination address
+	LLAddress net.HardwareAddr // a neighbor cache link layer address
+	CacheInfo *NeighCacheInfo  // cache statistics
+	IfIndex   uint32
+}
+
+// NeighAttributes unmarshals the contents of a byte slice into a NeighMessage.
+func (a *NeighAttributes) UnmarshalBinary(b []byte) error {
+	attrs, err := netlink.UnmarshalAttributes(b)
+	if err != nil {
+		return err
+	}
+
+	for _, attr := range attrs {
+		switch attr.Type {
+		case unix.NDA_UNSPEC:
+			//unused attribute
+		case unix.NDA_DST:
+			if len(attr.Data) != 4 && len(attr.Data) != 16 {
+				return errInvalidNeighMessageAttr
+			}
+			a.Address = attr.Data
+		case unix.NDA_LLADDR:
+			if len(attr.Data) != 6 {
+				return errInvalidNeighMessageAttr
+			}
+			a.LLAddress = attr.Data
+		case unix.NDA_CACHEINFO:
+			a.CacheInfo = &NeighCacheInfo{}
+			err := a.CacheInfo.UnmarshalBinary(attr.Data)
+			if err != nil {
+				return err
+			}
+		case unix.NDA_IFINDEX:
+			if len(attr.Data) != 4 {
+				return errInvalidNeighMessageAttr
+			}
+			a.IfIndex = nlenc.Uint32(attr.Data)
+		}
+	}
+
+	return nil
+}
+
+// MarshalBinary marshals a NeighAttributes into a byte slice.
+func (a *NeighAttributes) MarshalBinary() ([]byte, error) {
+	attrs := []netlink.Attribute{
+		{
+			Type: unix.NDA_UNSPEC,
+			Data: nlenc.Uint16Bytes(0),
+		},
+		{
+			Type: unix.NDA_DST,
+			Data: a.Address,
+		},
+		{
+			Type: unix.NDA_LLADDR,
+			Data: a.LLAddress,
+		},
+		{
+			Type: unix.NDA_IFINDEX,
+			Data: nlenc.Uint32Bytes(a.IfIndex),
+		},
+	}
+
+	return netlink.MarshalAttributes(attrs)
+}

--- a/vendor/github.com/jsimonetti/rtnetlink/route.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/route.go
@@ -20,9 +20,9 @@ var (
 var _ Message = &RouteMessage{}
 
 type RouteMessage struct {
-	Family    uint8 // Address family (current AFInet or AFInet6)
-	DstLength uint8 // Length of destination
-	SrcLength uint8 // Length of source
+	Family    uint8 // Address family (current unix.AF_INET or unix.AF_INET6)
+	DstLength uint8 // Length of destination prefix
+	SrcLength uint8 // Length of source prefix
 	Tos       uint8 // TOS filter
 	Table     uint8 // Routing table ID
 	Protocol  uint8 // Routing protocol
@@ -35,26 +35,6 @@ type RouteMessage struct {
 
 func (m *RouteMessage) MarshalBinary() ([]byte, error) {
 	b := make([]byte, unix.SizeofRtMsg)
-
-	// ensure that DstLength and SrcLength are correct
-	if m.Attributes.Dst != nil {
-		if m.Attributes.Dst.To4() != nil {
-			m.DstLength = 32
-		} else if m.Attributes.Dst.To16() != nil {
-			m.DstLength = 128
-		} else {
-			return nil, errInvalidRouteMessageAttr
-		}
-	}
-	if m.Attributes.Src != nil {
-		if m.Attributes.Src.To4() != nil {
-			m.SrcLength = 32
-		} else if m.Attributes.Src.To16() != nil {
-			m.SrcLength = 128
-		} else {
-			return nil, errInvalidRouteMessageAttr
-		}
-	}
 
 	b[0] = m.Family
 	b[1] = m.DstLength

--- a/vendor/github.com/jsimonetti/rtnetlink/route.go
+++ b/vendor/github.com/jsimonetti/rtnetlink/route.go
@@ -1,0 +1,278 @@
+package rtnetlink
+
+import (
+	"errors"
+	"net"
+
+	"github.com/mdlayher/netlink"
+	"github.com/mdlayher/netlink/nlenc"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	// errInvalidRouteMessage is returned when a RouteMessage is malformed.
+	errInvalidRouteMessage = errors.New("rtnetlink RouteMessage is invalid or too short")
+
+	// errInvalidRouteMessageAttr is returned when link attributes are malformed.
+	errInvalidRouteMessageAttr = errors.New("rtnetlink RouteMessage has a wrong attribute data length")
+)
+
+var _ Message = &RouteMessage{}
+
+type RouteMessage struct {
+	Family    uint8 // Address family (current AFInet or AFInet6)
+	DstLength uint8 // Length of destination
+	SrcLength uint8 // Length of source
+	Tos       uint8 // TOS filter
+	Table     uint8 // Routing table ID
+	Protocol  uint8 // Routing protocol
+	Scope     uint8 // Distance to the destination
+	Type      uint8 // Route type
+	Flags     uint32
+
+	Attributes RouteAttributes
+}
+
+func (m *RouteMessage) MarshalBinary() ([]byte, error) {
+	b := make([]byte, unix.SizeofRtMsg)
+
+	// ensure that DstLength and SrcLength are correct
+	if m.Attributes.Dst != nil {
+		if m.Attributes.Dst.To4() != nil {
+			m.DstLength = 32
+		} else if m.Attributes.Dst.To16() != nil {
+			m.DstLength = 128
+		} else {
+			return nil, errInvalidRouteMessageAttr
+		}
+	}
+	if m.Attributes.Src != nil {
+		if m.Attributes.Src.To4() != nil {
+			m.SrcLength = 32
+		} else if m.Attributes.Src.To16() != nil {
+			m.SrcLength = 128
+		} else {
+			return nil, errInvalidRouteMessageAttr
+		}
+	}
+
+	b[0] = m.Family
+	b[1] = m.DstLength
+	b[2] = m.SrcLength
+	b[3] = m.Tos
+	b[4] = m.Table
+	b[5] = m.Protocol
+	b[6] = m.Scope
+	b[7] = m.Type
+	nlenc.PutUint32(b[8:12], m.Flags)
+
+	a, err := m.Attributes.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(b, a...), nil
+}
+
+func (m *RouteMessage) UnmarshalBinary(b []byte) error {
+	l := len(b)
+	if l < unix.SizeofRtMsg {
+		return errInvalidRouteMessage
+	}
+
+	m.Family = uint8(b[0])
+	m.DstLength = uint8(b[1])
+	m.SrcLength = uint8(b[2])
+	m.Tos = uint8(b[3])
+	m.Table = uint8(b[4])
+	m.Protocol = uint8(b[5])
+	m.Scope = uint8(b[6])
+	m.Type = uint8(b[7])
+	m.Flags = nlenc.Uint32(b[8:12])
+
+	if l > unix.SizeofRtMsg {
+		m.Attributes = RouteAttributes{}
+		err := m.Attributes.UnmarshalBinary(b[unix.SizeofRtMsg:])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// rtMessage is an empty method to sattisfy the Message interface.
+func (*RouteMessage) rtMessage() {}
+
+type RouteService struct {
+	c *Conn
+}
+
+// Add new route
+func (r *RouteService) Add(req *RouteMessage) error {
+	flags := netlink.Request | netlink.Create | netlink.Acknowledge | netlink.Excl
+	_, err := r.c.Execute(req, unix.RTM_NEWROUTE, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete existing route
+func (r *RouteService) Delete(req *RouteMessage) error {
+	flags := netlink.Request | netlink.Acknowledge
+	_, err := r.c.Execute(req, unix.RTM_DELROUTE, flags)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// List all routes
+func (r *RouteService) List() ([]RouteMessage, error) {
+	req := &RouteMessage{}
+
+	flags := netlink.Request | netlink.Dump
+	msgs, err := r.c.Execute(req, unix.RTM_GETROUTE, flags)
+	if err != nil {
+		return nil, err
+	}
+
+	routes := make([]RouteMessage, 0, len(msgs))
+	for _, m := range msgs {
+		route := (m).(*RouteMessage)
+		routes = append(routes, *route)
+	}
+
+	return routes, nil
+}
+
+type RouteAttributes struct {
+	Dst      net.IP
+	Src      net.IP
+	Gateway  net.IP
+	OutIface uint32
+	Priority uint32
+	Table    uint32
+}
+
+func (a *RouteAttributes) UnmarshalBinary(b []byte) error {
+	attrs, err := netlink.UnmarshalAttributes(b)
+	if err != nil {
+		return err
+	}
+	for _, attr := range attrs {
+		switch attr.Type {
+		case unix.RTA_UNSPEC:
+		case unix.RTA_DST:
+			if len(attr.Data) != 4 && len(attr.Data) != 16 {
+				return errInvalidRouteMessageAttr
+			}
+			a.Dst = attr.Data
+		case unix.RTA_PREFSRC:
+			if len(attr.Data) != 4 && len(attr.Data) != 16 {
+				return errInvalidRouteMessageAttr
+			}
+			a.Src = attr.Data
+		case unix.RTA_GATEWAY:
+			if len(attr.Data) != 4 && len(attr.Data) != 16 {
+				return errInvalidRouteMessageAttr
+			}
+			a.Gateway = attr.Data
+		case unix.RTA_OIF:
+			if len(attr.Data) != 4 {
+				return errInvalidRouteMessageAttr
+			}
+			a.OutIface = nlenc.Uint32(attr.Data)
+		case unix.RTA_PRIORITY:
+			if len(attr.Data) != 4 {
+				return errInvalidRouteMessageAttr
+			}
+			a.Priority = nlenc.Uint32(attr.Data)
+		case unix.RTA_TABLE:
+			if len(attr.Data) != 4 {
+				return errInvalidRouteMessageAttr
+			}
+			a.Table = nlenc.Uint32(attr.Data)
+		}
+	}
+
+	return nil
+}
+
+func (a *RouteAttributes) MarshalBinary() ([]byte, error) {
+	attrs := make([]netlink.Attribute, 0)
+
+	if a.Dst != nil {
+		if ipv4 := a.Dst.To4(); ipv4 == nil {
+			// Dst Addr is IPv6
+			attrs = append(attrs, netlink.Attribute{
+				Type: unix.RTA_DST,
+				Data: a.Dst,
+			})
+		} else {
+			// Dst Addr is IPv4
+			attrs = append(attrs, netlink.Attribute{
+				Type: unix.RTA_DST,
+				Data: ipv4,
+			})
+		}
+	}
+
+	if a.Src != nil {
+		if ipv4 := a.Src.To4(); ipv4 == nil {
+			// Src Addr is IPv6
+			attrs = append(attrs, netlink.Attribute{
+				Type: unix.RTA_PREFSRC,
+				Data: a.Src,
+			})
+		} else {
+			// Src Addr is IPv4
+			attrs = append(attrs, netlink.Attribute{
+				Type: unix.RTA_PREFSRC,
+				Data: ipv4,
+			})
+		}
+	}
+
+	if a.Gateway != nil {
+		if ipv4 := a.Gateway.To4(); ipv4 == nil {
+			// Gateway Addr is IPv6
+			attrs = append(attrs, netlink.Attribute{
+				Type: unix.RTA_GATEWAY,
+				Data: a.Gateway,
+			})
+		} else {
+			// Gateway Addr is IPv4
+			attrs = append(attrs, netlink.Attribute{
+				Type: unix.RTA_GATEWAY,
+				Data: ipv4,
+			})
+		}
+	}
+
+	if a.OutIface != 0 {
+		attrs = append(attrs, netlink.Attribute{
+			Type: unix.RTA_OIF,
+			Data: nlenc.Uint32Bytes(a.OutIface),
+		})
+	}
+
+	if a.Priority != 0 {
+		attrs = append(attrs, netlink.Attribute{
+			Type: unix.RTA_PRIORITY,
+			Data: nlenc.Uint32Bytes(a.Priority),
+		})
+	}
+
+	if a.Table != 0 {
+		attrs = append(attrs, netlink.Attribute{
+			Type: unix.RTA_TABLE,
+			Data: nlenc.Uint32Bytes(a.Table),
+		})
+	}
+
+	return netlink.MarshalAttributes(attrs)
+}

--- a/vendor/github.com/mdlayher/netlink/LICENSE.md
+++ b/vendor/github.com/mdlayher/netlink/LICENSE.md
@@ -1,0 +1,10 @@
+MIT License
+===========
+
+Copyright (C) 2016-2019 Matt Layher
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/mdlayher/netlink/align.go
+++ b/vendor/github.com/mdlayher/netlink/align.go
@@ -1,0 +1,37 @@
+package netlink
+
+import "unsafe"
+
+// Functions and values used to properly align netlink messages, headers,
+// and attributes.  Definitions taken from Linux kernel source.
+
+// #define NLMSG_ALIGNTO   4U
+const nlmsgAlignTo = 4
+
+// #define NLMSG_ALIGN(len) ( ((len)+NLMSG_ALIGNTO-1) & ~(NLMSG_ALIGNTO-1) )
+func nlmsgAlign(len int) int {
+	return ((len) + nlmsgAlignTo - 1) & ^(nlmsgAlignTo - 1)
+}
+
+// #define NLMSG_LENGTH(len) ((len) + NLMSG_HDRLEN)
+func nlmsgLength(len int) int {
+	return len + nlmsgHeaderLen
+}
+
+// #define NLMSG_HDRLEN     ((int) NLMSG_ALIGN(sizeof(struct nlmsghdr)))
+var nlmsgHeaderLen = nlmsgAlign(int(unsafe.Sizeof(Header{})))
+
+// #define NLA_ALIGNTO             4
+const nlaAlignTo = 4
+
+// #define NLA_ALIGN(len)          (((len) + NLA_ALIGNTO - 1) & ~(NLA_ALIGNTO - 1))
+func nlaAlign(len int) int {
+	return ((len) + nlaAlignTo - 1) & ^(nlaAlignTo - 1)
+}
+
+// Because this package's Attribute type contains a byte slice, unsafe.Sizeof
+// can't be used to determine the correct length.
+const sizeofAttribute = 4
+
+// #define NLA_HDRLEN              ((int) NLA_ALIGN(sizeof(struct nlattr)))
+var nlaHeaderLen = nlaAlign(sizeofAttribute)

--- a/vendor/github.com/mdlayher/netlink/attribute.go
+++ b/vendor/github.com/mdlayher/netlink/attribute.go
@@ -1,0 +1,442 @@
+package netlink
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/mdlayher/netlink/nlenc"
+)
+
+// errInvalidAttribute specifies if an Attribute's length is incorrect.
+var errInvalidAttribute = errors.New("invalid attribute; length too short or too large")
+
+// An Attribute is a netlink attribute.  Attributes are packed and unpacked
+// to and from the Data field of Message for some netlink families.
+type Attribute struct {
+	// Length of an Attribute, including this field and Type.
+	Length uint16
+
+	// The type of this Attribute, typically matched to a constant.
+	Type uint16
+
+	// An arbitrary payload which is specified by Type.
+	Data []byte
+}
+
+// marshal marshals the contents of a into b and returns the number of bytes
+// written to b, including attribute alignment padding.
+func (a *Attribute) marshal(b []byte) (int, error) {
+	if int(a.Length) < nlaHeaderLen {
+		return 0, errInvalidAttribute
+	}
+
+	nlenc.PutUint16(b[0:2], a.Length)
+	nlenc.PutUint16(b[2:4], a.Type)
+	n := copy(b[nlaHeaderLen:], a.Data)
+
+	return nlaHeaderLen + nlaAlign(n), nil
+}
+
+// unmarshal unmarshals the contents of a byte slice into an Attribute.
+func (a *Attribute) unmarshal(b []byte) error {
+	if len(b) < nlaHeaderLen {
+		return errInvalidAttribute
+	}
+
+	a.Length = nlenc.Uint16(b[0:2])
+	a.Type = nlenc.Uint16(b[2:4])
+
+	if int(a.Length) > len(b) {
+		return errInvalidAttribute
+	}
+
+	switch {
+	// No length, no data
+	case a.Length == 0:
+		a.Data = make([]byte, 0)
+	// Not enough length for any data
+	case int(a.Length) < nlaHeaderLen:
+		return errInvalidAttribute
+	// Data present
+	case int(a.Length) >= nlaHeaderLen:
+		a.Data = make([]byte, len(b[nlaHeaderLen:a.Length]))
+		copy(a.Data, b[nlaHeaderLen:a.Length])
+	}
+
+	return nil
+}
+
+// MarshalAttributes packs a slice of Attributes into a single byte slice.
+// In most cases, the Length field of each Attribute should be set to 0, so it
+// can be calculated and populated automatically for each Attribute.
+func MarshalAttributes(attrs []Attribute) ([]byte, error) {
+	// Count how many bytes we should allocate to store each attribute's contents.
+	var c int
+	for _, a := range attrs {
+		c += nlaHeaderLen + nlaAlign(len(a.Data))
+	}
+
+	// Advance through b with idx to place attribute data at the correct offset.
+	var idx int
+	b := make([]byte, c)
+	for _, a := range attrs {
+		// Infer the length of attribute if zero.
+		if a.Length == 0 {
+			a.Length = uint16(nlaHeaderLen + len(a.Data))
+		}
+
+		// Marshal a into b and advance idx to show many bytes are occupied.
+		n, err := a.marshal(b[idx:])
+		if err != nil {
+			return nil, err
+		}
+		idx += n
+	}
+
+	return b, nil
+}
+
+// UnmarshalAttributes unpacks a slice of Attributes from a single byte slice.
+//
+// It is recommend to use the AttributeDecoder type where possible instead of calling
+// UnmarshalAttributes and using package nlenc functions directly.
+func UnmarshalAttributes(b []byte) ([]Attribute, error) {
+	var attrs []Attribute
+	var i int
+	for {
+		if i > len(b) || len(b[i:]) == 0 {
+			break
+		}
+
+		var a Attribute
+		if err := (&a).unmarshal(b[i:]); err != nil {
+			return nil, err
+		}
+
+		if a.Length == 0 {
+			i += nlaHeaderLen
+			continue
+		}
+
+		i += nlaAlign(int(a.Length))
+
+		attrs = append(attrs, a)
+	}
+
+	return attrs, nil
+}
+
+// An AttributeDecoder provides a safe, iterator-like, API around attribute
+// decoding.
+//
+// It is recommend to use an AttributeDecoder where possible instead of calling
+// UnmarshalAttributes and using package nlenc functions directly.
+//
+// The Err method must be called after the Next method returns false to determine
+// if any errors occurred during iteration.
+type AttributeDecoder struct {
+	// ByteOrder defines a specific byte order to use when processing integer
+	// attributes.  ByteOrder should be set immediately after creating the
+	// AttributeDecoder: before any attributes are parsed.
+	//
+	// If not set, the native byte order will be used.
+	ByteOrder binary.ByteOrder
+
+	// The attributes being worked on, and the iterator index into the slice of
+	// attributes.
+	attrs []Attribute
+	i     int
+
+	// Any error encountered while decoding attributes.
+	err error
+}
+
+// NewAttributeDecoder creates an AttributeDecoder that unpacks Attributes
+// from b and prepares the decoder for iteration.
+func NewAttributeDecoder(b []byte) (*AttributeDecoder, error) {
+	attrs, err := UnmarshalAttributes(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return &AttributeDecoder{
+		// By default, use native byte order.
+		ByteOrder: nlenc.NativeEndian(),
+
+		attrs: attrs,
+	}, nil
+}
+
+// Next advances the decoder to the next netlink attribute.  It returns false
+// when no more attributes are present, or an error was encountered.
+func (ad *AttributeDecoder) Next() bool {
+	if ad.err != nil {
+		// Hit an error, stop iteration.
+		return false
+	}
+
+	ad.i++
+
+	// More attributes?
+	return len(ad.attrs) >= ad.i
+}
+
+// Type returns the Attribute.Type field of the current netlink attribute
+// pointed to by the decoder.
+func (ad *AttributeDecoder) Type() uint16 {
+	return ad.attr().Type
+}
+
+// attr returns the current Attribute pointed to by the decoder.
+func (ad *AttributeDecoder) attr() Attribute {
+	return ad.attrs[ad.i-1]
+}
+
+// data returns the Data field of the current Attribute pointed to by the decoder.
+func (ad *AttributeDecoder) data() []byte {
+	return ad.attr().Data
+}
+
+// Err returns the first error encountered by the decoder.
+func (ad *AttributeDecoder) Err() error {
+	return ad.err
+}
+
+// Bytes returns the raw bytes of the current Attribute's data.
+func (ad *AttributeDecoder) Bytes() []byte {
+	src := ad.data()
+	dest := make([]byte, len(src))
+	copy(dest, src)
+	return dest
+}
+
+// String returns the string representation of the current Attribute's data.
+func (ad *AttributeDecoder) String() string {
+	if ad.err != nil {
+		return ""
+	}
+
+	return nlenc.String(ad.data())
+}
+
+// Uint8 returns the uint8 representation of the current Attribute's data.
+func (ad *AttributeDecoder) Uint8() uint8 {
+	if ad.err != nil {
+		return 0
+	}
+
+	b := ad.data()
+	if len(b) != 1 {
+		ad.err = fmt.Errorf("netlink: attribute %d is not a uint8; length: %d", ad.Type(), len(b))
+		return 0
+	}
+
+	return uint8(b[0])
+}
+
+// Uint16 returns the uint16 representation of the current Attribute's data.
+func (ad *AttributeDecoder) Uint16() uint16 {
+	if ad.err != nil {
+		return 0
+	}
+
+	b := ad.data()
+	if len(b) != 2 {
+		ad.err = fmt.Errorf("netlink: attribute %d is not a uint16; length: %d", ad.Type(), len(b))
+		return 0
+	}
+
+	return ad.ByteOrder.Uint16(b)
+}
+
+// Uint32 returns the uint32 representation of the current Attribute's data.
+func (ad *AttributeDecoder) Uint32() uint32 {
+	if ad.err != nil {
+		return 0
+	}
+
+	b := ad.data()
+	if len(b) != 4 {
+		ad.err = fmt.Errorf("netlink: attribute %d is not a uint32; length: %d", ad.Type(), len(b))
+		return 0
+	}
+
+	return ad.ByteOrder.Uint32(b)
+}
+
+// Uint64 returns the uint64 representation of the current Attribute's data.
+func (ad *AttributeDecoder) Uint64() uint64 {
+	if ad.err != nil {
+		return 0
+	}
+
+	b := ad.data()
+	if len(b) != 8 {
+		ad.err = fmt.Errorf("netlink: attribute %d is not a uint64; length: %d", ad.Type(), len(b))
+		return 0
+	}
+
+	return ad.ByteOrder.Uint64(b)
+}
+
+// Do is a general purpose function which allows access to the current data
+// pointed to by the AttributeDecoder.
+//
+// Do can be used to allow parsing arbitrary data within the context of the
+// decoder.  Do is most useful when dealing with nested attributes, attribute
+// arrays, or decoding arbitrary types (such as C structures) which don't fit
+// cleanly into a typical unsigned integer value.
+//
+// The function fn should not retain any reference to the data b outside of the
+// scope of the function.
+func (ad *AttributeDecoder) Do(fn func(b []byte) error) {
+	if ad.err != nil {
+		return
+	}
+
+	b := ad.data()
+	if err := fn(b); err != nil {
+		ad.err = err
+	}
+}
+
+// An AttributeEncoder provides a safe way to encode attributes.
+//
+// It is recommended to use an AttributeEncoder where possible instead of
+// calling MarshalAttributes or using package nlenc directly.
+//
+// Errors from intermediate encoding steps are returned in the call to
+// Encode.
+type AttributeEncoder struct {
+	// ByteOrder defines a specific byte order to use when processing integer
+	// attributes.  ByteOrder should be set immediately after creating the
+	// AttributeEncoder: before any attributes are encoded.
+	//
+	// If not set, the native byte order will be used.
+	ByteOrder binary.ByteOrder
+
+	attrs []Attribute
+	err   error
+}
+
+// NewAttributeEncoder creates an AttributeEncoder that encodes Attributes.
+func NewAttributeEncoder() *AttributeEncoder {
+	return &AttributeEncoder{
+		ByteOrder: nlenc.NativeEndian(),
+	}
+}
+
+// Uint8 encodes uint8 data into an Attribute specified by typ.
+func (ae *AttributeEncoder) Uint8(typ uint16, v uint8) {
+	if ae.err != nil {
+		return
+	}
+
+	ae.attrs = append(ae.attrs, Attribute{
+		Type: typ,
+		Data: []byte{v},
+	})
+}
+
+// Uint16 encodes uint16 data into an Attribute specified by typ.
+func (ae *AttributeEncoder) Uint16(typ uint16, v uint16) {
+	if ae.err != nil {
+		return
+	}
+
+	b := make([]byte, 2)
+	ae.ByteOrder.PutUint16(b, v)
+
+	ae.attrs = append(ae.attrs, Attribute{
+		Type: typ,
+		Data: b,
+	})
+}
+
+// Uint32 encodes uint32 data into an Attribute specified by typ.
+func (ae *AttributeEncoder) Uint32(typ uint16, v uint32) {
+	if ae.err != nil {
+		return
+	}
+
+	b := make([]byte, 4)
+	ae.ByteOrder.PutUint32(b, v)
+
+	ae.attrs = append(ae.attrs, Attribute{
+		Type: typ,
+		Data: b,
+	})
+}
+
+// Uint64 encodes uint64 data into an Attribute specified by typ.
+func (ae *AttributeEncoder) Uint64(typ uint16, v uint64) {
+	if ae.err != nil {
+		return
+	}
+
+	b := make([]byte, 8)
+	ae.ByteOrder.PutUint64(b, v)
+
+	ae.attrs = append(ae.attrs, Attribute{
+		Type: typ,
+		Data: b,
+	})
+}
+
+// String encodes string s as a null-terminated string into an Attribute
+// specified by typ.
+func (ae *AttributeEncoder) String(typ uint16, s string) {
+	if ae.err != nil {
+		return
+	}
+
+	ae.attrs = append(ae.attrs, Attribute{
+		Type: typ,
+		Data: nlenc.Bytes(s),
+	})
+}
+
+// Bytes embeds raw byte data into an Attribute specified by typ.
+func (ae *AttributeEncoder) Bytes(typ uint16, b []byte) {
+	if ae.err != nil {
+		return
+	}
+
+	ae.attrs = append(ae.attrs, Attribute{
+		Type: typ,
+		Data: b,
+	})
+}
+
+// Do is a general purpose function to encode arbitrary data into an attribute
+// specified by typ.
+//
+// Do is especially helpful in encoding nested attributes, attribute arrays,
+// or encoding arbitrary types (such as C structures) which don't fit cleanly
+// into an unsigned integer value.
+func (ae *AttributeEncoder) Do(typ uint16, fn func() ([]byte, error)) {
+	if ae.err != nil {
+		return
+	}
+
+	b, err := fn()
+	if err != nil {
+		ae.err = err
+		return
+	}
+
+	ae.attrs = append(ae.attrs, Attribute{
+		Type: typ,
+		Data: b,
+	})
+}
+
+// Encode returns the encoded bytes representing the attributes.
+func (ae *AttributeEncoder) Encode() ([]byte, error) {
+	if ae.err != nil {
+		return nil, ae.err
+	}
+
+	return MarshalAttributes(ae.attrs)
+}

--- a/vendor/github.com/mdlayher/netlink/conn.go
+++ b/vendor/github.com/mdlayher/netlink/conn.go
@@ -1,0 +1,566 @@
+package netlink
+
+import (
+	"errors"
+	"math/rand"
+	"os"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"golang.org/x/net/bpf"
+)
+
+// A Conn is a connection to netlink.  A Conn can be used to send and
+// receives messages to and from netlink.
+//
+// A Conn is safe for concurrent use, but to avoid contention in
+// high-throughput applications, the caller should almost certainly create a
+// pool of Conns and distribute them among workers.
+type Conn struct {
+	// sock is the operating system-specific implementation of
+	// a netlink sockets connection.
+	sock Socket
+
+	// seq is an atomically incremented integer used to provide sequence
+	// numbers when Conn.Send is called.
+	seq *uint32
+
+	// pid is the PID assigned by netlink.
+	pid uint32
+
+	// d provides debugging capabilities for a Conn if not nil.
+	d *debugger
+
+	// mu serializes access to the netlink socket for the request/response
+	// transaction within Execute.
+	mu sync.RWMutex
+}
+
+// A Socket is an operating-system specific implementation of netlink
+// sockets used by Conn.
+type Socket interface {
+	Close() error
+	Send(m Message) error
+	SendMessages(m []Message) error
+	Receive() ([]Message, error)
+}
+
+// Dial dials a connection to netlink, using the specified netlink family.
+// Config specifies optional configuration for Conn.  If config is nil, a default
+// configuration will be used.
+func Dial(family int, config *Config) (*Conn, error) {
+	// Use OS-specific dial() to create Socket
+	c, pid, err := dial(family, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewConn(c, pid), nil
+}
+
+// NewConn creates a Conn using the specified Socket and PID for netlink
+// communications.
+//
+// NewConn is primarily useful for tests. Most applications should use
+// Dial instead.
+func NewConn(sock Socket, pid uint32) *Conn {
+	// Seed the sequence number using a random number generator.
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	seq := r.Uint32()
+
+	// Configure a debugger if arguments are set.
+	var d *debugger
+	if len(debugArgs) > 0 {
+		d = newDebugger(debugArgs)
+	}
+
+	return &Conn{
+		sock: sock,
+		seq:  &seq,
+		pid:  pid,
+		d:    d,
+	}
+}
+
+// debug executes fn with the debugger if the debugger is not nil.
+func (c *Conn) debug(fn func(d *debugger)) {
+	if c.d == nil {
+		return
+	}
+
+	fn(c.d)
+}
+
+// Close closes the connection. Close will unblock any concurrent calls to
+// Receive which are waiting on a response from the kernel.
+func (c *Conn) Close() error {
+	// Close does not acquire a lock because it must be able to interrupt any
+	// blocked system calls, such as when Receive is waiting on a multicast
+	// group message.
+	//
+	// We rely on the kernel to deal with concurrent operations to the netlink
+	// socket itself.
+	return newOpError("close", c.sock.Close())
+}
+
+// Execute sends a single Message to netlink using Send, receives one or more
+// replies using Receive, and then checks the validity of the replies against
+// the request using Validate.
+//
+// Execute acquires a lock for the duration of the function call which blocks
+// concurrent calls to Send, SendMessages, and Receive, in order to ensure
+// consistency between netlink request/reply messages.
+//
+// See the documentation of Send, Receive, and Validate for details about
+// each function.
+func (c *Conn) Execute(message Message) ([]Message, error) {
+	// Acquire the write lock and invoke the internal implementations of Send
+	// and Receive which require the lock already be held.
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	req, err := c.lockedSend(message)
+	if err != nil {
+		return nil, err
+	}
+
+	replies, err := c.lockedReceive()
+	if err != nil {
+		return nil, err
+	}
+
+	if err := Validate(req, replies); err != nil {
+		return nil, err
+	}
+
+	return replies, nil
+}
+
+// SendMessages sends multiple Messages to netlink. The handling of
+// a Header's Length, Sequence and PID fields is the same as when
+// calling Send.
+func (c *Conn) SendMessages(messages []Message) ([]Message, error) {
+	// Wait for any concurrent calls to Execute to finish before proceeding.
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	for idx, m := range messages {
+		ml := nlmsgLength(len(m.Data))
+
+		// TODO(mdlayher): fine-tune this limit.
+		if ml > (1024 * 32) {
+			return nil, errors.New("netlink message data too large")
+		}
+
+		c.fixMsg(&messages[idx], ml)
+	}
+
+	c.debug(func(d *debugger) {
+		for _, m := range messages {
+			d.debugf(1, "send msgs: %+v", m)
+		}
+	})
+
+	if err := c.sock.SendMessages(messages); err != nil {
+		c.debug(func(d *debugger) {
+			d.debugf(1, "send msgs: err: %v", err)
+		})
+
+		return nil, newOpError("send-messages", err)
+	}
+
+	return messages, nil
+}
+
+// Send sends a single Message to netlink.  In most cases, a Header's Length,
+// Sequence, and PID fields should be set to 0, so they can be populated
+// automatically before the Message is sent.  On success, Send returns a copy
+// of the Message with all parameters populated, for later validation.
+//
+// If Header.Length is 0, it will be automatically populated using the
+// correct length for the Message, including its payload.
+//
+// If Header.Sequence is 0, it will be automatically populated using the
+// next sequence number for this connection.
+//
+// If Header.PID is 0, it will be automatically populated using a PID
+// assigned by netlink.
+func (c *Conn) Send(message Message) (Message, error) {
+	// Wait for any concurrent calls to Execute to finish before proceeding.
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.lockedSend(message)
+}
+
+// lockedSend implements Send, but must be called with c.mu acquired for reading.
+// We rely on the kernel to deal with concurrent reads and writes to the netlink
+// socket itself.
+func (c *Conn) lockedSend(message Message) (Message, error) {
+	ml := nlmsgLength(len(message.Data))
+
+	// TODO(mdlayher): fine-tune this limit.
+	if ml > (1024 * 32) {
+		return Message{}, errors.New("netlink message data too large")
+	}
+
+	c.fixMsg(&message, ml)
+
+	c.debug(func(d *debugger) {
+		d.debugf(1, "send: %+v", message)
+	})
+
+	if err := c.sock.Send(message); err != nil {
+		c.debug(func(d *debugger) {
+			d.debugf(1, "send: err: %v", err)
+		})
+
+		return Message{}, newOpError("send", err)
+	}
+
+	return message, nil
+}
+
+// Receive receives one or more messages from netlink.  Multi-part messages are
+// handled transparently and returned as a single slice of Messages, with the
+// final empty "multi-part done" message removed.
+//
+// If any of the messages indicate a netlink error, that error will be returned.
+func (c *Conn) Receive() ([]Message, error) {
+	// Wait for any concurrent calls to Execute to finish before proceeding.
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.lockedReceive()
+}
+
+// lockedReceive implements Receive, but must be called with c.mu acquired for reading.
+// We rely on the kernel to deal with concurrent reads and writes to the netlink
+// socket itself.
+func (c *Conn) lockedReceive() ([]Message, error) {
+	msgs, err := c.receive()
+	if err != nil {
+		c.debug(func(d *debugger) {
+			d.debugf(1, "recv: err: %v", err)
+		})
+
+		return nil, err
+	}
+
+	c.debug(func(d *debugger) {
+		for _, m := range msgs {
+			d.debugf(1, "recv: %+v", m)
+		}
+	})
+
+	// When using nltest, it's possible for zero messages to be returned by receive.
+	if len(msgs) == 0 {
+		return msgs, nil
+	}
+
+	// Trim the final message with multi-part done indicator if
+	// present.
+	if m := msgs[len(msgs)-1]; m.Header.Flags&Multi != 0 && m.Header.Type == Done {
+		return msgs[:len(msgs)-1], nil
+	}
+
+	return msgs, nil
+}
+
+// receive is the internal implementation of Conn.Receive, which can be called
+// recursively to handle multi-part messages.
+func (c *Conn) receive() ([]Message, error) {
+	// NB: All non-nil errors returned from this function *must* be of type
+	// OpError in order to maintain the appropriate contract with callers of
+	// this package.
+	//
+	// This contract also applies to functions called within this function,
+	// such as checkMessage.
+
+	var res []Message
+	for {
+		msgs, err := c.sock.Receive()
+		if err != nil {
+			return nil, newOpError("receive", err)
+		}
+
+		// If this message is multi-part, we will need to perform an recursive call
+		// to continue draining the socket
+		var multi bool
+
+		for _, m := range msgs {
+			if err := checkMessage(m); err != nil {
+				return nil, err
+			}
+
+			// Does this message indicate a multi-part message?
+			if m.Header.Flags&Multi == 0 {
+				// No, check the next messages.
+				continue
+			}
+
+			// Does this message indicate the last message in a series of
+			// multi-part messages from a single read?
+			multi = m.Header.Type != Done
+		}
+
+		res = append(res, msgs...)
+
+		if !multi {
+			// No more messages coming.
+			return res, nil
+		}
+	}
+}
+
+// A groupJoinLeaver is a Socket that supports joining and leaving
+// netlink multicast groups.
+type groupJoinLeaver interface {
+	Socket
+	JoinGroup(group uint32) error
+	LeaveGroup(group uint32) error
+}
+
+// JoinGroup joins a netlink multicast group by its ID.
+func (c *Conn) JoinGroup(group uint32) error {
+	conn, ok := c.sock.(groupJoinLeaver)
+	if !ok {
+		return notSupported("join-group")
+	}
+
+	return newOpError("join-group", conn.JoinGroup(group))
+}
+
+// LeaveGroup leaves a netlink multicast group by its ID.
+func (c *Conn) LeaveGroup(group uint32) error {
+	conn, ok := c.sock.(groupJoinLeaver)
+	if !ok {
+		return notSupported("leave-group")
+	}
+
+	return newOpError("leave-group", conn.LeaveGroup(group))
+}
+
+// A bpfSetter is a Socket that supports setting and removing BPF filters.
+type bpfSetter interface {
+	Socket
+	bpf.Setter
+	RemoveBPF() error
+}
+
+// SetBPF attaches an assembled BPF program to a Conn.
+func (c *Conn) SetBPF(filter []bpf.RawInstruction) error {
+	conn, ok := c.sock.(bpfSetter)
+	if !ok {
+		return notSupported("set-bpf")
+	}
+
+	return newOpError("set-bpf", conn.SetBPF(filter))
+}
+
+// RemoveBPF removes a BPF filter from a Conn.
+func (c *Conn) RemoveBPF() error {
+	conn, ok := c.sock.(bpfSetter)
+	if !ok {
+		return notSupported("remove-bpf")
+	}
+
+	return newOpError("remove-bpf", conn.RemoveBPF())
+}
+
+// A deadlineSetter is a Socket that supports setting deadlines.
+type deadlineSetter interface {
+	Socket
+	SetDeadline(time.Time) error
+	SetReadDeadline(time.Time) error
+	SetWriteDeadline(time.Time) error
+}
+
+// SetDeadline sets the read and write deadlines associated with the connection.
+//
+// Deadline functionality is only supported on Go 1.12+. Calling this function
+// on older versions of Go will result in an error.
+func (c *Conn) SetDeadline(t time.Time) error {
+	conn, ok := c.sock.(deadlineSetter)
+	if !ok {
+		return notSupported("set-deadline")
+	}
+
+	return newOpError("set-deadline", conn.SetDeadline(t))
+}
+
+// SetReadDeadline sets the read deadline associated with the connection.
+//
+// Deadline functionality is only supported on Go 1.12+. Calling this function
+// on older versions of Go will result in an error.
+func (c *Conn) SetReadDeadline(t time.Time) error {
+	conn, ok := c.sock.(deadlineSetter)
+	if !ok {
+		return notSupported("set-read-deadline")
+	}
+
+	return newOpError("set-read-deadline", conn.SetReadDeadline(t))
+}
+
+// SetWriteDeadline sets the write deadline associated with the connection.
+//
+// Deadline functionality is only supported on Go 1.12+. Calling this function
+// on older versions of Go will result in an error.
+func (c *Conn) SetWriteDeadline(t time.Time) error {
+	conn, ok := c.sock.(deadlineSetter)
+	if !ok {
+		return notSupported("set-write-deadline")
+	}
+
+	return newOpError("set-write-deadline", conn.SetWriteDeadline(t))
+}
+
+// A ConnOption is a boolean option that may be set for a Conn.
+type ConnOption int
+
+// Possible ConnOption values.  These constants are equivalent to the Linux
+// setsockopt boolean options for netlink sockets.
+const (
+	PacketInfo ConnOption = iota
+	BroadcastError
+	NoENOBUFS
+	ListenAllNSID
+	CapAcknowledge
+)
+
+// An optionSetter is a Socket that supports setting netlink options.
+type optionSetter interface {
+	Socket
+	SetOption(option ConnOption, enable bool) error
+}
+
+// SetOption enables or disables a netlink socket option for the Conn.
+func (c *Conn) SetOption(option ConnOption, enable bool) error {
+	conn, ok := c.sock.(optionSetter)
+	if !ok {
+		return notSupported("set-option")
+	}
+
+	return newOpError("set-option", conn.SetOption(option, enable))
+}
+
+// A bufferSetter is a Socket that supports setting connection buffer sizes.
+type bufferSetter interface {
+	Socket
+	SetReadBuffer(bytes int) error
+	SetWriteBuffer(bytes int) error
+}
+
+// SetReadBuffer sets the size of the operating system's receive buffer
+// associated with the Conn.
+func (c *Conn) SetReadBuffer(bytes int) error {
+	conn, ok := c.sock.(bufferSetter)
+	if !ok {
+		return notSupported("set-read-buffer")
+	}
+
+	return newOpError("set-read-buffer", conn.SetReadBuffer(bytes))
+}
+
+// SetWriteBuffer sets the size of the operating system's transmit buffer
+// associated with the Conn.
+func (c *Conn) SetWriteBuffer(bytes int) error {
+	conn, ok := c.sock.(bufferSetter)
+	if !ok {
+		return notSupported("set-write-buffer")
+	}
+
+	return newOpError("set-write-buffer", conn.SetWriteBuffer(bytes))
+}
+
+// A filer is a Socket that supports retrieving its associated *os.File.
+type filer interface {
+	Socket
+	File() *os.File
+}
+
+var _ syscall.Conn = &Conn{}
+
+// TODO(mdlayher): mutex or similar to enforce syscall.RawConn contract of
+// FD remaining valid for duration of calls?
+
+// SyscallConn returns a raw network connection. This implements the
+// syscall.Conn interface.
+//
+// On Go 1.12+, all methods of the returned syscall.RawConn are supported and
+// the Conn is integrated with the runtime network poller. On versions of Go
+// prior to Go 1.12, only the Control method of the returned syscall.RawConn
+// is implemented.
+//
+// SyscallConn is intended for advanced use cases, such as getting and setting
+// arbitrary socket options using the netlink socket's file descriptor.
+//
+// Once invoked, it is the caller's responsibility to ensure that operations
+// performed using Conn and the syscall.RawConn do not conflict with
+// each other.
+func (c *Conn) SyscallConn() (syscall.RawConn, error) {
+	fc, ok := c.sock.(filer)
+	if !ok {
+		return nil, notSupported("syscall-conn")
+	}
+
+	return newRawConn(fc.File())
+}
+
+// fixMsg updates the fields of m using the logic specified in Send.
+func (c *Conn) fixMsg(m *Message, ml int) {
+	if m.Header.Length == 0 {
+		m.Header.Length = uint32(nlmsgAlign(ml))
+	}
+
+	if m.Header.Sequence == 0 {
+		m.Header.Sequence = c.nextSequence()
+	}
+
+	if m.Header.PID == 0 {
+		m.Header.PID = c.pid
+	}
+}
+
+// nextSequence atomically increments Conn's sequence number and returns
+// the incremented value.
+func (c *Conn) nextSequence() uint32 {
+	return atomic.AddUint32(c.seq, 1)
+}
+
+// Validate validates one or more reply Messages against a request Message,
+// ensuring that they contain matching sequence numbers and PIDs.
+func Validate(request Message, replies []Message) error {
+	for _, m := range replies {
+		// Check for mismatched sequence, unless:
+		//   - request had no sequence, meaning we are probably validating
+		//     a multicast reply
+		if m.Header.Sequence != request.Header.Sequence && request.Header.Sequence != 0 {
+			return newOpError("validate", errMismatchedSequence)
+		}
+
+		// Check for mismatched PID, unless:
+		//   - request had no PID, meaning we are either:
+		//     - validating a multicast reply
+		//     - netlink has not yet assigned us a PID
+		//   - response had no PID, meaning it's from the kernel as a multicast reply
+		if m.Header.PID != request.Header.PID && request.Header.PID != 0 && m.Header.PID != 0 {
+			return newOpError("validate", errMismatchedPID)
+		}
+	}
+
+	return nil
+}
+
+// Config contains options for a Conn.
+type Config struct {
+	// Groups is a bitmask which specifies multicast groups. If set to 0,
+	// no multicast group subscriptions will be made.
+	Groups uint32
+
+	// Network namespace the Conn needs to operate in. If set to 0,
+	// no network namespace will be entered.
+	NetNS int
+}

--- a/vendor/github.com/mdlayher/netlink/conn_linux.go
+++ b/vendor/github.com/mdlayher/netlink/conn_linux.go
@@ -1,0 +1,677 @@
+//+build linux
+
+package netlink
+
+import (
+	"math"
+	"os"
+	"runtime"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+
+	"golang.org/x/net/bpf"
+	"golang.org/x/sys/unix"
+)
+
+var _ Socket = &conn{}
+
+var _ deadlineSetter = &conn{}
+
+// A conn is the Linux implementation of a netlink sockets connection.
+//
+// All conn methods must wrap system call errors with os.NewSyscallError to
+// enable more intelligible error messages in OpError.
+type conn struct {
+	s  socket
+	sa *unix.SockaddrNetlink
+}
+
+// A socket is an interface over socket system calls.
+type socket interface {
+	Bind(sa unix.Sockaddr) error
+	Close() error
+	FD() int
+	File() *os.File
+	Getsockname() (unix.Sockaddr, error)
+	Recvmsg(p, oob []byte, flags int) (n int, oobn int, recvflags int, from unix.Sockaddr, err error)
+	Sendmsg(p, oob []byte, to unix.Sockaddr, flags int) error
+	SetDeadline(t time.Time) error
+	SetReadDeadline(t time.Time) error
+	SetWriteDeadline(t time.Time) error
+	SetSockoptSockFprog(level, opt int, fprog *unix.SockFprog) error
+	SetSockoptInt(level, opt, value int) error
+}
+
+// dial is the entry point for Dial.  dial opens a netlink socket using
+// system calls, and returns its PID.
+func dial(family int, config *Config) (*conn, uint32, error) {
+	// Prepare sysSocket's internal loop and create the socket.
+	//
+	// The conditional is inverted because a zero value of false is desired
+	// if no config, but it's easier to interpret within this code when the
+	// value is inverted.
+	if config == nil {
+		config = &Config{}
+	}
+
+	sock, err := newSysSocket(config)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if err := sock.Socket(family); err != nil {
+		return nil, 0, os.NewSyscallError("socket", err)
+	}
+
+	return bind(sock, config)
+}
+
+// bind binds a connection to netlink using the input socket, which may be
+// a system call implementation or a mocked one for tests.
+func bind(s socket, config *Config) (*conn, uint32, error) {
+	if config == nil {
+		config = &Config{}
+	}
+
+	addr := &unix.SockaddrNetlink{
+		Family: unix.AF_NETLINK,
+		Groups: config.Groups,
+	}
+
+	// Socket must be closed in the event of any system call errors, to avoid
+	// leaking file descriptors.
+
+	if err := s.Bind(addr); err != nil {
+		_ = s.Close()
+		return nil, 0, os.NewSyscallError("bind", err)
+	}
+
+	sa, err := s.Getsockname()
+	if err != nil {
+		_ = s.Close()
+		return nil, 0, os.NewSyscallError("getsockname", err)
+	}
+
+	pid := sa.(*unix.SockaddrNetlink).Pid
+
+	return &conn{
+		s:  s,
+		sa: addr,
+	}, pid, nil
+}
+
+// SendMessages serializes multiple Messages and sends them to netlink.
+func (c *conn) SendMessages(messages []Message) error {
+	var buf []byte
+	for _, m := range messages {
+		b, err := m.MarshalBinary()
+		if err != nil {
+			return err
+		}
+
+		buf = append(buf, b...)
+	}
+
+	addr := &unix.SockaddrNetlink{
+		Family: unix.AF_NETLINK,
+	}
+
+	return os.NewSyscallError("sendmsg", c.s.Sendmsg(buf, nil, addr, 0))
+}
+
+// Send sends a single Message to netlink.
+func (c *conn) Send(m Message) error {
+	b, err := m.MarshalBinary()
+	if err != nil {
+		return err
+	}
+
+	addr := &unix.SockaddrNetlink{
+		Family: unix.AF_NETLINK,
+	}
+
+	return os.NewSyscallError("sendmsg", c.s.Sendmsg(b, nil, addr, 0))
+}
+
+// Receive receives one or more Messages from netlink.
+func (c *conn) Receive() ([]Message, error) {
+	b := make([]byte, os.Getpagesize())
+	for {
+		// Peek at the buffer to see how many bytes are available.
+		//
+		// TODO(mdlayher): deal with OOB message data if available, such as
+		// when PacketInfo ConnOption is true.
+		n, _, _, _, err := c.s.Recvmsg(b, nil, unix.MSG_PEEK)
+		if err != nil {
+			return nil, os.NewSyscallError("recvmsg", err)
+		}
+
+		// Break when we can read all messages
+		if n < len(b) {
+			break
+		}
+
+		// Double in size if not enough bytes
+		b = make([]byte, len(b)*2)
+	}
+
+	// Read out all available messages
+	n, _, _, _, err := c.s.Recvmsg(b, nil, 0)
+	if err != nil {
+		return nil, os.NewSyscallError("recvmsg", err)
+	}
+
+	n = nlmsgAlign(n)
+
+	raw, err := syscall.ParseNetlinkMessage(b[:n])
+	if err != nil {
+		return nil, err
+	}
+
+	msgs := make([]Message, 0, len(raw))
+	for _, r := range raw {
+		m := Message{
+			Header: sysToHeader(r.Header),
+			Data:   r.Data,
+		}
+
+		msgs = append(msgs, m)
+	}
+
+	return msgs, nil
+}
+
+// Close closes the connection.
+func (c *conn) Close() error {
+	return os.NewSyscallError("close", c.s.Close())
+}
+
+// FD retrieves the file descriptor of the Conn.
+func (c *conn) FD() int {
+	return c.s.FD()
+}
+
+// File retrieves the *os.File associated with the Conn.
+func (c *conn) File() *os.File {
+	return c.s.File()
+}
+
+// JoinGroup joins a multicast group by ID.
+func (c *conn) JoinGroup(group uint32) error {
+	return os.NewSyscallError("setsockopt", c.s.SetSockoptInt(
+		unix.SOL_NETLINK,
+		unix.NETLINK_ADD_MEMBERSHIP,
+		int(group),
+	))
+}
+
+// LeaveGroup leaves a multicast group by ID.
+func (c *conn) LeaveGroup(group uint32) error {
+	return os.NewSyscallError("setsockopt", c.s.SetSockoptInt(
+		unix.SOL_NETLINK,
+		unix.NETLINK_DROP_MEMBERSHIP,
+		int(group),
+	))
+}
+
+// SetBPF attaches an assembled BPF program to a conn.
+func (c *conn) SetBPF(filter []bpf.RawInstruction) error {
+	prog := unix.SockFprog{
+		Len:    uint16(len(filter)),
+		Filter: (*unix.SockFilter)(unsafe.Pointer(&filter[0])),
+	}
+
+	return os.NewSyscallError("setsockopt", c.s.SetSockoptSockFprog(
+		unix.SOL_SOCKET,
+		unix.SO_ATTACH_FILTER,
+		&prog,
+	))
+}
+
+// RemoveBPF removes a BPF filter from a conn.
+func (c *conn) RemoveBPF() error {
+	// 0 argument is ignored by SO_DETACH_FILTER.
+	return os.NewSyscallError("setsockopt", c.s.SetSockoptInt(
+		unix.SOL_SOCKET,
+		unix.SO_DETACH_FILTER,
+		0,
+	))
+}
+
+// SetOption enables or disables a netlink socket option for the Conn.
+func (c *conn) SetOption(option ConnOption, enable bool) error {
+	o, ok := linuxOption(option)
+	if !ok {
+		// Return the typical Linux error for an unknown ConnOption.
+		return os.NewSyscallError("setsockopt", unix.ENOPROTOOPT)
+	}
+
+	var v int
+	if enable {
+		v = 1
+	}
+
+	return os.NewSyscallError("setsockopt", c.s.SetSockoptInt(
+		unix.SOL_NETLINK,
+		o,
+		v,
+	))
+}
+
+func (c *conn) SetDeadline(t time.Time) error {
+	return c.s.SetDeadline(t)
+}
+
+func (c *conn) SetReadDeadline(t time.Time) error {
+	return c.s.SetReadDeadline(t)
+}
+
+func (c *conn) SetWriteDeadline(t time.Time) error {
+	return c.s.SetWriteDeadline(t)
+}
+
+// SetReadBuffer sets the size of the operating system's receive buffer
+// associated with the Conn.
+func (c *conn) SetReadBuffer(bytes int) error {
+	return os.NewSyscallError("setsockopt", c.s.SetSockoptInt(
+		unix.SOL_SOCKET,
+		unix.SO_RCVBUF,
+		bytes,
+	))
+}
+
+// SetReadBuffer sets the size of the operating system's transmit buffer
+// associated with the Conn.
+func (c *conn) SetWriteBuffer(bytes int) error {
+	return os.NewSyscallError("setsockopt", c.s.SetSockoptInt(
+		unix.SOL_SOCKET,
+		unix.SO_SNDBUF,
+		bytes,
+	))
+}
+
+// linuxOption converts a ConnOption to its Linux value.
+func linuxOption(o ConnOption) (int, bool) {
+	switch o {
+	case PacketInfo:
+		return unix.NETLINK_PKTINFO, true
+	case BroadcastError:
+		return unix.NETLINK_BROADCAST_ERROR, true
+	case NoENOBUFS:
+		return unix.NETLINK_NO_ENOBUFS, true
+	case ListenAllNSID:
+		return unix.NETLINK_LISTEN_ALL_NSID, true
+	case CapAcknowledge:
+		return unix.NETLINK_CAP_ACK, true
+	default:
+		return 0, false
+	}
+}
+
+// sysToHeader converts a syscall.NlMsghdr to a Header.
+func sysToHeader(r syscall.NlMsghdr) Header {
+	// NB: the memory layout of Header and syscall.NlMsgHdr must be
+	// exactly the same for this unsafe cast to work
+	return *(*Header)(unsafe.Pointer(&r))
+}
+
+// newError converts an error number from netlink into the appropriate
+// system call error for Linux.
+func newError(errno int) error {
+	return syscall.Errno(errno)
+}
+
+var _ socket = &sysSocket{}
+
+// A sysSocket is a socket which uses system calls for socket operations.
+type sysSocket struct {
+	mu     sync.RWMutex
+	fd     *os.File
+	closed bool
+	g      *lockedNetNSGoroutine
+}
+
+// newSysSocket creates a sysSocket that optionally locks its internal goroutine
+// to a single thread.
+func newSysSocket(config *Config) (*sysSocket, error) {
+	g, err := newLockedNetNSGoroutine(config.NetNS)
+	if err != nil {
+		return nil, err
+	}
+	return &sysSocket{
+		g: g,
+	}, nil
+}
+
+// do runs f in a worker goroutine which can be locked to one thread.
+func (s *sysSocket) do(f func()) error {
+	// All operations handled by this function are assumed to only
+	// read from s.done.
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return syscall.EBADF
+	}
+
+	s.g.run(f)
+	return nil
+}
+
+// read executes f, a read function, against the associated file descriptor.
+func (s *sysSocket) read(f func(fd int) bool) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return syscall.EBADF
+	}
+
+	var err error
+	s.g.run(func() {
+		err = fdread(s.fd, f)
+	})
+	return err
+}
+
+// write executes f, a write function, against the associated file descriptor.
+func (s *sysSocket) write(f func(fd int) bool) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return syscall.EBADF
+	}
+
+	var err error
+	s.g.run(func() {
+		err = fdwrite(s.fd, f)
+	})
+	return err
+}
+
+// control executes f, a control function, against the associated file descriptor.
+func (s *sysSocket) control(f func(fd int)) error {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return syscall.EBADF
+	}
+
+	var err error
+	s.g.run(func() {
+		err = fdcontrol(s.fd, f)
+	})
+	return err
+}
+
+func (s *sysSocket) Socket(family int) error {
+	var (
+		fd  int
+		err error
+	)
+
+	doErr := s.do(func() {
+		fd, err = unix.Socket(
+			unix.AF_NETLINK,
+			unix.SOCK_RAW,
+			family,
+		)
+	})
+	if doErr != nil {
+		return doErr
+	}
+	if err != nil {
+		return err
+	}
+
+	if err := setBlockingMode(fd); err != nil {
+		return err
+	}
+
+	// When using Go 1.12+, the setBlockingMode call we just did puts the
+	// file descriptor into non-blocking mode. In that case, os.NewFile
+	// registers the file descriptor with the runtime poller, which is
+	// then used for all subsequent operations.
+	//
+	// See also: https://golang.org/pkg/os/#NewFile
+	s.fd = os.NewFile(uintptr(fd), "netlink")
+	return nil
+}
+
+func (s *sysSocket) Bind(sa unix.Sockaddr) error {
+	var err error
+	doErr := s.control(func(fd int) {
+		err = unix.Bind(fd, sa)
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	return err
+}
+
+func (s *sysSocket) Close() error {
+	// Be sure to acquire a write lock because we need to stop any other
+	// goroutines from sending system call requests after close.
+	// Any invocation of do() after this write lock unlocks is guaranteed
+	// to find s.done being true.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Close the socket from the main thread, this operation has no risk
+	// of routing data to the wrong socket.
+	err := s.fd.Close()
+	s.closed = true
+
+	// Stop the associated goroutine and wait for it to return.
+	s.g.stop()
+
+	return err
+}
+
+func (s *sysSocket) FD() int { return int(s.fd.Fd()) }
+
+func (s *sysSocket) File() *os.File { return s.fd }
+
+func (s *sysSocket) Getsockname() (unix.Sockaddr, error) {
+	var (
+		sa  unix.Sockaddr
+		err error
+	)
+
+	doErr := s.control(func(fd int) {
+		sa, err = unix.Getsockname(fd)
+	})
+	if doErr != nil {
+		return nil, doErr
+	}
+
+	return sa, err
+}
+
+func (s *sysSocket) Recvmsg(p, oob []byte, flags int) (int, int, int, unix.Sockaddr, error) {
+	var (
+		n, oobn, recvflags int
+		from               unix.Sockaddr
+		err                error
+	)
+
+	doErr := s.read(func(fd int) bool {
+		n, oobn, recvflags, from, err = unix.Recvmsg(fd, p, oob, flags)
+
+		// When the socket is in non-blocking mode, we might see
+		// EAGAIN and end up here. In that case, return false to
+		// let the poller wait for readiness. See the source code
+		// for internal/poll.FD.RawRead for more details.
+		//
+		// If the socket is in blocking mode, EAGAIN should never occur.
+		return err != syscall.EAGAIN
+	})
+	if doErr != nil {
+		return 0, 0, 0, nil, doErr
+	}
+
+	return n, oobn, recvflags, from, err
+}
+
+func (s *sysSocket) Sendmsg(p, oob []byte, to unix.Sockaddr, flags int) error {
+	var err error
+	doErr := s.write(func(fd int) bool {
+		err = unix.Sendmsg(fd, p, oob, to, flags)
+
+		// Analogous to Recvmsg. See the comments there.
+		return err != syscall.EAGAIN
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	return err
+}
+
+func (s *sysSocket) SetDeadline(t time.Time) error {
+	return s.fd.SetDeadline(t)
+}
+
+func (s *sysSocket) SetReadDeadline(t time.Time) error {
+	return s.fd.SetReadDeadline(t)
+}
+
+func (s *sysSocket) SetWriteDeadline(t time.Time) error {
+	return s.fd.SetWriteDeadline(t)
+}
+
+func (s *sysSocket) SetSockoptInt(level, opt, value int) error {
+	// Value must be in range of a C integer.
+	if value < math.MinInt32 || value > math.MaxInt32 {
+		return unix.EINVAL
+	}
+
+	var err error
+	doErr := s.control(func(fd int) {
+		err = unix.SetsockoptInt(fd, level, opt, value)
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	return err
+}
+
+func (s *sysSocket) SetSockoptSockFprog(level, opt int, fprog *unix.SockFprog) error {
+	var err error
+	doErr := s.control(func(fd int) {
+		err = unix.SetsockoptSockFprog(fd, level, opt, fprog)
+	})
+	if doErr != nil {
+		return doErr
+	}
+
+	return err
+}
+
+// lockedNetNSGoroutine is a worker goroutine locked to an operating system
+// thread, optionally configured to run in a non-default network namespace.
+type lockedNetNSGoroutine struct {
+	wg    sync.WaitGroup
+	doneC chan struct{}
+	funcC chan func()
+}
+
+func newLockedNetNSGoroutine(netNS int) (*lockedNetNSGoroutine, error) {
+	// Any bare syscall errors (e.g. setns) should be wrapped with
+	// os.NewSyscallError for the remainder of this function.
+
+	g := &lockedNetNSGoroutine{
+		doneC: make(chan struct{}),
+		funcC: make(chan func()),
+	}
+
+	errC := make(chan error)
+	g.wg.Add(1)
+
+	go func() {
+		// It is important to lock this goroutine to its OS thread for the duration
+		// of the netlink socket being used, or else the kernel may end up routing
+		// messages to the wrong places.
+		// See: http://lists.infradead.org/pipermail/libnl/2017-February/002293.html.
+		//
+		// The intent is to never unlock the OS thread, so that the thread
+		// will terminate when the goroutine exits starting in Go 1.10:
+		// https://go-review.googlesource.com/c/go/+/46038.
+		//
+		// However, due to recent instability and a potential bad interaction
+		// with the Go runtime for threads which are not unlocked, we have
+		// elected to temporarily unlock the thread when the goroutine terminates:
+		// https://github.com/golang/go/issues/25128#issuecomment-410764489.
+
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		defer g.wg.Done()
+
+		// The user requested the Conn to operate in a non-default network namespace.
+		if netNS != 0 {
+
+			// Get the current namespace of the thread the goroutine is locked to.
+			origNetNS, err := getThreadNetNS()
+			if err != nil {
+				errC <- err
+				return
+			}
+
+			// Set the network namespace of the current thread using
+			// the file descriptor provided by the user.
+			err = setThreadNetNS(netNS)
+			if err != nil {
+				errC <- err
+				return
+			}
+
+			// Once the thread's namespace has been successfully manipulated,
+			// make sure we change it back when the goroutine returns.
+			defer setThreadNetNS(origNetNS)
+		}
+
+		// Signal to caller that initialization was successful.
+		errC <- nil
+
+		for {
+			select {
+			case <-g.doneC:
+				return
+			case f := <-g.funcC:
+				f()
+			}
+		}
+	}()
+
+	// Wait for the goroutine to return err or nil.
+	if err := <-errC; err != nil {
+		return nil, err
+	}
+
+	return g, nil
+}
+
+// stop signals the goroutine to stop and blocks until it does.
+//
+// It is invalid to call run concurrently with stop. It is also invalid to
+// call run after stop has returned.
+func (g *lockedNetNSGoroutine) stop() {
+	close(g.doneC)
+	g.wg.Wait()
+}
+
+// run runs f on the worker goroutine.
+func (g *lockedNetNSGoroutine) run(f func()) {
+	done := make(chan struct{})
+	g.funcC <- func() {
+		defer close(done)
+		f()
+	}
+	<-done
+}

--- a/vendor/github.com/mdlayher/netlink/conn_others.go
+++ b/vendor/github.com/mdlayher/netlink/conn_others.go
@@ -1,0 +1,29 @@
+//+build !linux
+
+package netlink
+
+import (
+	"fmt"
+	"runtime"
+)
+
+// errUnimplemented is returned by all functions on platforms that
+// cannot make use of netlink sockets.
+var errUnimplemented = fmt.Errorf("netlink: not implemented on %s/%s",
+	runtime.GOOS, runtime.GOARCH)
+
+var _ Socket = &conn{}
+
+// A conn is the no-op implementation of a netlink sockets connection.
+type conn struct{}
+
+// All cross-platform functions and Socket methods are unimplemented outside
+// of Linux.
+
+func dial(_ int, _ *Config) (*conn, uint32, error) { return nil, 0, errUnimplemented }
+func newError(_ int) error                         { return errUnimplemented }
+
+func (c *conn) Send(_ Message) error           { return errUnimplemented }
+func (c *conn) SendMessages(_ []Message) error { return errUnimplemented }
+func (c *conn) Receive() ([]Message, error)    { return nil, errUnimplemented }
+func (c *conn) Close() error                   { return errUnimplemented }

--- a/vendor/github.com/mdlayher/netlink/debug.go
+++ b/vendor/github.com/mdlayher/netlink/debug.go
@@ -1,0 +1,69 @@
+package netlink
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Arguments used to create a debugger.
+var debugArgs []string
+
+func init() {
+	// Is netlink debugging enabled?
+	s := os.Getenv("NLDEBUG")
+	if s == "" {
+		return
+	}
+
+	debugArgs = strings.Split(s, ",")
+}
+
+// A debugger is used to provide debugging information about a netlink connection.
+type debugger struct {
+	Log   *log.Logger
+	Level int
+}
+
+// newDebugger creates a debugger by parsing key=value arguments.
+func newDebugger(args []string) *debugger {
+	d := &debugger{
+		Log:   log.New(os.Stderr, "nl: ", 0),
+		Level: 1,
+	}
+
+	for _, a := range args {
+		kv := strings.Split(a, "=")
+		if len(kv) != 2 {
+			// Ignore malformed pairs and assume callers wants defaults.
+			continue
+		}
+
+		switch kv[0] {
+		// Select the log level for the debugger.
+		case "level":
+			level, err := strconv.Atoi(kv[1])
+			if err != nil {
+				panicf("netlink: invalid NLDEBUG level: %q", a)
+			}
+
+			d.Level = level
+		}
+	}
+
+	return d
+}
+
+// debugf prints debugging information at the specified level, if d.Level is
+// high enough to print the message.
+func (d *debugger) debugf(level int, format string, v ...interface{}) {
+	if d.Level >= level {
+		d.Log.Printf(format, v...)
+	}
+}
+
+func panicf(format string, a ...interface{}) {
+	panic(fmt.Sprintf(format, a...))
+}

--- a/vendor/github.com/mdlayher/netlink/doc.go
+++ b/vendor/github.com/mdlayher/netlink/doc.go
@@ -1,0 +1,22 @@
+// Package netlink provides low-level access to Linux netlink sockets.
+//
+//
+// Debugging
+//
+// This package supports rudimentary netlink connection debugging support.
+// To enable this, run your binary with the NLDEBUG environment variable set.
+// Debugging information will be output to stderr with a prefix of "nl:".
+//
+// To use the debugging defaults, use:
+//
+//   $ NLDEBUG=1 ./nlctl
+//
+// To configure individual aspects of the debugger, pass key/value options such
+// as:
+//
+//   $ NLDEBUG=level=1 ./nlctl
+//
+// Available key/value debugger options include:
+//
+//   level=N: specify the debugging level (only "1" is currently supported)
+package netlink

--- a/vendor/github.com/mdlayher/netlink/errors.go
+++ b/vendor/github.com/mdlayher/netlink/errors.go
@@ -1,0 +1,119 @@
+package netlink
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+)
+
+// Error messages which can be returned by Validate.
+var (
+	errMismatchedSequence = errors.New("mismatched sequence in netlink reply")
+	errMismatchedPID      = errors.New("mismatched PID in netlink reply")
+	errShortErrorMessage  = errors.New("not enough data for netlink error code")
+)
+
+// Errors which can be returned by a Socket that does not implement
+// all exposed methods of Conn.
+
+var errNotSupported = errors.New("operation not supported")
+
+// notSupported provides a concise constructor for "not supported" errors.
+func notSupported(op string) error {
+	return newOpError(op, errNotSupported)
+}
+
+// IsNotExist determines if an error is produced as the result of querying some
+// file, object, resource, etc. which does not exist.  Users of this package
+// should always use netlink.IsNotExist, rather than os.IsNotExist, when
+// checking for specific netlink-related errors.
+//
+// Errors types created by this package, such as OpError, can be used with
+// IsNotExist, but this function also defers to the behavior of os.IsNotExist
+// for unrecognized error types.
+func IsNotExist(err error) bool {
+	switch err := err.(type) {
+	case *OpError:
+		// TODO(mdlayher): more error handling logic?
+
+		// Unwrap the inner error and use the stdlib's logic.
+		return os.IsNotExist(err.Err)
+	default:
+		return os.IsNotExist(err)
+	}
+}
+
+var _ error = &OpError{}
+var _ net.Error = &OpError{}
+
+// An OpError is an error produced as the result of a failed netlink operation.
+type OpError struct {
+	// Op is the operation which caused this OpError, such as "send"
+	// or "receive".
+	Op string
+
+	// Err is the underlying error which caused this OpError.
+	//
+	// If Err was produced by a system call error, Err will be of type
+	// *os.SyscallError. If Err was produced by an error code in a netlink
+	// message, Err will contain a raw error value type such as a unix.Errno.
+	//
+	// Most callers should inspect Err using a helper such as IsNotExist.
+	Err error
+}
+
+// newOpError is a small wrapper for creating an OpError. As a convenience, it
+// returns nil if the input err is nil: akin to os.NewSyscallError.
+func newOpError(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+
+	return &OpError{
+		Op:  op,
+		Err: err,
+	}
+}
+
+func (e *OpError) Error() string {
+	if e == nil {
+		return "<nil>"
+	}
+
+	return fmt.Sprintf("netlink %s: %v", e.Op, e.Err)
+}
+
+// Portions of this code taken from the Go standard library:
+//
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+type timeout interface {
+	Timeout() bool
+}
+
+// Timeout reports whether the error was caused by an I/O timeout.
+func (e *OpError) Timeout() bool {
+	if ne, ok := e.Err.(*os.SyscallError); ok {
+		t, ok := ne.Err.(timeout)
+		return ok && t.Timeout()
+	}
+	t, ok := e.Err.(timeout)
+	return ok && t.Timeout()
+}
+
+type temporary interface {
+	Temporary() bool
+}
+
+// Temporary reports whether an operation may succeed if retried.
+func (e *OpError) Temporary() bool {
+	if ne, ok := e.Err.(*os.SyscallError); ok {
+		t, ok := ne.Err.(temporary)
+		return ok && t.Temporary()
+	}
+	t, ok := e.Err.(temporary)
+	return ok && t.Temporary()
+}

--- a/vendor/github.com/mdlayher/netlink/fdcall_gteq_1.12.go
+++ b/vendor/github.com/mdlayher/netlink/fdcall_gteq_1.12.go
@@ -1,0 +1,44 @@
+//+build go1.12,linux
+
+package netlink
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// setBlockingMode puts the file descriptor into non-blocking mode.
+func setBlockingMode(sysfd int) error {
+	return unix.SetNonblock(sysfd, true)
+}
+
+func fdread(fd *os.File, f func(int) (done bool)) error {
+	rc, err := fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return rc.Read(func(sysfd uintptr) bool {
+		return f(int(sysfd))
+	})
+}
+
+func fdwrite(fd *os.File, f func(int) (done bool)) error {
+	rc, err := fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return rc.Write(func(sysfd uintptr) bool {
+		return f(int(sysfd))
+	})
+}
+
+func fdcontrol(fd *os.File, f func(int)) error {
+	rc, err := fd.SyscallConn()
+	if err != nil {
+		return err
+	}
+	return rc.Control(func(sysfd uintptr) {
+		f(int(sysfd))
+	})
+}

--- a/vendor/github.com/mdlayher/netlink/fdcall_lt_1.12.go
+++ b/vendor/github.com/mdlayher/netlink/fdcall_lt_1.12.go
@@ -1,0 +1,29 @@
+//+build !go1.12,linux
+
+package netlink
+
+import "os"
+
+// setBlockingMode exists for compatibility reasons: prior to Go 1.12,
+// package netlink used blocking file descriptors, and did not support
+// deadlines. This variant of setBlockingMode, which does nothing (i.e.
+// it leaves the file descriptor in blocking mode), maintains compatibility
+// for users up to and including Go 1.11.
+func setBlockingMode(sysfd int) error {
+	return nil
+}
+
+func fdread(fd *os.File, f func(int) (done bool)) error {
+	f(int(fd.Fd()))
+	return nil
+}
+
+func fdwrite(fd *os.File, f func(int) (done bool)) error {
+	f(int(fd.Fd()))
+	return nil
+}
+
+func fdcontrol(fd *os.File, f func(int)) error {
+	f(int(fd.Fd()))
+	return nil
+}

--- a/vendor/github.com/mdlayher/netlink/fuzz.go
+++ b/vendor/github.com/mdlayher/netlink/fuzz.go
@@ -1,0 +1,34 @@
+//+build gofuzz
+
+package netlink
+
+func Fuzz(data []byte) int {
+	return fuzzAttributes(data)
+	// return fuzzMessage(data)
+}
+
+func fuzzAttributes(data []byte) int {
+	attrs, err := UnmarshalAttributes(data)
+	if err != nil {
+		return 0
+	}
+
+	if _, err := MarshalAttributes(attrs); err != nil {
+		panic(err)
+	}
+
+	return 1
+}
+
+func fuzzMessage(data []byte) int {
+	var m Message
+	if err := (&m).UnmarshalBinary(data); err != nil {
+		return 0
+	}
+
+	if _, err := m.MarshalBinary(); err != nil {
+		panic(err)
+	}
+
+	return 1
+}

--- a/vendor/github.com/mdlayher/netlink/message.go
+++ b/vendor/github.com/mdlayher/netlink/message.go
@@ -1,0 +1,260 @@
+package netlink
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/mdlayher/netlink/nlenc"
+)
+
+// Various errors which may occur when attempting to marshal or unmarshal
+// a Message to and from its binary form.
+var (
+	errIncorrectMessageLength = errors.New("netlink message header length incorrect")
+	errShortMessage           = errors.New("not enough data to create a netlink message")
+	errUnalignedMessage       = errors.New("input data is not properly aligned for netlink message")
+)
+
+// HeaderFlags specify flags which may be present in a Header.
+type HeaderFlags uint16
+
+const (
+	// General netlink communication flags.
+
+	// Request indicates a request to netlink.
+	Request HeaderFlags = 1
+
+	// Multi indicates a multi-part message, terminated by Done on the
+	// last message.
+	Multi HeaderFlags = 2
+
+	// Acknowledge requests that netlink reply with an acknowledgement
+	// using Error and, if needed, an error code.
+	Acknowledge HeaderFlags = 4
+
+	// Echo requests that netlink echo this request back to the sender.
+	Echo HeaderFlags = 8
+
+	// DumpInterrupted indicates that a dump was inconsistent due to a
+	// sequence change.
+	DumpInterrupted HeaderFlags = 16
+
+	// DumpFiltered indicates that a dump was filtered as requested.
+	DumpFiltered HeaderFlags = 32
+
+	// Flags used to retrieve data from netlink.
+
+	// Root requests that netlink return a complete table instead of a
+	// single entry.
+	Root HeaderFlags = 0x100
+
+	// Match requests that netlink return a list of all matching entries.
+	Match HeaderFlags = 0x200
+
+	// Atomic requests that netlink send an atomic snapshot of its entries.
+	// Requires CAP_NET_ADMIN or an effective UID of 0.
+	Atomic HeaderFlags = 0x400
+
+	// Dump requests that netlink return a complete list of all entries.
+	Dump HeaderFlags = Root | Match
+
+	// Flags used to create objects.
+
+	// Replace indicates request replaces an existing matching object.
+	Replace HeaderFlags = 0x100
+
+	// Excl indicates request does not replace the object if it already exists.
+	Excl HeaderFlags = 0x200
+
+	// Create indicates request creates an object if it doesn't already exist.
+	Create HeaderFlags = 0x400
+
+	// Append indicates request adds to the end of the object list.
+	Append HeaderFlags = 0x800
+)
+
+// String returns the string representation of a HeaderFlags.
+func (f HeaderFlags) String() string {
+	names := []string{
+		"request",
+		"multi",
+		"acknowledge",
+		"echo",
+		"dumpinterrupted",
+		"dumpfiltered",
+	}
+
+	var s string
+
+	left := uint(f)
+
+	for i, name := range names {
+		if f&(1<<uint(i)) != 0 {
+			if s != "" {
+				s += "|"
+			}
+
+			s += name
+
+			left ^= (1 << uint(i))
+		}
+	}
+
+	if s == "" && left == 0 {
+		s = "0"
+	}
+
+	if left > 0 {
+		if s != "" {
+			s += "|"
+		}
+		s += fmt.Sprintf("%#x", left)
+	}
+
+	return s
+}
+
+// HeaderType specifies the type of a Header.
+type HeaderType uint16
+
+const (
+	// Noop indicates that no action was taken.
+	Noop HeaderType = 0x1
+
+	// Error indicates an error code is present, which is also used to indicate
+	// success when the code is 0.
+	Error HeaderType = 0x2
+
+	// Done indicates the end of a multi-part message.
+	Done HeaderType = 0x3
+
+	// Overrun indicates that data was lost from this message.
+	Overrun HeaderType = 0x4
+)
+
+// String returns the string representation of a HeaderType.
+func (t HeaderType) String() string {
+	switch t {
+	case Noop:
+		return "noop"
+	case Error:
+		return "error"
+	case Done:
+		return "done"
+	case Overrun:
+		return "overrun"
+	default:
+		return fmt.Sprintf("unknown(%d)", t)
+	}
+}
+
+// NB: the memory layout of Header and Linux's syscall.NlMsgHdr must be
+// exactly the same.  Cannot reorder, change data type, add, or remove fields.
+// Named types of the same size (e.g. HeaderFlags is a uint16) are okay.
+
+// A Header is a netlink header.  A Header is sent and received with each
+// Message to indicate metadata regarding a Message.
+type Header struct {
+	// Length of a Message, including this Header.
+	Length uint32
+
+	// Contents of a Message.
+	Type HeaderType
+
+	// Flags which may be used to modify a request or response.
+	Flags HeaderFlags
+
+	// The sequence number of a Message.
+	Sequence uint32
+
+	// The process ID of the sending process.
+	PID uint32
+}
+
+// A Message is a netlink message.  It contains a Header and an arbitrary
+// byte payload, which may be decoded using information from the Header.
+//
+// Data is encoded in the native endianness of the host system.  For easier
+// of encoding and decoding of integers, use package nlenc.
+type Message struct {
+	Header Header
+	Data   []byte
+}
+
+// MarshalBinary marshals a Message into a byte slice.
+func (m Message) MarshalBinary() ([]byte, error) {
+	ml := nlmsgAlign(int(m.Header.Length))
+	if ml < nlmsgHeaderLen || ml != int(m.Header.Length) {
+		return nil, errIncorrectMessageLength
+	}
+
+	b := make([]byte, ml)
+
+	nlenc.PutUint32(b[0:4], m.Header.Length)
+	nlenc.PutUint16(b[4:6], uint16(m.Header.Type))
+	nlenc.PutUint16(b[6:8], uint16(m.Header.Flags))
+	nlenc.PutUint32(b[8:12], m.Header.Sequence)
+	nlenc.PutUint32(b[12:16], m.Header.PID)
+	copy(b[16:], m.Data)
+
+	return b, nil
+}
+
+// UnmarshalBinary unmarshals the contents of a byte slice into a Message.
+func (m *Message) UnmarshalBinary(b []byte) error {
+	if len(b) < nlmsgHeaderLen {
+		return errShortMessage
+	}
+	if len(b) != nlmsgAlign(len(b)) {
+		return errUnalignedMessage
+	}
+
+	// Don't allow misleading length
+	m.Header.Length = nlenc.Uint32(b[0:4])
+	if int(m.Header.Length) != len(b) {
+		return errShortMessage
+	}
+
+	m.Header.Type = HeaderType(nlenc.Uint16(b[4:6]))
+	m.Header.Flags = HeaderFlags(nlenc.Uint16(b[6:8]))
+	m.Header.Sequence = nlenc.Uint32(b[8:12])
+	m.Header.PID = nlenc.Uint32(b[12:16])
+	m.Data = b[16:]
+
+	return nil
+}
+
+// checkMessage checks a single Message for netlink errors.
+func checkMessage(m Message) error {
+	// NB: All non-nil errors returned from this function *must* be of type
+	// OpError in order to maintain the appropriate contract with callers of
+	// this package.
+
+	const success = 0
+
+	// Per libnl documentation, only messages that indicate type error can
+	// contain error codes:
+	// https://www.infradead.org/~tgr/libnl/doc/core.html#core_errmsg.
+	//
+	// However, at one point, this package checked both done and error for
+	// error codes.  Because there was no issue associated with the change,
+	// it is unknown whether this change was correct or not.  If you run into
+	// a problem with your application because of this change, please file
+	// an issue.
+	if m.Header.Type != Error {
+		return nil
+	}
+
+	if len(m.Data) < 4 {
+		return newOpError("receive", errShortErrorMessage)
+	}
+
+	if c := nlenc.Int32(m.Data[0:4]); c != success {
+		// Error code is a negative integer, convert it into an OS-specific raw
+		// system call error, but do not wrap with os.NewSyscallError to signify
+		// that this error was produced by a netlink message; not a system call.
+		return newOpError("receive", newError(-1*int(c)))
+	}
+
+	return nil
+}

--- a/vendor/github.com/mdlayher/netlink/netns_linux.go
+++ b/vendor/github.com/mdlayher/netlink/netns_linux.go
@@ -1,0 +1,27 @@
+//+build linux
+
+package netlink
+
+import (
+	"fmt"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// getThreadNetNS gets the network namespace file descriptor of the thread the current goroutine
+// is running on. Make sure to call runtime.LockOSThread() before this so the goroutine does not
+// get scheduled on another thread in the meantime.
+func getThreadNetNS() (int, error) {
+	file, err := os.Open(fmt.Sprintf("/proc/%d/task/%d/ns/net", unix.Getpid(), unix.Gettid()))
+	if err != nil {
+		return -1, err
+	}
+	return int(file.Fd()), nil
+}
+
+// setThreadNetNS sets the network namespace of the thread of the current goroutine to
+// the namespace described by the user-provided file descriptor.
+func setThreadNetNS(fd int) error {
+	return os.NewSyscallError("setns", unix.Setns(fd, unix.CLONE_NEWNET))
+}

--- a/vendor/github.com/mdlayher/netlink/nlenc/doc.go
+++ b/vendor/github.com/mdlayher/netlink/nlenc/doc.go
@@ -1,0 +1,3 @@
+// Package nlenc implements encoding and decoding functions for netlink
+// messages and attributes.
+package nlenc

--- a/vendor/github.com/mdlayher/netlink/nlenc/endian.go
+++ b/vendor/github.com/mdlayher/netlink/nlenc/endian.go
@@ -1,0 +1,14 @@
+package nlenc
+
+import "encoding/binary"
+
+// NativeEndian returns the native byte order of this system.
+func NativeEndian() binary.ByteOrder {
+	// Determine endianness by storing a uint16 in a byte slice.
+	b := Uint16Bytes(1)
+	if b[0] == 1 {
+		return binary.LittleEndian
+	}
+
+	return binary.BigEndian
+}

--- a/vendor/github.com/mdlayher/netlink/nlenc/int.go
+++ b/vendor/github.com/mdlayher/netlink/nlenc/int.go
@@ -1,0 +1,150 @@
+package nlenc
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// PutUint8 encodes a uint8 into b.
+// If b is not exactly 1 byte in length, PutUint8 will panic.
+func PutUint8(b []byte, v uint8) {
+	if l := len(b); l != 1 {
+		panic(fmt.Sprintf("PutUint8: unexpected byte slice length: %d", l))
+	}
+
+	b[0] = v
+}
+
+// PutUint16 encodes a uint16 into b using the host machine's native endianness.
+// If b is not exactly 2 bytes in length, PutUint16 will panic.
+func PutUint16(b []byte, v uint16) {
+	if l := len(b); l != 2 {
+		panic(fmt.Sprintf("PutUint16: unexpected byte slice length: %d", l))
+	}
+
+	*(*uint16)(unsafe.Pointer(&b[0])) = v
+}
+
+// PutUint32 encodes a uint32 into b using the host machine's native endianness.
+// If b is not exactly 4 bytes in length, PutUint32 will panic.
+func PutUint32(b []byte, v uint32) {
+	if l := len(b); l != 4 {
+		panic(fmt.Sprintf("PutUint32: unexpected byte slice length: %d", l))
+	}
+
+	*(*uint32)(unsafe.Pointer(&b[0])) = v
+}
+
+// PutUint64 encodes a uint64 into b using the host machine's native endianness.
+// If b is not exactly 8 bytes in length, PutUint64 will panic.
+func PutUint64(b []byte, v uint64) {
+	if l := len(b); l != 8 {
+		panic(fmt.Sprintf("PutUint64: unexpected byte slice length: %d", l))
+	}
+
+	*(*uint64)(unsafe.Pointer(&b[0])) = v
+}
+
+// PutInt32 encodes a int32 into b using the host machine's native endianness.
+// If b is not exactly 4 bytes in length, PutInt32 will panic.
+func PutInt32(b []byte, v int32) {
+	if l := len(b); l != 4 {
+		panic(fmt.Sprintf("PutInt32: unexpected byte slice length: %d", l))
+	}
+
+	*(*int32)(unsafe.Pointer(&b[0])) = v
+}
+
+// Uint8 decodes a uint8 from b.
+// If b is not exactly 1 byte in length, Uint8 will panic.
+func Uint8(b []byte) uint8 {
+	if l := len(b); l != 1 {
+		panic(fmt.Sprintf("Uint8: unexpected byte slice length: %d", l))
+	}
+
+	return b[0]
+}
+
+// Uint16 decodes a uint16 from b using the host machine's native endianness.
+// If b is not exactly 2 bytes in length, Uint16 will panic.
+func Uint16(b []byte) uint16 {
+	if l := len(b); l != 2 {
+		panic(fmt.Sprintf("Uint16: unexpected byte slice length: %d", l))
+	}
+
+	return *(*uint16)(unsafe.Pointer(&b[0]))
+}
+
+// Uint32 decodes a uint32 from b using the host machine's native endianness.
+// If b is not exactly 4 bytes in length, Uint32 will panic.
+func Uint32(b []byte) uint32 {
+	if l := len(b); l != 4 {
+		panic(fmt.Sprintf("Uint32: unexpected byte slice length: %d", l))
+	}
+
+	return *(*uint32)(unsafe.Pointer(&b[0]))
+}
+
+// Uint64 decodes a uint64 from b using the host machine's native endianness.
+// If b is not exactly 8 bytes in length, Uint64 will panic.
+func Uint64(b []byte) uint64 {
+	if l := len(b); l != 8 {
+		panic(fmt.Sprintf("Uint64: unexpected byte slice length: %d", l))
+	}
+
+	return *(*uint64)(unsafe.Pointer(&b[0]))
+}
+
+// Int32 decodes an int32 from b using the host machine's native endianness.
+// If b is not exactly 4 bytes in length, Int32 will panic.
+func Int32(b []byte) int32 {
+	if l := len(b); l != 4 {
+		panic(fmt.Sprintf("Int32: unexpected byte slice length: %d", l))
+	}
+
+	return *(*int32)(unsafe.Pointer(&b[0]))
+}
+
+// Uint8Bytes encodes a uint8 into a newly-allocated byte slice. It is a
+// shortcut for allocating a new byte slice and filling it using PutUint8.
+func Uint8Bytes(v uint8) []byte {
+	b := make([]byte, 1)
+	PutUint8(b, v)
+	return b
+}
+
+// Uint16Bytes encodes a uint16 into a newly-allocated byte slice using the
+// host machine's native endianness.  It is a shortcut for allocating a new
+// byte slice and filling it using PutUint16.
+func Uint16Bytes(v uint16) []byte {
+	b := make([]byte, 2)
+	PutUint16(b, v)
+	return b
+}
+
+// Uint32Bytes encodes a uint32 into a newly-allocated byte slice using the
+// host machine's native endianness.  It is a shortcut for allocating a new
+// byte slice and filling it using PutUint32.
+func Uint32Bytes(v uint32) []byte {
+	b := make([]byte, 4)
+	PutUint32(b, v)
+	return b
+}
+
+// Uint64Bytes encodes a uint64 into a newly-allocated byte slice using the
+// host machine's native endianness.  It is a shortcut for allocating a new
+// byte slice and filling it using PutUint64.
+func Uint64Bytes(v uint64) []byte {
+	b := make([]byte, 8)
+	PutUint64(b, v)
+	return b
+}
+
+// Int32Bytes encodes a int32 into a newly-allocated byte slice using the
+// host machine's native endianness.  It is a shortcut for allocating a new
+// byte slice and filling it using PutInt32.
+func Int32Bytes(v int32) []byte {
+	b := make([]byte, 4)
+	PutInt32(b, v)
+	return b
+}

--- a/vendor/github.com/mdlayher/netlink/nlenc/string.go
+++ b/vendor/github.com/mdlayher/netlink/nlenc/string.go
@@ -1,0 +1,14 @@
+package nlenc
+
+import "bytes"
+
+// Bytes returns a null-terminated byte slice with the contents of s.
+func Bytes(s string) []byte {
+	return append([]byte(s), 0x00)
+}
+
+// String returns a string with the contents of b from a null-terminated
+// byte slice.
+func String(b []byte) string {
+	return string(bytes.TrimSuffix(b, []byte{0x00}))
+}

--- a/vendor/github.com/mdlayher/netlink/rawconn_gteq_1.12.go
+++ b/vendor/github.com/mdlayher/netlink/rawconn_gteq_1.12.go
@@ -1,0 +1,12 @@
+//+build go1.12
+
+package netlink
+
+import (
+	"os"
+	"syscall"
+)
+
+func newRawConn(fd *os.File) (syscall.RawConn, error) {
+	return fd.SyscallConn()
+}

--- a/vendor/github.com/mdlayher/netlink/rawconn_lt_1.12.go
+++ b/vendor/github.com/mdlayher/netlink/rawconn_lt_1.12.go
@@ -1,0 +1,32 @@
+//+build !go1.12
+
+package netlink
+
+import (
+	"os"
+	"syscall"
+)
+
+func newRawConn(fd *os.File) (syscall.RawConn, error) {
+	return &rawConn{fd: fd.Fd()}, nil
+}
+
+var _ syscall.RawConn = &rawConn{}
+
+// A rawConn is a syscall.RawConn.
+type rawConn struct {
+	fd uintptr
+}
+
+func (rc *rawConn) Control(f func(fd uintptr)) error {
+	f(rc.fd)
+	return nil
+}
+
+func (rc *rawConn) Read(_ func(fd uintptr) (done bool)) error {
+	return notSupported("syscall-conn-read")
+}
+
+func (rc *rawConn) Write(_ func(fd uintptr) (done bool)) error {
+	return notSupported("syscall-conn-write")
+}

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_386.go
@@ -443,6 +443,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -451,6 +479,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -576,6 +607,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -650,6 +682,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_amd64.go
@@ -444,6 +444,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -452,6 +480,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -577,6 +608,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -651,6 +683,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_arm.go
@@ -447,6 +447,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -455,6 +483,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -580,6 +611,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -654,6 +686,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_arm64.go
@@ -445,6 +445,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -453,6 +481,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -578,6 +609,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -652,6 +684,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips.go
@@ -446,6 +446,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -454,6 +482,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -579,6 +610,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -653,6 +685,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips64.go
@@ -445,6 +445,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -453,6 +481,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -578,6 +609,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -652,6 +684,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mips64le.go
@@ -445,6 +445,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -453,6 +481,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -578,6 +609,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -652,6 +684,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_mipsle.go
@@ -446,6 +446,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -454,6 +482,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -579,6 +610,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -653,6 +685,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64.go
@@ -446,6 +446,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -454,6 +482,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -579,6 +610,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -653,6 +685,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_ppc64le.go
@@ -446,6 +446,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -454,6 +482,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -579,6 +610,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -653,6 +685,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_riscv64.go
@@ -445,6 +445,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -453,6 +481,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -578,6 +609,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -652,6 +684,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_s390x.go
@@ -444,6 +444,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -452,6 +480,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -577,6 +608,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -651,6 +683,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (

--- a/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
+++ b/vendor/golang.org/x/sys/unix/ztypes_linux_sparc64.go
@@ -448,6 +448,34 @@ const (
 )
 
 const (
+	NDA_UNSPEC           = 0x0
+	NDA_DST              = 0x1
+	NDA_LLADDR           = 0x2
+	NDA_CACHEINFO        = 0x3
+	NDA_PROBES           = 0x4
+	NDA_VLAN             = 0x5
+	NDA_PORT             = 0x6
+	NDA_VNI              = 0x7
+	NDA_IFINDEX          = 0x8
+	NDA_MASTER           = 0x9
+	NDA_LINK_NETNSID     = 0xa
+	NDA_SRC_VNI          = 0xb
+	NTF_USE              = 0x1
+	NTF_SELF             = 0x2
+	NTF_MASTER           = 0x4
+	NTF_PROXY            = 0x8
+	NTF_EXT_LEARNED      = 0x10
+	NTF_OFFLOADED        = 0x20
+	NTF_ROUTER           = 0x80
+	NUD_INCOMPLETE       = 0x1
+	NUD_REACHABLE        = 0x2
+	NUD_STALE            = 0x4
+	NUD_DELAY            = 0x8
+	NUD_PROBE            = 0x10
+	NUD_FAILED           = 0x20
+	NUD_NOARP            = 0x40
+	NUD_PERMANENT        = 0x80
+	NUD_NONE             = 0x0
 	IFA_UNSPEC           = 0x0
 	IFA_ADDRESS          = 0x1
 	IFA_LOCAL            = 0x2
@@ -456,6 +484,9 @@ const (
 	IFA_ANYCAST          = 0x5
 	IFA_CACHEINFO        = 0x6
 	IFA_MULTICAST        = 0x7
+	IFA_FLAGS            = 0x8
+	IFA_RT_PRIORITY      = 0x9
+	IFA_TARGET_NETNSID   = 0xa
 	IFLA_UNSPEC          = 0x0
 	IFLA_ADDRESS         = 0x1
 	IFLA_BROADCAST       = 0x2
@@ -581,6 +612,7 @@ const (
 	SizeofRtMsg          = 0xc
 	SizeofRtNexthop      = 0x8
 	SizeofNdUseroptmsg   = 0x10
+	SizeofNdMsg          = 0xc
 )
 
 type NlMsghdr struct {
@@ -655,6 +687,16 @@ type NdUseroptmsg struct {
 	Icmp_code uint8
 	Pad2      uint16
 	Pad3      uint32
+}
+
+type NdMsg struct {
+	Family  uint8
+	Pad1    uint8
+	Pad2    uint16
+	Ifindex int32
+	State   uint16
+	Flags   uint8
+	Type    uint8
 }
 
 const (


### PR DESCRIPTION
Fixes #1186

This PR will swap out vishvananda/netlink in favor of jsimonetti/rtnetlink.
It is functionally complete.

I am unsure about the `route add` subcommand and made some educated guesses about what the functionality should be. I am confused that the nexthop needs to be a CIDR instead of an IP.
Please be sure to review that part with additional scrutiny.

All other commands reflect the original commands output and function. Some additional formatting and info was added to the `neigh` and `link` subcommands so more closely resemble iproute2.