### PR TITLE
These changes fix observed problems with using our cpio on synthetic file systems

### DIFF
--- a/cmds/core/cpio/cpio.go
+++ b/cmds/core/cpio/cpio.go
@@ -50,6 +50,7 @@ func main() {
 	flag.Parse()
 	if *d {
 		debug = log.Printf
+		cpio.Debug = log.Printf
 	}
 
 	a := flag.Args()
@@ -90,7 +91,8 @@ func main() {
 			name := scanner.Text()
 			rec, err := cr.GetRecord(name)
 			if err != nil {
-				log.Fatalf("Getting record of %q failed: %v", name, err)
+				log.Printf("Getting record of %q failed: %v", name, err)
+				continue
 			}
 			if err := rw.WriteRecord(rec); err != nil {
 				log.Fatalf("Writing record %q failed: %v", name, err)

--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -247,6 +247,13 @@ func (r *Recorder) GetRecord(path string) (Record, error) {
 		if done {
 			return Record{Info: info}, nil
 		}
+		// Check whether we can access it at all.
+		// If not, return an error. Callers of this function
+		// can determine whether that is fatal; in the cpio
+		// command, it should not be.
+		if err := unix.Access(path, unix.R_OK); err != nil {
+			return Record{}, err
+		}
 		return Record{Info: info, ReaderAt: newLazyFile(path)}, nil
 
 	case os.ModeSymlink:

--- a/pkg/uio/lazy.go
+++ b/pkg/uio/lazy.go
@@ -41,7 +41,7 @@ func (lr *LazyOpener) Read(p []byte) (int, error) {
 // Close implements io.Closer.Close.
 func (lr *LazyOpener) Close() error {
 	if c, ok := lr.r.(io.Closer); ok {
-		return c.Close()
+		c.Close()
 	}
 	return nil
 }

--- a/pkg/uio/lazy_test.go
+++ b/pkg/uio/lazy_test.go
@@ -7,6 +7,7 @@ package uio
 import (
 	"fmt"
 	"io"
+	"os"
 	"testing"
 )
 
@@ -21,6 +22,16 @@ type mockReader struct {
 func (m *mockReader) Read([]byte) (int, error) {
 	m.called = true
 	return 0, m.err
+}
+
+func (m *mockReader) Close() error {
+	if m == nil {
+		return os.ErrInvalid
+	}
+	if m.err != nil {
+		return os.ErrInvalid
+	}
+	return nil
 }
 
 func TestLazyOpenerRead(t *testing.T) {
@@ -67,6 +78,9 @@ func TestLazyOpenerRead(t *testing.T) {
 				if tt.openReader.err != nil && err != tt.openReader.err {
 					t.Errorf("Read() = %v, want %v", err, tt.openReader.err)
 				}
+			}
+			if err := lr.Close(); err != nil {
+				t.Errorf("Close(): got %v, want nil", err)
 			}
 		})
 	}


### PR DESCRIPTION
It was not behaving like the standard cpio or tar. Now it seems to.

The uio fix is not exactly intuitive but I am pretty sure it's right; we always
act like the open succeeded, which means we should act like the close did too.