### PR TITLE
integration: Rename bzImage to kernel

### DIFF
--- a/integration/integration.go
+++ b/integration/integration.go
@@ -282,9 +282,9 @@ func QEMU(o *Options) (*qemu.Options, error) {
 		return nil, err
 	}
 
-	// Copy kernel to tmpDir.
-	bzImage := filepath.Join(tmpDir, "bzImage")
-	if err := cp.Copy(os.Getenv("UROOT_KERNEL"), bzImage); err != nil {
+	// Copy kernel to tmpDir for tests involving kexec.
+	kernel := filepath.Join(tmpDir, "kernel")
+	if err := cp.Copy(os.Getenv("UROOT_KERNEL"), kernel); err != nil {
 		return nil, err
 	}
 
@@ -308,7 +308,7 @@ func QEMU(o *Options) (*qemu.Options, error) {
 
 	return &qemu.Options{
 		Initramfs:    outputFile,
-		Kernel:       bzImage,
+		Kernel:       kernel,
 		KernelArgs:   kernelArgs,
 		SerialOutput: logFile,
 		Timeout:      o.Timeout,

--- a/integration/testcmd/kexec/uinit/kexec.go
+++ b/integration/testcmd/kexec/uinit/kexec.go
@@ -35,7 +35,7 @@ func main() {
 		sh.RunOrDie("kexec",
 			"-i", "/testdata/initramfs.cpio",
 			"-c", cmdLine,
-			"/testdata/bzImage")
+			"/testdata/kernel")
 	} else {
 		unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF)
 	}

--- a/integration/testdata/pxe/pxelinux.cfg/default
+++ b/integration/testdata/pxe/pxelinux.cfg/default
@@ -1,4 +1,4 @@
 DEFAULT normal
 
 LABEL normal
-LINUX bzImage
+LINUX kernel


### PR DESCRIPTION
Calling it a bzImage is confusing for non-x86 platforms.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>