### PR TITLE
dhclient: support search domain options

### DIFF
--- a/pkg/dhclient/dhclient.go
+++ b/pkg/dhclient/dhclient.go
@@ -16,6 +16,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -128,14 +129,7 @@ func WriteDNSSettings(ns []net.IP, sl []string, domain string) error {
 	}
 	if sl != nil {
 		rc.WriteString("search ")
-		for index, label := range sl {
-			if index != len(sl)-1 {
-				rc.WriteString(fmt.Sprintf("%s ", label))
-			} else {
-				rc.WriteString(fmt.Sprintf("%s", label))
-
-			}
-		}
+		rc.WriteString(strings.Join(sl, " "))
 		rc.WriteString("\n")
 	}
 	return ioutil.WriteFile("/etc/resolv.conf", rc.Bytes(), 0644)

--- a/pkg/dhclient/dhclient.go
+++ b/pkg/dhclient/dhclient.go
@@ -108,18 +108,35 @@ func Configure6(iface netlink.Link, packet *dhcpv6.Message) error {
 	}
 
 	if ips := p.DNS(); ips != nil {
-		if err := WriteDNSSettings(ips); err != nil {
+		if err := WriteDNSSettings(ips, nil, ""); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// WriteDNSSettings writes the given IPs as nameservers to resolv.conf.
-func WriteDNSSettings(ips []net.IP) error {
+// WriteDNSSettings writes the given nameservers, search list, and domain to resolv.conf.
+func WriteDNSSettings(ns []net.IP, sl []string, domain string) error {
 	rc := &bytes.Buffer{}
-	for _, ip := range ips {
-		rc.WriteString(fmt.Sprintf("nameserver %s\n", ip))
+	if domain != "" {
+		rc.WriteString(fmt.Sprintf("domain %s\n", domain))
+	}
+	if ns != nil {
+		for _, ip := range ns {
+			rc.WriteString(fmt.Sprintf("nameserver %s\n", ip))
+		}
+	}
+	if sl != nil {
+		rc.WriteString("search ")
+		for index, label := range sl {
+			if index != len(sl)-1 {
+				rc.WriteString(fmt.Sprintf("%s ", label))
+			} else {
+				rc.WriteString(fmt.Sprintf("%s", label))
+
+			}
+		}
+		rc.WriteString("\n")
 	}
 	return ioutil.WriteFile("/etc/resolv.conf", rc.Bytes(), 0644)
 }

--- a/pkg/dhclient/dhcp4.go
+++ b/pkg/dhclient/dhcp4.go
@@ -31,8 +31,24 @@ func NewPacket4(iface netlink.Link, p *dhcpv4.DHCPv4) *Packet4 {
 	}
 }
 
+// Link is a netlink link
 func (p *Packet4) Link() netlink.Link {
 	return p.iface
+}
+
+// GatherDNSSettings gets the DNS related infromation from a dhcp packet
+// including, nameservers, domain, and search options
+func (p *Packet4) GatherDNSSettings() (ns []net.IP, sl []string, dom string) {
+	if nameservers := p.P.DNS(); nameservers != nil {
+		ns = nameservers
+	}
+	if searchList := p.P.DomainSearch(); searchList != nil {
+		sl = searchList.Labels
+	}
+	if domain := p.P.DomainName(); domain != "" {
+		dom = domain
+	}
+	return
 }
 
 // Configure configures interface using this packet.
@@ -79,11 +95,11 @@ func (p *Packet4) Configure() error {
 		}
 	}
 
-	if ips := p.P.DNS(); ips != nil {
-		if err := WriteDNSSettings(ips); err != nil {
-			return err
-		}
+	nameServers, searchList, domain := p.GatherDNSSettings()
+	if err := WriteDNSSettings(nameServers, searchList, domain); err != nil {
+		return err
 	}
+
 	return nil
 }
 
@@ -107,7 +123,9 @@ func (p *Packet4) Lease() *net.IPNet {
 }
 
 var (
-	ErrNoBootFile       = errors.New("no boot file name present in DHCP message")
+	//ErrNoBootFile represents that no pxe boot file was found
+	ErrNoBootFile = errors.New("no boot file name present in DHCP message")
+	//ErrNoServerHostName represents that no pxe boot server was found
 	ErrNoServerHostName = errors.New("no server host name present in DHCP message")
 )
 

--- a/pkg/dhclient/dhcp4.go
+++ b/pkg/dhclient/dhcp4.go
@@ -123,9 +123,9 @@ func (p *Packet4) Lease() *net.IPNet {
 }
 
 var (
-	//ErrNoBootFile represents that no pxe boot file was found
+	// ErrNoBootFile represents that no pxe boot file was found.
 	ErrNoBootFile = errors.New("no boot file name present in DHCP message")
-	//ErrNoServerHostName represents that no pxe boot server was found
+	// ErrNoServerHostName represents that no pxe boot server was found.
 	ErrNoServerHostName = errors.New("no server host name present in DHCP message")
 )
 


### PR DESCRIPTION
Add support for dhcp options 15 and 119. Adds the domain and search
options to resolv.conf.

Signed-off-by: Lincoln Thurlow <lincoln@isi.edu>