### PR TITLE
Higher-level multiboot interface

### DIFF
--- a/cmds/kexec/kexec_linux.go
+++ b/cmds/kexec/kexec_linux.go
@@ -104,13 +104,12 @@ func main() {
 		if mbk {
 			log.Printf("%s is a multiboot v1 kernel.", kernelpath)
 			image = &boot.MultibootImage{
-				Debug:   opts.debug,
 				Modules: opts.modules,
 				Path:    kernelpath,
 				Cmdline: newCmdline,
 			}
 		}
-		if err := image.Load(); err != nil {
+		if err := image.Load(opts.debug); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmds/kexec/kexec_linux.go
+++ b/cmds/kexec/kexec_linux.go
@@ -62,8 +62,6 @@ type file struct {
 }
 
 type mboot struct {
-	debug   bool
-	modules []string
 }
 
 func (f file) Load(path, cmdLine string) error {
@@ -85,23 +83,7 @@ func (f file) Load(path, cmdLine string) error {
 }
 
 func (mb mboot) Load(path, cmdLine string) error {
-	// Trampoline should be a part of current binary.
-	p, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("Cannot find current executable path: %v", err)
-	}
-	trampoline, err := filepath.EvalSymlinks(p)
-	if err != nil {
-		return fmt.Errorf("Cannot eval symlinks for %v: %v", p, err)
-	}
-	m := multiboot.New(path, cmdLine, trampoline, mb.modules)
-	if err := m.Load(mb.debug); err != nil {
-		return fmt.Errorf("Load failed: %v", err)
-	}
-	if err := kexec.Load(m.EntryPoint, m.Segments(), 0); err != nil {
-		return fmt.Errorf("kexec.Load() error: %v", err)
-	}
-	return nil
+	return multiboot.Load(mb.debug, path, cmdLine, mb.modules)
 }
 
 func main() {

--- a/cmds/kexec/kexec_linux.go
+++ b/cmds/kexec/kexec_linux.go
@@ -81,31 +81,19 @@ func main() {
 		}
 	}
 
-	// mbk indicates that we are a multiboot kernel
-	var mbk bool
-	var kernelpath string
 	if opts.load {
-		kernelpath = flag.Arg(0)
-		log.Printf("Loading %s for kernel.", kernelpath)
-
-		if err := multiboot.Probe(kernelpath); err == nil {
-			mbk = true
-		} else if err == multiboot.ErrFlagsNotSupported {
-			log.Fatal(err)
-		}
-	}
-	if opts.load {
+		kernelpath := flag.Arg(0)
 		var image boot.OSImage
-		image = &boot.LinuxImage{
-			Kernel:  uio.NewLazyFile(kernelpath),
-			Initrd:  uio.NewLazyFile(opts.initramfs),
-			Cmdline: newCmdline,
-		}
-		if mbk {
-			log.Printf("%s is a multiboot v1 kernel.", kernelpath)
+		if err := multiboot.Probe(kernelpath); err == nil {
 			image = &boot.MultibootImage{
 				Modules: opts.modules,
 				Path:    kernelpath,
+				Cmdline: newCmdline,
+			}
+		} else {
+			image = &boot.LinuxImage{
+				Kernel:  uio.NewLazyFile(kernelpath),
+				Initrd:  uio.NewLazyFile(opts.initramfs),
 				Cmdline: newCmdline,
 			}
 		}

--- a/cmds/pxeboot/pxeboot.go
+++ b/cmds/pxeboot/pxeboot.go
@@ -80,7 +80,10 @@ func Netboot(ifaceNames string) error {
 				img.ExecutionInfo(log.New(os.Stderr, "", log.LstdFlags))
 				return nil
 			}
-			if err := img.Execute(); err != nil {
+			if err := img.Load(); err != nil {
+				return fmt.Errorf("kexec load of %v failed: %v", img, err)
+			}
+			if err := boot.Execute(); err != nil {
 				return fmt.Errorf("kexec of %v failed: %v", img, err)
 			}
 

--- a/cmds/pxeboot/pxeboot.go
+++ b/cmds/pxeboot/pxeboot.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"net"
 	"net/url"
-	"os"
 	"path"
 	"regexp"
 	"time"
@@ -76,12 +75,11 @@ func Netboot(ifaceNames string) error {
 			cancel()
 			log.Printf("Got configuration: %s", img)
 
-			if *dryRun {
-				img.ExecutionInfo(log.New(os.Stderr, "", log.LstdFlags))
-				return nil
-			}
-			if err := img.Load(); err != nil {
+			if err := img.Load(*dryRun); err != nil {
 				return fmt.Errorf("kexec load of %v failed: %v", img, err)
+			}
+			if *dryRun {
+				return nil
 			}
 			if err := boot.Execute(); err != nil {
 				return fmt.Errorf("kexec of %v failed: %v", img, err)

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -8,7 +8,6 @@ package boot
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/u-root/u-root/pkg/kexec"
 )
@@ -17,16 +16,16 @@ import (
 type OSImage interface {
 	fmt.Stringer
 
-	// ExecutionInfo prints information about the OS image. A user should
-	// be able to use the kexec command line tool to execute the OSImage
-	// given the printed information.
-	ExecutionInfo(log *log.Logger)
-
 	// Load loads the OS image into kernel memory, ready for execution.
-	Load() error
+	//
+	// After Load is called, call boot.Execute() to stop Linux and boot the
+	// loaded OSImage.
+	Load(verbose bool) error
 }
 
 // Execute executes a previously loaded OSImage.
+//
+// This will only work if OSImage.Load was called on some OSImage.
 func Execute() error {
 	return kexec.Reboot()
 }

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -2,11 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package boot is the high-level interface for booting another operating
+// system.
 package boot
 
 import (
 	"fmt"
 	"log"
+
+	"github.com/u-root/u-root/pkg/kexec"
 )
 
 // OSImage represents a bootable OS package.
@@ -18,7 +22,11 @@ type OSImage interface {
 	// given the printed information.
 	ExecutionInfo(log *log.Logger)
 
-	// Execute kexec's the OS image: it loads the OS image into memory and
-	// jumps to the kernel's entry point.
-	Execute() error
+	// Load loads the OS image into kernel memory, ready for execution.
+	Load() error
+}
+
+// Execute executes a previously loaded OSImage.
+func Execute() error {
+	return kexec.Reboot()
 }

--- a/pkg/boot/linux.go
+++ b/pkg/boot/linux.go
@@ -74,8 +74,8 @@ func (li *LinuxImage) ExecutionInfo(l *log.Logger) {
 	l.Printf("Command line: %s", li.Cmdline)
 }
 
-// Execute implements OSImage.Execute and kexec's the kernel with its initramfs.
-func (li *LinuxImage) Execute() error {
+// Load implements OSImage.Load and kexec_load's the kernel with its initramfs.
+func (li *LinuxImage) Load() error {
 	if li.Kernel == nil {
 		return errors.New("LinuxImage.Kernel must be non-nil")
 	}
@@ -95,8 +95,5 @@ func (li *LinuxImage) Execute() error {
 		defer i.Close()
 	}
 
-	if err := kexec.FileLoad(k, i, li.Cmdline); err != nil {
-		return err
-	}
-	return kexec.Reboot()
+	return kexec.FileLoad(k, i, li.Cmdline)
 }

--- a/pkg/boot/linux.go
+++ b/pkg/boot/linux.go
@@ -50,32 +50,8 @@ func copyToFile(r io.Reader) (*os.File, error) {
 	return readOnlyF, nil
 }
 
-// ExecutionInfo implements OSImage.ExecutionInfo.
-func (li *LinuxImage) ExecutionInfo(l *log.Logger) {
-	k, err := copyToFile(uio.Reader(li.Kernel))
-	if err != nil {
-		l.Printf("Copying kernel to file: %v", err)
-	}
-	defer k.Close()
-
-	var i *os.File
-	if li.Initrd != nil {
-		i, err = copyToFile(uio.Reader(li.Initrd))
-		if err != nil {
-			l.Printf("Copying initrd to file: %v", err)
-		}
-		defer i.Close()
-	}
-
-	l.Printf("Kernel: %s", k.Name())
-	if i != nil {
-		l.Printf("Initrd: %s", i.Name())
-	}
-	l.Printf("Command line: %s", li.Cmdline)
-}
-
 // Load implements OSImage.Load and kexec_load's the kernel with its initramfs.
-func (li *LinuxImage) Load() error {
+func (li *LinuxImage) Load(verbose bool) error {
 	if li.Kernel == nil {
 		return errors.New("LinuxImage.Kernel must be non-nil")
 	}
@@ -95,5 +71,10 @@ func (li *LinuxImage) Load() error {
 		defer i.Close()
 	}
 
+	log.Printf("Kernel: %s", k.Name())
+	if i != nil {
+		log.Printf("Initrd: %s", i.Name())
+	}
+	log.Printf("Command line: %s", li.Cmdline)
 	return kexec.FileLoad(k, i, li.Cmdline)
 }

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/u-root/u-root/pkg/kexec"
 	"github.com/u-root/u-root/pkg/multiboot"
 )
 
@@ -30,17 +29,7 @@ func (MultibootImage) ExecutionInfo(log *log.Logger) {
 
 // Load implements OSImage.Load.
 func (mi *MultibootImage) Load() error {
-	m, err := multiboot.New(mi.Path, mi.Cmdline, mi.Modules)
-	if err != nil {
-		return err
-	}
-	if err := m.Load(mi.Debug); err != nil {
-		return err
-	}
-	if err := kexec.Load(m.EntryPoint, m.Segments(), 0); err != nil {
-		return fmt.Errorf("kexec.Load() error: %v", err)
-	}
-	return nil
+	return multiboot.Load(mi.Debug, mi.Path, mi.Cmdline, mi.Modules)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -7,6 +7,7 @@ package boot
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/u-root/u-root/pkg/multiboot"
 )
@@ -33,6 +34,7 @@ func (mi *MultibootImage) Load() error {
 }
 
 // String implements fmt.Stringer.
-func (MultibootImage) String() string {
-	return fmt.Sprintf("multiboot images unimplemented")
+func (mi *MultibootImage) String() string {
+	return fmt.Sprintf("MultibootImage(\n  KernelPath: %s\n  Cmdline: %s\n  Modules: %s\n)",
+		mi.Path, mi.Cmdline, strings.Join(mi.Modules, ", "))
 }

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -6,7 +6,6 @@ package boot
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/u-root/u-root/pkg/multiboot"
@@ -15,7 +14,6 @@ import (
 // MultibootImage is a multiboot-formated OSImage, such as ESXi, Xen, Akaros,
 // tboot.
 type MultibootImage struct {
-	Debug   bool
 	Path    string
 	Cmdline string
 	Modules []string
@@ -23,14 +21,9 @@ type MultibootImage struct {
 
 var _ OSImage = &MultibootImage{}
 
-// ExecutionInfo implements OSImage.ExecutionInfo.
-func (MultibootImage) ExecutionInfo(log *log.Logger) {
-	log.Printf("Multiboot images are unsupported")
-}
-
 // Load implements OSImage.Load.
-func (mi *MultibootImage) Load() error {
-	return multiboot.Load(mi.Debug, mi.Path, mi.Cmdline, mi.Modules)
+func (mi *MultibootImage) Load(verbose bool) error {
+	return multiboot.Load(verbose, mi.Path, mi.Cmdline, mi.Modules)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -12,7 +12,8 @@ import (
 	"github.com/u-root/u-root/pkg/multiboot"
 )
 
-// MultibootImage is a multiboot-formated OSImage.
+// MultibootImage is a multiboot-formated OSImage, such as ESXi, Xen, Akaros,
+// tboot.
 type MultibootImage struct {
 	Debug   bool
 	Path    string
@@ -27,8 +28,8 @@ func (MultibootImage) ExecutionInfo(log *log.Logger) {
 	log.Printf("Multiboot images are unsupported")
 }
 
-// Execute implements OSImage.Execute.
-func (mi *MultibootImage) Execute() error {
+// Load implements OSImage.Load.
+func (mi *MultibootImage) Load() error {
 	m, err := multiboot.New(mi.Path, mi.Cmdline, mi.Modules)
 	if err != nil {
 		return err
@@ -39,7 +40,7 @@ func (mi *MultibootImage) Execute() error {
 	if err := kexec.Load(m.EntryPoint, m.Segments(), 0); err != nil {
 		return fmt.Errorf("kexec.Load() error: %v", err)
 	}
-	return kexec.Reboot()
+	return nil
 }
 
 // String implements fmt.Stringer.

--- a/pkg/multiboot/description.go
+++ b/pkg/multiboot/description.go
@@ -36,7 +36,7 @@ type Description struct {
 
 // Description returns string representation of
 // multiboot information.
-func (m multiboot) Description() (string, error) {
+func (m multiboot) description() (string, error) {
 	var modules []ModuleDesc
 	for i, mod := range m.loadedModules {
 		name := strings.Fields(m.modules[i])[0]

--- a/pkg/multiboot/description.go
+++ b/pkg/multiboot/description.go
@@ -36,7 +36,7 @@ type Description struct {
 
 // Description returns string representation of
 // multiboot information.
-func (m Multiboot) Description() (string, error) {
+func (m multiboot) Description() (string, error) {
 	var modules []ModuleDesc
 	for i, mod := range m.loadedModules {
 		name := strings.Fields(m.modules[i])[0]

--- a/pkg/multiboot/module.go
+++ b/pkg/multiboot/module.go
@@ -34,7 +34,7 @@ type Module struct {
 
 type modules []Module
 
-func (m *Multiboot) addModules() (uintptr, error) {
+func (m *multiboot) addModules() (uintptr, error) {
 	loaded, data, err := loadModules(m.modules)
 	if err != nil {
 		return 0, err

--- a/pkg/uio/lazy.go
+++ b/pkg/uio/lazy.go
@@ -6,6 +6,7 @@ package uio
 
 import (
 	"io"
+	"os"
 )
 
 // LazyOpener is a lazy io.Reader.
@@ -59,6 +60,16 @@ type LazyOpenerAt struct {
 	r    io.ReaderAt
 	err  error
 	open func() (io.ReaderAt, error)
+}
+
+// NewLazyFile returns a lazy ReaderAt opened from path.
+func NewLazyFile(path string) ReadAtCloser {
+	if len(path) == 0 {
+		return nil
+	}
+	return NewLazyOpenerAt(func() (io.ReaderAt, error) {
+		return os.Open(path)
+	})
 }
 
 // NewLazyOpenerAt returns a lazy io.ReaderAt based on `open`.

--- a/xcmds/esxiboot/esxiboot.go
+++ b/xcmds/esxiboot/esxiboot.go
@@ -171,7 +171,7 @@ func main() {
 		Modules: opts.modules,
 	}
 
-	if err := mi.Load(); err != nil {
+	if err := mi.Load(false /*not verbose*/); err != nil {
 		log.Fatalf("Failed to load multiboot image: %v", err)
 	}
 	if err := boot.Execute(); err != nil {


### PR DESCRIPTION
 - users shouldn't have to figure out what trampoline to use -- it's an implementation detail (make the multiboot package figure it out on its own)
 - use boot.MultibootImage instead of multiboot.Multiboot -- the multiboot package should be internal.