### PR TITLE
provide a function to get net interfaces from an RE

### DIFF
--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -12,14 +12,12 @@ import (
 	"net"
 	"net/url"
 	"path"
-	"regexp"
 	"time"
 
 	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/dhclient"
 	"github.com/u-root/u-root/pkg/ipxe"
 	"github.com/u-root/u-root/pkg/pxe"
-	"github.com/vishvananda/netlink"
 )
 
 var (
@@ -35,17 +33,9 @@ const (
 
 // Netboot boots all interfaces matched by the regex in ifaceNames.
 func Netboot(ifaceNames string) error {
-	ifs, err := netlink.LinkList()
+	filteredIfs, err := dhclient.Interfaces(ifaceNames)
 	if err != nil {
 		return err
-	}
-
-	var filteredIfs []netlink.Link
-	ifregex := regexp.MustCompilePOSIX(ifaceNames)
-	for _, iface := range ifs {
-		if ifregex.MatchString(iface.Attrs().Name) {
-			filteredIfs = append(filteredIfs, iface)
-		}
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), (1<<dhcpTries)*dhcpTimeout)

--- a/cmds/core/dhclient/dhclient.go
+++ b/cmds/core/dhclient/dhclient.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"flag"
 	"log"
-	"regexp"
 	"time"
 
 	"github.com/u-root/u-root/pkg/dhclient"
@@ -43,22 +42,9 @@ func main() {
 		ifName = flag.Args()[0]
 	}
 
-	ifRE := regexp.MustCompilePOSIX(ifName)
-
-	ifnames, err := netlink.LinkList()
+	filteredIfs, err := dhclient.Interfaces(ifName)
 	if err != nil {
-		log.Fatalf("Can't get list of link names: %v", err)
-	}
-
-	var filteredIfs []netlink.Link
-	for _, iface := range ifnames {
-		if ifRE.MatchString(iface.Attrs().Name) {
-			filteredIfs = append(filteredIfs, iface)
-		}
-	}
-
-	if len(filteredIfs) == 0 {
-		log.Fatalf("No interfaces match %s", ifName)
+		log.Fatal(err)
 	}
 
 	configureAll(filteredIfs)

--- a/cmds/core/dhclient/dhclient_test.go
+++ b/cmds/core/dhclient/dhclient_test.go
@@ -19,7 +19,7 @@ var tests = []struct {
 	{
 		iface:  "nosuchanimal",
 		isIPv4: "-ipv4=true",
-		out:    "No interfaces match nosuchanimal\n",
+		out:    "no interfaces match nosuchanimal\n",
 	},
 }
 

--- a/pkg/dhclient/iface.go
+++ b/pkg/dhclient/iface.go
@@ -1,0 +1,39 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dhclient
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/vishvananda/netlink"
+)
+
+// Interfaces takes an RE and returns a
+// []netlink.Link that matches it, or an error. It is an error
+// for the returned list to be empty.
+func Interfaces(ifName string) ([]netlink.Link, error) {
+	ifRE, err := regexp.CompilePOSIX(ifName)
+	if err != nil {
+		return nil, err
+	}
+
+	ifnames, err := netlink.LinkList()
+	if err != nil {
+		return nil, fmt.Errorf("can not get list of link names: %v", err)
+	}
+
+	var filteredIfs []netlink.Link
+	for _, iface := range ifnames {
+		if ifRE.MatchString(iface.Attrs().Name) {
+			filteredIfs = append(filteredIfs, iface)
+		}
+	}
+
+	if len(filteredIfs) == 0 {
+		return nil, fmt.Errorf("no interfaces match %s", ifName)
+	}
+	return filteredIfs, nil
+}

--- a/pkg/dhclient/iface_test.go
+++ b/pkg/dhclient/iface_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dhclient
+
+import "testing"
+
+// TestSimple tests the cases where we should have at least one.
+func TestInterfaces(t *testing.T) {
+	l, err := Interfaces(".")
+	if err != nil {
+		t.Fatalf("Checking \".\": got %v, want nil", err)
+	}
+	if len(l) == 0 {
+		t.Fatalf("Checking \".\": got no elements, want at least one")
+	}
+	// Grab the first one, wrap it in ^$, and we should only get one back.
+	one := "^" + l[0].Attrs().Name + "$"
+	l, err = Interfaces(one)
+	if err != nil {
+		t.Fatalf("Checking %s: got %v, want nil", one, err)
+	}
+	if len(l) != 1 {
+		t.Errorf("Matching %s: got %d elements(%v), expect 1", one, len(l), l)
+	}
+}


### PR DESCRIPTION
It's handy to be able to take an RE and get a set of interfaces
from it. We've found a need for this function in more than one
program now; time to make it part of a package.

The Interfaces function takes an RE and returns a list of
netlink.Link that matches it, or an error. It is an error
for the returned list to be empty.