### PR TITLE
pkg/uroot: stop spamming long error messages

### DIFF
--- a/pkg/uroot/builder/bb/bb.go
+++ b/pkg/uroot/builder/bb/bb.go
@@ -325,7 +325,7 @@ func NewPackage(name string, pkgPath string, srcFiles []string, importer types.I
 	}
 	tpkg, err := conf.Check(pkgPath, p.fset, p.sortedFiles, &p.typeInfo)
 	if err != nil {
-		return nil, fmt.Errorf("type checking failed: %#v: %v", importer, err)
+		return nil, fmt.Errorf("type checking failed: %v", err)
 	}
 	p.types = tpkg
 	return p, nil


### PR DESCRIPTION
The importer was only included to debug the build system itself, not for
users.

Signed-off-by: Chris Koch <chrisko@google.com>