### PR TITLE
kexec: allow allocating memory as firmware-reserved

### DIFF
--- a/integration/multiboot_test.go
+++ b/integration/multiboot_test.go
@@ -61,7 +61,7 @@ func testMultiboot(t *testing.T, kernel string) {
 		t.Fatalf("Cannot unmarshal multiboot information from executed kernel: %v", err)
 	}
 	if !reflect.DeepEqual(got, want) {
-		t.Errorf("kexec failed: got %v, want %v", got, want)
+		t.Errorf("kexec failed: got\n%#v, want\n%#v", got, want)
 	}
 }
 

--- a/pkg/kexec/memory_linux_test.go
+++ b/pkg/kexec/memory_linux_test.go
@@ -131,6 +131,17 @@ func TestAlignPhys(t *testing.T) {
 			},
 		},
 		{
+			name: "unaligned_size",
+			seg: Segment{
+				Buf:  Range{Start: 0x1000, Size: 0x1022},
+				Phys: Range{Start: 0x2000, Size: 0x1022},
+			},
+			want: Segment{
+				Buf:  Range{Start: 0x1000, Size: 0x1022},
+				Phys: Range{Start: 0x2000, Size: 0x2000},
+			},
+		},
+		{
 			name: "empty_buf",
 			seg: Segment{
 				Buf:  Range{Start: 0x1011, Size: 0},
@@ -256,14 +267,12 @@ func TestDedup(t *testing.T) {
 
 func TestFindSpaceIn(t *testing.T) {
 	for i, tt := range []struct {
-		name    string
-		rs      Ranges
-		size    uint
-		limit   Range
-		minAddr uintptr
-		maxAddr uintptr
-		want    uintptr
-		err     error
+		name  string
+		rs    Ranges
+		size  uint
+		limit Range
+		want  Range
+		err   error
 	}{
 		{
 			name: "no space above 0x1000",
@@ -272,7 +281,6 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0x1000, MaxAddr),
-			want:  0,
 			err:   ErrNotEnoughSpace{Size: 0x10},
 		},
 		{
@@ -282,7 +290,6 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0, 0x1000),
-			want:  0,
 			err:   ErrNotEnoughSpace{Size: 0x10},
 		},
 		{
@@ -293,7 +300,7 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0x1000, MaxAddr),
-			want:  0x1000,
+			want:  Range{Start: 0x1000, Size: 0x10},
 		},
 		{
 			name: "just enough space under 0x1000",
@@ -304,7 +311,7 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0, 0x1000),
-			want:  0xFF0,
+			want:  Range{Start: 0xFF0, Size: 0x10},
 		},
 		{
 			name: "all spaces abvoe 0x1000 and under 0x2000 are too small",
@@ -317,7 +324,6 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0x1000, 0x2000),
-			want:  0,
 			err:   ErrNotEnoughSpace{Size: 0x10},
 		},
 		{
@@ -327,7 +333,7 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0x1000, MaxAddr),
-			want:  0x1000,
+			want:  Range{Start: 0x1000, Size: 0x10},
 		},
 		{
 			name: "space is split across 0x1000, with enough space under",
@@ -336,7 +342,7 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0, 0x1000),
-			want:  0xFF0,
+			want:  Range{Start: 0xFF0, Size: 0x10},
 		},
 		{
 			name: "space is split across 0x1000 and 0x2000, but not enough space above or below",
@@ -346,7 +352,6 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0x1000, 0x2000),
-			want:  0,
 			err:   ErrNotEnoughSpace{Size: 0x10},
 		},
 		{
@@ -357,14 +362,13 @@ func TestFindSpaceIn(t *testing.T) {
 			},
 			size:  0x10,
 			limit: RangeFromInterval(0x1000, MaxAddr),
-			want:  0x1010,
+			want:  Range{Start: 0x1010, Size: 0x10},
 		},
 		{
 			name:  "no ranges",
 			rs:    Ranges{},
 			size:  0x10,
 			limit: RangeFromInterval(0, MaxAddr),
-			want:  0,
 			err:   ErrNotEnoughSpace{Size: 0x10},
 		},
 		{
@@ -372,13 +376,12 @@ func TestFindSpaceIn(t *testing.T) {
 			rs:    Ranges{},
 			size:  0,
 			limit: RangeFromInterval(0, MaxAddr),
-			want:  0,
 			err:   ErrNotEnoughSpace{Size: 0},
 		},
 	} {
 		t.Run(fmt.Sprintf("test_%d_%s", i, tt.name), func(t *testing.T) {
 			got, err := tt.rs.FindSpaceIn(tt.size, tt.limit)
-			if got != tt.want || err != tt.err {
+			if !reflect.DeepEqual(got, tt.want) || err != tt.err {
 				t.Errorf("%s.FindSpaceIn(%#x, limit = %s) = (%#x, %v), want (%#x, %v)", tt.rs, tt.size, tt.limit, got, err, tt.want, tt.err)
 			}
 		})
@@ -569,6 +572,106 @@ func TestAdjacent(t *testing.T) {
 			}
 			if got2 != tt.want {
 				t.Errorf("%s.Adjacent(%s) = %v, want %v", tt.r2, tt.r1, got2, tt.want)
+			}
+		})
+	}
+}
+
+func TestMemoryMapInsert(t *testing.T) {
+	for i, tt := range []struct {
+		m    MemoryMap
+		r    TypedRange
+		want MemoryMap
+	}{
+		{
+			// r is entirely within m's one range.
+			m: MemoryMap{
+				TypedRange{Range: Range{Start: 0, Size: 0x2000}, Type: RangeRAM},
+			},
+			r: TypedRange{Range: Range{Start: 0x100, Size: 0x100}, Type: RangeReserved},
+			want: MemoryMap{
+				TypedRange{Range: Range{Start: 0, Size: 0x100}, Type: RangeRAM},
+				TypedRange{Range: Range{Start: 0x100, Size: 0x100}, Type: RangeReserved},
+				TypedRange{Range: Range{Start: 0x200, Size: 0x2000 - 0x200}, Type: RangeRAM},
+			},
+		},
+		{
+			// r sits across three RAM ranges.
+			m: MemoryMap{
+				TypedRange{Range: Range{Start: 0, Size: 0x150}, Type: RangeRAM},
+				TypedRange{Range: Range{Start: 0x150, Size: 0x50}, Type: RangeRAM},
+				TypedRange{Range: Range{Start: 0x1a0, Size: 0x100}, Type: RangeRAM},
+			},
+			r: TypedRange{Range: Range{Start: 0x100, Size: 0x100}, Type: RangeReserved},
+			want: MemoryMap{
+				TypedRange{Range: Range{Start: 0, Size: 0x100}, Type: RangeRAM},
+				TypedRange{Range: Range{Start: 0x100, Size: 0x100}, Type: RangeReserved},
+				TypedRange{Range: Range{Start: 0x200, Size: 0xa0}, Type: RangeRAM},
+			},
+		},
+		{
+			// r is a superset of the ranges in m.
+			m: MemoryMap{
+				TypedRange{Range: Range{Start: 0x100, Size: 0x50}, Type: RangeRAM},
+			},
+			r: TypedRange{Range: Range{Start: 0x100, Size: 0x100}, Type: RangeReserved},
+			want: MemoryMap{
+				TypedRange{Range: Range{Start: 0x100, Size: 0x100}, Type: RangeReserved},
+			},
+		},
+		{
+			// r is the first range in the map.
+			m: MemoryMap{},
+			r: TypedRange{Range: Range{Start: 0x100, Size: 0x100}, Type: RangeReserved},
+			want: MemoryMap{
+				TypedRange{Range: Range{Start: 0x100, Size: 0x100}, Type: RangeReserved},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			// Make a copy for the Errorf print.
+			m := tt.m
+			tt.m.Insert(tt.r)
+
+			if !reflect.DeepEqual(tt.m, tt.want) {
+				t.Errorf("\n%v.Insert(%s) =\n%v, want\n%v", m, tt.r, tt.m, tt.want)
+			}
+		})
+	}
+}
+
+func TestSegmentsInsert(t *testing.T) {
+	for i, tt := range []struct {
+		segs Segments
+		s    Segment
+		want Segments
+	}{
+		{
+			segs: Segments{
+				Segment{Phys: Range{Start: 0x2000, Size: 0x20}},
+				Segment{Phys: Range{Start: 0x4000, Size: 0x20}},
+			},
+			s: Segment{Phys: Range{Start: 0x3000, Size: 0x20}},
+			want: Segments{
+				Segment{Phys: Range{Start: 0x2000, Size: 0x20}},
+				Segment{Phys: Range{Start: 0x3000, Size: 0x20}},
+				Segment{Phys: Range{Start: 0x4000, Size: 0x20}},
+			},
+		},
+		{
+			segs: Segments{},
+			s:    Segment{Phys: Range{Start: 0x3000, Size: 0x20}},
+			want: Segments{
+				Segment{Phys: Range{Start: 0x3000, Size: 0x20}},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
+			before := tt.segs
+			tt.segs.Insert(tt.s)
+
+			if !reflect.DeepEqual(tt.segs, tt.want) {
+				t.Errorf("\n%v.Insert(%v) = \n%v, want \n%v", before, tt.s, tt.segs, tt.want)
 			}
 		})
 	}

--- a/pkg/multiboot/module.go
+++ b/pkg/multiboot/module.go
@@ -41,12 +41,12 @@ func (m *multiboot) addModules() (uintptr, error) {
 		return 0, err
 	}
 
-	addr, err := m.mem.AddKexecSegment(data)
+	cmdlineRange, err := m.mem.AddKexecSegment(data)
 	if err != nil {
 		return 0, err
 	}
 
-	loaded.fix(uint32(addr))
+	loaded.fix(uint32(cmdlineRange.Start))
 
 	m.loadedModules = loaded
 
@@ -54,7 +54,11 @@ func (m *multiboot) addModules() (uintptr, error) {
 	if err != nil {
 		return 0, err
 	}
-	return m.mem.AddKexecSegment(b)
+	modRange, err := m.mem.AddKexecSegment(b)
+	if err != nil {
+		return 0, err
+	}
+	return modRange.Start, nil
 }
 
 // loadModules loads module files.

--- a/pkg/multiboot/multiboot.go
+++ b/pkg/multiboot/multiboot.go
@@ -235,7 +235,7 @@ func (m multiboot) memoryMap() memoryMaps {
 			// Size is really used for skipping to the next pair.
 			Size:     uint32(sizeofMemoryMap) - 4,
 			BaseAddr: uint64(r.Start),
-			Length:   uint64(r.Size) + 1,
+			Length:   uint64(r.Size),
 			Type:     typ,
 		}
 		ret = append(ret, v)

--- a/pkg/multiboot/multiboot.go
+++ b/pkg/multiboot/multiboot.go
@@ -209,22 +209,19 @@ func (m *multiboot) addInfo() (addr uintptr, err error) {
 		return 0, err
 	}
 
-	addr, err = m.mem.FindSpace(infoSize)
+	r, err := m.mem.FindSpace(infoSize)
 	if err != nil {
 		return 0, err
 	}
 
-	d, err := iw.marshal(addr)
+	d, err := iw.marshal(r.Start)
 	if err != nil {
 		return 0, err
 	}
 	m.info = iw.info
 
-	addr, err = m.mem.AddKexecSegment(d)
-	if err != nil {
-		return 0, err
-	}
-	return addr, nil
+	m.mem.Segments.Insert(kexec.NewSegment(d, r))
+	return r.Start, nil
 }
 
 func (m multiboot) memoryMap() memoryMaps {
@@ -252,11 +249,11 @@ func (m *multiboot) addMmap() (addr uintptr, size uint, err error) {
 	if err != nil {
 		return 0, 0, err
 	}
-	addr, err = m.mem.AddKexecSegment(d)
+	r, err := m.mem.AddKexecSegment(d)
 	if err != nil {
 		return 0, 0, err
 	}
-	return addr, uint(len(mmap)) * sizeofMemoryMap, nil
+	return r.Start, uint(len(mmap)) * sizeofMemoryMap, nil
 }
 
 func (m multiboot) memoryBoundaries() (lower, upper uint32) {
@@ -342,10 +339,9 @@ func (m *multiboot) addTrampoline() (entry uintptr, err error) {
 		return 0, err
 	}
 
-	addr, err := m.mem.AddKexecSegment(d)
+	r, err := m.mem.AddKexecSegment(d)
 	if err != nil {
 		return 0, err
 	}
-
-	return addr, nil
+	return r.Start, nil
 }


### PR DESCRIPTION
Pre-requisite for inserting things traditionally marked as reserved by firmware in memory maps like ACPI tables or iSCSI Boot Firmware Table.

Signed-off-by: Chris Koch <chrisko@google.com>