### PR TITLE
kexec: remove rsdp command line parameter.

### DIFF
--- a/pkg/kexec/kexec_linux_amd64.go
+++ b/pkg/kexec/kexec_linux_amd64.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/u-root/u-root/pkg/acpi"
 	"golang.org/x/sys/unix"
 )
 
@@ -23,11 +22,6 @@ func FileLoad(kernel, ramfs *os.File, cmdline string) error {
 		ramfsfd = int(ramfs.Fd())
 	} else {
 		flags |= unix.KEXEC_FILE_NO_INITRAMFS
-	}
-
-	if base, _, err := acpi.GetRSDP(); err != nil {
-		// Prepend the RSDP.
-		cmdline = fmt.Sprintf("acpi_rsdp=%#x %s", base, cmdline)
 	}
 
 	if err := unix.KexecFileLoad(int(kernel.Fd()), ramfsfd, cmdline, flags); err != nil {


### PR DESCRIPTION
With the fixrsdp command, there should no longer be a need for this
command line parameter. This was also wrong as it only ever added the
parameter if we got an error back.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>