### PR TITLE
cpio: make hardlinks work

### DIFF
--- a/cmds/core/cpio/cpio.go
+++ b/cmds/core/cpio/cpio.go
@@ -67,6 +67,7 @@ func main() {
 	switch op {
 	case "i":
 		rr := archiver.Reader(os.Stdin)
+		ww := cpio.NewUnixFiler()
 		for {
 			rec, err := rr.ReadRecord()
 			if err == io.EOF {
@@ -76,7 +77,7 @@ func main() {
 				log.Fatalf("error reading records: %v", err)
 			}
 			debug("Creating %s\n", rec)
-			if err := cpio.CreateFile(rec); err != nil {
+			if err := ww.Create(rec); err != nil {
 				log.Printf("Creating %q failed: %v", rec.Name, err)
 			}
 		}

--- a/pkg/cpio/cpio.go
+++ b/pkg/cpio/cpio.go
@@ -45,7 +45,10 @@ import (
 
 var (
 	formatMap = make(map[string]RecordFormat)
-	Debug     = func(string, ...interface{}) {}
+
+	// Debug can be used to set a logging function, e.g. log.Printf,
+	// for debug messages.
+	Debug = func(string, ...interface{}) {}
 )
 
 // Record represents a CPIO record, which represents a Unix file.
@@ -124,6 +127,11 @@ type RecordWriter interface {
 type RecordFormat interface {
 	Reader(r io.ReaderAt) RecordReader
 	Writer(w io.Writer) RecordWriter
+}
+
+// A Filer is used to create files from Records.
+type Filer interface {
+	Create(Record) error
 }
 
 // Format returns the RecordFormat with that name, if it exists.

--- a/pkg/cpio/hardlink_test.go
+++ b/pkg/cpio/hardlink_test.go
@@ -1,0 +1,114 @@
+// Copyright 2012 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package cpio
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// Create a file, with one hard link, and verify that we
+// create the records and then unpack it correctly.
+func TestHardLink(t *testing.T) {
+	dir, err := ioutil.TempDir("", "TestHardLink")
+	if err != nil {
+		t.Fatalf("Tempdir: got %v, want nil", err)
+	}
+	t.Logf("Testing in %v", dir)
+	defer os.RemoveAll(dir)
+	f1 := filepath.Join(dir, "a")
+	if err := ioutil.WriteFile(f1, nil, 0666); err != nil {
+		t.Fatalf("create %s: got %v, want nil", f1, err)
+	}
+	f2 := filepath.Join(dir, "b")
+	if err := unix.Link(f1, f2); err != nil {
+		t.Fatalf("link %s to %s: got %v, want nil", f1, f2, err)
+	}
+	buf := &bytes.Buffer{}
+	w := Newc.Writer(buf)
+	cr := NewRecorder()
+	names := []string{f1, f2}
+	var rec Record
+	for _, n := range names {
+		rec, err = cr.GetRecord(n)
+
+		if err != nil {
+			t.Fatalf("Getting record of %q: got %v, want nil", n, err)
+		}
+		if err := w.WriteRecord(rec); err != nil {
+			t.Fatalf("Writing record %q: got %v, want nil", n, err)
+		}
+	}
+
+	// Programatically create a Hardlink record.
+	f3 := filepath.Join(dir, "c")
+	hl := Hardlink(f3, rec.Info)
+
+	if err := w.WriteRecord(hl); err != nil {
+		t.Fatalf("Writing record %s: got %v, want nil", rec, err)
+	}
+	for _, n := range names {
+		if err := os.Remove(n); err != nil {
+			t.Fatalf("remove: got %v, want nil", err)
+		}
+	}
+	if err := WriteTrailer(w); err != nil {
+		t.Fatalf("Writing trailer record: got %v, want nil", err)
+	}
+
+	rr := Newc.Reader(bytes.NewReader(buf.Bytes()))
+
+	ww := NewUnixFiler(func(f *UnixFiler) {
+		f.Root = "/"
+	})
+	var nread int
+	for {
+		rec, err := rr.ReadRecord()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("Reading records: got %v, want nil", err)
+		}
+		t.Logf("Creating %s\n", rec)
+		// "/" seems scary but just recreates the tempdir
+		// we had before.
+		if err := ww.Create(rec); err != nil {
+			log.Printf("Creating %q failed: %v", rec.Name, err)
+		}
+		nread++
+	}
+
+	if nread != 3 {
+		t.Errorf("reading records: got %d, want 3", nread)
+	}
+	fi, err := os.Stat(names[0])
+	if err != nil {
+		t.Fatalf("Stat %q: got %v, want nil", names[0], err)
+	}
+	ino := fi.Sys().(*syscall.Stat_t).Ino
+
+	names = append(names, f3)
+	for _, n := range names {
+		fi, err := os.Stat(n)
+		if err != nil {
+			t.Fatalf("Stat %q: got %v, want nil", n, err)
+		}
+		t.Logf("Stat %q gets %v", n, fi)
+		if ino != fi.Sys().(*syscall.Stat_t).Ino {
+			t.Errorf("%q: inode got %v, want %v", n, fi.Sys().(*syscall.Stat_t).Ino, ino)
+		}
+	}
+}

--- a/pkg/cpio/utils.go
+++ b/pkg/cpio/utils.go
@@ -50,6 +50,14 @@ func Symlink(name string, target string) Record {
 	}
 }
 
+// Hardlink returns a hardlink record from an existing file.
+// Everything is the same save the Name. The reader is empty.
+func Hardlink(name string, i Info) Record {
+	var r = Record{Info: i}
+	r.Info.Name = name
+	return r
+}
+
 // Directory returns a directory record at name.
 func Directory(name string, mode uint64) Record {
 	return Record{

--- a/pkg/uroot/initramfs/dir.go
+++ b/pkg/uroot/initramfs/dir.go
@@ -41,17 +41,19 @@ func (da DirArchiver) OpenWriter(l logger.Logger, path, goos, goarch string) (Wr
 		}
 	}
 	l.Printf("Path is %s", path)
-	return dirWriter{path}, nil
+	return &dirWriter{Filer: cpio.NewUnixFiler(func(f *cpio.UnixFiler) {
+		f.Root = path
+	})}, nil
 }
 
 // dirWriter implements Writer.
 type dirWriter struct {
-	dir string
+	cpio.Filer
 }
 
 // WriteRecord implements Writer.WriteRecord.
 func (dw dirWriter) WriteRecord(r cpio.Record) error {
-	return cpio.CreateFileInRoot(r, dw.dir, false)
+	return dw.Filer.Create(r)
 }
 
 // Finish implements Writer.Finish.

--- a/tools/testramfs/testramfs.go
+++ b/tools/testramfs/testramfs.go
@@ -97,6 +97,9 @@ func main() {
 	}
 
 	r := archiver.Reader(f)
+	w := cpio.NewUnixFiler(func(f *cpio.UnixFiler) {
+		f.Root = tempDir
+	})
 	for {
 		rec, err := r.ReadRecord()
 		if err == io.EOF {
@@ -105,7 +108,9 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		cpio.CreateFileInRoot(rec, tempDir, false)
+		if err := w.Create(rec); err != nil {
+			log.Fatal(err)
+		}
 	}
 
 	cmd, err := pty.New()

--- a/uroot_test.go
+++ b/uroot_test.go
@@ -48,9 +48,12 @@ func (b buildSourceValidator) Validate(a *cpio.Archive) error {
 		return err
 	}
 
+	w := cpio.NewUnixFiler(func(f*cpio.UnixFiler){
+		f.Root = dir
+	})
 	// Unpack into dir.
 	err = cpio.ForEachRecord(a.Reader(), func(r cpio.Record) error {
-		return cpio.CreateFileInRoot(r, dir, false)
+		return w.Create(r)
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
We correctly detect hard links when creating an archive, but when
reading an archive we were not correctly creating them.