### PR TITLE
multiboot: unexport more internals

### DIFF
--- a/pkg/multiboot/header.go
+++ b/pkg/multiboot/header.go
@@ -21,9 +21,11 @@ var ErrFlagsNotSupported = errors.New("multiboot header flags not supported yet"
 
 const headerMagic = 0x1BADB002
 
+type headerFlag uint32
+
 const (
-	flagHeaderPageAlign  Flag = 0x00000001
-	flagHeaderMemoryInfo      = 0x00000002
+	flagHeaderPageAlign  headerFlag = 0x00000001
+	flagHeaderMemoryInfo            = 0x00000002
 
 	// ignore this flag for now
 	flagHeaderMultibootVideoMode = 0x00000004
@@ -34,7 +36,7 @@ const (
 // mandatory is a mandatory part of Multiboot v1 header.
 type mandatory struct {
 	Magic    uint32
-	Flags    Flag
+	Flags    headerFlag
 	Checksum uint32
 }
 
@@ -52,19 +54,19 @@ type optional struct {
 	Depth    uint32
 }
 
-// Header represents a Multiboot v1 header loaded from the file.
-type Header struct {
+// header represents a Multiboot v1 header loaded from the file.
+type header struct {
 	mandatory
 	optional
 }
 
 // parseHeader parses multiboot header as defined in
 // https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#OS-image-format
-func parseHeader(r io.Reader) (Header, error) {
+func parseHeader(r io.Reader) (header, error) {
 	mandatorySize := binary.Size(mandatory{})
 	optionalSize := binary.Size(optional{})
 	sizeofHeader := mandatorySize + optionalSize
-	var hdr Header
+	var hdr header
 	// The multiboot header must be contained completely within the
 	// first 8192 bytes of the OS image.
 	buf := make([]byte, 8192)

--- a/pkg/multiboot/info.go
+++ b/pkg/multiboot/info.go
@@ -13,12 +13,12 @@ import (
 	"github.com/u-root/u-root/pkg/ubinary"
 )
 
-var sizeofInfo = uint32(binary.Size(Info{}))
+var sizeofInfo = uint32(binary.Size(info{}))
 
-type Flag uint32
+type flag uint32
 
 const (
-	flagInfoMemory Flag = 1 << iota
+	flagInfoMemory flag = 1 << iota
 	flagInfoBootDev
 	flagInfoCmdLine
 	flagInfoMods
@@ -33,9 +33,9 @@ const (
 	flagInfoFrameBuffer
 )
 
-// Info represents the Multiboot v1 info passed to the loaded kernel.
-type Info struct {
-	Flags    Flag
+// info represents the Multiboot v1 info passed to the loaded kernel.
+type info struct {
+	Flags    flag
 	MemLower uint32
 	MemUpper uint32
 
@@ -82,7 +82,7 @@ type Info struct {
 }
 
 type infoWrapper struct {
-	Info
+	info
 
 	CmdLine        string
 	BootLoaderName string
@@ -92,12 +92,12 @@ type infoWrapper struct {
 // expected by the kernel being loaded.
 func (iw *infoWrapper) marshal(base uintptr) ([]byte, error) {
 	offset := sizeofInfo + uint32(base)
-	iw.Info.CmdLine = offset
+	iw.info.CmdLine = offset
 	offset += uint32(len(iw.CmdLine)) + 1
-	iw.Info.BootLoaderName = offset
+	iw.info.BootLoaderName = offset
 
 	buf := bytes.Buffer{}
-	if err := binary.Write(&buf, ubinary.NativeEndian, iw.Info); err != nil {
+	if err := binary.Write(&buf, ubinary.NativeEndian, iw.info); err != nil {
 		return nil, err
 	}
 

--- a/pkg/multiboot/module.go
+++ b/pkg/multiboot/module.go
@@ -18,8 +18,8 @@ import (
 	"github.com/u-root/u-root/pkg/ubinary"
 )
 
-// A Module represents a module to be loaded along with the kernel.
-type Module struct {
+// A module represents a module to be loaded along with the kernel.
+type module struct {
 	// Start is the inclusive start of the Module memory location
 	Start uint32
 	// End is the exclusive end of the Module memory location.
@@ -32,7 +32,7 @@ type Module struct {
 	Reserved uint32
 }
 
-type modules []Module
+type modules []module
 
 func (m *multiboot) addModules() (uintptr, error) {
 	loaded, data, err := loadModules(m.modules)
@@ -100,7 +100,7 @@ func alignUp(buf *bytes.Buffer) error {
 	return err
 }
 
-func (m *Module) loadModule(buf *bytes.Buffer, name string) error {
+func (m *module) loadModule(buf *bytes.Buffer, name string) error {
 	log.Printf("Adding module %v", name)
 
 	b, err := readFile(name)
@@ -122,7 +122,7 @@ func (m *Module) loadModule(buf *bytes.Buffer, name string) error {
 	return nil
 }
 
-func (m *Module) setCmdLine(buf *bytes.Buffer, cmdLine string) error {
+func (m *module) setCmdLine(buf *bytes.Buffer, cmdLine string) error {
 	m.CmdLine = uint32(buf.Len())
 	if _, err := buf.WriteString(cmdLine); err != nil {
 		return err

--- a/pkg/multiboot/multiboot_test.go
+++ b/pkg/multiboot/multiboot_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 )
 
-func createFile(hdr *Header, offset, size int) (io.Reader, error) {
+func createFile(hdr *header, offset, size int) (io.Reader, error) {
 	buf := bytes.Repeat([]byte{0xDE, 0xAD, 0xBE, 0xEF}, (size+4)/4)
 	buf = buf[:size]
 	if hdr != nil {
@@ -26,16 +26,16 @@ func createFile(hdr *Header, offset, size int) (io.Reader, error) {
 	return bytes.NewReader(buf), nil
 }
 
-type flag string
+type testFlag string
 
 const (
-	flagGood        flag = "good"
-	flagUnsupported      = "unsup"
-	flagBad              = "bad"
+	flagGood        testFlag = "good"
+	flagUnsupported          = "unsup"
+	flagBad                  = "bad"
 )
 
-func createHeader(fl flag) Header {
-	flags := Flag(0x00000002)
+func createHeader(fl testFlag) header {
+	flags := headerFlag(0x00000002)
 	var checksum uint32
 	switch fl {
 	case flagGood:
@@ -47,7 +47,7 @@ func createHeader(fl flag) Header {
 		checksum = 0xFFFFFFFF - headerMagic - uint32(flags) + 1
 	}
 
-	return Header{
+	return header{
 		mandatory: mandatory{
 			Magic:    headerMagic,
 			Flags:    flags,
@@ -74,7 +74,7 @@ func TestParseHeader(t *testing.T) {
 	sizeofHeader := mandatorySize + optionalSize
 
 	for _, test := range []struct {
-		flags  flag
+		flags  testFlag
 		offset int
 		size   int
 		err    error


### PR DESCRIPTION
Also disambiguate info-structure flags from executable file header flags.

Signed-off-by: Chris Koch <chrisko@google.com>