### PR TITLE
Improve behavior of mount.SwitchRoot

### DIFF
--- a/pkg/mount/switch_root_linux.go
+++ b/pkg/mount/switch_root_linux.go
@@ -224,7 +224,7 @@ func NewRoot(newRoot string) error {
 
 	log.Printf("switch_root: Deleting old /")
 	if err := RecursiveDelete(int(oldRoot.Fd())); err != nil {
-		panic(err)
+		return err
 	}
 	return nil
 }

--- a/pkg/mount/switch_root_linux.go
+++ b/pkg/mount/switch_root_linux.go
@@ -147,17 +147,9 @@ func AddSpecialMounts(newRoot string) error {
 			log.Printf("switch_root: Skipping %q as it is not a mount", mount)
 			continue
 		}
-		// Make sure the target dir exists and is empty.
-		fi, err := os.Stat(path)
-		if os.IsNotExist(err) {
-			if err := unix.Mkdir(path, 0); err != nil {
-				return err
-			}
-		} else if err != nil {
+		// Make sure the target dir exists.
+		if err := os.MkdirAll(path, 0755); err != nil {
 			return err
-		}
-		if !fi.IsDir() {
-			return fmt.Errorf("%q must be a dir", path)
 		}
 		if err := MoveMount(mount, path); err != nil {
 			return err

--- a/pkg/mount/switch_root_linux.go
+++ b/pkg/mount/switch_root_linux.go
@@ -148,17 +148,14 @@ func AddSpecialMounts(newRoot string) error {
 			continue
 		}
 		// Make sure the target dir exists and is empty.
-		if _, err := os.Stat(path); os.IsNotExist(err) {
+		if fi, err := os.Stat(path); os.IsNotExist(err) {
 			if err := unix.Mkdir(path, 0); err != nil {
 				return err
 			}
 		} else if err != nil {
 			return err
-		}
-		if empty, err := DirIsEmpty(path); err != nil {
-			return err
-		} else if !empty {
-			return fmt.Errorf("%v must be empty", path)
+		} else if !fi.IsDir() {
+			return fmt.Errorf("%v must be a dir", path)
 		}
 		if err := MoveMount(mount, path); err != nil {
 			return err

--- a/pkg/mount/switch_root_linux.go
+++ b/pkg/mount/switch_root_linux.go
@@ -126,19 +126,26 @@ func MoveMount(oldPath string, newPath string) error {
 // 'special' in this context refers to the following non-blockdevice backed
 // mounts that are almost always used: /dev, /proc, /sys, and /run.
 // This function will create the target directories, if necessary.
-// If the target directories already exists, they must be empty.
+// If the target directories already exist, they must be empty.
 // This function skips missing mounts.
 func AddSpecialMounts(newRoot string) error {
 	var mounts = []string{"/dev", "/proc", "/sys", "/run"}
 
 	for _, mount := range mounts {
 		path := filepath.Join(newRoot, mount)
-		// Skip all mounting if the directory does not exists.
+		// Skip all mounting if the directory does not exist.
 		if _, err := os.Stat(mount); os.IsNotExist(err) {
-			fmt.Println("switch_root: Skipping", mount)
+			log.Printf("switch_root: Skipping %s as the dir does not exist", mount)
 			continue
 		} else if err != nil {
 			return err
+		}
+		// Also skip if not currently a mount point
+		if same, err := SameFilesystem("/", mount); err != nil {
+			return err
+		} else if same {
+			log.Printf("switch_root: Skipping %s as it is not a mount", mount)
+			continue
 		}
 		// Make sure the target dir exists and is empty.
 		if _, err := os.Stat(path); os.IsNotExist(err) {
@@ -158,6 +165,20 @@ func AddSpecialMounts(newRoot string) error {
 		}
 	}
 	return nil
+}
+
+// SameFilesystem returns true if both paths reside in the same filesystem.
+// This is achieved by comparing Stat_t.Dev, which contains the fs device's
+// major/minor numbers.
+func SameFilesystem(path1, path2 string) (bool, error) {
+	var stat1, stat2 unix.Stat_t
+	if err := unix.Stat(path1, &stat1); err != nil {
+		return false, err
+	}
+	if err := unix.Stat(path2, &stat2); err != nil {
+		return false, err
+	}
+	return stat1.Dev == stat2.Dev, nil
 }
 
 // SwitchRoot moves special mounts (dev, proc, sys, run) to the new directory,

--- a/pkg/mount/switch_root_linux.go
+++ b/pkg/mount/switch_root_linux.go
@@ -135,7 +135,7 @@ func AddSpecialMounts(newRoot string) error {
 		path := filepath.Join(newRoot, mount)
 		// Skip all mounting if the directory does not exist.
 		if _, err := os.Stat(mount); os.IsNotExist(err) {
-			log.Printf("switch_root: Skipping %s as the dir does not exist", mount)
+			log.Printf("switch_root: Skipping %q as the dir does not exist", mount)
 			continue
 		} else if err != nil {
 			return err
@@ -144,18 +144,20 @@ func AddSpecialMounts(newRoot string) error {
 		if same, err := SameFilesystem("/", mount); err != nil {
 			return err
 		} else if same {
-			log.Printf("switch_root: Skipping %s as it is not a mount", mount)
+			log.Printf("switch_root: Skipping %q as it is not a mount", mount)
 			continue
 		}
 		// Make sure the target dir exists and is empty.
-		if fi, err := os.Stat(path); os.IsNotExist(err) {
+		fi, err := os.Stat(path)
+		if os.IsNotExist(err) {
 			if err := unix.Mkdir(path, 0); err != nil {
 				return err
 			}
 		} else if err != nil {
 			return err
-		} else if !fi.IsDir() {
-			return fmt.Errorf("%v must be a dir", path)
+		}
+		if !fi.IsDir() {
+			return fmt.Errorf("%q must be a dir", path)
 		}
 		if err := MoveMount(mount, path); err != nil {
 			return err


### PR DESCRIPTION
* do not move special mounts if they aren't mounts
* do not panic on error
* allow target dirs to be non-empty