### PR TITLE
cpu: run as init

### DIFF
--- a/pkg/uroot/util/root_linux.go
+++ b/pkg/uroot/util/root_linux.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux
-
 // Package util contains various u-root utility functions.
 package util
 
@@ -14,6 +12,7 @@ import (
 	"os"
 	"runtime"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/u-root/u-root/pkg/cmdline"
@@ -230,4 +229,21 @@ func Rootfs() {
 		create(cgroupsnamespace)
 	}
 
+}
+
+// FindFileSystem returns nil if a file system is installed.
+// It rereads /proc/filesystems each time as the supported file systems can change
+// as modules are added and removed.
+func FindFileSystem(fs string) error {
+	b, err := ioutil.ReadFile("/proc/filesystems")
+	if err != nil {
+		return err
+	}
+	for _, l := range strings.Split(string(b), "\n") {
+		f := strings.Fields(l)
+		if (len(f) > 1 && f[0] == "nodev" && f[1] == fs) || (len(f) > 0 && f[0] != "nodev" && f[0] == fs) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s not found", fs)
 }

--- a/pkg/uroot/util/root_linux_test.go
+++ b/pkg/uroot/util/root_linux_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package util
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFindFileSystem(t *testing.T) {
+	var tests = []struct {
+		name string
+		err  string
+	}{
+		{"rootfs", "<nil>"},
+		{"bogusfs", "bogusfs not found"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := FindFileSystem(tt.name)
+			// There has to be a better way to do this.
+			if fmt.Sprintf("%v", err) != tt.err {
+				t.Errorf("%s: got %v, want %v", tt.name, err, tt.err)
+			}
+		})
+	}
+}

--- a/xcmds/cpu/doc.go
+++ b/xcmds/cpu/doc.go
@@ -1,4 +1,4 @@
-// Copyright 2019 the u-root Authors. All rights reserved
+// Copyright 2018-2019 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -62,4 +62,70 @@
 //           Indicates we are the remote side of the cpu session
 //     -srv string
 //           what server to run (default "unpfs")
+// Examples
+// In these examples, cpu runs with warning messages enabled.
+// The first message is a warning that cpu could not use overlayfs to build a
+// a reasonable union mount. The next are showing you what it is mounting, the
+// union mount having failed.
+// These mounts are the best we could do for a reasonable compromise of
+// wanting local resources visible (e.g. /dev) and using resources from the
+// remote machine (e.g. /etc, /lib, /usr and so on).
+// u-root doesn't really need /lib and /usr, and u-root's /etc is minimal by design,
+// so this works.
+// Also note that the user's 9p server running on the local machine is mounted at /tmp/cpu.
+// We can turn these off at some point but for now, in early days, we may want them.
+// Note that these messages come from the remote side.
+// cpu to a machine with bash as your shell and run a command
+//   cpu -sp 23 date
+//     2019/05/17 16:53:22 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
+//     2019/05/17 16:53:22 Mounted /tmp/cpu/lib on /lib
+//     2019/05/17 16:53:22 Mounted /tmp/cpu/lib64 on /lib64
+//     2019/05/17 16:53:22 Warning: mounting /tmp/cpu/lib32 on /lib32 failed: no such file or directory
+//     2019/05/17 16:53:22 Mounted /tmp/cpu/usr on /usr
+//     2019/05/17 16:53:22 Mounted /tmp/cpu/bin on /bin
+//     2019/05/17 16:53:22 Mounted /tmp/cpu/etc on /etc
+//     Fri May 17 16:53:23 UTC 2019
+// cpu to a machine and run $SHELL (since no arguments were given)
+// NOTE: $SHELL is NOT installed on the remote machine! It (and all its .so's and . files) 
+// come from the local machine.
+// cpu sp -23
+//    2019/05/17 16:58:04 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
+//    2019/05/17 16:58:04 Mounted /tmp/cpu/lib on /lib
+//    2019/05/17 16:58:04 Mounted /tmp/cpu/lib64 on /lib64
+//    2019/05/17 16:58:04 Warning: mounting /tmp/cpu/lib32 on /lib32 failed: no such file or directory
+//    2019/05/17 16:58:04 Mounted /tmp/cpu/usr on /usr
+//    2019/05/17 16:58:04 Mounted /tmp/cpu/bin on /bin
+//    2019/05/17 16:58:05 Mounted /tmp/cpu/etc on /etc
+//    root@(none):/# echo ~
+//    /tmp/cpu/home/rminnich
+//    root@(none):/# ls ~
+//    IDAPROPASSWORD  go      ida-7.2  projects            salishan2019random~
+//    bin             gopath  papers   salishan2019random  snap
+//    root@(none):/#
+//    # Now that we are on the node, modprobe something
+//    root@(none):/# depmod
+//    depmod: ERROR: could not open directory /lib/modules/5.0.0-rc3+: No such file or directory
+//    depmod: FATAL: could not search modules: No such file or directory
+//    root@(none):/# 
+//    # Note that, if we had the right modules on our LOCAL machine for this remote machine, we could
+//    # insert them. This further means you can build a modular kernel in FLASH and insmod needed modules
+//    # later (as long as your core kernel has networking, that is!). Modules could include, e.g., an AHCI
+//    # driver.
+//    # run the lspci command but redirect output to ~
+//    # note it is not installed on the remote machine; it comes from our local machine.
+//    root@(none):/# lspci
+//    00:00.0 Host bridge: Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
+//    00:01.0 VGA compatible controller: Device 1234:1111 (rev 02)
+//    00:02.0 Unclassified device [00ff]: Red Hat, Inc. Virtio RNG
+//    00:03.0 Ethernet controller: Intel Corporation 82540EM Gigabit Ethernet Controller (rev 03)
+//    00:1f.0 ISA bridge: Intel Corporation 82801IB (ICH9) LPC Interface Controller (rev 02)
+//    00:1f.2 SATA controller: Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode] (rev 02)
+//    00:1f.3 SMBus: Intel Corporation 82801I (ICH9 Family) SMBus Controller (rev 02)
+//    root@(none):/# lspci > ~/xyz
+//    root@(none):/# exit
+//    # exit and notice that file is on my local machine now:
+//    exit
+//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/xcmds/cpu$ ls -l ~/xyz
+//    -rw-r--r-- 1 rminnich rminnich 577 May 17 17:06 /home/rminnich/xyz
+//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/xcmds/cpu$
 package main

