### PR TITLE
u-root: automagically adjust absolute paths with a warning

### DIFF
--- a/pkg/uroot/initramfs/files.go
+++ b/pkg/uroot/initramfs/files.go
@@ -6,6 +6,7 @@ package initramfs
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -52,7 +53,12 @@ func (af *Files) addFile(src string, dest string, follow bool) error {
 	src = filepath.Clean(src)
 	dest = path.Clean(dest)
 	if path.IsAbs(dest) {
-		return fmt.Errorf("archive path %q must not be absolute (host source %q)", dest, src)
+		r, err := filepath.Rel("/", dest)
+		if err != nil {
+			return fmt.Errorf("%q is an absolute path and can't make it relative to /: %v", dest, err)
+		}
+		log.Printf("Warning: You used an absolute path %q and it was adjusted to %q", dest, r)
+		dest = r
 	}
 
 	// We check if it's a directory first. If a directory already exists as

--- a/pkg/uroot/initramfs/files_test.go
+++ b/pkg/uroot/initramfs/files_test.go
@@ -196,10 +196,19 @@ func TestFilesAddFile(t *testing.T) {
 			},
 		},
 		{
-			name:        "destination path must not be absolute",
-			src:         regularFile.Name(),
-			dest:        "/bar/foo",
-			errContains: "must not be absolute",
+			name: "absolute destination paths are made relative",
+			af: &Files{
+				Files: map[string]string{},
+			},
+			src:  dir,
+			dest: "/bar/foo",
+			result: &Files{
+				Files: map[string]string{
+					"bar/foo":      dir,
+					"bar/foo/foo":  filepath.Join(dir, "foo"),
+					"bar/foo/foo2": filepath.Join(dir, "foo2"),
+				},
+			},
 		},
 		{
 			name: "add a directory",

--- a/uroot_test.go
+++ b/uroot_test.go
@@ -95,6 +95,14 @@ func TestUrootCmdline(t *testing.T) {
 			},
 		},
 		{
+			name: "fix usage of an absolute path",
+			args: []string{"-nocmd", "-files=/bin:/bin"},
+			err:  nil,
+			validators: []itest.ArchiveValidator{
+				itest.HasFile{"bin/bash"},
+			},
+		},
+		{
 			name: "include multiple extra files",
 			args: []string{"-nocmd", "-files=/bin/bash", "-files=/bin/ls", fmt.Sprintf("-files=%s", samplef.Name())},
 			validators: []itest.ArchiveValidator{


### PR DESCRIPTION
u-root will not create archives with absolute paths in them.
It's too dangerous: one wrong command in a wrong window and
your machine is toast. I've done it.

The path rewrite commands of the form -files /etc:/etc
were therefore forbidden, but people find this inconvenient.

Now, when we have an absolute path as the destination, we will
adjust it to be relative to /.

A test is included.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>