### PR TITLE
ensure that cpio does not create corrupt archives

### DIFF
--- a/pkg/cpio/newc.go
+++ b/pkg/cpio/newc.go
@@ -163,6 +163,9 @@ func (w *writer) WriteRecord(f Record) error {
 	if err != nil {
 		return err
 	}
+	if m != int64(f.Info.FileSize) {
+		return fmt.Errorf("WriteRecord: %s: wrote %d bytes of file instead of %d bytes; archive is now corrupt", f.Info.Name, m, f.Info.FileSize)
+	}
 	if c, ok := f.ReaderAt.(io.Closer); ok {
 		if err := c.Close(); err != nil {
 			return err


### PR DESCRIPTION
Let's do a thought experiment: you wish to save, say, /sys/log,
a directory of files that contain messages from various daemons.

You also want to verify that it worked right.
find /sys/log | cpio o | cpio -v i | wc

You discover that the number of files in /sys/log, and what wc
reports from cpio i, differ.
Or, worse, you are told the archive is corrupt.

What happened? Our cpio has a problem: it stats the file
to get the size, but then does not verify that the actual number
of bytes it wrote matches the stat.

Recall that newc records consist of a header, with an embedded size,
with a block of data that is supposed to match that size. The location
of the next record is determine by adding the size in the header
to the header offset. If you are thinking this is a fragile format,
you're right; it is one reason cpio has fallen out of use.

If less data is written than the header indicates, the header for the
next file will land in what looks like data; the file will be lost.
Further, cpio will look in the wrong place for the next header and
in the best case will see what looks like a bad header.

If the file has grown, and more data is written than the header
indicates, then cpio will unknowingly read file data for the current
file as header for the next file and try to interpret
it as a header, which will also give the appearance of a corrupt
archive.

There are two possible results of this, equally bad.
In the /sys/log example, if logrotate was running while you ran
cpio, the file might have changed from non-zero to zero bytes; the
header for the next file will land in an area that is expected to be
data and the file won't be seen. Or, if a file grew between the stat
and the read, current file data will be sitting in place of next file
header. These races are not uncommon and it's why most archivers and
file transfer programs have code to detect them.

There are ways to resolve this problem; most tar and cpio commands
will produce valid archives; rsync will print a warning but work.
u-root cpio, however, can produce a corrupt archive when files are changing.
At the very least we should return an error if we are
going to write a corrupt archive.

In WriteRecord, we add a check to ensure the amount of data written
matches the FileSize in the header. If it does not, we return an
error.