### PR TITLE
circleci: increase test timeout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,8 @@ jobs:
       - checkout
       - run:
           name: Test all
-          command: go test -a -ldflags '-s' ./...
+          command: go test -a -timeout 15m -ldflags '-s' ./...
+          no_output_timeout: 15m
       - run:
           name: Test coverage
           command: go test -cover `go list ./... | grep github.com/u-root/u-root/`


### PR DESCRIPTION
I'm not sure why, but the total timeout has increased a little over 10
minutes. CircleCI has a default timeout of 10m when no output is
detected and Golang has a 10m default timeout for all tests together.

To make #1310 pass.