### PR TITLE
circleci amd64: enable virtfs

### DIFF
--- a/.circleci/images/test-image-amd64/Dockerfile
+++ b/.circleci/images/test-image-amd64/Dockerfile
@@ -49,6 +49,7 @@ RUN set -eux;                                                          \
     cd build;                                                          \
     ../configure                                                       \
         --target-list=x86_64-softmmu                                   \
+        --enable-virtfs                                                \
         --disable-docs                                                 \
         --disable-sdl                                                  \
         --disable-kvm;                                                 \


### PR DESCRIPTION
@rjoleary @hugelgupf I believe this is the only option needed for qemu to support 9p