--- a/xcmds/cpu/init.go
+++ b/xcmds/cpu/init.go
@@ -1,0 +1,61 @@
+// Copyright 2018-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This is init code for the case that cpu finds itself as pid 1.
+// This is duplicative of the real init, but we're implementing it
+// as a duplicate so we can get some idea of:
+// what an init package should have
+// what an init interface should have
+// So we take a bit of duplication now to better understand these
+// things. We also assume for now this is a busybox environment.
+// It is unusual (I guess?) for cpu to be an init in anything else.
+// So far, the case for an init pkg is not as strong as I thought
+// it might be.
+package main
+
+import (
+	"flag"
+	"log"
+	"os/exec"
+	"syscall"
+
+	"github.com/u-root/u-root/pkg/uroot/util"
+)
+
+var (
+	test     = flag.Bool("test", false, "Test mode: don't try to set control tty")
+	osInitGo = func() {}
+)
+
+func cpuSetup() error {
+	log.Printf("Welcome to Plan 9(tm)!")
+	util.Rootfs()
+	log.Printf("Done Rootfs")
+	osInitGo()
+	// TODO: this needs to be added as prt of the Rootfs() stuff
+	if o, err := exec.Command("ip", "link", "set", "dev", "lo", "up").CombinedOutput(); err != nil {
+		log.Fatalf("ip link set dev lo: %v (%v)", string(o), err)
+	}
+	return nil
+}
+
+func cpuDone(c chan int) {
+	// We need to reap all children before exiting.
+	var procs int
+	log.Printf("init: Waiting for orphaned children")
+	for {
+		var s syscall.WaitStatus
+		var r syscall.Rusage
+		p, err := syscall.Wait4(-1, &s, 0, &r)
+		if p == -1 {
+			break
+		}
+		log.Printf("%v: exited with %v, status %v, rusage %v", p, err, s, r)
+		procs++
+	}
+	log.Printf("cpu: All commands exited")
+	log.Printf("cpu: Syncing filesystems")
+	syscall.Sync()
+	c <- procs
+}


### PR DESCRIPTION
cpu will do init-like things if it is run as pid 1, or the optional -init flag is supplied.

Building and testing with qemu:

```
go run . -build=bb -files ssh_host_rsa_key:etc/ssh/ssh_host_rsa_key -initcmd=/bbin/cpu -files ~/.ssh/cpu_rsa.pub:key.pub all github.com/u-root/u-root/xcmds/cpu

sudo /usr/bin/qemu-system-x86_64 -kernel \
     /home/rminnich/projects/linuxboot/linux/arch/x86/boot/bzImage \
	-cpu  max \
     -s   \
     -m 1024m \
     -machine q35  \
     -initrd /tmp/initramfs.linux_amd64.cpio \
    -object rng-random,filename=/dev/urandom,id=rng0 \
    -device virtio-rng-pci,rng=rng0 \
     -device e1000,netdev=n1 \
     -netdev user,id=n1,hostfwd=tcp:127.0.0.1:23-:2222,net=192.168.1.0/24,host=192.168.1.1 \
     -serial stdio  \
     -append earlyprintk=ttyS0,115200\ console=ttyS0 \
     -monitor /dev/null  \
```

Choosing what and how to mount where was a real pain.
This would all be far simpler if linux had a usable unionfs. overlay
file system doesn't count, it's just not usable for this purpose.

I wrote one in 1996 that implemented plan 9 style unions but could never get them to
use it. It was about 200 lines.

http://www.drdobbs.com/private-namespaces-for-linux/184404878

example usage:

cpu to the port redirect we set up in the qemu command, setting server port to 23 and running bash.
The bash will come from the node we are on via the 9p mount.

```
rminnich@xcpu:~/gopath/src/github.com/u-root/u-root$ cpu -sp 23 -h 127.0.0.1  bash
2019/04/25 17:02:29 Overlayfs mount failed: invalid argument. Proceeding with selective mounts from /tmp/cpu into /
2019/04/25 17:02:29 Mounted /tmp/cpu/lib on /lib
2019/04/25 17:02:29 Mounted /tmp/cpu/lib64 on /lib64
2019/04/25 17:02:29 Warning: mounting /tmp/cpu/lib32 on /lib32 failed: no such file or directory
2019/04/25 17:02:29 Mounted /tmp/cpu/usr on /usr
2019/04/25 17:02:29 Mounted /tmp/cpu/bin on /bin
2019/04/25 17:02:29 Mounted /tmp/cpu/etc on /etc
root@(none):/# ls -l /tmp/cpu/tmp # show the tmp on the machine we came from
total 34176
drwxrwxr-x 1 root root     4096 Apr 24 15:41 a
drwxrwxr-x 2 root root     4096 Apr 24 15:32 b
drwxrwxr-x 2 root root     4096 Apr 24 15:38 c
-rwxr-xr-x 1 root root 17482088 Apr 25 17:01 initramfs.linux_amd64.cpio
drwxrwxr-x 2 root root     4096 Apr 24 15:41 lower
-rwxr-xr-x 1 root root 17429440 Apr 19 21:08 ls
drwxrwxr-x 2 root root     4096 Apr 24 15:40 merged
drwxrwxr-x 2 root root     4096 Apr 24 15:40 overlay
-rw------- 1 root root       98 Apr 19 00:22 serverauth.SNZGdwspM2
-rw-r--r-- 1 root root    10018 Apr 25 01:03 shit
drwx------ 2 root root     4096 Apr 19 00:22 ssh-j54g5ZYpdfrl
drwx------ 3 root root     4096 Apr 22 19:50 systemd-private-3adc037b922b4002a24164205c1b0e84-systemd-resolved.service-ryr39J
drwx------ 3 root root     4096 Apr 22 19:50 systemd-private-3adc037b922b4002a24164205c1b0e84-systemd-timesyncd.service-jmvUhp
drwxrwxr-x 2 root root     4096 Apr 24 15:41 upper
drwx------ 2 root root     4096 Apr 19 00:21 vmware-root
drwx------ 2 root root     4096 Apr 22 19:50 vmware-root_101358-852028269
drwx------ 2 root root     4096 Apr 22 19:50 vmware-root_101437-2108977411
drwx------ 2 root root     4096 Apr 19 00:05 vmware-root_520-2957059313
drwxrwxr-x 3 root root     4096 Apr 25 01:03 work
root@(none):/# ls ~ # show $HOME
IDAPROPASSWORD  go      ida-7.2  projects            salishan2019random~
bin             gopath  papers   salishan2019random  snap
root@(none):/# exit
rminnich@xcpu:~/gopath/src/github.com/u-root/u-root$
```