### PR TITLE
WIP: use the hugelgupf/9p package for a builtin 9p server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -108,6 +108,19 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:79010d143b3a132808a76a612ad34b878a1020a30016a60cd879d60bf63308e1"
+  name = "github.com/hugelgupf/p9"
+  packages = [
+    "localfs",
+    "p9",
+    "unimplfs",
+    "vecnet",
+  ]
+  pruneopts = "NUT"
+  revision = "7ba0920fba11f7a99b28401f1a01852643f3717d"
+
+[[projects]]
+  branch = "master"
   digest = "1:9e9d2460ed0526ccf14606cf378a608a7a1a3c538f368e9989c8e0d70837cf56"
   name = "github.com/insomniacslk/dhcp"
   packages = [
@@ -417,6 +430,8 @@
     "github.com/google/go-cmp/cmp",
     "github.com/google/go-tpm/tpm",
     "github.com/google/goexpect",
+    "github.com/hugelgupf/p9/localfs",
+    "github.com/hugelgupf/p9/p9",
     "github.com/insomniacslk/dhcp/dhcpv4",
     "github.com/insomniacslk/dhcp/dhcpv4/nclient4",
     "github.com/insomniacslk/dhcp/dhcpv4/server4",

--- a/cmds/exp/cpu/TESTCPU
+++ b/cmds/exp/cpu/TESTCPU
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+# You will need to put your host key and private key somewhere. They will be placed in the proper place in the image.
+go run . -build=bb \
+	-initcmd=/bbin/cpu\
+        	-files ~/.ssh/cpu_rsa.pub:key.pub -files /bin/fusermount all github.com/u-root/u-root/cmds/exp/cpu
+
+echo	-files ssh_host_rsa_key:etc/ssh/ssh_host_rsa_key \
+
+sudo /usr/bin/qemu-system-x86_64 -kernel \
+     /home/rminnich/projects/linuxboot/linux/arch/x86/boot/bzImage \
+	-cpu  max \
+     -s   \
+     -m 1024m \
+     -machine q35  \
+     -initrd /tmp/initramfs.linux_amd64.cpio \
+    -object rng-random,filename=/dev/urandom,id=rng0 \
+    -device virtio-rng-pci,rng=rng0 \
+     -device e1000,netdev=n1 \
+     -netdev user,id=n1,hostfwd=tcp:127.0.0.1:23-:2222,net=192.168.1.0/24,host=192.168.1.1 \
+     -serial stdio  \
+     -append earlyprintk=ttyS0,115200\ console=ttyS0 \
+     -monitor /dev/null  \
+     -cdrom /tmp/iso
+     
+     # note we will exit here so the trash below is not a problem
+     exit 0
+
+
+# add the following line to qemu if you want to snoop packets.
+	-object filter-dump,id=f1,netdev=n1,file=/tmp/vm0.pcap \
+
+
+# from the client side, you can, for example:
+./cpu  -srv=unpfs -h 127.0.0.1 -sp 23 -key ~/.ssh/cpu_rsa

--- a/cmds/exp/cpu/cpu.go
+++ b/cmds/exp/cpu/cpu.go
@@ -23,6 +23,8 @@ import (
 	// We use this ssh because it implements port redirection.
 	// It can not, however, unpack password-protected keys yet.
 	"github.com/gliderlabs/ssh"
+	"github.com/hugelgupf/p9/localfs"
+	"github.com/hugelgupf/p9/p9"
 	"github.com/kr/pty" // TODO: get rid of krpty
 	"github.com/u-root/u-root/pkg/termios"
 	"github.com/u-root/u-root/pkg/uroot/util"
@@ -37,14 +39,14 @@ var (
 	pubKeyFile  = flag.String("pk", "key.pub", "file for public key")
 	port        = flag.String("sp", "2222", "ssh default port")
 
-	debug     = flag.Bool("d", false, "enable debug prints")
+	debug     = flag.Bool("d", true, "enable debug prints")
 	runAsInit = flag.Bool("init", false, "run as init (Debug only; normal test is if we are pid 1")
 	v         = func(string, ...interface{}) {}
 	remote    = flag.Bool("remote", false, "indicates we are the remote side of the cpu session")
 	network   = flag.String("network", "tcp", "network to use")
 	host      = flag.String("h", "localhost", "host to use")
 	keyFile   = flag.String("key", filepath.Join(os.Getenv("HOME"), ".ssh/cpu_rsa"), "key file")
-	srv9p     = flag.String("srv", "unpfs", "what server to run")
+	srv9p     = flag.String("srv", "", "what server to run -- to use internal servers, leave this empty")
 	bin       = flag.String("bin", "cpu", "path of cpu binary")
 	port9p    = flag.String("port9p", "", "port9p # on remote machine for 9p mount")
 	dbg9p     = flag.Bool("dbg9p", false, "show 9p io")
@@ -220,7 +222,7 @@ func runRemote(cmd, port9p string) error {
 // TODO: make it more private, and also, have server only take
 // one connection or use stdin/stdout
 func srv(ctx context.Context) (net.Conn, *exec.Cmd, error) {
-	c := exec.CommandContext(ctx, "unpfs", "tcp!localhost!5641", *root)
+	c := exec.CommandContext(ctx, *srv9p, "tcp!localhost!5641", *root)
 	o, err := c.StdoutPipe()
 	if err != nil {
 		return nil, nil, err
@@ -270,18 +272,7 @@ func runClient(a string) error {
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithCancel(context.Background())
-	srvSock, p, err := srv(ctx)
-	if err != nil {
-		cancel()
-		return err
-	}
-	defer func() {
-		cancel()
-		p.Wait()
-	}()
 	// Arrange port forwarding from remote ssh to our server.
-
 	// Request the remote side to open port 5640 on all interfaces.
 	// Note: cl.Listen returns a TCP listener with network is "tcp"
 	// or variants. This lets us use a listen deadline.
@@ -296,9 +287,33 @@ func runClient(a string) error {
 	port := ap[len(ap)-1]
 	v("listener %T %v addr %v port %v", l, l, l.Addr().String(), port)
 
-	go forward(l, srvSock)
-	v("Connected to %v", cl)
-
+	if *srv9p == "" {
+		if false {
+			c, err := l.Accept()
+			v("forward: c %v err %v", c, err)
+			if err != nil {
+				v("forward: accept: %v", err)
+				return err
+			}
+			if err := p9.NewServer(&localfs.Local{}).Serve(l); err != nil {
+				return err
+			}
+		}
+		go p9.NewServer(&localfs.Local{}).Serve(l)
+	} else {
+		ctx, cancel := context.WithCancel(context.Background())
+		srvSock, p, err := srv(ctx)
+		if err != nil {
+			cancel()
+			return err
+		}
+		defer func() {
+			cancel()
+			p.Wait()
+		}()
+		go forward(l, srvSock)
+		v("Connected to %v", cl)
+	}
 	// now run stuff.
 	if err := shell(cl, a, port); err != nil {
 		return err
@@ -500,7 +515,7 @@ func doInit() error {
 	if err := cpuSetup(); err != nil {
 		log.Printf("CPU setup error with cpu running as init: %v", err)
 	}
-	cmds := [][]string{{"/bin/defaultsh"}, {"/bbin/dhclient", "-verbose"}}
+	cmds := [][]string{{"/bin/defaultsh"}, {"/bbin/dhclient", "-v"}}
 	verbose("Try to run %v", cmds)
 
 	for _, v := range cmds {

--- a/vendor/github.com/hugelgupf/p9/LICENSE
+++ b/vendor/github.com/hugelgupf/p9/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/hugelgupf/p9/localfs/localfs.go
+++ b/vendor/github.com/hugelgupf/p9/localfs/localfs.go
@@ -1,0 +1,270 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localfs
+
+import (
+	"log"
+	"os"
+	"path"
+	"syscall"
+
+	"github.com/hugelgupf/p9/p9"
+	"github.com/hugelgupf/p9/unimplfs"
+)
+
+// Local is a p9.Attacher.
+type Local struct {
+	p9.DefaultWalkGetAttr
+	unimplfs.NoopFile
+
+	path string
+	file *os.File
+}
+
+// Attach implements p9.Attacher.Attach.
+func (l *Local) Attach() (p9.File, error) {
+	return &Local{path: "/"}, nil
+}
+
+var (
+	_ p9.File     = &Local{}
+	_ p9.Attacher = &Local{}
+)
+
+// info constructs a QID for this file.
+func (l *Local) info() (p9.QID, os.FileInfo, error) {
+	var (
+		qid p9.QID
+		fi  os.FileInfo
+		err error
+	)
+
+	// Stat the file.
+	if l.file != nil {
+		fi, err = l.file.Stat()
+	} else {
+		fi, err = os.Lstat(l.path)
+	}
+	if err != nil {
+		log.Printf("error stating %#v: %v", l, err)
+		return qid, nil, err
+	}
+
+	// Construct the QID type.
+	qid.Type = p9.ModeFromOS(fi.Mode()).QIDType()
+
+	// Save the path from the Ino.
+	qid.Path = fi.Sys().(*syscall.Stat_t).Ino
+	return qid, fi, nil
+}
+
+// Walk implements p9.File.Walk.
+func (l *Local) Walk(names []string) ([]p9.QID, p9.File, error) {
+	var qids []p9.QID
+	last := &Local{path: l.path}
+	for _, name := range names {
+		c := &Local{path: path.Join(last.path, name)}
+		qid, _, err := c.info()
+		if err != nil {
+			return nil, nil, err
+		}
+		qids = append(qids, qid)
+		last = c
+	}
+	return qids, last, nil
+}
+
+// FSync implements p9.File.FSync.
+func (l *Local) FSync() error {
+	return l.file.Sync()
+}
+
+// GetAttr implements p9.File.GetAttr.
+//
+// Not fully implemented.
+func (l *Local) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+	qid, fi, err := l.info()
+	if err != nil {
+		return qid, p9.AttrMask{}, p9.Attr{}, err
+	}
+
+	stat := fi.Sys().(*syscall.Stat_t)
+	attr := p9.Attr{
+		Mode:             p9.FileMode(stat.Mode),
+		UID:              p9.UID(stat.Uid),
+		GID:              p9.GID(stat.Gid),
+		NLink:            stat.Nlink,
+		RDev:             stat.Rdev,
+		Size:             uint64(stat.Size),
+		BlockSize:        uint64(stat.Blksize),
+		Blocks:           uint64(stat.Blocks),
+		ATimeSeconds:     uint64(stat.Atim.Sec),
+		ATimeNanoSeconds: uint64(stat.Atim.Nsec),
+		MTimeSeconds:     uint64(stat.Mtim.Sec),
+		MTimeNanoSeconds: uint64(stat.Mtim.Nsec),
+		CTimeSeconds:     uint64(stat.Ctim.Sec),
+		CTimeNanoSeconds: uint64(stat.Ctim.Nsec),
+	}
+	valid := p9.AttrMask{
+		Mode:   true,
+		UID:    true,
+		GID:    true,
+		NLink:  true,
+		RDev:   true,
+		Size:   true,
+		Blocks: true,
+		ATime:  true,
+		MTime:  true,
+		CTime:  true,
+	}
+
+	return qid, valid, attr, nil
+}
+
+// Close implements p9.File.Close.
+func (l *Local) Close() error {
+	if l.file != nil {
+		return l.file.Close()
+	}
+	return nil
+}
+
+// Open implements p9.File.Open.
+func (l *Local) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
+	qid, _, err := l.info()
+	if err != nil {
+		return qid, 0, err
+	}
+
+	// Do the actual open.
+	f, err := os.OpenFile(l.path, int(mode), 0)
+	if err != nil {
+		return qid, 0, err
+	}
+	l.file = f
+
+	return qid, 4096, nil
+}
+
+// Read implements p9.File.Read.
+func (l *Local) ReadAt(p []byte, offset uint64) (int, error) {
+	return l.file.ReadAt(p, int64(offset))
+}
+
+// Write implements p9.File.Write.
+func (l *Local) WriteAt(p []byte, offset uint64) (int, error) {
+	return l.file.WriteAt(p, int64(offset))
+}
+
+// Create implements p9.File.Create.
+func (l *Local) Create(name string, mode p9.OpenFlags, permissions p9.FileMode, _ p9.UID, _ p9.GID) (p9.File, p9.QID, uint32, error) {
+	f, err := os.OpenFile(l.path, int(mode)|syscall.O_CREAT|syscall.O_EXCL, os.FileMode(permissions))
+	if err != nil {
+		return nil, p9.QID{}, 0, err
+	}
+
+	l2 := &Local{path: path.Join(l.path, name), file: f}
+	qid, _, err := l2.info()
+	if err != nil {
+		l2.Close()
+		return nil, p9.QID{}, 0, err
+	}
+
+	return l2, qid, 4096, nil
+}
+
+// Mkdir implements p9.File.Mkdir.
+//
+// Not properly implemented.
+func (l *Local) Mkdir(name string, permissions p9.FileMode, _ p9.UID, _ p9.GID) (p9.QID, error) {
+	if err := os.Mkdir(path.Join(l.path, name), os.FileMode(permissions)); err != nil {
+		return p9.QID{}, err
+	}
+
+	// Blank QID.
+	return p9.QID{}, nil
+}
+
+// Symlink implements p9.File.Symlink.
+//
+// Not properly implemented.
+func (l *Local) Symlink(oldname string, newname string, _ p9.UID, _ p9.GID) (p9.QID, error) {
+	if err := os.Symlink(oldname, path.Join(l.path, newname)); err != nil {
+		return p9.QID{}, err
+	}
+
+	// Blank QID.
+	return p9.QID{}, nil
+}
+
+// Link implements p9.File.Link.
+//
+// Not properly implemented.
+func (l *Local) Link(target p9.File, newname string) error {
+	return os.Link(target.(*Local).path, path.Join(l.path, newname))
+}
+
+// Readdir implements p9.File.Readdir.
+func (l *Local) Readdir(offset uint64, count uint32) ([]p9.Dirent, error) {
+	// We only do *all* dirents in single shot.
+	const maxDirentBuffer = 1024 * 1024
+	buf := make([]byte, maxDirentBuffer)
+	n, err := syscall.ReadDirent(int(l.file.Fd()), buf)
+	if err != nil {
+		// Return zero entries.
+		return nil, nil
+	}
+
+	// Parse the entries; note that we read up to offset+count here.
+	_, newCount, newNames := syscall.ParseDirent(buf[:n], int(offset)+int(count), nil)
+	var dirents []p9.Dirent
+	for i := int(offset); i >= 0 && i < newCount; i++ {
+		entry := Local{path: path.Join(l.path, newNames[i])}
+		qid, _, err := entry.info()
+		if err != nil {
+			continue
+		}
+		dirents = append(dirents, p9.Dirent{
+			QID:    qid,
+			Type:   qid.Type,
+			Name:   newNames[i],
+			Offset: uint64(i + 1),
+		})
+	}
+
+	return dirents, nil
+}
+
+// Readlink implements p9.File.Readlink.
+//
+// Not properly implemented.
+func (l *Local) Readlink() (string, error) {
+	return os.Readlink(l.path)
+}
+
+// Flush implements p9.File.Flush.
+func (l *Local) Flush() error {
+	return nil
+}
+
+// Renamed implements p9.File.Renamed.
+func (l *Local) Renamed(parent p9.File, newName string) {
+	l.path = path.Join(parent.(*Local).path, newName)
+}
+
+// Allocate implements p9.File.Allocate.
+func (l *Local) Allocate(mode p9.AllocateMode, offset, length uint64) error {
+	return syscall.Fallocate(int(l.file.Fd()), mode.ToLinux(), int64(offset), int64(length))
+}

--- a/vendor/github.com/hugelgupf/p9/p9/buffer.go
+++ b/vendor/github.com/hugelgupf/p9/p9/buffer.go
@@ -1,0 +1,253 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"encoding/binary"
+)
+
+// encoder is used for messages and 9P primitives.
+type encoder interface {
+	// decode decodes from the given buffer. decode may be called more than once
+	// to reuse the instance. It must clear any previous state.
+	//
+	// This may not fail, exhaustion will be recorded in the buffer.
+	decode(b *buffer)
+
+	// encode encodes to the given buffer.
+	//
+	// This may not fail.
+	encode(b *buffer)
+}
+
+// order is the byte order used for encoding.
+var order = binary.LittleEndian
+
+// buffer is a slice that is consumed.
+//
+// This is passed to the encoder methods.
+type buffer struct {
+	// data is the underlying data. This may grow during encode.
+	data []byte
+
+	// overflow indicates whether an overflow has occurred.
+	overflow bool
+}
+
+// append appends n bytes to the buffer and returns a slice pointing to the
+// newly appended bytes.
+func (b *buffer) append(n int) []byte {
+	b.data = append(b.data, make([]byte, n)...)
+	return b.data[len(b.data)-n:]
+}
+
+// consume consumes n bytes from the buffer.
+func (b *buffer) consume(n int) ([]byte, bool) {
+	if !b.has(n) {
+		b.markOverrun()
+		return nil, false
+	}
+	rval := b.data[:n]
+	b.data = b.data[n:]
+	return rval, true
+}
+
+// has returns true if n bytes are available.
+func (b *buffer) has(n int) bool {
+	return len(b.data) >= n
+}
+
+// markOverrun immediately marks this buffer as overrun.
+//
+// This is used by ReadString, since some invalid data implies the rest of the
+// buffer is no longer valid either.
+func (b *buffer) markOverrun() {
+	b.overflow = true
+}
+
+// isOverrun returns true if this buffer has run past the end.
+func (b *buffer) isOverrun() bool {
+	return b.overflow
+}
+
+// Read8 reads a byte from the buffer.
+func (b *buffer) Read8() uint8 {
+	v, ok := b.consume(1)
+	if !ok {
+		return 0
+	}
+	return uint8(v[0])
+}
+
+// Read16 reads a 16-bit value from the buffer.
+func (b *buffer) Read16() uint16 {
+	v, ok := b.consume(2)
+	if !ok {
+		return 0
+	}
+	return order.Uint16(v)
+}
+
+// Read32 reads a 32-bit value from the buffer.
+func (b *buffer) Read32() uint32 {
+	v, ok := b.consume(4)
+	if !ok {
+		return 0
+	}
+	return order.Uint32(v)
+}
+
+// Read64 reads a 64-bit value from the buffer.
+func (b *buffer) Read64() uint64 {
+	v, ok := b.consume(8)
+	if !ok {
+		return 0
+	}
+	return order.Uint64(v)
+}
+
+// ReadQIDType reads a QIDType value.
+func (b *buffer) ReadQIDType() QIDType {
+	return QIDType(b.Read8())
+}
+
+// ReadTag reads a Tag value.
+func (b *buffer) ReadTag() tag {
+	return tag(b.Read16())
+}
+
+// ReadFID reads a FID value.
+func (b *buffer) ReadFID() fid {
+	return fid(b.Read32())
+}
+
+// ReadUID reads a UID value.
+func (b *buffer) ReadUID() UID {
+	return UID(b.Read32())
+}
+
+// ReadGID reads a GID value.
+func (b *buffer) ReadGID() GID {
+	return GID(b.Read32())
+}
+
+// ReadPermissions reads a file mode value and applies the mask for permissions.
+func (b *buffer) ReadPermissions() FileMode {
+	return b.ReadFileMode() & permissionsMask
+}
+
+// ReadFileMode reads a file mode value.
+func (b *buffer) ReadFileMode() FileMode {
+	return FileMode(b.Read32())
+}
+
+// ReadOpenFlags reads an OpenFlags.
+func (b *buffer) ReadOpenFlags() OpenFlags {
+	return OpenFlags(b.Read32())
+}
+
+// ReadMsgType writes a msgType.
+func (b *buffer) ReadMsgType() msgType {
+	return msgType(b.Read8())
+}
+
+// ReadString deserializes a string.
+func (b *buffer) ReadString() string {
+	l := b.Read16()
+	if !b.has(int(l)) {
+		// Mark the buffer as corrupted.
+		b.markOverrun()
+		return ""
+	}
+
+	bs := make([]byte, l)
+	for i := 0; i < int(l); i++ {
+		bs[i] = byte(b.Read8())
+	}
+	return string(bs)
+}
+
+// Write8 writes a byte to the buffer.
+func (b *buffer) Write8(v uint8) {
+	b.append(1)[0] = byte(v)
+}
+
+// Write16 writes a 16-bit value to the buffer.
+func (b *buffer) Write16(v uint16) {
+	order.PutUint16(b.append(2), v)
+}
+
+// Write32 writes a 32-bit value to the buffer.
+func (b *buffer) Write32(v uint32) {
+	order.PutUint32(b.append(4), v)
+}
+
+// Write64 writes a 64-bit value to the buffer.
+func (b *buffer) Write64(v uint64) {
+	order.PutUint64(b.append(8), v)
+}
+
+// WriteQIDType writes a QIDType value.
+func (b *buffer) WriteQIDType(qidType QIDType) {
+	b.Write8(uint8(qidType))
+}
+
+// WriteTag writes a Tag value.
+func (b *buffer) WriteTag(tag tag) {
+	b.Write16(uint16(tag))
+}
+
+// WriteFID writes a FID value.
+func (b *buffer) WriteFID(fid fid) {
+	b.Write32(uint32(fid))
+}
+
+// WriteUID writes a UID value.
+func (b *buffer) WriteUID(uid UID) {
+	b.Write32(uint32(uid))
+}
+
+// WriteGID writes a GID value.
+func (b *buffer) WriteGID(gid GID) {
+	b.Write32(uint32(gid))
+}
+
+// WritePermissions applies a permissions mask and writes the FileMode.
+func (b *buffer) WritePermissions(perm FileMode) {
+	b.WriteFileMode(perm & permissionsMask)
+}
+
+// WriteFileMode writes a FileMode.
+func (b *buffer) WriteFileMode(mode FileMode) {
+	b.Write32(uint32(mode))
+}
+
+// WriteOpenFlags writes an OpenFlags.
+func (b *buffer) WriteOpenFlags(flags OpenFlags) {
+	b.Write32(uint32(flags))
+}
+
+// WriteMsgType writes a MsgType.
+func (b *buffer) WriteMsgType(t msgType) {
+	b.Write8(uint8(t))
+}
+
+// WriteString serializes the given string.
+func (b *buffer) WriteString(s string) {
+	b.Write16(uint16(len(s)))
+	for i := 0; i < len(s); i++ {
+		b.Write8(byte(s[i]))
+	}
+}

--- a/vendor/github.com/hugelgupf/p9/p9/client.go
+++ b/vendor/github.com/hugelgupf/p9/p9/client.go
@@ -1,0 +1,306 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"syscall"
+)
+
+// ErrOutOfTags indicates no tags are available.
+var ErrOutOfTags = errors.New("out of tags -- messages lost?")
+
+// ErrOutOfFIDs indicates no more FIDs are available.
+var ErrOutOfFIDs = errors.New("out of FIDs -- messages lost?")
+
+// ErrUnexpectedTag indicates a response with an unexpected tag was received.
+var ErrUnexpectedTag = errors.New("unexpected tag in response")
+
+// ErrVersionsExhausted indicates that all versions to negotiate have been exhausted.
+var ErrVersionsExhausted = errors.New("exhausted all versions to negotiate")
+
+// ErrBadVersionString indicates that the version string is malformed or unsupported.
+var ErrBadVersionString = errors.New("bad version string")
+
+// ErrBadResponse indicates the response didn't match the request.
+type ErrBadResponse struct {
+	Got  msgType
+	Want msgType
+}
+
+// Error returns a highly descriptive error.
+func (e *ErrBadResponse) Error() string {
+	return fmt.Sprintf("unexpected message type: got %v, want %v", e.Got, e.Want)
+}
+
+// response is the asynchronous return from recv.
+//
+// This is used in the pending map below.
+type response struct {
+	r    message
+	done chan error
+}
+
+var responsePool = sync.Pool{
+	New: func() interface{} {
+		return &response{
+			done: make(chan error, 1),
+		}
+	},
+}
+
+// Client is at least a 9P2000.L client.
+type Client struct {
+	// socket is the connected socket.
+	socket net.Conn
+
+	// tagPool is the collection of available tags.
+	tagPool pool
+
+	// fidPool is the collection of available fids.
+	fidPool pool
+
+	// pending is the set of pending messages.
+	pending   map[tag]*response
+	pendingMu sync.Mutex
+
+	// sendMu is the lock for sending a request.
+	sendMu sync.Mutex
+
+	// recvr is essentially a mutex for calling recv.
+	//
+	// Whoever writes to this channel is permitted to call recv. When
+	// finished calling recv, this channel should be emptied.
+	recvr chan bool
+
+	// messageSize is the maximum total size of a message.
+	messageSize uint32
+
+	// payloadSize is the maximum payload size of a read or write
+	// request.  For large reads and writes this means that the
+	// read or write is broken up into buffer-size/payloadSize
+	// requests.
+	payloadSize uint32
+
+	// version is the agreed upon version X of 9P2000.L.Google.X.
+	// version 0 implies 9P2000.L.
+	version uint32
+}
+
+// NewClient creates a new client.  It performs a Tversion exchange with
+// the server to assert that messageSize is ok to use.
+//
+// You should not use the same socket for multiple clients.
+func NewClient(socket net.Conn, messageSize uint32, version string) (*Client, error) {
+	// Need at least one byte of payload.
+	if messageSize <= msgRegistry.largestFixedSize {
+		return nil, &ErrMessageTooLarge{
+			size:  messageSize,
+			msize: msgRegistry.largestFixedSize,
+		}
+	}
+
+	// Compute a payload size and round to 512 (normal block size)
+	// if it's larger than a single block.
+	payloadSize := messageSize - msgRegistry.largestFixedSize
+	if payloadSize > 512 && payloadSize%512 != 0 {
+		payloadSize -= (payloadSize % 512)
+	}
+	c := &Client{
+		socket:      socket,
+		tagPool:     pool{start: 1, limit: uint64(noTag)},
+		fidPool:     pool{start: 1, limit: uint64(noFID)},
+		pending:     make(map[tag]*response),
+		recvr:       make(chan bool, 1),
+		messageSize: messageSize,
+		payloadSize: payloadSize,
+	}
+	// Agree upon a version.
+	requested, ok := parseVersion(version)
+	if !ok {
+		return nil, ErrBadVersionString
+	}
+	for {
+		rversion := rversion{}
+		err := c.sendRecv(&tversion{Version: versionString(requested), MSize: messageSize}, &rversion)
+
+		// The server told us to try again with a lower version.
+		if err == syscall.EAGAIN {
+			if requested == lowestSupportedVersion {
+				return nil, ErrVersionsExhausted
+			}
+			requested--
+			continue
+		}
+
+		// We requested an impossible version or our other parameters were bogus.
+		if err != nil {
+			return nil, err
+		}
+
+		// Parse the version.
+		version, ok := parseVersion(rversion.Version)
+		if !ok {
+			// The server gave us a bad version. We return a generically worrisome error.
+			log.Printf("server returned bad version string %q", rversion.Version)
+			return nil, ErrBadVersionString
+		}
+		c.version = version
+		break
+	}
+	return c, nil
+}
+
+// handleOne handles a single incoming message.
+//
+// This should only be called with the token from recvr. Note that the received
+// tag will automatically be cleared from pending.
+func (c *Client) handleOne() {
+	t, r, err := recv(c.socket, c.messageSize, func(t tag, mt msgType) (message, error) {
+		c.pendingMu.Lock()
+		resp := c.pending[t]
+		c.pendingMu.Unlock()
+
+		// Not expecting this message?
+		if resp == nil {
+			log.Printf("client received unexpected tag %v, ignoring", t)
+			return nil, ErrUnexpectedTag
+		}
+
+		// Is it an error? We specifically allow this to
+		// go through, and then we deserialize below.
+		if mt == msgRlerror {
+			return &rlerror{}, nil
+		}
+
+		// Does it match expectations?
+		if mt != resp.r.typ() {
+			return nil, &ErrBadResponse{Got: mt, Want: resp.r.typ()}
+		}
+
+		// Return the response.
+		return resp.r, nil
+	})
+
+	if err != nil {
+		// No tag was extracted (probably a socket error).
+		//
+		// Likely catastrophic. Notify all waiters and clear pending.
+		c.pendingMu.Lock()
+		for _, resp := range c.pending {
+			resp.done <- err
+		}
+		c.pending = make(map[tag]*response)
+		c.pendingMu.Unlock()
+	} else {
+		// Process the tag.
+		//
+		// We know that is is contained in the map because our lookup function
+		// above must have succeeded (found the tag) to return nil err.
+		c.pendingMu.Lock()
+		resp := c.pending[t]
+		delete(c.pending, t)
+		c.pendingMu.Unlock()
+		resp.r = r
+		resp.done <- err
+	}
+}
+
+// waitAndRecv co-ordinates with other receivers to handle responses.
+func (c *Client) waitAndRecv(done chan error) error {
+	for {
+		select {
+		case err := <-done:
+			return err
+		case c.recvr <- true:
+			select {
+			case err := <-done:
+				// It's possible that we got the token, despite
+				// done also being available. Check for that.
+				<-c.recvr
+				return err
+			default:
+				// Handle receiving one tag.
+				c.handleOne()
+
+				// Return the token.
+				<-c.recvr
+			}
+		}
+	}
+}
+
+// sendRecv performs a roundtrip message exchange.
+//
+// This is called by internal functions.
+func (c *Client) sendRecv(tm message, rm message) error {
+	t, ok := c.tagPool.Get()
+	if !ok {
+		return ErrOutOfTags
+	}
+	defer c.tagPool.Put(t)
+
+	// Indicate we're expecting a response.
+	//
+	// Note that the tag will be cleared from pending
+	// automatically (see handleOne for details).
+	resp := responsePool.Get().(*response)
+	defer responsePool.Put(resp)
+	resp.r = rm
+	c.pendingMu.Lock()
+	c.pending[tag(t)] = resp
+	c.pendingMu.Unlock()
+
+	// Send the request over the wire.
+	c.sendMu.Lock()
+	err := send(c.socket, tag(t), tm)
+	c.sendMu.Unlock()
+	if err != nil {
+		return fmt.Errorf("send: %v", err)
+	}
+
+	// Co-ordinate with other receivers.
+	if err := c.waitAndRecv(resp.done); err != nil {
+		return fmt.Errorf("wait: %v", err)
+	}
+
+	// Is it an error message?
+	//
+	// For convenience, we transform these directly
+	// into errors. Handlers need not handle this case.
+	if rlerr, ok := resp.r.(*rlerror); ok {
+		return syscall.Errno(rlerr.Error)
+	}
+
+	// At this point, we know it matches.
+	//
+	// Per recv call above, we will only allow a type
+	// match (and give our r) or an instance of Rlerror.
+	return nil
+}
+
+// Version returns the negotiated 9P2000.L.Google version number.
+func (c *Client) Version() uint32 {
+	return c.version
+}
+
+// Close closes the underlying socket.
+func (c *Client) Close() error {
+	return c.socket.Close()
+}

--- a/vendor/github.com/hugelgupf/p9/p9/client_file.go
+++ b/vendor/github.com/hugelgupf/p9/p9/client_file.go
@@ -1,0 +1,612 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"runtime"
+	"sync/atomic"
+	"syscall"
+)
+
+// Attach attaches to a server.
+//
+// Note that authentication is not currently supported.
+func (c *Client) Attach(name string) (File, error) {
+	id, ok := c.fidPool.Get()
+	if !ok {
+		return nil, ErrOutOfFIDs
+	}
+
+	rattach := rattach{}
+	if err := c.sendRecv(&tattach{fid: fid(id), Auth: tauth{AttachName: name, Authenticationfid: noFID, UID: NoUID}}, &rattach); err != nil {
+		c.fidPool.Put(id)
+		return nil, err
+	}
+
+	return c.newFile(fid(id)), nil
+}
+
+// newFile returns a new client file.
+func (c *Client) newFile(fid fid) *clientFile {
+	cf := &clientFile{
+		client: c,
+		fid:    fid,
+	}
+
+	// Make sure the file is closed.
+	runtime.SetFinalizer(cf, (*clientFile).Close)
+
+	return cf
+}
+
+// clientFile is provided to clients.
+//
+// This proxies all of the interfaces found in file.go.
+type clientFile struct {
+	// client is the originating client.
+	client *Client
+
+	// fid is the fid for this file.
+	fid fid
+
+	// closed indicates whether this file has been closed.
+	closed uint32
+}
+
+// Walk implements File.Walk.
+func (c *clientFile) Walk(names []string) ([]QID, File, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return nil, nil, syscall.EBADF
+	}
+
+	id, ok := c.client.fidPool.Get()
+	if !ok {
+		return nil, nil, ErrOutOfFIDs
+	}
+
+	rwalk := rwalk{}
+	if err := c.client.sendRecv(&twalk{fid: c.fid, newFID: fid(id), Names: names}, &rwalk); err != nil {
+		c.client.fidPool.Put(id)
+		return nil, nil, err
+	}
+
+	// Return a new client file.
+	return rwalk.QIDs, c.client.newFile(fid(id)), nil
+}
+
+// WalkGetAttr implements File.WalkGetAttr.
+func (c *clientFile) WalkGetAttr(components []string) ([]QID, File, AttrMask, Attr, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return nil, nil, AttrMask{}, Attr{}, syscall.EBADF
+	}
+
+	if !versionSupportsTwalkgetattr(c.client.version) {
+		qids, file, err := c.Walk(components)
+		if err != nil {
+			return nil, nil, AttrMask{}, Attr{}, err
+		}
+		_, valid, attr, err := file.GetAttr(AttrMaskAll())
+		if err != nil {
+			file.Close()
+			return nil, nil, AttrMask{}, Attr{}, err
+		}
+		return qids, file, valid, attr, nil
+	}
+
+	id, ok := c.client.fidPool.Get()
+	if !ok {
+		return nil, nil, AttrMask{}, Attr{}, ErrOutOfFIDs
+	}
+
+	rwalkgetattr := rwalkgetattr{}
+	if err := c.client.sendRecv(&twalkgetattr{fid: c.fid, newFID: fid(id), Names: components}, &rwalkgetattr); err != nil {
+		c.client.fidPool.Put(id)
+		return nil, nil, AttrMask{}, Attr{}, err
+	}
+
+	// Return a new client file.
+	return rwalkgetattr.QIDs, c.client.newFile(fid(id)), rwalkgetattr.Valid, rwalkgetattr.Attr, nil
+}
+
+// StatFS implements File.StatFS.
+func (c *clientFile) StatFS() (FSStat, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return FSStat{}, syscall.EBADF
+	}
+
+	rstatfs := rstatfs{}
+	if err := c.client.sendRecv(&tstatfs{fid: c.fid}, &rstatfs); err != nil {
+		return FSStat{}, err
+	}
+
+	return rstatfs.FSStat, nil
+}
+
+// FSync implements File.FSync.
+func (c *clientFile) FSync() error {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return syscall.EBADF
+	}
+
+	return c.client.sendRecv(&tfsync{fid: c.fid}, &rfsync{})
+}
+
+// GetAttr implements File.GetAttr.
+func (c *clientFile) GetAttr(req AttrMask) (QID, AttrMask, Attr, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return QID{}, AttrMask{}, Attr{}, syscall.EBADF
+	}
+
+	rgetattr := rgetattr{}
+	if err := c.client.sendRecv(&tgetattr{fid: c.fid, AttrMask: req}, &rgetattr); err != nil {
+		return QID{}, AttrMask{}, Attr{}, err
+	}
+
+	return rgetattr.QID, rgetattr.Valid, rgetattr.Attr, nil
+}
+
+// SetAttr implements File.SetAttr.
+func (c *clientFile) SetAttr(valid SetAttrMask, attr SetAttr) error {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return syscall.EBADF
+	}
+
+	return c.client.sendRecv(&tsetattr{fid: c.fid, Valid: valid, SetAttr: attr}, &rsetattr{})
+}
+
+// Allocate implements File.Allocate.
+func (c *clientFile) Allocate(mode AllocateMode, offset, length uint64) error {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return syscall.EBADF
+	}
+	if !versionSupportsTallocate(c.client.version) {
+		return syscall.EOPNOTSUPP
+	}
+
+	return c.client.sendRecv(&tallocate{fid: c.fid, Mode: mode, Offset: offset, Length: length}, &rallocate{})
+}
+
+// Remove implements File.Remove.
+//
+// N.B. This method is no longer part of the file interface and should be
+// considered deprecated.
+func (c *clientFile) Remove() error {
+	// Avoid double close.
+	if !atomic.CompareAndSwapUint32(&c.closed, 0, 1) {
+		return syscall.EBADF
+	}
+	runtime.SetFinalizer(c, nil)
+
+	// Send the remove message.
+	if err := c.client.sendRecv(&tremove{fid: c.fid}, &rremove{}); err != nil {
+		return err
+	}
+
+	// "It is correct to consider remove to be a clunk with the side effect
+	// of removing the file if permissions allow."
+	// https://swtch.com/plan9port/man/man9/remove.html
+
+	// Return the fid to the pool.
+	c.client.fidPool.Put(uint64(c.fid))
+	return nil
+}
+
+// Close implements File.Close.
+func (c *clientFile) Close() error {
+	// Avoid double close.
+	if !atomic.CompareAndSwapUint32(&c.closed, 0, 1) {
+		return syscall.EBADF
+	}
+	runtime.SetFinalizer(c, nil)
+
+	// Send the close message.
+	if err := c.client.sendRecv(&tclunk{fid: c.fid}, &rclunk{}); err != nil {
+		// If an error occurred, we toss away the fid. This isn't ideal,
+		// but I'm not sure what else makes sense in this context.
+		log.Printf("Tclunk failed, losing fid %v: %v", c.fid, err)
+		return err
+	}
+
+	// Return the fid to the pool.
+	c.client.fidPool.Put(uint64(c.fid))
+	return nil
+}
+
+// Open implements File.Open.
+func (c *clientFile) Open(flags OpenFlags) (QID, uint32, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return QID{}, 0, syscall.EBADF
+	}
+
+	rlopen := rlopen{}
+	if err := c.client.sendRecv(&tlopen{fid: c.fid, Flags: flags}, &rlopen); err != nil {
+		return QID{}, 0, err
+	}
+
+	return rlopen.QID, rlopen.IoUnit, nil
+}
+
+// chunk applies fn to p in chunkSize-sized chunks until fn returns a partial result, p is
+// exhausted, or an error is encountered (which may be io.EOF).
+func chunk(chunkSize uint32, fn func([]byte, uint64) (int, error), p []byte, offset uint64) (int, error) {
+	// Some p9.Clients depend on executing fn on zero-byte buffers. Handle this
+	// as a special case (normally it is fine to short-circuit and return (0, nil)).
+	if len(p) == 0 {
+		return fn(p, offset)
+	}
+
+	// total is the cumulative bytes processed.
+	var total int
+	for {
+		var n int
+		var err error
+
+		// We're done, don't bother trying to do anything more.
+		if total == len(p) {
+			return total, nil
+		}
+
+		// Apply fn to a chunkSize-sized (or less) chunk of p.
+		if len(p) < total+int(chunkSize) {
+			n, err = fn(p[total:], offset)
+		} else {
+			n, err = fn(p[total:total+int(chunkSize)], offset)
+		}
+		total += n
+		offset += uint64(n)
+
+		// Return whatever we have processed if we encounter an error. This error
+		// could be io.EOF.
+		if err != nil {
+			return total, err
+		}
+
+		// Did we get a partial result? If so, return it immediately.
+		if n < int(chunkSize) {
+			return total, nil
+		}
+
+		// If we received more bytes than we ever requested, this is a problem.
+		if total > len(p) {
+			panic(fmt.Sprintf("bytes completed (%d)) > requested (%d)", total, len(p)))
+		}
+	}
+}
+
+// ReadAt proxies File.ReadAt.
+func (c *clientFile) ReadAt(p []byte, offset uint64) (int, error) {
+	return chunk(c.client.payloadSize, c.readAt, p, offset)
+}
+
+func (c *clientFile) readAt(p []byte, offset uint64) (int, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return 0, syscall.EBADF
+	}
+
+	rread := rread{Data: p}
+	if err := c.client.sendRecv(&tread{fid: c.fid, Offset: offset, Count: uint32(len(p))}, &rread); err != nil {
+		return 0, err
+	}
+
+	// The message may have been truncated, or for some reason a new buffer
+	// allocated. This isn't the common path, but we make sure that if the
+	// payload has changed we copy it. See transport.go for more information.
+	if len(p) > 0 && len(rread.Data) > 0 && &rread.Data[0] != &p[0] {
+		copy(p, rread.Data)
+	}
+
+	// io.EOF is not an error that a p9 server can return. Use POSIX semantics to
+	// return io.EOF manually: zero bytes were returned and a non-zero buffer was used.
+	if len(rread.Data) == 0 && len(p) > 0 {
+		return 0, io.EOF
+	}
+
+	return len(rread.Data), nil
+}
+
+// WriteAt proxies File.WriteAt.
+func (c *clientFile) WriteAt(p []byte, offset uint64) (int, error) {
+	return chunk(c.client.payloadSize, c.writeAt, p, offset)
+}
+
+func (c *clientFile) writeAt(p []byte, offset uint64) (int, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return 0, syscall.EBADF
+	}
+
+	rwrite := rwrite{}
+	if err := c.client.sendRecv(&twrite{fid: c.fid, Offset: offset, Data: p}, &rwrite); err != nil {
+		return 0, err
+	}
+
+	return int(rwrite.Count), nil
+}
+
+// ReadWriterFile wraps a File and implements io.ReadWriter, io.ReaderAt, and io.WriterAt.
+type ReadWriterFile struct {
+	File   File
+	Offset uint64
+}
+
+// Read implements part of the io.ReadWriter interface.
+func (r *ReadWriterFile) Read(p []byte) (int, error) {
+	n, err := r.File.ReadAt(p, r.Offset)
+	r.Offset += uint64(n)
+	if err != nil {
+		return n, err
+	}
+	if n == 0 && len(p) > 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// ReadAt implements the io.ReaderAt interface.
+func (r *ReadWriterFile) ReadAt(p []byte, offset int64) (int, error) {
+	n, err := r.File.ReadAt(p, uint64(offset))
+	if err != nil {
+		return 0, err
+	}
+	if n == 0 && len(p) > 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+// Write implements part of the io.ReadWriter interface.
+func (r *ReadWriterFile) Write(p []byte) (int, error) {
+	n, err := r.File.WriteAt(p, r.Offset)
+	r.Offset += uint64(n)
+	if err != nil {
+		return n, err
+	}
+	if n < len(p) {
+		return n, io.ErrShortWrite
+	}
+	return n, nil
+}
+
+// WriteAt implements the io.WriteAt interface.
+func (r *ReadWriterFile) WriteAt(p []byte, offset int64) (int, error) {
+	n, err := r.File.WriteAt(p, uint64(offset))
+	if err != nil {
+		return n, err
+	}
+	if n < len(p) {
+		return n, io.ErrShortWrite
+	}
+	return n, nil
+}
+
+// Rename implements File.Rename.
+func (c *clientFile) Rename(dir File, name string) error {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return syscall.EBADF
+	}
+
+	clientDir, ok := dir.(*clientFile)
+	if !ok {
+		return syscall.EBADF
+	}
+
+	return c.client.sendRecv(&trename{fid: c.fid, Directory: clientDir.fid, Name: name}, &rrename{})
+}
+
+// Create implements File.Create.
+func (c *clientFile) Create(name string, openFlags OpenFlags, permissions FileMode, uid UID, gid GID) (File, QID, uint32, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return nil, QID{}, 0, syscall.EBADF
+	}
+
+	msg := tlcreate{
+		fid:         c.fid,
+		Name:        name,
+		OpenFlags:   openFlags,
+		Permissions: permissions,
+		GID:         NoGID,
+	}
+
+	if versionSupportsTucreation(c.client.version) {
+		msg.GID = gid
+		rucreate := rucreate{}
+		if err := c.client.sendRecv(&tucreate{tlcreate: msg, UID: uid}, &rucreate); err != nil {
+			return nil, QID{}, 0, err
+		}
+		return c, rucreate.QID, rucreate.IoUnit, nil
+	}
+
+	rlcreate := rlcreate{}
+	if err := c.client.sendRecv(&msg, &rlcreate); err != nil {
+		return nil, QID{}, 0, err
+	}
+
+	return c, rlcreate.QID, rlcreate.IoUnit, nil
+}
+
+// Mkdir implements File.Mkdir.
+func (c *clientFile) Mkdir(name string, permissions FileMode, uid UID, gid GID) (QID, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return QID{}, syscall.EBADF
+	}
+
+	msg := tmkdir{
+		Directory:   c.fid,
+		Name:        name,
+		Permissions: permissions,
+		GID:         NoGID,
+	}
+
+	if versionSupportsTucreation(c.client.version) {
+		msg.GID = gid
+		rumkdir := rumkdir{}
+		if err := c.client.sendRecv(&tumkdir{tmkdir: msg, UID: uid}, &rumkdir); err != nil {
+			return QID{}, err
+		}
+		return rumkdir.QID, nil
+	}
+
+	rmkdir := rmkdir{}
+	if err := c.client.sendRecv(&msg, &rmkdir); err != nil {
+		return QID{}, err
+	}
+
+	return rmkdir.QID, nil
+}
+
+// Symlink implements File.Symlink.
+func (c *clientFile) Symlink(oldname string, newname string, uid UID, gid GID) (QID, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return QID{}, syscall.EBADF
+	}
+
+	msg := tsymlink{
+		Directory: c.fid,
+		Name:      newname,
+		Target:    oldname,
+		GID:       NoGID,
+	}
+
+	if versionSupportsTucreation(c.client.version) {
+		msg.GID = gid
+		rusymlink := rusymlink{}
+		if err := c.client.sendRecv(&tusymlink{tsymlink: msg, UID: uid}, &rusymlink); err != nil {
+			return QID{}, err
+		}
+		return rusymlink.QID, nil
+	}
+
+	rsymlink := rsymlink{}
+	if err := c.client.sendRecv(&msg, &rsymlink); err != nil {
+		return QID{}, err
+	}
+
+	return rsymlink.QID, nil
+}
+
+// Link implements File.Link.
+func (c *clientFile) Link(target File, newname string) error {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return syscall.EBADF
+	}
+
+	targetFile, ok := target.(*clientFile)
+	if !ok {
+		return syscall.EBADF
+	}
+
+	return c.client.sendRecv(&tlink{Directory: c.fid, Name: newname, Target: targetFile.fid}, &rlink{})
+}
+
+// Mknod implements File.Mknod.
+func (c *clientFile) Mknod(name string, mode FileMode, major uint32, minor uint32, uid UID, gid GID) (QID, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return QID{}, syscall.EBADF
+	}
+
+	msg := tmknod{
+		Directory: c.fid,
+		Name:      name,
+		Mode:      mode,
+		Major:     major,
+		Minor:     minor,
+		GID:       NoGID,
+	}
+
+	if versionSupportsTucreation(c.client.version) {
+		msg.GID = gid
+		rumknod := rumknod{}
+		if err := c.client.sendRecv(&tumknod{tmknod: msg, UID: uid}, &rumknod); err != nil {
+			return QID{}, err
+		}
+		return rumknod.QID, nil
+	}
+
+	rmknod := rmknod{}
+	if err := c.client.sendRecv(&msg, &rmknod); err != nil {
+		return QID{}, err
+	}
+
+	return rmknod.QID, nil
+}
+
+// RenameAt implements File.RenameAt.
+func (c *clientFile) RenameAt(oldname string, newdir File, newname string) error {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return syscall.EBADF
+	}
+
+	clientNewDir, ok := newdir.(*clientFile)
+	if !ok {
+		return syscall.EBADF
+	}
+
+	return c.client.sendRecv(&trenameat{OldDirectory: c.fid, OldName: oldname, NewDirectory: clientNewDir.fid, NewName: newname}, &rrenameat{})
+}
+
+// UnlinkAt implements File.UnlinkAt.
+func (c *clientFile) UnlinkAt(name string, flags uint32) error {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return syscall.EBADF
+	}
+
+	return c.client.sendRecv(&tunlinkat{Directory: c.fid, Name: name, Flags: flags}, &runlinkat{})
+}
+
+// Readdir implements File.Readdir.
+func (c *clientFile) Readdir(offset uint64, count uint32) ([]Dirent, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return nil, syscall.EBADF
+	}
+
+	rreaddir := rreaddir{}
+	if err := c.client.sendRecv(&treaddir{Directory: c.fid, Offset: offset, Count: count}, &rreaddir); err != nil {
+		return nil, err
+	}
+
+	return rreaddir.Entries, nil
+}
+
+// Readlink implements File.Readlink.
+func (c *clientFile) Readlink() (string, error) {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return "", syscall.EBADF
+	}
+
+	rreadlink := rreadlink{}
+	if err := c.client.sendRecv(&treadlink{fid: c.fid}, &rreadlink); err != nil {
+		return "", err
+	}
+
+	return rreadlink.Target, nil
+}
+
+// Flush implements File.Flush.
+func (c *clientFile) Flush() error {
+	if atomic.LoadUint32(&c.closed) != 0 {
+		return syscall.EBADF
+	}
+
+	if !VersionSupportsTflushf(c.client.version) {
+		return nil
+	}
+
+	return c.client.sendRecv(&tflushf{fid: c.fid}, &rflushf{})
+}
+
+// Renamed implements File.Renamed.
+func (c *clientFile) Renamed(newDir File, newName string) {}

--- a/vendor/github.com/hugelgupf/p9/p9/file.go
+++ b/vendor/github.com/hugelgupf/p9/p9/file.go
@@ -1,0 +1,237 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"syscall"
+)
+
+// Attacher is provided by the server.
+type Attacher interface {
+	// Attach returns a new File.
+	//
+	// The client-side attach will be translate to a series of walks from
+	// the file returned by this Attach call.
+	Attach() (File, error)
+}
+
+// File is a set of operations corresponding to a single node.
+//
+// Note that on the server side, the server logic places constraints on
+// concurrent operations to make things easier. This may reduce the need for
+// complex, error-prone locking and logic in the backend. These are documented
+// for each method.
+//
+// There are three different types of guarantees provided:
+//
+// none: There is no concurrency guarantee. The method may be invoked
+// concurrently with any other method on any other file.
+//
+// read: The method is guaranteed to be exclusive of any write or global
+// operation that is mutating the state of the directory tree starting at this
+// node. For example, this means creating new files, symlinks, directories or
+// renaming a directory entry (or renaming in to this target), but the method
+// may be called concurrently with other read methods.
+//
+// write: The method is guaranteed to be exclusive of any read, write or global
+// operation that is mutating the state of the directory tree starting at this
+// node, as described in read above. There may however, be other write
+// operations executing concurrently on other components in the directory tree.
+//
+// global: The method is guaranteed to be exclusive of any read, write or
+// global operation.
+type File interface {
+	// Walk walks to the path components given in names.
+	//
+	// Walk returns QIDs in the same order that the names were passed in.
+	//
+	// An empty list of arguments should return a copy of the current file.
+	//
+	// On the server, Walk has a read concurrency guarantee.
+	Walk(names []string) ([]QID, File, error)
+
+	// WalkGetAttr walks to the next file and returns its maximal set of
+	// attributes.
+	//
+	// Server-side p9.Files may return syscall.ENOSYS to indicate that Walk
+	// and GetAttr should be used separately to satisfy this request.
+	//
+	// On the server, WalkGetAttr has a read concurrency guarantee.
+	WalkGetAttr([]string) ([]QID, File, AttrMask, Attr, error)
+
+	// StatFS returns information about the file system associated with
+	// this file.
+	//
+	// On the server, StatFS has no concurrency guarantee.
+	StatFS() (FSStat, error)
+
+	// GetAttr returns attributes of this node.
+	//
+	// On the server, GetAttr has a read concurrency guarantee.
+	GetAttr(req AttrMask) (QID, AttrMask, Attr, error)
+
+	// SetAttr sets attributes on this node.
+	//
+	// On the server, SetAttr has a write concurrency guarantee.
+	SetAttr(valid SetAttrMask, attr SetAttr) error
+
+	// Allocate allows the caller to directly manipulate the allocated disk space
+	// for the file. See fallocate(2) for more details.
+	Allocate(mode AllocateMode, offset, length uint64) error
+
+	// Close is called when all references are dropped on the server side,
+	// and Close should be called by the client to drop all references.
+	//
+	// For server-side implementations of Close, the error is ignored.
+	//
+	// Close must be called even when Open has not been called.
+	//
+	// On the server, Close has no concurrency guarantee.
+	Close() error
+
+	// Open must be called prior to using Read, Write or Readdir. Once Open
+	// is called, some operations, such as Walk, will no longer work.
+	//
+	// On the client, Open should be called only once. The fd return is
+	// optional, and may be nil.
+	//
+	// On the server, Open has a read concurrency guarantee.  Open is
+	// guaranteed to be called only once.
+	//
+	// N.B. The server must resolve any lazy paths when open is called.
+	// After this point, read and write may be called on files with no
+	// deletion check, so resolving in the data path is not viable.
+	Open(mode OpenFlags) (QID, uint32, error)
+
+	// Read reads from this file. Open must be called first.
+	//
+	// This may return io.EOF in addition to syscall.Errno values.
+	//
+	// On the server, ReadAt has a read concurrency guarantee. See Open for
+	// additional requirements regarding lazy path resolution.
+	ReadAt(p []byte, offset uint64) (int, error)
+
+	// Write writes to this file. Open must be called first.
+	//
+	// This may return io.EOF in addition to syscall.Errno values.
+	//
+	// On the server, WriteAt has a read concurrency guarantee. See Open
+	// for additional requirements regarding lazy path resolution.
+	WriteAt(p []byte, offset uint64) (int, error)
+
+	// FSync syncs this node. Open must be called first.
+	//
+	// On the server, FSync has a read concurrency guarantee.
+	FSync() error
+
+	// Create creates a new regular file and opens it according to the
+	// flags given. This file is already Open.
+	//
+	// N.B. On the client, the returned file is a reference to the current
+	// file, which now represents the created file. This is not the case on
+	// the server. These semantics are very subtle and can easily lead to
+	// bugs, but are a consequence of the 9P create operation.
+	//
+	// On the server, Create has a write concurrency guarantee.
+	Create(name string, flags OpenFlags, permissions FileMode, uid UID, gid GID) (File, QID, uint32, error)
+
+	// Mkdir creates a subdirectory.
+	//
+	// On the server, Mkdir has a write concurrency guarantee.
+	Mkdir(name string, permissions FileMode, uid UID, gid GID) (QID, error)
+
+	// Symlink makes a new symbolic link.
+	//
+	// On the server, Symlink has a write concurrency guarantee.
+	Symlink(oldName string, newName string, uid UID, gid GID) (QID, error)
+
+	// Link makes a new hard link.
+	//
+	// On the server, Link has a write concurrency guarantee.
+	Link(target File, newName string) error
+
+	// Mknod makes a new device node.
+	//
+	// On the server, Mknod has a write concurrency guarantee.
+	Mknod(name string, mode FileMode, major uint32, minor uint32, uid UID, gid GID) (QID, error)
+
+	// Rename renames the file.
+	//
+	// Rename will never be called on the server, and RenameAt will always
+	// be used instead.
+	Rename(newDir File, newName string) error
+
+	// RenameAt renames a given file to a new name in a potentially new
+	// directory.
+	//
+	// oldName must be a name relative to this file, which must be a
+	// directory. newName is a name relative to newDir.
+	//
+	// On the server, RenameAt has a global concurrency guarantee.
+	RenameAt(oldName string, newDir File, newName string) error
+
+	// UnlinkAt the given named file.
+	//
+	// name must be a file relative to this directory.
+	//
+	// Flags are implementation-specific (e.g. O_DIRECTORY), but are
+	// generally Linux unlinkat(2) flags.
+	//
+	// On the server, UnlinkAt has a write concurrency guarantee.
+	UnlinkAt(name string, flags uint32) error
+
+	// Readdir reads directory entries.
+	//
+	// This may return io.EOF in addition to syscall.Errno values.
+	//
+	// On the server, Readdir has a read concurrency guarantee.
+	Readdir(offset uint64, count uint32) ([]Dirent, error)
+
+	// Readlink reads the link target.
+	//
+	// On the server, Readlink has a read concurrency guarantee.
+	Readlink() (string, error)
+
+	// Flush is called prior to Close.
+	//
+	// Whereas Close drops all references to the file, Flush cleans up the
+	// file state. Behavior is implementation-specific.
+	//
+	// Flush is not related to flush(9p). Flush is an extension to 9P2000.L,
+	// see version.go.
+	//
+	// On the server, Flush has a read concurrency guarantee.
+	Flush() error
+
+	// Renamed is called when this node is renamed.
+	//
+	// This may not fail. The file will hold a reference to its parent
+	// within the p9 package, and is therefore safe to use for the lifetime
+	// of this File (until Close is called).
+	//
+	// This method should not be called by clients, who should use the
+	// relevant Rename methods. (Although the method will be a no-op.)
+	//
+	// On the server, Renamed has a global concurrency guarantee.
+	Renamed(newDir File, newName string)
+}
+
+// DefaultWalkGetAttr implements File.WalkGetAttr to return ENOSYS for server-side Files.
+type DefaultWalkGetAttr struct{}
+
+// WalkGetAttr implements File.WalkGetAttr.
+func (DefaultWalkGetAttr) WalkGetAttr([]string) ([]QID, File, AttrMask, Attr, error) {
+	return nil, nil, AttrMask{}, Attr{}, syscall.ENOSYS
+}

--- a/vendor/github.com/hugelgupf/p9/p9/handlers.go
+++ b/vendor/github.com/hugelgupf/p9/p9/handlers.go
@@ -1,0 +1,1261 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"sync/atomic"
+	"syscall"
+)
+
+// ExtractErrno extracts a syscall.Errno from a error, best effort.
+func ExtractErrno(err error) syscall.Errno {
+	switch err {
+	case os.ErrNotExist:
+		return syscall.ENOENT
+	case os.ErrExist:
+		return syscall.EEXIST
+	case os.ErrPermission:
+		return syscall.EACCES
+	case os.ErrInvalid:
+		return syscall.EINVAL
+	}
+
+	// Attempt to unwrap.
+	switch e := err.(type) {
+	case syscall.Errno:
+		return e
+	case *os.PathError:
+		return ExtractErrno(e.Err)
+	case *os.SyscallError:
+		return ExtractErrno(e.Err)
+	}
+
+	// Default case.
+	log.Printf("unknown error: %v", err)
+	return syscall.EIO
+}
+
+// newErr returns a new error message from an error.
+func newErr(err error) *rlerror {
+	return &rlerror{Error: uint32(ExtractErrno(err))}
+}
+
+// handler is implemented for server-handled messages.
+//
+// See server.go for call information.
+type handler interface {
+	// Handle handles the given message.
+	//
+	// This may modify the server state. The handle function must return a
+	// message which will be sent back to the client. It may be useful to
+	// use newErr to automatically extract an error message.
+	handle(cs *connState) message
+}
+
+// handle implements handler.handle.
+func (t *tversion) handle(cs *connState) message {
+	if t.MSize == 0 {
+		return newErr(syscall.EINVAL)
+	}
+	if t.MSize > maximumLength {
+		return newErr(syscall.EINVAL)
+	}
+	atomic.StoreUint32(&cs.messageSize, t.MSize)
+	requested, ok := parseVersion(t.Version)
+	if !ok {
+		return newErr(syscall.EINVAL)
+	}
+	// The server cannot support newer versions that it doesn't know about.  In this
+	// case we return EAGAIN to tell the client to try again with a lower version.
+	if requested > highestSupportedVersion {
+		return newErr(syscall.EAGAIN)
+	}
+	// From Tversion(9P): "The server may respond with the client’s version
+	// string, or a version string identifying an earlier defined protocol version".
+	atomic.StoreUint32(&cs.version, requested)
+	return &rversion{
+		MSize:   t.MSize,
+		Version: t.Version,
+	}
+}
+
+// handle implements handler.handle.
+func (t *tflush) handle(cs *connState) message {
+	cs.WaitTag(t.OldTag)
+	return &rflush{}
+}
+
+// checkSafeName validates the name and returns nil or returns an error.
+func checkSafeName(name string) error {
+	if name != "" && !strings.Contains(name, "/") && name != "." && name != ".." {
+		return nil
+	}
+	return syscall.EINVAL
+}
+
+// handle implements handler.handle.
+func (t *tclunk) handle(cs *connState) message {
+	if !cs.DeleteFID(t.fid) {
+		return newErr(syscall.EBADF)
+	}
+	return &rclunk{}
+}
+
+// handle implements handler.handle.
+func (t *tremove) handle(cs *connState) message {
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// Frustratingly, because we can't be guaranteed that a rename is not
+	// occurring simultaneously with this removal, we need to acquire the
+	// global rename lock for this kind of remove operation to ensure that
+	// ref.parent does not change out from underneath us.
+	//
+	// This is why Tremove is a bad idea, and clients should generally use
+	// Tunlinkat. All p9 clients will use Tunlinkat.
+	err := ref.safelyGlobal(func() error {
+		// Is this a root? Can't remove that.
+		if ref.isRoot() {
+			return syscall.EINVAL
+		}
+
+		// N.B. this remove operation is permitted, even if the file is open.
+		// See also rename below for reasoning.
+
+		// Is this file already deleted?
+		if ref.isDeleted() {
+			return syscall.EINVAL
+		}
+
+		// Retrieve the file's proper name.
+		name := ref.parent.pathNode.nameFor(ref)
+
+		// Attempt the removal.
+		if err := ref.parent.file.UnlinkAt(name, 0); err != nil {
+			return err
+		}
+
+		// Mark all relevant fids as deleted. We don't need to lock any
+		// individual nodes because we already hold the global lock.
+		ref.parent.markChildDeleted(name)
+		return nil
+	})
+
+	// "The remove request asks the file server both to remove the file
+	// represented by fid and to clunk the fid, even if the remove fails."
+	//
+	// "It is correct to consider remove to be a clunk with the side effect
+	// of removing the file if permissions allow."
+	// https://swtch.com/plan9port/man/man9/remove.html
+	if !cs.DeleteFID(t.fid) {
+		return newErr(syscall.EBADF)
+	}
+	if err != nil {
+		return newErr(err)
+	}
+
+	return &rremove{}
+}
+
+// handle implements handler.handle.
+//
+// We don't support authentication, so this just returns ENOSYS.
+func (t *tauth) handle(cs *connState) message {
+	return newErr(syscall.ENOSYS)
+}
+
+// handle implements handler.handle.
+func (t *tattach) handle(cs *connState) message {
+	// Ensure no authentication fid is provided.
+	if t.Auth.Authenticationfid != noFID {
+		return newErr(syscall.EINVAL)
+	}
+
+	// Must provide an absolute path.
+	if path.IsAbs(t.Auth.AttachName) {
+		// Trim off the leading / if the path is absolute. We always
+		// treat attach paths as absolute and call attach with the root
+		// argument on the server file for clarity.
+		t.Auth.AttachName = t.Auth.AttachName[1:]
+	}
+
+	// Do the attach on the root.
+	sf, err := cs.server.attacher.Attach()
+	if err != nil {
+		return newErr(err)
+	}
+	qid, valid, attr, err := sf.GetAttr(AttrMaskAll())
+	if err != nil {
+		sf.Close() // Drop file.
+		return newErr(err)
+	}
+	if !valid.Mode {
+		sf.Close() // Drop file.
+		return newErr(syscall.EINVAL)
+	}
+
+	// Build a transient reference.
+	root := &fidRef{
+		server:   cs.server,
+		parent:   nil,
+		file:     sf,
+		refs:     1,
+		mode:     attr.Mode.FileType(),
+		pathNode: cs.server.pathTree,
+	}
+	defer root.DecRef()
+
+	// Attach the root?
+	if len(t.Auth.AttachName) == 0 {
+		cs.InsertFID(t.fid, root)
+		return &rattach{QID: qid}
+	}
+
+	// We want the same traversal checks to apply on attach, so always
+	// attach at the root and use the regular walk paths.
+	names := strings.Split(t.Auth.AttachName, "/")
+	_, newRef, _, _, err := doWalk(cs, root, names, false)
+	if err != nil {
+		return newErr(err)
+	}
+	defer newRef.DecRef()
+
+	// Insert the fid.
+	cs.InsertFID(t.fid, newRef)
+	return &rattach{QID: qid}
+}
+
+// CanOpen returns whether this file open can be opened, read and written to.
+//
+// This includes everything except symlinks and sockets.
+func CanOpen(mode FileMode) bool {
+	return mode.IsRegular() || mode.IsDir() || mode.IsNamedPipe() || mode.IsBlockDevice() || mode.IsCharacterDevice()
+}
+
+// handle implements handler.handle.
+func (t *tlopen) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	ref.openedMu.Lock()
+	defer ref.openedMu.Unlock()
+
+	// Has it been opened already?
+	if ref.opened || !CanOpen(ref.mode) {
+		return newErr(syscall.EINVAL)
+	}
+
+	// Are flags valid?
+	flags := t.Flags &^ OpenFlagsIgnoreMask
+	if flags&^OpenFlagsModeMask != 0 {
+		return newErr(syscall.EINVAL)
+	}
+
+	// Is this an attempt to open a directory as writable? Don't accept.
+	if ref.mode.IsDir() && flags != ReadOnly {
+		return newErr(syscall.EINVAL)
+	}
+
+	var (
+		qid    QID
+		ioUnit uint32
+	)
+	if err := ref.safelyRead(func() (err error) {
+		// Has it been deleted already?
+		if ref.isDeleted() {
+			return syscall.EINVAL
+		}
+
+		// Do the open.
+		qid, ioUnit, err = ref.file.Open(t.Flags)
+		return err
+	}); err != nil {
+		return newErr(err)
+	}
+
+	// Mark file as opened and set open mode.
+	ref.opened = true
+	ref.openFlags = t.Flags
+
+	return &rlopen{QID: qid, IoUnit: ioUnit}
+}
+
+func (t *tlcreate) do(cs *connState, uid UID) (*rlcreate, error) {
+	// Don't allow complex names.
+	if err := checkSafeName(t.Name); err != nil {
+		return nil, err
+	}
+
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return nil, syscall.EBADF
+	}
+	defer ref.DecRef()
+
+	var (
+		nsf    File
+		qid    QID
+		ioUnit uint32
+		newRef *fidRef
+	)
+	if err := ref.safelyWrite(func() (err error) {
+		// Don't allow creation from non-directories or deleted directories.
+		if ref.isDeleted() || !ref.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// Not allowed on open directories.
+		if _, opened := ref.OpenFlags(); opened {
+			return syscall.EINVAL
+		}
+
+		// Do the create.
+		nsf, qid, ioUnit, err = ref.file.Create(t.Name, t.OpenFlags, t.Permissions, uid, t.GID)
+		if err != nil {
+			return err
+		}
+
+		newRef = &fidRef{
+			server:    cs.server,
+			parent:    ref,
+			file:      nsf,
+			opened:    true,
+			openFlags: t.OpenFlags,
+			mode:      ModeRegular,
+			pathNode:  ref.pathNode.pathNodeFor(t.Name),
+		}
+		ref.pathNode.addChild(newRef, t.Name)
+		ref.IncRef() // Acquire parent reference.
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	// Replace the fid reference.
+	cs.InsertFID(t.fid, newRef)
+
+	return &rlcreate{rlopen: rlopen{QID: qid, IoUnit: ioUnit}}, nil
+}
+
+// handle implements handler.handle.
+func (t *tlcreate) handle(cs *connState) message {
+	rlcreate, err := t.do(cs, NoUID)
+	if err != nil {
+		return newErr(err)
+	}
+	return rlcreate
+}
+
+// handle implements handler.handle.
+func (t *tsymlink) handle(cs *connState) message {
+	rsymlink, err := t.do(cs, NoUID)
+	if err != nil {
+		return newErr(err)
+	}
+	return rsymlink
+}
+
+func (t *tsymlink) do(cs *connState, uid UID) (*rsymlink, error) {
+	// Don't allow complex names.
+	if err := checkSafeName(t.Name); err != nil {
+		return nil, err
+	}
+
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.Directory)
+	if !ok {
+		return nil, syscall.EBADF
+	}
+	defer ref.DecRef()
+
+	var qid QID
+	if err := ref.safelyWrite(func() (err error) {
+		// Don't allow symlinks from non-directories or deleted directories.
+		if ref.isDeleted() || !ref.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// Not allowed on open directories.
+		if _, opened := ref.OpenFlags(); opened {
+			return syscall.EINVAL
+		}
+
+		// Do the symlink.
+		qid, err = ref.file.Symlink(t.Target, t.Name, uid, t.GID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return &rsymlink{QID: qid}, nil
+}
+
+// handle implements handler.handle.
+func (t *tlink) handle(cs *connState) message {
+	// Don't allow complex names.
+	if err := checkSafeName(t.Name); err != nil {
+		return newErr(err)
+	}
+
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.Directory)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// Lookup the other fid.
+	refTarget, ok := cs.LookupFID(t.Target)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer refTarget.DecRef()
+
+	if err := ref.safelyWrite(func() (err error) {
+		// Don't allow create links from non-directories or deleted directories.
+		if ref.isDeleted() || !ref.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// Not allowed on open directories.
+		if _, opened := ref.OpenFlags(); opened {
+			return syscall.EINVAL
+		}
+
+		// Do the link.
+		return ref.file.Link(refTarget.file, t.Name)
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rlink{}
+}
+
+// handle implements handler.handle.
+func (t *trenameat) handle(cs *connState) message {
+	// Don't allow complex names.
+	if err := checkSafeName(t.OldName); err != nil {
+		return newErr(err)
+	}
+	if err := checkSafeName(t.NewName); err != nil {
+		return newErr(err)
+	}
+
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.OldDirectory)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// Lookup the other fid.
+	refTarget, ok := cs.LookupFID(t.NewDirectory)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer refTarget.DecRef()
+
+	// Perform the rename holding the global lock.
+	if err := ref.safelyGlobal(func() (err error) {
+		// Don't allow renaming across deleted directories.
+		if ref.isDeleted() || !ref.mode.IsDir() || refTarget.isDeleted() || !refTarget.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// Not allowed on open directories.
+		if _, opened := ref.OpenFlags(); opened {
+			return syscall.EINVAL
+		}
+
+		// Is this the same file? If yes, short-circuit and return success.
+		if ref.pathNode == refTarget.pathNode && t.OldName == t.NewName {
+			return nil
+		}
+
+		// Attempt the actual rename.
+		if err := ref.file.RenameAt(t.OldName, refTarget.file, t.NewName); err != nil {
+			return err
+		}
+
+		// Update the path tree.
+		ref.renameChildTo(t.OldName, refTarget, t.NewName)
+		return nil
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rrenameat{}
+}
+
+// handle implements handler.handle.
+func (t *tunlinkat) handle(cs *connState) message {
+	// Don't allow complex names.
+	if err := checkSafeName(t.Name); err != nil {
+		return newErr(err)
+	}
+
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.Directory)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	if err := ref.safelyWrite(func() (err error) {
+		// Don't allow deletion from non-directories or deleted directories.
+		if ref.isDeleted() || !ref.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// Not allowed on open directories.
+		if _, opened := ref.OpenFlags(); opened {
+			return syscall.EINVAL
+		}
+
+		// Before we do the unlink itself, we need to ensure that there
+		// are no operations in flight on associated path node. The
+		// child's path node lock must be held to ensure that the
+		// unlinkat marking the child deleted below is atomic with
+		// respect to any other read or write operations.
+		//
+		// This is one case where we have a lock ordering issue, but
+		// since we always acquire deeper in the hierarchy, we know
+		// that we are free of lock cycles.
+		childPathNode := ref.pathNode.pathNodeFor(t.Name)
+		childPathNode.opMu.Lock()
+		defer childPathNode.opMu.Unlock()
+
+		// Do the unlink.
+		err = ref.file.UnlinkAt(t.Name, t.Flags)
+		if err != nil {
+			return err
+		}
+
+		// Mark the path as deleted.
+		ref.markChildDeleted(t.Name)
+		return nil
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &runlinkat{}
+}
+
+// handle implements handler.handle.
+func (t *trename) handle(cs *connState) message {
+	// Don't allow complex names.
+	if err := checkSafeName(t.Name); err != nil {
+		return newErr(err)
+	}
+
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// Lookup the target.
+	refTarget, ok := cs.LookupFID(t.Directory)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer refTarget.DecRef()
+
+	if err := ref.safelyGlobal(func() (err error) {
+		// Don't allow a root rename.
+		if ref.isRoot() {
+			return syscall.EINVAL
+		}
+
+		// Don't allow renaming deleting entries, or target non-directories.
+		if ref.isDeleted() || refTarget.isDeleted() || !refTarget.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// If the parent is deleted, but we not, something is seriously wrong.
+		// It's fail to die at this point with an assertion failure.
+		if ref.parent.isDeleted() {
+			panic(fmt.Sprintf("parent %+v deleted, child %+v is not", ref.parent, ref))
+		}
+
+		// N.B. The rename operation is allowed to proceed on open files. It
+		// does impact the state of its parent, but this is merely a sanity
+		// check in any case, and the operation is safe. There may be other
+		// files corresponding to the same path that are renamed anyways.
+
+		// Check for the exact same file and short-circuit.
+		oldName := ref.parent.pathNode.nameFor(ref)
+		if ref.parent.pathNode == refTarget.pathNode && oldName == t.Name {
+			return nil
+		}
+
+		// Call the rename method on the parent.
+		if err := ref.parent.file.RenameAt(oldName, refTarget.file, t.Name); err != nil {
+			return err
+		}
+
+		// Update the path tree.
+		ref.parent.renameChildTo(oldName, refTarget, t.Name)
+		return nil
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rrename{}
+}
+
+// handle implements handler.handle.
+func (t *treadlink) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	var target string
+	if err := ref.safelyRead(func() (err error) {
+		// Don't allow readlink on deleted files. There is no need to
+		// check if this file is opened because symlinks cannot be
+		// opened.
+		if ref.isDeleted() || !ref.mode.IsSymlink() {
+			return syscall.EINVAL
+		}
+
+		// Do the read.
+		target, err = ref.file.Readlink()
+		return err
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rreadlink{target}
+}
+
+// handle implements handler.handle.
+func (t *tread) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// Constrain the size of the read buffer.
+	if int(t.Count) > int(maximumLength) {
+		return newErr(syscall.ENOBUFS)
+	}
+
+	var (
+		data = make([]byte, t.Count)
+		n    int
+	)
+	if err := ref.safelyRead(func() (err error) {
+		// Has it been opened already?
+		openFlags, opened := ref.OpenFlags()
+		if !opened {
+			return syscall.EINVAL
+		}
+
+		// Can it be read? Check permissions.
+		if openFlags&OpenFlagsModeMask == WriteOnly {
+			return syscall.EPERM
+		}
+
+		n, err = ref.file.ReadAt(data, t.Offset)
+		return err
+	}); err != nil && err != io.EOF {
+		return newErr(err)
+	}
+
+	return &rread{Data: data[:n]}
+}
+
+// handle implements handler.handle.
+func (t *twrite) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	var n int
+	if err := ref.safelyRead(func() (err error) {
+		// Has it been opened already?
+		openFlags, opened := ref.OpenFlags()
+		if !opened {
+			return syscall.EINVAL
+		}
+
+		// Can it be written? Check permissions.
+		if openFlags&OpenFlagsModeMask == ReadOnly {
+			return syscall.EPERM
+		}
+
+		n, err = ref.file.WriteAt(t.Data, t.Offset)
+		return err
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rwrite{Count: uint32(n)}
+}
+
+// handle implements handler.handle.
+func (t *tmknod) handle(cs *connState) message {
+	rmknod, err := t.do(cs, NoUID)
+	if err != nil {
+		return newErr(err)
+	}
+	return rmknod
+}
+
+func (t *tmknod) do(cs *connState, uid UID) (*rmknod, error) {
+	// Don't allow complex names.
+	if err := checkSafeName(t.Name); err != nil {
+		return nil, err
+	}
+
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.Directory)
+	if !ok {
+		return nil, syscall.EBADF
+	}
+	defer ref.DecRef()
+
+	var qid QID
+	if err := ref.safelyWrite(func() (err error) {
+		// Don't allow mknod on deleted files.
+		if ref.isDeleted() || !ref.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// Not allowed on open directories.
+		if _, opened := ref.OpenFlags(); opened {
+			return syscall.EINVAL
+		}
+
+		// Do the mknod.
+		qid, err = ref.file.Mknod(t.Name, t.Mode, t.Major, t.Minor, uid, t.GID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return &rmknod{QID: qid}, nil
+}
+
+// handle implements handler.handle.
+func (t *tmkdir) handle(cs *connState) message {
+	rmkdir, err := t.do(cs, NoUID)
+	if err != nil {
+		return newErr(err)
+	}
+	return rmkdir
+}
+
+func (t *tmkdir) do(cs *connState, uid UID) (*rmkdir, error) {
+	// Don't allow complex names.
+	if err := checkSafeName(t.Name); err != nil {
+		return nil, err
+	}
+
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.Directory)
+	if !ok {
+		return nil, syscall.EBADF
+	}
+	defer ref.DecRef()
+
+	var qid QID
+	if err := ref.safelyWrite(func() (err error) {
+		// Don't allow mkdir on deleted files.
+		if ref.isDeleted() || !ref.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// Not allowed on open directories.
+		if _, opened := ref.OpenFlags(); opened {
+			return syscall.EINVAL
+		}
+
+		// Do the mkdir.
+		qid, err = ref.file.Mkdir(t.Name, t.Permissions, uid, t.GID)
+		return err
+	}); err != nil {
+		return nil, err
+	}
+
+	return &rmkdir{QID: qid}, nil
+}
+
+// handle implements handler.handle.
+func (t *tgetattr) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// We allow getattr on deleted files. Depending on the backing
+	// implementation, it's possible that races exist that might allow
+	// fetching attributes of other files. But we need to generally allow
+	// refreshing attributes and this is a minor leak, if at all.
+
+	var (
+		qid   QID
+		valid AttrMask
+		attr  Attr
+	)
+	if err := ref.safelyRead(func() (err error) {
+		qid, valid, attr, err = ref.file.GetAttr(t.AttrMask)
+		return err
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rgetattr{QID: qid, Valid: valid, Attr: attr}
+}
+
+// handle implements handler.handle.
+func (t *tsetattr) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	if err := ref.safelyWrite(func() error {
+		// We don't allow setattr on files that have been deleted.
+		// This might be technically incorrect, as it's possible that
+		// there were multiple links and you can still change the
+		// corresponding inode information.
+		if ref.isDeleted() {
+			return syscall.EINVAL
+		}
+
+		// Set the attributes.
+		return ref.file.SetAttr(t.Valid, t.SetAttr)
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rsetattr{}
+}
+
+// handle implements handler.handle.
+func (t *tallocate) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	if err := ref.safelyWrite(func() error {
+		// Has it been opened already?
+		openFlags, opened := ref.OpenFlags()
+		if !opened {
+			return syscall.EINVAL
+		}
+
+		// Can it be written? Check permissions.
+		if openFlags&OpenFlagsModeMask == ReadOnly {
+			return syscall.EBADF
+		}
+
+		// We don't allow allocate on files that have been deleted.
+		if ref.isDeleted() {
+			return syscall.EINVAL
+		}
+
+		return ref.file.Allocate(t.Mode, t.Offset, t.Length)
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rallocate{}
+}
+
+// handle implements handler.handle.
+func (t *txattrwalk) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// We don't support extended attributes.
+	return newErr(syscall.ENODATA)
+}
+
+// handle implements handler.handle.
+func (t *txattrcreate) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// We don't support extended attributes.
+	return newErr(syscall.ENOSYS)
+}
+
+// handle implements handler.handle.
+func (t *treaddir) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.Directory)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	var entries []Dirent
+	if err := ref.safelyRead(func() (err error) {
+		// Don't allow reading deleted directories.
+		if ref.isDeleted() || !ref.mode.IsDir() {
+			return syscall.EINVAL
+		}
+
+		// Has it been opened already?
+		if _, opened := ref.OpenFlags(); !opened {
+			return syscall.EINVAL
+		}
+
+		// Read the entries.
+		entries, err = ref.file.Readdir(t.Offset, t.Count)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rreaddir{Count: t.Count, Entries: entries}
+}
+
+// handle implements handler.handle.
+func (t *tfsync) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	if err := ref.safelyRead(func() (err error) {
+		// Has it been opened already?
+		if _, opened := ref.OpenFlags(); !opened {
+			return syscall.EINVAL
+		}
+
+		// Perform the sync.
+		return ref.file.FSync()
+	}); err != nil {
+		return newErr(err)
+	}
+
+	return &rfsync{}
+}
+
+// handle implements handler.handle.
+func (t *tstatfs) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	st, err := ref.file.StatFS()
+	if err != nil {
+		return newErr(err)
+	}
+
+	return &rstatfs{st}
+}
+
+// handle implements handler.handle.
+func (t *tflushf) handle(cs *connState) message {
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	if err := ref.safelyRead(ref.file.Flush); err != nil {
+		return newErr(err)
+	}
+
+	return &rflushf{}
+}
+
+// walkOne walks zero or one path elements.
+//
+// The slice passed as qids is append and returned.
+func walkOne(qids []QID, from File, names []string, getattr bool) ([]QID, File, AttrMask, Attr, error) {
+	if len(names) > 1 {
+		// We require exactly zero or one elements.
+		return nil, nil, AttrMask{}, Attr{}, syscall.EINVAL
+	}
+	var (
+		localQIDs []QID
+		sf        File
+		valid     AttrMask
+		attr      Attr
+		err       error
+	)
+	switch {
+	case getattr:
+		localQIDs, sf, valid, attr, err = from.WalkGetAttr(names)
+		// Can't put fallthrough in the if because Go.
+		if err != syscall.ENOSYS {
+			break
+		}
+		fallthrough
+	default:
+		localQIDs, sf, err = from.Walk(names)
+		if err != nil {
+			// No way to walk this element.
+			break
+		}
+		if getattr {
+			_, valid, attr, err = sf.GetAttr(AttrMaskAll())
+			if err != nil {
+				// Don't leak the file.
+				sf.Close()
+			}
+		}
+	}
+	if err != nil {
+		// Error walking, don't return anything.
+		return nil, nil, AttrMask{}, Attr{}, err
+	}
+	if len(localQIDs) != 1 {
+		// Expected a single QID.
+		sf.Close()
+		return nil, nil, AttrMask{}, Attr{}, syscall.EINVAL
+	}
+	return append(qids, localQIDs...), sf, valid, attr, nil
+}
+
+// doWalk walks from a given fidRef.
+//
+// This enforces that all intermediate nodes are walkable (directories). The
+// fidRef returned (newRef) has a reference associated with it that is now
+// owned by the caller and must be handled appropriately.
+func doWalk(cs *connState, ref *fidRef, names []string, getattr bool) (qids []QID, newRef *fidRef, valid AttrMask, attr Attr, err error) {
+	// Check the names.
+	for _, name := range names {
+		err = checkSafeName(name)
+		if err != nil {
+			return
+		}
+	}
+
+	// Has it been opened already?
+	if _, opened := ref.OpenFlags(); opened {
+		err = syscall.EBUSY
+		return
+	}
+
+	// Is this an empty list? Handle specially. We don't actually need to
+	// validate anything since this is always permitted.
+	if len(names) == 0 {
+		var sf File // Temporary.
+		if err := ref.maybeParent().safelyRead(func() (err error) {
+			// Clone the single element.
+			qids, sf, valid, attr, err = walkOne(nil, ref.file, nil, getattr)
+			if err != nil {
+				return err
+			}
+
+			newRef = &fidRef{
+				server:   cs.server,
+				parent:   ref.parent,
+				file:     sf,
+				mode:     ref.mode,
+				pathNode: ref.pathNode,
+
+				// For the clone case, the cloned fid must
+				// preserve the deleted property of the
+				// original fid.
+				deleted: ref.deleted,
+			}
+			if !ref.isRoot() {
+				if !newRef.isDeleted() {
+					// Add only if a non-root node; the same node.
+					ref.parent.pathNode.addChild(newRef, ref.parent.pathNode.nameFor(ref))
+				}
+				ref.parent.IncRef() // Acquire parent reference.
+			}
+			// doWalk returns a reference.
+			newRef.IncRef()
+			return nil
+		}); err != nil {
+			return nil, nil, AttrMask{}, Attr{}, err
+		}
+		// Do not return the new QID.
+		return nil, newRef, valid, attr, nil
+	}
+
+	// Do the walk, one element at a time.
+	walkRef := ref
+	walkRef.IncRef()
+	for i := 0; i < len(names); i++ {
+		// We won't allow beyond past symlinks; stop here if this isn't
+		// a proper directory and we have additional paths to walk.
+		if !walkRef.mode.IsDir() {
+			walkRef.DecRef() // Drop walk reference; no lock required.
+			return nil, nil, AttrMask{}, Attr{}, syscall.EINVAL
+		}
+
+		var sf File // Temporary.
+		if err := walkRef.safelyRead(func() (err error) {
+			// Pass getattr = true to walkOne since we need the file type for
+			// newRef.
+			qids, sf, valid, attr, err = walkOne(qids, walkRef.file, names[i:i+1], true)
+			if err != nil {
+				return err
+			}
+
+			// Note that we don't need to acquire a lock on any of
+			// these individual instances. That's because they are
+			// not actually addressable via a fid. They are
+			// anonymous. They exist in the tree for tracking
+			// purposes.
+			newRef := &fidRef{
+				server:   cs.server,
+				parent:   walkRef,
+				file:     sf,
+				mode:     attr.Mode.FileType(),
+				pathNode: walkRef.pathNode.pathNodeFor(names[i]),
+			}
+			walkRef.pathNode.addChild(newRef, names[i])
+			// We allow our walk reference to become the new parent
+			// reference here and so we don't IncRef. Instead, just
+			// set walkRef to the newRef above and acquire a new
+			// walk reference.
+			walkRef = newRef
+			walkRef.IncRef()
+			return nil
+		}); err != nil {
+			walkRef.DecRef() // Drop the old walkRef.
+			return nil, nil, AttrMask{}, Attr{}, err
+		}
+	}
+
+	// Success.
+	return qids, walkRef, valid, attr, nil
+}
+
+// handle implements handler.handle.
+func (t *twalk) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// Do the walk.
+	qids, newRef, _, _, err := doWalk(cs, ref, t.Names, false)
+	if err != nil {
+		return newErr(err)
+	}
+	defer newRef.DecRef()
+
+	// Install the new fid.
+	cs.InsertFID(t.newFID, newRef)
+	return &rwalk{QIDs: qids}
+}
+
+// handle implements handler.handle.
+func (t *twalkgetattr) handle(cs *connState) message {
+	// Lookup the fid.
+	ref, ok := cs.LookupFID(t.fid)
+	if !ok {
+		return newErr(syscall.EBADF)
+	}
+	defer ref.DecRef()
+
+	// Do the walk.
+	qids, newRef, valid, attr, err := doWalk(cs, ref, t.Names, true)
+	if err != nil {
+		return newErr(err)
+	}
+	defer newRef.DecRef()
+
+	// Install the new fid.
+	cs.InsertFID(t.newFID, newRef)
+	return &rwalkgetattr{QIDs: qids, Valid: valid, Attr: attr}
+}
+
+// handle implements handler.handle.
+func (t *tucreate) handle(cs *connState) message {
+	rlcreate, err := t.tlcreate.do(cs, t.UID)
+	if err != nil {
+		return newErr(err)
+	}
+	return &rucreate{*rlcreate}
+}
+
+// handle implements handler.handle.
+func (t *tumkdir) handle(cs *connState) message {
+	rmkdir, err := t.tmkdir.do(cs, t.UID)
+	if err != nil {
+		return newErr(err)
+	}
+	return &rumkdir{*rmkdir}
+}
+
+// handle implements handler.handle.
+func (t *tusymlink) handle(cs *connState) message {
+	rsymlink, err := t.tsymlink.do(cs, t.UID)
+	if err != nil {
+		return newErr(err)
+	}
+	return &rusymlink{*rsymlink}
+}
+
+// handle implements handler.handle.
+func (t *tumknod) handle(cs *connState) message {
+	rmknod, err := t.tmknod.do(cs, t.UID)
+	if err != nil {
+		return newErr(err)
+	}
+	return &rumknod{*rmknod}
+}

--- a/vendor/github.com/hugelgupf/p9/p9/messages.go
+++ b/vendor/github.com/hugelgupf/p9/p9/messages.go
@@ -1,0 +1,2259 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"fmt"
+	"math"
+)
+
+// ErrInvalidMsgType is returned when an unsupported message type is found.
+type ErrInvalidMsgType struct {
+	msgType
+}
+
+// Error returns a useful string.
+func (e *ErrInvalidMsgType) Error() string {
+	return fmt.Sprintf("invalid message type: %d", e.msgType)
+}
+
+// message is a generic 9P message.
+type message interface {
+	encoder
+	fmt.Stringer
+
+	// Type returns the message type number.
+	typ() msgType
+}
+
+// payloader is a special message which may include an inline payload.
+type payloader interface {
+	// FixedSize returns the size of the fixed portion of this message.
+	FixedSize() uint32
+
+	// Payload returns the payload for sending.
+	Payload() []byte
+
+	// SetPayload returns the decoded message.
+	//
+	// This is going to be total message size - FixedSize. But this should
+	// be validated during decode, which will be called after SetPayload.
+	SetPayload([]byte)
+}
+
+// tversion is a version request.
+type tversion struct {
+	// MSize is the message size to use.
+	MSize uint32
+
+	// Version is the version string.
+	//
+	// For this implementation, this must be 9P2000.L.
+	Version string
+}
+
+// decode implements encoder.decode.
+func (t *tversion) decode(b *buffer) {
+	t.MSize = b.Read32()
+	t.Version = b.ReadString()
+}
+
+// encode implements encoder.encode.
+func (t *tversion) encode(b *buffer) {
+	b.Write32(t.MSize)
+	b.WriteString(t.Version)
+}
+
+// Type implements message.Type.
+func (*tversion) typ() msgType {
+	return msgTversion
+}
+
+// String implements fmt.Stringer.
+func (t *tversion) String() string {
+	return fmt.Sprintf("Tversion{MSize: %d, Version: %s}", t.MSize, t.Version)
+}
+
+// rversion is a version response.
+type rversion struct {
+	// MSize is the negotiated size.
+	MSize uint32
+
+	// Version is the negotiated version.
+	Version string
+}
+
+// decode implements encoder.decode.
+func (r *rversion) decode(b *buffer) {
+	r.MSize = b.Read32()
+	r.Version = b.ReadString()
+}
+
+// encode implements encoder.encode.
+func (r *rversion) encode(b *buffer) {
+	b.Write32(r.MSize)
+	b.WriteString(r.Version)
+}
+
+// Type implements message.Type.
+func (*rversion) typ() msgType {
+	return msgRversion
+}
+
+// String implements fmt.Stringer.
+func (r *rversion) String() string {
+	return fmt.Sprintf("Rversion{MSize: %d, Version: %s}", r.MSize, r.Version)
+}
+
+// tflush is a flush request.
+type tflush struct {
+	// OldTag is the tag to wait on.
+	OldTag tag
+}
+
+// decode implements encoder.decode.
+func (t *tflush) decode(b *buffer) {
+	t.OldTag = b.ReadTag()
+}
+
+// encode implements encoder.encode.
+func (t *tflush) encode(b *buffer) {
+	b.WriteTag(t.OldTag)
+}
+
+// Type implements message.Type.
+func (*tflush) typ() msgType {
+	return msgTflush
+}
+
+// String implements fmt.Stringer.
+func (t *tflush) String() string {
+	return fmt.Sprintf("Tflush{OldTag: %d}", t.OldTag)
+}
+
+// rflush is a flush response.
+type rflush struct {
+}
+
+// decode implements encoder.decode.
+func (*rflush) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rflush) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rflush) typ() msgType {
+	return msgRflush
+}
+
+// String implements fmt.Stringer.
+func (r *rflush) String() string {
+	return fmt.Sprintf("Rflush{}")
+}
+
+// twalk is a walk request.
+type twalk struct {
+	// fid is the fid to be walked.
+	fid fid
+
+	// newFID is the resulting fid.
+	newFID fid
+
+	// Names are the set of names to be walked.
+	Names []string
+}
+
+// decode implements encoder.decode.
+func (t *twalk) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.newFID = b.ReadFID()
+	n := b.Read16()
+	t.Names = t.Names[:0]
+	for i := 0; i < int(n); i++ {
+		t.Names = append(t.Names, b.ReadString())
+	}
+}
+
+// encode implements encoder.encode.
+func (t *twalk) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.WriteFID(t.newFID)
+	b.Write16(uint16(len(t.Names)))
+	for _, name := range t.Names {
+		b.WriteString(name)
+	}
+}
+
+// Type implements message.Type.
+func (*twalk) typ() msgType {
+	return msgTwalk
+}
+
+// String implements fmt.Stringer.
+func (t *twalk) String() string {
+	return fmt.Sprintf("Twalk{FID: %d, newFID: %d, Names: %v}", t.fid, t.newFID, t.Names)
+}
+
+// rwalk is a walk response.
+type rwalk struct {
+	// QIDs are the set of QIDs returned.
+	QIDs []QID
+}
+
+// decode implements encoder.decode.
+func (r *rwalk) decode(b *buffer) {
+	n := b.Read16()
+	r.QIDs = r.QIDs[:0]
+	for i := 0; i < int(n); i++ {
+		var q QID
+		q.decode(b)
+		r.QIDs = append(r.QIDs, q)
+	}
+}
+
+// encode implements encoder.encode.
+func (r *rwalk) encode(b *buffer) {
+	b.Write16(uint16(len(r.QIDs)))
+	for _, q := range r.QIDs {
+		q.encode(b)
+	}
+}
+
+// Type implements message.Type.
+func (*rwalk) typ() msgType {
+	return msgRwalk
+}
+
+// String implements fmt.Stringer.
+func (r *rwalk) String() string {
+	return fmt.Sprintf("Rwalk{QIDs: %v}", r.QIDs)
+}
+
+// tclunk is a close request.
+type tclunk struct {
+	// fid is the fid to be closed.
+	fid fid
+}
+
+// decode implements encoder.decode.
+func (t *tclunk) decode(b *buffer) {
+	t.fid = b.ReadFID()
+}
+
+// encode implements encoder.encode.
+func (t *tclunk) encode(b *buffer) {
+	b.WriteFID(t.fid)
+}
+
+// Type implements message.Type.
+func (*tclunk) typ() msgType {
+	return msgTclunk
+}
+
+// String implements fmt.Stringer.
+func (t *tclunk) String() string {
+	return fmt.Sprintf("Tclunk{FID: %d}", t.fid)
+}
+
+// rclunk is a close response.
+type rclunk struct{}
+
+// decode implements encoder.decode.
+func (*rclunk) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rclunk) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rclunk) typ() msgType {
+	return msgRclunk
+}
+
+// String implements fmt.Stringer.
+func (r *rclunk) String() string {
+	return fmt.Sprintf("Rclunk{}")
+}
+
+// tremove is a remove request.
+type tremove struct {
+	// fid is the fid to be removed.
+	fid fid
+}
+
+// decode implements encoder.decode.
+func (t *tremove) decode(b *buffer) {
+	t.fid = b.ReadFID()
+}
+
+// encode implements encoder.encode.
+func (t *tremove) encode(b *buffer) {
+	b.WriteFID(t.fid)
+}
+
+// Type implements message.Type.
+func (*tremove) typ() msgType {
+	return msgTremove
+}
+
+// String implements fmt.Stringer.
+func (t *tremove) String() string {
+	return fmt.Sprintf("Tremove{FID: %d}", t.fid)
+}
+
+// rremove is a remove response.
+type rremove struct {
+}
+
+// decode implements encoder.decode.
+func (*rremove) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rremove) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rremove) typ() msgType {
+	return msgRremove
+}
+
+// String implements fmt.Stringer.
+func (r *rremove) String() string {
+	return fmt.Sprintf("Rremove{}")
+}
+
+// rlerror is an error response.
+//
+// Note that this replaces the error code used in 9p.
+type rlerror struct {
+	Error uint32
+}
+
+// decode implements encoder.decode.
+func (r *rlerror) decode(b *buffer) {
+	r.Error = b.Read32()
+}
+
+// encode implements encoder.encode.
+func (r *rlerror) encode(b *buffer) {
+	b.Write32(r.Error)
+}
+
+// Type implements message.Type.
+func (*rlerror) typ() msgType {
+	return msgRlerror
+}
+
+// String implements fmt.Stringer.
+func (r *rlerror) String() string {
+	return fmt.Sprintf("Rlerror{Error: %d}", r.Error)
+}
+
+// tauth is an authentication request.
+type tauth struct {
+	// Authenticationfid is the fid to attach the authentication result.
+	Authenticationfid fid
+
+	// UserName is the user to attach.
+	UserName string
+
+	// AttachName is the attach name.
+	AttachName string
+
+	// UserID is the numeric identifier for UserName.
+	UID UID
+}
+
+// decode implements encoder.decode.
+func (t *tauth) decode(b *buffer) {
+	t.Authenticationfid = b.ReadFID()
+	t.UserName = b.ReadString()
+	t.AttachName = b.ReadString()
+	t.UID = b.ReadUID()
+}
+
+// encode implements encoder.encode.
+func (t *tauth) encode(b *buffer) {
+	b.WriteFID(t.Authenticationfid)
+	b.WriteString(t.UserName)
+	b.WriteString(t.AttachName)
+	b.WriteUID(t.UID)
+}
+
+// Type implements message.Type.
+func (*tauth) typ() msgType {
+	return msgTauth
+}
+
+// String implements fmt.Stringer.
+func (t *tauth) String() string {
+	return fmt.Sprintf("Tauth{AuthFID: %d, UserName: %s, AttachName: %s, UID: %d", t.Authenticationfid, t.UserName, t.AttachName, t.UID)
+}
+
+// rauth is an authentication response.
+//
+// encode, decode and Length are inherited directly from QID.
+type rauth struct {
+	QID
+}
+
+// Type implements message.Type.
+func (*rauth) typ() msgType {
+	return msgRauth
+}
+
+// String implements fmt.Stringer.
+func (r *rauth) String() string {
+	return fmt.Sprintf("Rauth{QID: %s}", r.QID)
+}
+
+// tattach is an attach request.
+type tattach struct {
+	// fid is the fid to be attached.
+	fid fid
+
+	// Auth is the embedded authentication request.
+	//
+	// See client.Attach for information regarding authentication.
+	Auth tauth
+}
+
+// decode implements encoder.decode.
+func (t *tattach) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Auth.decode(b)
+}
+
+// encode implements encoder.encode.
+func (t *tattach) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	t.Auth.encode(b)
+}
+
+// Type implements message.Type.
+func (*tattach) typ() msgType {
+	return msgTattach
+}
+
+// String implements fmt.Stringer.
+func (t *tattach) String() string {
+	return fmt.Sprintf("Tattach{FID: %d, AuthFID: %d, UserName: %s, AttachName: %s, UID: %d}", t.fid, t.Auth.Authenticationfid, t.Auth.UserName, t.Auth.AttachName, t.Auth.UID)
+}
+
+// rattach is an attach response.
+type rattach struct {
+	QID
+}
+
+// Type implements message.Type.
+func (*rattach) typ() msgType {
+	return msgRattach
+}
+
+// String implements fmt.Stringer.
+func (r *rattach) String() string {
+	return fmt.Sprintf("Rattach{QID: %s}", r.QID)
+}
+
+// tlopen is an open request.
+type tlopen struct {
+	// fid is the fid to be opened.
+	fid fid
+
+	// Flags are the open flags.
+	Flags OpenFlags
+}
+
+// decode implements encoder.decode.
+func (t *tlopen) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Flags = b.ReadOpenFlags()
+}
+
+// encode implements encoder.encode.
+func (t *tlopen) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.WriteOpenFlags(t.Flags)
+}
+
+// Type implements message.Type.
+func (*tlopen) typ() msgType {
+	return msgTlopen
+}
+
+// String implements fmt.Stringer.
+func (t *tlopen) String() string {
+	return fmt.Sprintf("Tlopen{FID: %d, Flags: %v}", t.fid, t.Flags)
+}
+
+// rlopen is a open response.
+type rlopen struct {
+	// QID is the file's QID.
+	QID QID
+
+	// IoUnit is the recommended I/O unit.
+	IoUnit uint32
+}
+
+// decode implements encoder.decode.
+func (r *rlopen) decode(b *buffer) {
+	r.QID.decode(b)
+	r.IoUnit = b.Read32()
+}
+
+// encode implements encoder.encode.
+func (r *rlopen) encode(b *buffer) {
+	r.QID.encode(b)
+	b.Write32(r.IoUnit)
+}
+
+// Type implements message.Type.
+func (*rlopen) typ() msgType {
+	return msgRlopen
+}
+
+// String implements fmt.Stringer.
+func (r *rlopen) String() string {
+	return fmt.Sprintf("Rlopen{QID: %s, IoUnit: %d}", r.QID, r.IoUnit)
+}
+
+// tlcreate is a create request.
+type tlcreate struct {
+	// fid is the parent fid.
+	//
+	// This becomes the new file.
+	fid fid
+
+	// Name is the file name to create.
+	Name string
+
+	// Mode is the open mode (O_RDWR, etc.).
+	//
+	// Note that flags like O_TRUNC are ignored, as is O_EXCL. All
+	// create operations are exclusive.
+	OpenFlags OpenFlags
+
+	// Permissions is the set of permission bits.
+	Permissions FileMode
+
+	// GID is the group ID to use for creating the file.
+	GID GID
+}
+
+// decode implements encoder.decode.
+func (t *tlcreate) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Name = b.ReadString()
+	t.OpenFlags = b.ReadOpenFlags()
+	t.Permissions = b.ReadPermissions()
+	t.GID = b.ReadGID()
+}
+
+// encode implements encoder.encode.
+func (t *tlcreate) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.WriteString(t.Name)
+	b.WriteOpenFlags(t.OpenFlags)
+	b.WritePermissions(t.Permissions)
+	b.WriteGID(t.GID)
+}
+
+// Type implements message.Type.
+func (*tlcreate) typ() msgType {
+	return msgTlcreate
+}
+
+// String implements fmt.Stringer.
+func (t *tlcreate) String() string {
+	return fmt.Sprintf("Tlcreate{FID: %d, Name: %s, OpenFlags: %s, Permissions: 0o%o, GID: %d}", t.fid, t.Name, t.OpenFlags, t.Permissions, t.GID)
+}
+
+// rlcreate is a create response.
+//
+// The encode, decode, etc. methods are inherited from Rlopen.
+type rlcreate struct {
+	rlopen
+}
+
+// Type implements message.Type.
+func (*rlcreate) typ() msgType {
+	return msgRlcreate
+}
+
+// String implements fmt.Stringer.
+func (r *rlcreate) String() string {
+	return fmt.Sprintf("Rlcreate{QID: %s, IoUnit: %d}", r.QID, r.IoUnit)
+}
+
+// tsymlink is a symlink request.
+type tsymlink struct {
+	// Directory is the directory fid.
+	Directory fid
+
+	// Name is the new in the directory.
+	Name string
+
+	// Target is the symlink target.
+	Target string
+
+	// GID is the owning group.
+	GID GID
+}
+
+// decode implements encoder.decode.
+func (t *tsymlink) decode(b *buffer) {
+	t.Directory = b.ReadFID()
+	t.Name = b.ReadString()
+	t.Target = b.ReadString()
+	t.GID = b.ReadGID()
+}
+
+// encode implements encoder.encode.
+func (t *tsymlink) encode(b *buffer) {
+	b.WriteFID(t.Directory)
+	b.WriteString(t.Name)
+	b.WriteString(t.Target)
+	b.WriteGID(t.GID)
+}
+
+// Type implements message.Type.
+func (*tsymlink) typ() msgType {
+	return msgTsymlink
+}
+
+// String implements fmt.Stringer.
+func (t *tsymlink) String() string {
+	return fmt.Sprintf("Tsymlink{DirectoryFID: %d, Name: %s, Target: %s, GID: %d}", t.Directory, t.Name, t.Target, t.GID)
+}
+
+// rsymlink is a symlink response.
+type rsymlink struct {
+	// QID is the new symlink's QID.
+	QID QID
+}
+
+// decode implements encoder.decode.
+func (r *rsymlink) decode(b *buffer) {
+	r.QID.decode(b)
+}
+
+// encode implements encoder.encode.
+func (r *rsymlink) encode(b *buffer) {
+	r.QID.encode(b)
+}
+
+// Type implements message.Type.
+func (*rsymlink) typ() msgType {
+	return msgRsymlink
+}
+
+// String implements fmt.Stringer.
+func (r *rsymlink) String() string {
+	return fmt.Sprintf("Rsymlink{QID: %s}", r.QID)
+}
+
+// tlink is a link request.
+type tlink struct {
+	// Directory is the directory to contain the link.
+	Directory fid
+
+	// fid is the target.
+	Target fid
+
+	// Name is the new source name.
+	Name string
+}
+
+// decode implements encoder.decode.
+func (t *tlink) decode(b *buffer) {
+	t.Directory = b.ReadFID()
+	t.Target = b.ReadFID()
+	t.Name = b.ReadString()
+}
+
+// encode implements encoder.encode.
+func (t *tlink) encode(b *buffer) {
+	b.WriteFID(t.Directory)
+	b.WriteFID(t.Target)
+	b.WriteString(t.Name)
+}
+
+// Type implements message.Type.
+func (*tlink) typ() msgType {
+	return msgTlink
+}
+
+// String implements fmt.Stringer.
+func (t *tlink) String() string {
+	return fmt.Sprintf("Tlink{DirectoryFID: %d, TargetFID: %d, Name: %s}", t.Directory, t.Target, t.Name)
+}
+
+// rlink is a link response.
+type rlink struct {
+}
+
+// Type implements message.Type.
+func (*rlink) typ() msgType {
+	return msgRlink
+}
+
+// decode implements encoder.decode.
+func (*rlink) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rlink) encode(b *buffer) {
+}
+
+// String implements fmt.Stringer.
+func (r *rlink) String() string {
+	return fmt.Sprintf("Rlink{}")
+}
+
+// trenameat is a rename request.
+type trenameat struct {
+	// OldDirectory is the source directory.
+	OldDirectory fid
+
+	// OldName is the source file name.
+	OldName string
+
+	// NewDirectory is the target directory.
+	NewDirectory fid
+
+	// NewName is the new file name.
+	NewName string
+}
+
+// decode implements encoder.decode.
+func (t *trenameat) decode(b *buffer) {
+	t.OldDirectory = b.ReadFID()
+	t.OldName = b.ReadString()
+	t.NewDirectory = b.ReadFID()
+	t.NewName = b.ReadString()
+}
+
+// encode implements encoder.encode.
+func (t *trenameat) encode(b *buffer) {
+	b.WriteFID(t.OldDirectory)
+	b.WriteString(t.OldName)
+	b.WriteFID(t.NewDirectory)
+	b.WriteString(t.NewName)
+}
+
+// Type implements message.Type.
+func (*trenameat) typ() msgType {
+	return msgTrenameat
+}
+
+// String implements fmt.Stringer.
+func (t *trenameat) String() string {
+	return fmt.Sprintf("TrenameAt{OldDirectoryFID: %d, OldName: %s, NewDirectoryFID: %d, NewName: %s}", t.OldDirectory, t.OldName, t.NewDirectory, t.NewName)
+}
+
+// rrenameat is a rename response.
+type rrenameat struct {
+}
+
+// decode implements encoder.decode.
+func (*rrenameat) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rrenameat) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rrenameat) typ() msgType {
+	return msgRrenameat
+}
+
+// String implements fmt.Stringer.
+func (r *rrenameat) String() string {
+	return fmt.Sprintf("Rrenameat{}")
+}
+
+// tunlinkat is an unlink request.
+type tunlinkat struct {
+	// Directory is the originating directory.
+	Directory fid
+
+	// Name is the name of the entry to unlink.
+	Name string
+
+	// Flags are extra flags (e.g. O_DIRECTORY). These are not interpreted by p9.
+	Flags uint32
+}
+
+// decode implements encoder.decode.
+func (t *tunlinkat) decode(b *buffer) {
+	t.Directory = b.ReadFID()
+	t.Name = b.ReadString()
+	t.Flags = b.Read32()
+}
+
+// encode implements encoder.encode.
+func (t *tunlinkat) encode(b *buffer) {
+	b.WriteFID(t.Directory)
+	b.WriteString(t.Name)
+	b.Write32(t.Flags)
+}
+
+// Type implements message.Type.
+func (*tunlinkat) typ() msgType {
+	return msgTunlinkat
+}
+
+// String implements fmt.Stringer.
+func (t *tunlinkat) String() string {
+	return fmt.Sprintf("Tunlinkat{DirectoryFID: %d, Name: %s, Flags: 0x%X}", t.Directory, t.Name, t.Flags)
+}
+
+// runlinkat is an unlink response.
+type runlinkat struct {
+}
+
+// decode implements encoder.decode.
+func (*runlinkat) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*runlinkat) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*runlinkat) typ() msgType {
+	return msgRunlinkat
+}
+
+// String implements fmt.Stringer.
+func (r *runlinkat) String() string {
+	return fmt.Sprintf("Runlinkat{}")
+}
+
+// trename is a rename request.
+type trename struct {
+	// fid is the fid to rename.
+	fid fid
+
+	// Directory is the target directory.
+	Directory fid
+
+	// Name is the new file name.
+	Name string
+}
+
+// decode implements encoder.decode.
+func (t *trename) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Directory = b.ReadFID()
+	t.Name = b.ReadString()
+}
+
+// encode implements encoder.encode.
+func (t *trename) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.WriteFID(t.Directory)
+	b.WriteString(t.Name)
+}
+
+// Type implements message.Type.
+func (*trename) typ() msgType {
+	return msgTrename
+}
+
+// String implements fmt.Stringer.
+func (t *trename) String() string {
+	return fmt.Sprintf("Trename{FID: %d, DirectoryFID: %d, Name: %s}", t.fid, t.Directory, t.Name)
+}
+
+// rrename is a rename response.
+type rrename struct {
+}
+
+// decode implements encoder.decode.
+func (*rrename) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rrename) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rrename) typ() msgType {
+	return msgRrename
+}
+
+// String implements fmt.Stringer.
+func (r *rrename) String() string {
+	return fmt.Sprintf("Rrename{}")
+}
+
+// treadlink is a readlink request.
+type treadlink struct {
+	// fid is the symlink.
+	fid fid
+}
+
+// decode implements encoder.decode.
+func (t *treadlink) decode(b *buffer) {
+	t.fid = b.ReadFID()
+}
+
+// encode implements encoder.encode.
+func (t *treadlink) encode(b *buffer) {
+	b.WriteFID(t.fid)
+}
+
+// Type implements message.Type.
+func (*treadlink) typ() msgType {
+	return msgTreadlink
+}
+
+// String implements fmt.Stringer.
+func (t *treadlink) String() string {
+	return fmt.Sprintf("Treadlink{FID: %d}", t.fid)
+}
+
+// rreadlink is a readlink response.
+type rreadlink struct {
+	// Target is the symlink target.
+	Target string
+}
+
+// decode implements encoder.decode.
+func (r *rreadlink) decode(b *buffer) {
+	r.Target = b.ReadString()
+}
+
+// encode implements encoder.encode.
+func (r *rreadlink) encode(b *buffer) {
+	b.WriteString(r.Target)
+}
+
+// Type implements message.Type.
+func (*rreadlink) typ() msgType {
+	return msgRreadlink
+}
+
+// String implements fmt.Stringer.
+func (r *rreadlink) String() string {
+	return fmt.Sprintf("Rreadlink{Target: %s}", r.Target)
+}
+
+// tread is a read request.
+type tread struct {
+	// fid is the fid to read.
+	fid fid
+
+	// Offset indicates the file offset.
+	Offset uint64
+
+	// Count indicates the number of bytes to read.
+	Count uint32
+}
+
+// decode implements encoder.decode.
+func (t *tread) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Offset = b.Read64()
+	t.Count = b.Read32()
+}
+
+// encode implements encoder.encode.
+func (t *tread) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.Write64(t.Offset)
+	b.Write32(t.Count)
+}
+
+// Type implements message.Type.
+func (*tread) typ() msgType {
+	return msgTread
+}
+
+// String implements fmt.Stringer.
+func (t *tread) String() string {
+	return fmt.Sprintf("Tread{FID: %d, Offset: %d, Count: %d}", t.fid, t.Offset, t.Count)
+}
+
+// rread is the response for a Tread.
+type rread struct {
+	// Data is the resulting data.
+	Data []byte
+}
+
+// decode implements encoder.decode.
+//
+// Data is automatically decoded via Payload.
+func (r *rread) decode(b *buffer) {
+	count := b.Read32()
+	if count != uint32(len(r.Data)) {
+		b.markOverrun()
+	}
+}
+
+// encode implements encoder.encode.
+//
+// Data is automatically encoded via Payload.
+func (r *rread) encode(b *buffer) {
+	b.Write32(uint32(len(r.Data)))
+}
+
+// Type implements message.Type.
+func (*rread) typ() msgType {
+	return msgRread
+}
+
+// FixedSize implements payloader.FixedSize.
+func (*rread) FixedSize() uint32 {
+	return 4
+}
+
+// Payload implements payloader.Payload.
+func (r *rread) Payload() []byte {
+	return r.Data
+}
+
+// SetPayload implements payloader.SetPayload.
+func (r *rread) SetPayload(p []byte) {
+	r.Data = p
+}
+
+// String implements fmt.Stringer.
+func (r *rread) String() string {
+	return fmt.Sprintf("Rread{len(Data): %d}", len(r.Data))
+}
+
+// twrite is a write request.
+type twrite struct {
+	// fid is the fid to read.
+	fid fid
+
+	// Offset indicates the file offset.
+	Offset uint64
+
+	// Data is the data to be written.
+	Data []byte
+}
+
+// decode implements encoder.decode.
+func (t *twrite) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Offset = b.Read64()
+	count := b.Read32()
+	if count != uint32(len(t.Data)) {
+		b.markOverrun()
+	}
+}
+
+// encode implements encoder.encode.
+//
+// This uses the buffer payload to avoid a copy.
+func (t *twrite) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.Write64(t.Offset)
+	b.Write32(uint32(len(t.Data)))
+}
+
+// Type implements message.Type.
+func (*twrite) typ() msgType {
+	return msgTwrite
+}
+
+// FixedSize implements payloader.FixedSize.
+func (*twrite) FixedSize() uint32 {
+	return 16
+}
+
+// Payload implements payloader.Payload.
+func (t *twrite) Payload() []byte {
+	return t.Data
+}
+
+// SetPayload implements payloader.SetPayload.
+func (t *twrite) SetPayload(p []byte) {
+	t.Data = p
+}
+
+// String implements fmt.Stringer.
+func (t *twrite) String() string {
+	return fmt.Sprintf("Twrite{FID: %v, Offset %d, len(Data): %d}", t.fid, t.Offset, len(t.Data))
+}
+
+// rwrite is the response for a Twrite.
+type rwrite struct {
+	// Count indicates the number of bytes successfully written.
+	Count uint32
+}
+
+// decode implements encoder.decode.
+func (r *rwrite) decode(b *buffer) {
+	r.Count = b.Read32()
+}
+
+// encode implements encoder.encode.
+func (r *rwrite) encode(b *buffer) {
+	b.Write32(r.Count)
+}
+
+// Type implements message.Type.
+func (*rwrite) typ() msgType {
+	return msgRwrite
+}
+
+// String implements fmt.Stringer.
+func (r *rwrite) String() string {
+	return fmt.Sprintf("Rwrite{Count: %d}", r.Count)
+}
+
+// tmknod is a mknod request.
+type tmknod struct {
+	// Directory is the parent directory.
+	Directory fid
+
+	// Name is the device name.
+	Name string
+
+	// Mode is the device mode and permissions.
+	Mode FileMode
+
+	// Major is the device major number.
+	Major uint32
+
+	// Minor is the device minor number.
+	Minor uint32
+
+	// GID is the device GID.
+	GID GID
+}
+
+// decode implements encoder.decode.
+func (t *tmknod) decode(b *buffer) {
+	t.Directory = b.ReadFID()
+	t.Name = b.ReadString()
+	t.Mode = b.ReadFileMode()
+	t.Major = b.Read32()
+	t.Minor = b.Read32()
+	t.GID = b.ReadGID()
+}
+
+// encode implements encoder.encode.
+func (t *tmknod) encode(b *buffer) {
+	b.WriteFID(t.Directory)
+	b.WriteString(t.Name)
+	b.WriteFileMode(t.Mode)
+	b.Write32(t.Major)
+	b.Write32(t.Minor)
+	b.WriteGID(t.GID)
+}
+
+// Type implements message.Type.
+func (*tmknod) typ() msgType {
+	return msgTmknod
+}
+
+// String implements fmt.Stringer.
+func (t *tmknod) String() string {
+	return fmt.Sprintf("Tmknod{DirectoryFID: %d, Name: %s, Mode: 0o%o, Major: %d, Minor: %d, GID: %d}", t.Directory, t.Name, t.Mode, t.Major, t.Minor, t.GID)
+}
+
+// rmknod is a mknod response.
+type rmknod struct {
+	// QID is the resulting QID.
+	QID QID
+}
+
+// decode implements encoder.decode.
+func (r *rmknod) decode(b *buffer) {
+	r.QID.decode(b)
+}
+
+// encode implements encoder.encode.
+func (r *rmknod) encode(b *buffer) {
+	r.QID.encode(b)
+}
+
+// Type implements message.Type.
+func (*rmknod) typ() msgType {
+	return msgRmknod
+}
+
+// String implements fmt.Stringer.
+func (r *rmknod) String() string {
+	return fmt.Sprintf("Rmknod{QID: %s}", r.QID)
+}
+
+// tmkdir is a mkdir request.
+type tmkdir struct {
+	// Directory is the parent directory.
+	Directory fid
+
+	// Name is the new directory name.
+	Name string
+
+	// Permissions is the set of permission bits.
+	Permissions FileMode
+
+	// GID is the owning group.
+	GID GID
+}
+
+// decode implements encoder.decode.
+func (t *tmkdir) decode(b *buffer) {
+	t.Directory = b.ReadFID()
+	t.Name = b.ReadString()
+	t.Permissions = b.ReadPermissions()
+	t.GID = b.ReadGID()
+}
+
+// encode implements encoder.encode.
+func (t *tmkdir) encode(b *buffer) {
+	b.WriteFID(t.Directory)
+	b.WriteString(t.Name)
+	b.WritePermissions(t.Permissions)
+	b.WriteGID(t.GID)
+}
+
+// Type implements message.Type.
+func (*tmkdir) typ() msgType {
+	return msgTmkdir
+}
+
+// String implements fmt.Stringer.
+func (t *tmkdir) String() string {
+	return fmt.Sprintf("Tmkdir{DirectoryFID: %d, Name: %s, Permissions: 0o%o, GID: %d}", t.Directory, t.Name, t.Permissions, t.GID)
+}
+
+// rmkdir is a mkdir response.
+type rmkdir struct {
+	// QID is the resulting QID.
+	QID QID
+}
+
+// decode implements encoder.decode.
+func (r *rmkdir) decode(b *buffer) {
+	r.QID.decode(b)
+}
+
+// encode implements encoder.encode.
+func (r *rmkdir) encode(b *buffer) {
+	r.QID.encode(b)
+}
+
+// Type implements message.Type.
+func (*rmkdir) typ() msgType {
+	return msgRmkdir
+}
+
+// String implements fmt.Stringer.
+func (r *rmkdir) String() string {
+	return fmt.Sprintf("Rmkdir{QID: %s}", r.QID)
+}
+
+// tgetattr is a getattr request.
+type tgetattr struct {
+	// fid is the fid to get attributes for.
+	fid fid
+
+	// AttrMask is the set of attributes to get.
+	AttrMask AttrMask
+}
+
+// decode implements encoder.decode.
+func (t *tgetattr) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.AttrMask.decode(b)
+}
+
+// encode implements encoder.encode.
+func (t *tgetattr) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	t.AttrMask.encode(b)
+}
+
+// Type implements message.Type.
+func (*tgetattr) typ() msgType {
+	return msgTgetattr
+}
+
+// String implements fmt.Stringer.
+func (t *tgetattr) String() string {
+	return fmt.Sprintf("Tgetattr{FID: %d, AttrMask: %s}", t.fid, t.AttrMask)
+}
+
+// rgetattr is a getattr response.
+type rgetattr struct {
+	// Valid indicates which fields are valid.
+	Valid AttrMask
+
+	// QID is the QID for this file.
+	QID
+
+	// Attr is the set of attributes.
+	Attr Attr
+}
+
+// decode implements encoder.decode.
+func (r *rgetattr) decode(b *buffer) {
+	r.Valid.decode(b)
+	r.QID.decode(b)
+	r.Attr.decode(b)
+}
+
+// encode implements encoder.encode.
+func (r *rgetattr) encode(b *buffer) {
+	r.Valid.encode(b)
+	r.QID.encode(b)
+	r.Attr.encode(b)
+}
+
+// Type implements message.Type.
+func (*rgetattr) typ() msgType {
+	return msgRgetattr
+}
+
+// String implements fmt.Stringer.
+func (r *rgetattr) String() string {
+	return fmt.Sprintf("Rgetattr{Valid: %v, QID: %s, Attr: %s}", r.Valid, r.QID, r.Attr)
+}
+
+// tsetattr is a setattr request.
+type tsetattr struct {
+	// fid is the fid to change.
+	fid fid
+
+	// Valid is the set of bits which will be used.
+	Valid SetAttrMask
+
+	// SetAttr is the set request.
+	SetAttr SetAttr
+}
+
+// decode implements encoder.decode.
+func (t *tsetattr) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Valid.decode(b)
+	t.SetAttr.decode(b)
+}
+
+// encode implements encoder.encode.
+func (t *tsetattr) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	t.Valid.encode(b)
+	t.SetAttr.encode(b)
+}
+
+// Type implements message.Type.
+func (*tsetattr) typ() msgType {
+	return msgTsetattr
+}
+
+// String implements fmt.Stringer.
+func (t *tsetattr) String() string {
+	return fmt.Sprintf("Tsetattr{FID: %d, Valid: %v, SetAttr: %s}", t.fid, t.Valid, t.SetAttr)
+}
+
+// rsetattr is a setattr response.
+type rsetattr struct {
+}
+
+// decode implements encoder.decode.
+func (*rsetattr) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rsetattr) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rsetattr) typ() msgType {
+	return msgRsetattr
+}
+
+// String implements fmt.Stringer.
+func (r *rsetattr) String() string {
+	return fmt.Sprintf("Rsetattr{}")
+}
+
+// tallocate is an allocate request. This is an extension to 9P protocol, not
+// present in the 9P2000.L standard.
+type tallocate struct {
+	fid    fid
+	Mode   AllocateMode
+	Offset uint64
+	Length uint64
+}
+
+// decode implements encoder.decode.
+func (t *tallocate) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Mode.decode(b)
+	t.Offset = b.Read64()
+	t.Length = b.Read64()
+}
+
+// encode implements encoder.encode.
+func (t *tallocate) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	t.Mode.encode(b)
+	b.Write64(t.Offset)
+	b.Write64(t.Length)
+}
+
+// Type implements message.Type.
+func (*tallocate) typ() msgType {
+	return msgTallocate
+}
+
+// String implements fmt.Stringer.
+func (t *tallocate) String() string {
+	return fmt.Sprintf("Tallocate{FID: %d, Offset: %d, Length: %d}", t.fid, t.Offset, t.Length)
+}
+
+// rallocate is an allocate response.
+type rallocate struct {
+}
+
+// decode implements encoder.decode.
+func (*rallocate) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rallocate) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rallocate) typ() msgType {
+	return msgRallocate
+}
+
+// String implements fmt.Stringer.
+func (r *rallocate) String() string {
+	return fmt.Sprintf("Rallocate{}")
+}
+
+// txattrwalk walks extended attributes.
+type txattrwalk struct {
+	// fid is the fid to check for attributes.
+	fid fid
+
+	// newFID is the new fid associated with the attributes.
+	newFID fid
+
+	// Name is the attribute name.
+	Name string
+}
+
+// decode implements encoder.decode.
+func (t *txattrwalk) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.newFID = b.ReadFID()
+	t.Name = b.ReadString()
+}
+
+// encode implements encoder.encode.
+func (t *txattrwalk) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.WriteFID(t.newFID)
+	b.WriteString(t.Name)
+}
+
+// Type implements message.Type.
+func (*txattrwalk) typ() msgType {
+	return msgTxattrwalk
+}
+
+// String implements fmt.Stringer.
+func (t *txattrwalk) String() string {
+	return fmt.Sprintf("Txattrwalk{FID: %d, newFID: %d, Name: %s}", t.fid, t.newFID, t.Name)
+}
+
+// rxattrwalk is a xattrwalk response.
+type rxattrwalk struct {
+	// Size is the size of the extended attribute.
+	Size uint64
+}
+
+// decode implements encoder.decode.
+func (r *rxattrwalk) decode(b *buffer) {
+	r.Size = b.Read64()
+}
+
+// encode implements encoder.encode.
+func (r *rxattrwalk) encode(b *buffer) {
+	b.Write64(r.Size)
+}
+
+// Type implements message.Type.
+func (*rxattrwalk) typ() msgType {
+	return msgRxattrwalk
+}
+
+// String implements fmt.Stringer.
+func (r *rxattrwalk) String() string {
+	return fmt.Sprintf("Rxattrwalk{Size: %d}", r.Size)
+}
+
+// txattrcreate prepare to set extended attributes.
+type txattrcreate struct {
+	// fid is input/output parameter, it identifies the file on which
+	// extended attributes will be set but after successful Rxattrcreate
+	// it is used to write the extended attribute value.
+	fid fid
+
+	// Name is the attribute name.
+	Name string
+
+	// Size of the attribute value. When the fid is clunked it has to match
+	// the number of bytes written to the fid.
+	AttrSize uint64
+
+	// Linux setxattr(2) flags.
+	Flags uint32
+}
+
+// decode implements encoder.decode.
+func (t *txattrcreate) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.Name = b.ReadString()
+	t.AttrSize = b.Read64()
+	t.Flags = b.Read32()
+}
+
+// encode implements encoder.encode.
+func (t *txattrcreate) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.WriteString(t.Name)
+	b.Write64(t.AttrSize)
+	b.Write32(t.Flags)
+}
+
+// Type implements message.Type.
+func (*txattrcreate) typ() msgType {
+	return msgTxattrcreate
+}
+
+// String implements fmt.Stringer.
+func (t *txattrcreate) String() string {
+	return fmt.Sprintf("Txattrcreate{FID: %d, Name: %s, AttrSize: %d, Flags: %d}", t.fid, t.Name, t.AttrSize, t.Flags)
+}
+
+// rxattrcreate is a xattrcreate response.
+type rxattrcreate struct {
+}
+
+// decode implements encoder.decode.
+func (r *rxattrcreate) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (r *rxattrcreate) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rxattrcreate) typ() msgType {
+	return msgRxattrcreate
+}
+
+// String implements fmt.Stringer.
+func (r *rxattrcreate) String() string {
+	return fmt.Sprintf("Rxattrcreate{}")
+}
+
+// treaddir is a readdir request.
+type treaddir struct {
+	// Directory is the directory fid to read.
+	Directory fid
+
+	// Offset is the offset to read at.
+	Offset uint64
+
+	// Count is the number of bytes to read.
+	Count uint32
+}
+
+// decode implements encoder.decode.
+func (t *treaddir) decode(b *buffer) {
+	t.Directory = b.ReadFID()
+	t.Offset = b.Read64()
+	t.Count = b.Read32()
+}
+
+// encode implements encoder.encode.
+func (t *treaddir) encode(b *buffer) {
+	b.WriteFID(t.Directory)
+	b.Write64(t.Offset)
+	b.Write32(t.Count)
+}
+
+// Type implements message.Type.
+func (*treaddir) typ() msgType {
+	return msgTreaddir
+}
+
+// String implements fmt.Stringer.
+func (t *treaddir) String() string {
+	return fmt.Sprintf("Treaddir{DirectoryFID: %d, Offset: %d, Count: %d}", t.Directory, t.Offset, t.Count)
+}
+
+// rreaddir is a readdir response.
+type rreaddir struct {
+	// Count is the byte limit.
+	//
+	// This should always be set from the Treaddir request.
+	Count uint32
+
+	// Entries are the resulting entries.
+	//
+	// This may be constructed in decode.
+	Entries []Dirent
+
+	// payload is the encoded payload.
+	//
+	// This is constructed by encode.
+	payload []byte
+}
+
+// decode implements encoder.decode.
+func (r *rreaddir) decode(b *buffer) {
+	r.Count = b.Read32()
+	entriesBuf := buffer{data: r.payload}
+	r.Entries = r.Entries[:0]
+	for {
+		var d Dirent
+		d.decode(&entriesBuf)
+		if entriesBuf.isOverrun() {
+			// Couldn't decode a complete entry.
+			break
+		}
+		r.Entries = append(r.Entries, d)
+	}
+}
+
+// encode implements encoder.encode.
+func (r *rreaddir) encode(b *buffer) {
+	entriesBuf := buffer{}
+	for _, d := range r.Entries {
+		d.encode(&entriesBuf)
+		if len(entriesBuf.data) >= int(r.Count) {
+			break
+		}
+	}
+	if len(entriesBuf.data) < int(r.Count) {
+		r.Count = uint32(len(entriesBuf.data))
+		r.payload = entriesBuf.data
+	} else {
+		r.payload = entriesBuf.data[:r.Count]
+	}
+	b.Write32(uint32(r.Count))
+}
+
+// Type implements message.Type.
+func (*rreaddir) typ() msgType {
+	return msgRreaddir
+}
+
+// FixedSize implements payloader.FixedSize.
+func (*rreaddir) FixedSize() uint32 {
+	return 4
+}
+
+// Payload implements payloader.Payload.
+func (r *rreaddir) Payload() []byte {
+	return r.payload
+}
+
+// SetPayload implements payloader.SetPayload.
+func (r *rreaddir) SetPayload(p []byte) {
+	r.payload = p
+}
+
+// String implements fmt.Stringer.
+func (r *rreaddir) String() string {
+	return fmt.Sprintf("Rreaddir{Count: %d, Entries: %s}", r.Count, r.Entries)
+}
+
+// Tfsync is an fsync request.
+type tfsync struct {
+	// fid is the fid to sync.
+	fid fid
+}
+
+// decode implements encoder.decode.
+func (t *tfsync) decode(b *buffer) {
+	t.fid = b.ReadFID()
+}
+
+// encode implements encoder.encode.
+func (t *tfsync) encode(b *buffer) {
+	b.WriteFID(t.fid)
+}
+
+// Type implements message.Type.
+func (*tfsync) typ() msgType {
+	return msgTfsync
+}
+
+// String implements fmt.Stringer.
+func (t *tfsync) String() string {
+	return fmt.Sprintf("Tfsync{FID: %d}", t.fid)
+}
+
+// rfsync is an fsync response.
+type rfsync struct {
+}
+
+// decode implements encoder.decode.
+func (*rfsync) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rfsync) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rfsync) typ() msgType {
+	return msgRfsync
+}
+
+// String implements fmt.Stringer.
+func (r *rfsync) String() string {
+	return fmt.Sprintf("Rfsync{}")
+}
+
+// tstatfs is a stat request.
+type tstatfs struct {
+	// fid is the root.
+	fid fid
+}
+
+// decode implements encoder.decode.
+func (t *tstatfs) decode(b *buffer) {
+	t.fid = b.ReadFID()
+}
+
+// encode implements encoder.encode.
+func (t *tstatfs) encode(b *buffer) {
+	b.WriteFID(t.fid)
+}
+
+// Type implements message.Type.
+func (*tstatfs) typ() msgType {
+	return msgTstatfs
+}
+
+// String implements fmt.Stringer.
+func (t *tstatfs) String() string {
+	return fmt.Sprintf("Tstatfs{FID: %d}", t.fid)
+}
+
+// rstatfs is the response for a Tstatfs.
+type rstatfs struct {
+	// FSStat is the stat result.
+	FSStat FSStat
+}
+
+// decode implements encoder.decode.
+func (r *rstatfs) decode(b *buffer) {
+	r.FSStat.decode(b)
+}
+
+// encode implements encoder.encode.
+func (r *rstatfs) encode(b *buffer) {
+	r.FSStat.encode(b)
+}
+
+// Type implements message.Type.
+func (*rstatfs) typ() msgType {
+	return msgRstatfs
+}
+
+// String implements fmt.Stringer.
+func (r *rstatfs) String() string {
+	return fmt.Sprintf("Rstatfs{FSStat: %v}", r.FSStat)
+}
+
+// tflushf is a flush file request, not to be confused with tflush.
+type tflushf struct {
+	// fid is the fid to be flushed.
+	fid fid
+}
+
+// decode implements encoder.decode.
+func (t *tflushf) decode(b *buffer) {
+	t.fid = b.ReadFID()
+}
+
+// encode implements encoder.encode.
+func (t *tflushf) encode(b *buffer) {
+	b.WriteFID(t.fid)
+}
+
+// Type implements message.Type.
+func (*tflushf) typ() msgType {
+	return msgTflushf
+}
+
+// String implements fmt.Stringer.
+func (t *tflushf) String() string {
+	return fmt.Sprintf("Tflushf{FID: %d}", t.fid)
+}
+
+// rflushf is a flush file response.
+type rflushf struct {
+}
+
+// decode implements encoder.decode.
+func (*rflushf) decode(b *buffer) {
+}
+
+// encode implements encoder.encode.
+func (*rflushf) encode(b *buffer) {
+}
+
+// Type implements message.Type.
+func (*rflushf) typ() msgType {
+	return msgRflushf
+}
+
+// String implements fmt.Stringer.
+func (*rflushf) String() string {
+	return fmt.Sprintf("Rflushf{}")
+}
+
+// twalkgetattr is a walk request.
+type twalkgetattr struct {
+	// fid is the fid to be walked.
+	fid fid
+
+	// newFID is the resulting fid.
+	newFID fid
+
+	// Names are the set of names to be walked.
+	Names []string
+}
+
+// decode implements encoder.decode.
+func (t *twalkgetattr) decode(b *buffer) {
+	t.fid = b.ReadFID()
+	t.newFID = b.ReadFID()
+	n := b.Read16()
+	t.Names = t.Names[:0]
+	for i := 0; i < int(n); i++ {
+		t.Names = append(t.Names, b.ReadString())
+	}
+}
+
+// encode implements encoder.encode.
+func (t *twalkgetattr) encode(b *buffer) {
+	b.WriteFID(t.fid)
+	b.WriteFID(t.newFID)
+	b.Write16(uint16(len(t.Names)))
+	for _, name := range t.Names {
+		b.WriteString(name)
+	}
+}
+
+// Type implements message.Type.
+func (*twalkgetattr) typ() msgType {
+	return msgTwalkgetattr
+}
+
+// String implements fmt.Stringer.
+func (t *twalkgetattr) String() string {
+	return fmt.Sprintf("Twalkgetattr{FID: %d, newFID: %d, Names: %v}", t.fid, t.newFID, t.Names)
+}
+
+// rwalkgetattr is a walk response.
+type rwalkgetattr struct {
+	// Valid indicates which fields are valid in the Attr below.
+	Valid AttrMask
+
+	// Attr is the set of attributes for the last QID (the file walked to).
+	Attr Attr
+
+	// QIDs are the set of QIDs returned.
+	QIDs []QID
+}
+
+// decode implements encoder.decode.
+func (r *rwalkgetattr) decode(b *buffer) {
+	r.Valid.decode(b)
+	r.Attr.decode(b)
+	n := b.Read16()
+	r.QIDs = r.QIDs[:0]
+	for i := 0; i < int(n); i++ {
+		var q QID
+		q.decode(b)
+		r.QIDs = append(r.QIDs, q)
+	}
+}
+
+// encode implements encoder.encode.
+func (r *rwalkgetattr) encode(b *buffer) {
+	r.Valid.encode(b)
+	r.Attr.encode(b)
+	b.Write16(uint16(len(r.QIDs)))
+	for _, q := range r.QIDs {
+		q.encode(b)
+	}
+}
+
+// Type implements message.Type.
+func (*rwalkgetattr) typ() msgType {
+	return msgRwalkgetattr
+}
+
+// String implements fmt.Stringer.
+func (r *rwalkgetattr) String() string {
+	return fmt.Sprintf("Rwalkgetattr{Valid: %s, Attr: %s, QIDs: %v}", r.Valid, r.Attr, r.QIDs)
+}
+
+// tucreate is a tlcreate message that includes a UID.
+type tucreate struct {
+	tlcreate
+
+	// UID is the UID to use as the effective UID in creation messages.
+	UID UID
+}
+
+// decode implements encoder.decode.
+func (t *tucreate) decode(b *buffer) {
+	t.tlcreate.decode(b)
+	t.UID = b.ReadUID()
+}
+
+// encode implements encoder.encode.
+func (t *tucreate) encode(b *buffer) {
+	t.tlcreate.encode(b)
+	b.WriteUID(t.UID)
+}
+
+// Type implements message.Type.
+func (t *tucreate) typ() msgType {
+	return msgTucreate
+}
+
+// String implements fmt.Stringer.
+func (t *tucreate) String() string {
+	return fmt.Sprintf("Tucreate{Tlcreate: %v, UID: %d}", &t.tlcreate, t.UID)
+}
+
+// rucreate is a file creation response.
+type rucreate struct {
+	rlcreate
+}
+
+// Type implements message.Type.
+func (*rucreate) typ() msgType {
+	return msgRucreate
+}
+
+// String implements fmt.Stringer.
+func (r *rucreate) String() string {
+	return fmt.Sprintf("Rucreate{%v}", &r.rlcreate)
+}
+
+// tumkdir is a Tmkdir message that includes a UID.
+type tumkdir struct {
+	tmkdir
+
+	// UID is the UID to use as the effective UID in creation messages.
+	UID UID
+}
+
+// decode implements encoder.decode.
+func (t *tumkdir) decode(b *buffer) {
+	t.tmkdir.decode(b)
+	t.UID = b.ReadUID()
+}
+
+// encode implements encoder.encode.
+func (t *tumkdir) encode(b *buffer) {
+	t.tmkdir.encode(b)
+	b.WriteUID(t.UID)
+}
+
+// Type implements message.Type.
+func (t *tumkdir) typ() msgType {
+	return msgTumkdir
+}
+
+// String implements fmt.Stringer.
+func (t *tumkdir) String() string {
+	return fmt.Sprintf("Tumkdir{Tmkdir: %v, UID: %d}", &t.tmkdir, t.UID)
+}
+
+// rumkdir is a umkdir response.
+type rumkdir struct {
+	rmkdir
+}
+
+// Type implements message.Type.
+func (*rumkdir) typ() msgType {
+	return msgRumkdir
+}
+
+// String implements fmt.Stringer.
+func (r *rumkdir) String() string {
+	return fmt.Sprintf("Rumkdir{%v}", &r.rmkdir)
+}
+
+// tumknod is a Tmknod message that includes a UID.
+type tumknod struct {
+	tmknod
+
+	// UID is the UID to use as the effective UID in creation messages.
+	UID UID
+}
+
+// decode implements encoder.decode.
+func (t *tumknod) decode(b *buffer) {
+	t.tmknod.decode(b)
+	t.UID = b.ReadUID()
+}
+
+// encode implements encoder.encode.
+func (t *tumknod) encode(b *buffer) {
+	t.tmknod.encode(b)
+	b.WriteUID(t.UID)
+}
+
+// Type implements message.Type.
+func (t *tumknod) typ() msgType {
+	return msgTumknod
+}
+
+// String implements fmt.Stringer.
+func (t *tumknod) String() string {
+	return fmt.Sprintf("Tumknod{Tmknod: %v, UID: %d}", &t.tmknod, t.UID)
+}
+
+// rumknod is a umknod response.
+type rumknod struct {
+	rmknod
+}
+
+// Type implements message.Type.
+func (*rumknod) typ() msgType {
+	return msgRumknod
+}
+
+// String implements fmt.Stringer.
+func (r *rumknod) String() string {
+	return fmt.Sprintf("Rumknod{%v}", &r.rmknod)
+}
+
+// tusymlink is a Tsymlink message that includes a UID.
+type tusymlink struct {
+	tsymlink
+
+	// UID is the UID to use as the effective UID in creation messages.
+	UID UID
+}
+
+// decode implements encoder.decode.
+func (t *tusymlink) decode(b *buffer) {
+	t.tsymlink.decode(b)
+	t.UID = b.ReadUID()
+}
+
+// encode implements encoder.encode.
+func (t *tusymlink) encode(b *buffer) {
+	t.tsymlink.encode(b)
+	b.WriteUID(t.UID)
+}
+
+// Type implements message.Type.
+func (t *tusymlink) typ() msgType {
+	return msgTusymlink
+}
+
+// String implements fmt.Stringer.
+func (t *tusymlink) String() string {
+	return fmt.Sprintf("Tusymlink{Tsymlink: %v, UID: %d}", &t.tsymlink, t.UID)
+}
+
+// rusymlink is a usymlink response.
+type rusymlink struct {
+	rsymlink
+}
+
+// Type implements message.Type.
+func (*rusymlink) typ() msgType {
+	return msgRusymlink
+}
+
+// String implements fmt.Stringer.
+func (r *rusymlink) String() string {
+	return fmt.Sprintf("Rusymlink{%v}", &r.rsymlink)
+}
+
+const maxCacheSize = 3
+
+// msgFactory is used to reduce allocations by caching messages for reuse.
+type msgFactory struct {
+	create func() message
+	cache  chan message
+}
+
+// msgRegistry indexes all message factories by type.
+var msgRegistry registry
+
+type registry struct {
+	factories [math.MaxUint8]msgFactory
+
+	// largestFixedSize is computed so that given some message size M, you can
+	// compute the maximum payload size (e.g. for Twrite, Rread) with
+	// M-largestFixedSize. You could do this individual on a per-message basis,
+	// but it's easier to compute a single maximum safe payload.
+	largestFixedSize uint32
+}
+
+// get returns a new message by type.
+//
+// An error is returned in the case of an unknown message.
+//
+// This takes, and ignores, a message tag so that it may be used directly as a
+// lookuptagAndType function for recv (by design).
+func (r *registry) get(_ tag, t msgType) (message, error) {
+	entry := &r.factories[t]
+	if entry.create == nil {
+		return nil, &ErrInvalidMsgType{t}
+	}
+
+	select {
+	case msg := <-entry.cache:
+		return msg, nil
+	default:
+		return entry.create(), nil
+	}
+}
+
+func (r *registry) put(msg message) {
+	if p, ok := msg.(payloader); ok {
+		p.SetPayload(nil)
+	}
+
+	entry := &r.factories[msg.typ()]
+	select {
+	case entry.cache <- msg:
+	default:
+	}
+}
+
+// register registers the given message type.
+//
+// This may cause panic on failure and should only be used from init.
+func (r *registry) register(t msgType, fn func() message) {
+	if int(t) >= len(r.factories) {
+		panic(fmt.Sprintf("message type %d is too large. It must be smaller than %d", t, len(r.factories)))
+	}
+	if r.factories[t].create != nil {
+		panic(fmt.Sprintf("duplicate message type %d: first is %T, second is %T", t, r.factories[t].create(), fn()))
+	}
+	r.factories[t] = msgFactory{
+		create: fn,
+		cache:  make(chan message, maxCacheSize),
+	}
+
+	if size := calculateSize(fn()); size > r.largestFixedSize {
+		r.largestFixedSize = size
+	}
+}
+
+func calculateSize(m message) uint32 {
+	if p, ok := m.(payloader); ok {
+		return p.FixedSize()
+	}
+	var dataBuf buffer
+	m.encode(&dataBuf)
+	return uint32(len(dataBuf.data))
+}
+
+func init() {
+	msgRegistry.register(msgRlerror, func() message { return &rlerror{} })
+	msgRegistry.register(msgTstatfs, func() message { return &tstatfs{} })
+	msgRegistry.register(msgRstatfs, func() message { return &rstatfs{} })
+	msgRegistry.register(msgTlopen, func() message { return &tlopen{} })
+	msgRegistry.register(msgRlopen, func() message { return &rlopen{} })
+	msgRegistry.register(msgTlcreate, func() message { return &tlcreate{} })
+	msgRegistry.register(msgRlcreate, func() message { return &rlcreate{} })
+	msgRegistry.register(msgTsymlink, func() message { return &tsymlink{} })
+	msgRegistry.register(msgRsymlink, func() message { return &rsymlink{} })
+	msgRegistry.register(msgTmknod, func() message { return &tmknod{} })
+	msgRegistry.register(msgRmknod, func() message { return &rmknod{} })
+	msgRegistry.register(msgTrename, func() message { return &trename{} })
+	msgRegistry.register(msgRrename, func() message { return &rrename{} })
+	msgRegistry.register(msgTreadlink, func() message { return &treadlink{} })
+	msgRegistry.register(msgRreadlink, func() message { return &rreadlink{} })
+	msgRegistry.register(msgTgetattr, func() message { return &tgetattr{} })
+	msgRegistry.register(msgRgetattr, func() message { return &rgetattr{} })
+	msgRegistry.register(msgTsetattr, func() message { return &tsetattr{} })
+	msgRegistry.register(msgRsetattr, func() message { return &rsetattr{} })
+	msgRegistry.register(msgTxattrwalk, func() message { return &txattrwalk{} })
+	msgRegistry.register(msgRxattrwalk, func() message { return &rxattrwalk{} })
+	msgRegistry.register(msgTxattrcreate, func() message { return &txattrcreate{} })
+	msgRegistry.register(msgRxattrcreate, func() message { return &rxattrcreate{} })
+	msgRegistry.register(msgTreaddir, func() message { return &treaddir{} })
+	msgRegistry.register(msgRreaddir, func() message { return &rreaddir{} })
+	msgRegistry.register(msgTfsync, func() message { return &tfsync{} })
+	msgRegistry.register(msgRfsync, func() message { return &rfsync{} })
+	msgRegistry.register(msgTlink, func() message { return &tlink{} })
+	msgRegistry.register(msgRlink, func() message { return &rlink{} })
+	msgRegistry.register(msgTmkdir, func() message { return &tmkdir{} })
+	msgRegistry.register(msgRmkdir, func() message { return &rmkdir{} })
+	msgRegistry.register(msgTrenameat, func() message { return &trenameat{} })
+	msgRegistry.register(msgRrenameat, func() message { return &rrenameat{} })
+	msgRegistry.register(msgTunlinkat, func() message { return &tunlinkat{} })
+	msgRegistry.register(msgRunlinkat, func() message { return &runlinkat{} })
+	msgRegistry.register(msgTversion, func() message { return &tversion{} })
+	msgRegistry.register(msgRversion, func() message { return &rversion{} })
+	msgRegistry.register(msgTauth, func() message { return &tauth{} })
+	msgRegistry.register(msgRauth, func() message { return &rauth{} })
+	msgRegistry.register(msgTattach, func() message { return &tattach{} })
+	msgRegistry.register(msgRattach, func() message { return &rattach{} })
+	msgRegistry.register(msgTflush, func() message { return &tflush{} })
+	msgRegistry.register(msgRflush, func() message { return &rflush{} })
+	msgRegistry.register(msgTwalk, func() message { return &twalk{} })
+	msgRegistry.register(msgRwalk, func() message { return &rwalk{} })
+	msgRegistry.register(msgTread, func() message { return &tread{} })
+	msgRegistry.register(msgRread, func() message { return &rread{} })
+	msgRegistry.register(msgTwrite, func() message { return &twrite{} })
+	msgRegistry.register(msgRwrite, func() message { return &rwrite{} })
+	msgRegistry.register(msgTclunk, func() message { return &tclunk{} })
+	msgRegistry.register(msgRclunk, func() message { return &rclunk{} })
+	msgRegistry.register(msgTremove, func() message { return &tremove{} })
+	msgRegistry.register(msgRremove, func() message { return &rremove{} })
+	msgRegistry.register(msgTflushf, func() message { return &tflushf{} })
+	msgRegistry.register(msgRflushf, func() message { return &rflushf{} })
+	msgRegistry.register(msgTwalkgetattr, func() message { return &twalkgetattr{} })
+	msgRegistry.register(msgRwalkgetattr, func() message { return &rwalkgetattr{} })
+	msgRegistry.register(msgTucreate, func() message { return &tucreate{} })
+	msgRegistry.register(msgRucreate, func() message { return &rucreate{} })
+	msgRegistry.register(msgTumkdir, func() message { return &tumkdir{} })
+	msgRegistry.register(msgRumkdir, func() message { return &rumkdir{} })
+	msgRegistry.register(msgTumknod, func() message { return &tumknod{} })
+	msgRegistry.register(msgRumknod, func() message { return &rumknod{} })
+	msgRegistry.register(msgTusymlink, func() message { return &tusymlink{} })
+	msgRegistry.register(msgRusymlink, func() message { return &rusymlink{} })
+	msgRegistry.register(msgTallocate, func() message { return &tallocate{} })
+	msgRegistry.register(msgRallocate, func() message { return &rallocate{} })
+}

--- a/vendor/github.com/hugelgupf/p9/p9/p9.go
+++ b/vendor/github.com/hugelgupf/p9/p9/p9.go
@@ -1,0 +1,1128 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package p9 is a 9P2000.L implementation.
+//
+// Servers implement Attacher and File interfaces.
+//
+// Clients can use Client.
+package p9
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"strings"
+	"sync/atomic"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// Debug can be assigned to log.Printf to print messages received and sent.
+var Debug = func(fmt string, v ...interface{}) {}
+
+// OpenFlags is the mode passed to Open and Create operations.
+//
+// These correspond to bits sent over the wire.
+type OpenFlags uint32
+
+const (
+	// ReadOnly is a Topen and Tcreate flag indicating read-only mode.
+	ReadOnly OpenFlags = 0
+
+	// WriteOnly is a Topen and Tcreate flag indicating write-only mode.
+	WriteOnly OpenFlags = 1
+
+	// ReadWrite is a Topen flag indicates read-write mode.
+	ReadWrite OpenFlags = 2
+
+	// OpenFlagsModeMask is a mask of valid OpenFlags mode bits.
+	OpenFlagsModeMask OpenFlags = 3
+
+	// OpenFlagsIgnoreMask is a list of OpenFlags mode bits that are ignored for Tlopen.
+	// Note that syscall.O_LARGEFILE is set to zero, use value from Linux fcntl.h.
+	OpenFlagsIgnoreMask OpenFlags = syscall.O_DIRECTORY | syscall.O_NOATIME | 0100000
+)
+
+// OSFlags converts a p9.OpenFlags to an int compatible with open(2).
+func (o OpenFlags) OSFlags() int {
+	return int(o & OpenFlagsModeMask)
+}
+
+// String implements fmt.Stringer.
+func (o OpenFlags) String() string {
+	switch o {
+	case ReadOnly:
+		return "ReadOnly"
+	case WriteOnly:
+		return "WriteOnly"
+	case ReadWrite:
+		return "ReadWrite"
+	case OpenFlagsModeMask:
+		return "OpenFlagsModeMask"
+	case OpenFlagsIgnoreMask:
+		return "OpenFlagsIgnoreMask"
+	default:
+		return "UNDEFINED"
+	}
+}
+
+// tag is a message tag.
+type tag uint16
+
+// fid is a file identifier.
+type fid uint64
+
+// FileMode are flags corresponding to file modes.
+//
+// These correspond to bits sent over the wire.
+// These also correspond to mode_t bits.
+type FileMode uint32
+
+const (
+	// FileModeMask is a mask of all the file mode bits of FileMode.
+	FileModeMask FileMode = 0170000
+
+	// ModeSocket is an (unused) mode bit for a socket.
+	ModeSocket FileMode = 0140000
+
+	// ModeSymlink is a mode bit for a symlink.
+	ModeSymlink FileMode = 0120000
+
+	// ModeRegular is a mode bit for regular files.
+	ModeRegular FileMode = 0100000
+
+	// ModeBlockDevice is a mode bit for block devices.
+	ModeBlockDevice FileMode = 060000
+
+	// ModeDirectory is a mode bit for directories.
+	ModeDirectory FileMode = 040000
+
+	// ModeCharacterDevice is a mode bit for a character device.
+	ModeCharacterDevice FileMode = 020000
+
+	// ModeNamedPipe is a mode bit for a named pipe.
+	ModeNamedPipe FileMode = 010000
+
+	// Read is a mode bit indicating read permission.
+	Read FileMode = 04
+
+	// Write is a mode bit indicating write permission.
+	Write FileMode = 02
+
+	// Exec is a mode bit indicating exec permission.
+	Exec FileMode = 01
+
+	// AllPermissions is a mask with rwx bits set for user, group and others.
+	AllPermissions FileMode = 0777
+
+	// Sticky is a mode bit indicating sticky directories.
+	Sticky FileMode = 01000
+
+	// permissionsMask is the mask to apply to FileModes for permissions. It
+	// includes rwx bits for user, group and others, and sticky bit.
+	permissionsMask FileMode = 01777
+)
+
+// QIDType is the most significant byte of the FileMode word, to be used as the
+// Type field of p9.QID.
+func (m FileMode) QIDType() QIDType {
+	switch {
+	case m.IsDir():
+		return TypeDir
+	case m.IsSocket(), m.IsNamedPipe(), m.IsCharacterDevice():
+		// Best approximation.
+		return TypeAppendOnly
+	case m.IsSymlink():
+		return TypeSymlink
+	default:
+		return TypeRegular
+	}
+}
+
+// FileType returns the file mode without the permission bits.
+func (m FileMode) FileType() FileMode {
+	return m & FileModeMask
+}
+
+// Permissions returns just the permission bits of the mode.
+func (m FileMode) Permissions() FileMode {
+	return m & permissionsMask
+}
+
+// Writable returns the mode with write bits added.
+func (m FileMode) Writable() FileMode {
+	return m | 0222
+}
+
+// IsReadable returns true if m represents a file that can be read.
+func (m FileMode) IsReadable() bool {
+	return m&0444 != 0
+}
+
+// IsWritable returns true if m represents a file that can be written to.
+func (m FileMode) IsWritable() bool {
+	return m&0222 != 0
+}
+
+// IsExecutable returns true if m represents a file that can be executed.
+func (m FileMode) IsExecutable() bool {
+	return m&0111 != 0
+}
+
+// IsRegular returns true if m is a regular file.
+func (m FileMode) IsRegular() bool {
+	return m&FileModeMask == ModeRegular
+}
+
+// IsDir returns true if m represents a directory.
+func (m FileMode) IsDir() bool {
+	return m&FileModeMask == ModeDirectory
+}
+
+// IsNamedPipe returns true if m represents a named pipe.
+func (m FileMode) IsNamedPipe() bool {
+	return m&FileModeMask == ModeNamedPipe
+}
+
+// IsCharacterDevice returns true if m represents a character device.
+func (m FileMode) IsCharacterDevice() bool {
+	return m&FileModeMask == ModeCharacterDevice
+}
+
+// IsBlockDevice returns true if m represents a character device.
+func (m FileMode) IsBlockDevice() bool {
+	return m&FileModeMask == ModeBlockDevice
+}
+
+// IsSocket returns true if m represents a socket.
+func (m FileMode) IsSocket() bool {
+	return m&FileModeMask == ModeSocket
+}
+
+// IsSymlink returns true if m represents a symlink.
+func (m FileMode) IsSymlink() bool {
+	return m&FileModeMask == ModeSymlink
+}
+
+// ModeFromOS returns a FileMode from an os.FileMode.
+func ModeFromOS(mode os.FileMode) FileMode {
+	m := FileMode(mode.Perm())
+	switch {
+	case mode.IsDir():
+		m |= ModeDirectory
+	case mode&os.ModeSymlink != 0:
+		m |= ModeSymlink
+	case mode&os.ModeSocket != 0:
+		m |= ModeSocket
+	case mode&os.ModeNamedPipe != 0:
+		m |= ModeNamedPipe
+	case mode&os.ModeCharDevice != 0:
+		m |= ModeCharacterDevice
+	case mode&os.ModeDevice != 0:
+		m |= ModeBlockDevice
+	default:
+		m |= ModeRegular
+	}
+	return m
+}
+
+// OSMode converts a p9.FileMode to an os.FileMode.
+func (m FileMode) OSMode() os.FileMode {
+	var osMode os.FileMode
+	osMode |= os.FileMode(m.Permissions())
+	switch {
+	case m.IsDir():
+		osMode |= os.ModeDir
+	case m.IsSymlink():
+		osMode |= os.ModeSymlink
+	case m.IsSocket():
+		osMode |= os.ModeSocket
+	case m.IsNamedPipe():
+		osMode |= os.ModeNamedPipe
+	case m.IsCharacterDevice():
+		osMode |= os.ModeCharDevice | os.ModeDevice
+	case m.IsBlockDevice():
+		osMode |= os.ModeDevice
+	}
+	return osMode
+}
+
+// UID represents a user ID.
+type UID uint32
+
+// Ok returns true if uid is not NoUID.
+func (uid UID) Ok() bool {
+	return uid != NoUID
+}
+
+// GID represents a group ID.
+type GID uint32
+
+// Ok returns true if gid is not NoGID.
+func (gid GID) Ok() bool {
+	return gid != NoGID
+}
+
+const (
+	// notag is a sentinel used to indicate no valid tag.
+	noTag tag = math.MaxUint16
+
+	// Nofid is a sentinel used to indicate no valid fid.
+	noFID fid = math.MaxUint32
+
+	// NoUID is a sentinel used to indicate no valid UID.
+	NoUID UID = math.MaxUint32
+
+	// NoGID is a sentinel used to indicate no valid GID.
+	NoGID GID = math.MaxUint32
+)
+
+// msgType is a type identifier.
+type msgType uint8
+
+// msgType declarations.
+const (
+	msgTlerror      msgType = 6
+	msgRlerror              = 7
+	msgTstatfs              = 8
+	msgRstatfs              = 9
+	msgTlopen               = 12
+	msgRlopen               = 13
+	msgTlcreate             = 14
+	msgRlcreate             = 15
+	msgTsymlink             = 16
+	msgRsymlink             = 17
+	msgTmknod               = 18
+	msgRmknod               = 19
+	msgTrename              = 20
+	msgRrename              = 21
+	msgTreadlink            = 22
+	msgRreadlink            = 23
+	msgTgetattr             = 24
+	msgRgetattr             = 25
+	msgTsetattr             = 26
+	msgRsetattr             = 27
+	msgTxattrwalk           = 30
+	msgRxattrwalk           = 31
+	msgTxattrcreate         = 32
+	msgRxattrcreate         = 33
+	msgTreaddir             = 40
+	msgRreaddir             = 41
+	msgTfsync               = 50
+	msgRfsync               = 51
+	msgTlink                = 70
+	msgRlink                = 71
+	msgTmkdir               = 72
+	msgRmkdir               = 73
+	msgTrenameat            = 74
+	msgRrenameat            = 75
+	msgTunlinkat            = 76
+	msgRunlinkat            = 77
+	msgTversion             = 100
+	msgRversion             = 101
+	msgTauth                = 102
+	msgRauth                = 103
+	msgTattach              = 104
+	msgRattach              = 105
+	msgTflush               = 108
+	msgRflush               = 109
+	msgTwalk                = 110
+	msgRwalk                = 111
+	msgTread                = 116
+	msgRread                = 117
+	msgTwrite               = 118
+	msgRwrite               = 119
+	msgTclunk               = 120
+	msgRclunk               = 121
+	msgTremove              = 122
+	msgRremove              = 123
+	msgTflushf              = 124
+	msgRflushf              = 125
+	msgTwalkgetattr         = 126
+	msgRwalkgetattr         = 127
+	msgTucreate             = 128
+	msgRucreate             = 129
+	msgTumkdir              = 130
+	msgRumkdir              = 131
+	msgTumknod              = 132
+	msgRumknod              = 133
+	msgTusymlink            = 134
+	msgRusymlink            = 135
+	msgTlconnect            = 136
+	msgRlconnect            = 137
+	msgTallocate            = 138
+	msgRallocate            = 139
+)
+
+// QIDType represents the file type for QIDs.
+//
+// QIDType corresponds to the high 8 bits of a Plan 9 file mode.
+type QIDType uint8
+
+const (
+	// TypeDir represents a directory type.
+	TypeDir QIDType = 0x80
+
+	// TypeAppendOnly represents an append only file.
+	TypeAppendOnly QIDType = 0x40
+
+	// TypeExclusive represents an exclusive-use file.
+	TypeExclusive QIDType = 0x20
+
+	// TypeMount represents a mounted channel.
+	TypeMount QIDType = 0x10
+
+	// TypeAuth represents an authentication file.
+	TypeAuth QIDType = 0x08
+
+	// TypeTemporary represents a temporary file.
+	TypeTemporary QIDType = 0x04
+
+	// TypeSymlink represents a symlink.
+	TypeSymlink QIDType = 0x02
+
+	// TypeLink represents a hard link.
+	TypeLink QIDType = 0x01
+
+	// TypeRegular represents a regular file.
+	TypeRegular QIDType = 0x00
+)
+
+// QID is a unique file identifier.
+//
+// This may be embedded in other requests and responses.
+type QID struct {
+	// Type is the highest order byte of the file mode.
+	Type QIDType
+
+	// Version is an arbitrary server version number.
+	Version uint32
+
+	// Path is a unique server identifier for this path (e.g. inode).
+	Path uint64
+}
+
+// String implements fmt.Stringer.
+func (q QID) String() string {
+	return fmt.Sprintf("QID{Type: %d, Version: %d, Path: %d}", q.Type, q.Version, q.Path)
+}
+
+// decode implements encoder.decode.
+func (q *QID) decode(b *buffer) {
+	q.Type = b.ReadQIDType()
+	q.Version = b.Read32()
+	q.Path = b.Read64()
+}
+
+// encode implements encoder.encode.
+func (q *QID) encode(b *buffer) {
+	b.WriteQIDType(q.Type)
+	b.Write32(q.Version)
+	b.Write64(q.Path)
+}
+
+// QIDGenerator is a simple generator for QIDs that atomically increments Path
+// values.
+type QIDGenerator struct {
+	// uids is an ever increasing value that can be atomically incremented
+	// to provide unique Path values for QIDs.
+	uids uint64
+}
+
+// Get returns a new 9P unique ID with a unique Path given a QID type.
+//
+// While the 9P spec allows Version to be incremented every time the file is
+// modified, we currently do not use the Version member for anything.  Hence,
+// it is set to 0.
+func (q *QIDGenerator) Get(t QIDType) QID {
+	return QID{
+		Type:    t,
+		Version: 0,
+		Path:    atomic.AddUint64(&q.uids, 1),
+	}
+}
+
+// FSStat is used by statfs.
+type FSStat struct {
+	// Type is the filesystem type.
+	Type uint32
+
+	// BlockSize is the blocksize.
+	BlockSize uint32
+
+	// Blocks is the number of blocks.
+	Blocks uint64
+
+	// BlocksFree is the number of free blocks.
+	BlocksFree uint64
+
+	// BlocksAvailable is the number of blocks *available*.
+	BlocksAvailable uint64
+
+	// Files is the number of files available.
+	Files uint64
+
+	// FilesFree is the number of free file nodes.
+	FilesFree uint64
+
+	// FSID is the filesystem ID.
+	FSID uint64
+
+	// NameLength is the maximum name length.
+	NameLength uint32
+}
+
+// decode implements encoder.decode.
+func (f *FSStat) decode(b *buffer) {
+	f.Type = b.Read32()
+	f.BlockSize = b.Read32()
+	f.Blocks = b.Read64()
+	f.BlocksFree = b.Read64()
+	f.BlocksAvailable = b.Read64()
+	f.Files = b.Read64()
+	f.FilesFree = b.Read64()
+	f.FSID = b.Read64()
+	f.NameLength = b.Read32()
+}
+
+// encode implements encoder.encode.
+func (f *FSStat) encode(b *buffer) {
+	b.Write32(f.Type)
+	b.Write32(f.BlockSize)
+	b.Write64(f.Blocks)
+	b.Write64(f.BlocksFree)
+	b.Write64(f.BlocksAvailable)
+	b.Write64(f.Files)
+	b.Write64(f.FilesFree)
+	b.Write64(f.FSID)
+	b.Write32(f.NameLength)
+}
+
+// AttrMask is a mask of attributes for getattr.
+type AttrMask struct {
+	Mode        bool
+	NLink       bool
+	UID         bool
+	GID         bool
+	RDev        bool
+	ATime       bool
+	MTime       bool
+	CTime       bool
+	INo         bool
+	Size        bool
+	Blocks      bool
+	BTime       bool
+	Gen         bool
+	DataVersion bool
+}
+
+// Contains returns true if a contains all of the attributes masked as b.
+func (a AttrMask) Contains(b AttrMask) bool {
+	if b.Mode && !a.Mode {
+		return false
+	}
+	if b.NLink && !a.NLink {
+		return false
+	}
+	if b.UID && !a.UID {
+		return false
+	}
+	if b.GID && !a.GID {
+		return false
+	}
+	if b.RDev && !a.RDev {
+		return false
+	}
+	if b.ATime && !a.ATime {
+		return false
+	}
+	if b.MTime && !a.MTime {
+		return false
+	}
+	if b.CTime && !a.CTime {
+		return false
+	}
+	if b.INo && !a.INo {
+		return false
+	}
+	if b.Size && !a.Size {
+		return false
+	}
+	if b.Blocks && !a.Blocks {
+		return false
+	}
+	if b.BTime && !a.BTime {
+		return false
+	}
+	if b.Gen && !a.Gen {
+		return false
+	}
+	if b.DataVersion && !a.DataVersion {
+		return false
+	}
+	return true
+}
+
+// Empty returns true if no fields are masked.
+func (a AttrMask) Empty() bool {
+	return !a.Mode && !a.NLink && !a.UID && !a.GID && !a.RDev && !a.ATime && !a.MTime && !a.CTime && !a.INo && !a.Size && !a.Blocks && !a.BTime && !a.Gen && !a.DataVersion
+}
+
+// AttrMaskAll returns an AttrMask with all fields masked.
+func AttrMaskAll() AttrMask {
+	return AttrMask{
+		Mode:        true,
+		NLink:       true,
+		UID:         true,
+		GID:         true,
+		RDev:        true,
+		ATime:       true,
+		MTime:       true,
+		CTime:       true,
+		INo:         true,
+		Size:        true,
+		Blocks:      true,
+		BTime:       true,
+		Gen:         true,
+		DataVersion: true,
+	}
+}
+
+// String implements fmt.Stringer.
+func (a AttrMask) String() string {
+	var masks []string
+	if a.Mode {
+		masks = append(masks, "Mode")
+	}
+	if a.NLink {
+		masks = append(masks, "NLink")
+	}
+	if a.UID {
+		masks = append(masks, "UID")
+	}
+	if a.GID {
+		masks = append(masks, "GID")
+	}
+	if a.RDev {
+		masks = append(masks, "RDev")
+	}
+	if a.ATime {
+		masks = append(masks, "ATime")
+	}
+	if a.MTime {
+		masks = append(masks, "MTime")
+	}
+	if a.CTime {
+		masks = append(masks, "CTime")
+	}
+	if a.INo {
+		masks = append(masks, "INo")
+	}
+	if a.Size {
+		masks = append(masks, "Size")
+	}
+	if a.Blocks {
+		masks = append(masks, "Blocks")
+	}
+	if a.BTime {
+		masks = append(masks, "BTime")
+	}
+	if a.Gen {
+		masks = append(masks, "Gen")
+	}
+	if a.DataVersion {
+		masks = append(masks, "DataVersion")
+	}
+	return fmt.Sprintf("AttrMask{with: %s}", strings.Join(masks, " "))
+}
+
+// decode implements encoder.decode.
+func (a *AttrMask) decode(b *buffer) {
+	mask := b.Read64()
+	a.Mode = mask&0x00000001 != 0
+	a.NLink = mask&0x00000002 != 0
+	a.UID = mask&0x00000004 != 0
+	a.GID = mask&0x00000008 != 0
+	a.RDev = mask&0x00000010 != 0
+	a.ATime = mask&0x00000020 != 0
+	a.MTime = mask&0x00000040 != 0
+	a.CTime = mask&0x00000080 != 0
+	a.INo = mask&0x00000100 != 0
+	a.Size = mask&0x00000200 != 0
+	a.Blocks = mask&0x00000400 != 0
+	a.BTime = mask&0x00000800 != 0
+	a.Gen = mask&0x00001000 != 0
+	a.DataVersion = mask&0x00002000 != 0
+}
+
+// encode implements encoder.encode.
+func (a *AttrMask) encode(b *buffer) {
+	var mask uint64
+	if a.Mode {
+		mask |= 0x00000001
+	}
+	if a.NLink {
+		mask |= 0x00000002
+	}
+	if a.UID {
+		mask |= 0x00000004
+	}
+	if a.GID {
+		mask |= 0x00000008
+	}
+	if a.RDev {
+		mask |= 0x00000010
+	}
+	if a.ATime {
+		mask |= 0x00000020
+	}
+	if a.MTime {
+		mask |= 0x00000040
+	}
+	if a.CTime {
+		mask |= 0x00000080
+	}
+	if a.INo {
+		mask |= 0x00000100
+	}
+	if a.Size {
+		mask |= 0x00000200
+	}
+	if a.Blocks {
+		mask |= 0x00000400
+	}
+	if a.BTime {
+		mask |= 0x00000800
+	}
+	if a.Gen {
+		mask |= 0x00001000
+	}
+	if a.DataVersion {
+		mask |= 0x00002000
+	}
+	b.Write64(mask)
+}
+
+// Attr is a set of attributes for getattr.
+type Attr struct {
+	Mode             FileMode
+	UID              UID
+	GID              GID
+	NLink            uint64
+	RDev             uint64
+	Size             uint64
+	BlockSize        uint64
+	Blocks           uint64
+	ATimeSeconds     uint64
+	ATimeNanoSeconds uint64
+	MTimeSeconds     uint64
+	MTimeNanoSeconds uint64
+	CTimeSeconds     uint64
+	CTimeNanoSeconds uint64
+	BTimeSeconds     uint64
+	BTimeNanoSeconds uint64
+	Gen              uint64
+	DataVersion      uint64
+}
+
+// String implements fmt.Stringer.
+func (a Attr) String() string {
+	return fmt.Sprintf("Attr{Mode: 0o%o, UID: %d, GID: %d, NLink: %d, RDev: %d, Size: %d, BlockSize: %d, Blocks: %d, ATime: {Sec: %d, NanoSec: %d}, MTime: {Sec: %d, NanoSec: %d}, CTime: {Sec: %d, NanoSec: %d}, BTime: {Sec: %d, NanoSec: %d}, Gen: %d, DataVersion: %d}",
+		a.Mode, a.UID, a.GID, a.NLink, a.RDev, a.Size, a.BlockSize, a.Blocks, a.ATimeSeconds, a.ATimeNanoSeconds, a.MTimeSeconds, a.MTimeNanoSeconds, a.CTimeSeconds, a.CTimeNanoSeconds, a.BTimeSeconds, a.BTimeNanoSeconds, a.Gen, a.DataVersion)
+}
+
+// encode implements encoder.encode.
+func (a *Attr) encode(b *buffer) {
+	b.WriteFileMode(a.Mode)
+	b.WriteUID(a.UID)
+	b.WriteGID(a.GID)
+	b.Write64(a.NLink)
+	b.Write64(a.RDev)
+	b.Write64(a.Size)
+	b.Write64(a.BlockSize)
+	b.Write64(a.Blocks)
+	b.Write64(a.ATimeSeconds)
+	b.Write64(a.ATimeNanoSeconds)
+	b.Write64(a.MTimeSeconds)
+	b.Write64(a.MTimeNanoSeconds)
+	b.Write64(a.CTimeSeconds)
+	b.Write64(a.CTimeNanoSeconds)
+	b.Write64(a.BTimeSeconds)
+	b.Write64(a.BTimeNanoSeconds)
+	b.Write64(a.Gen)
+	b.Write64(a.DataVersion)
+}
+
+// decode implements encoder.decode.
+func (a *Attr) decode(b *buffer) {
+	a.Mode = b.ReadFileMode()
+	a.UID = b.ReadUID()
+	a.GID = b.ReadGID()
+	a.NLink = b.Read64()
+	a.RDev = b.Read64()
+	a.Size = b.Read64()
+	a.BlockSize = b.Read64()
+	a.Blocks = b.Read64()
+	a.ATimeSeconds = b.Read64()
+	a.ATimeNanoSeconds = b.Read64()
+	a.MTimeSeconds = b.Read64()
+	a.MTimeNanoSeconds = b.Read64()
+	a.CTimeSeconds = b.Read64()
+	a.CTimeNanoSeconds = b.Read64()
+	a.BTimeSeconds = b.Read64()
+	a.BTimeNanoSeconds = b.Read64()
+	a.Gen = b.Read64()
+	a.DataVersion = b.Read64()
+}
+
+// StatToAttr converts a Linux syscall stat structure to an Attr.
+func StatToAttr(s *syscall.Stat_t, req AttrMask) (Attr, AttrMask) {
+	attr := Attr{
+		UID: NoUID,
+		GID: NoGID,
+	}
+	if req.Mode {
+		// p9.FileMode corresponds to Linux mode_t.
+		attr.Mode = FileMode(s.Mode)
+	}
+	if req.NLink {
+		attr.NLink = s.Nlink
+	}
+	if req.UID {
+		attr.UID = UID(s.Uid)
+	}
+	if req.GID {
+		attr.GID = GID(s.Gid)
+	}
+	if req.RDev {
+		attr.RDev = s.Dev
+	}
+	if req.ATime {
+		attr.ATimeSeconds = uint64(s.Atim.Sec)
+		attr.ATimeNanoSeconds = uint64(s.Atim.Nsec)
+	}
+	if req.MTime {
+		attr.MTimeSeconds = uint64(s.Mtim.Sec)
+		attr.MTimeNanoSeconds = uint64(s.Mtim.Nsec)
+	}
+	if req.CTime {
+		attr.CTimeSeconds = uint64(s.Ctim.Sec)
+		attr.CTimeNanoSeconds = uint64(s.Ctim.Nsec)
+	}
+	if req.Size {
+		attr.Size = uint64(s.Size)
+	}
+	if req.Blocks {
+		attr.BlockSize = uint64(s.Blksize)
+		attr.Blocks = uint64(s.Blocks)
+	}
+
+	// Use the req field because we already have it.
+	req.BTime = false
+	req.Gen = false
+	req.DataVersion = false
+
+	return attr, req
+}
+
+// SetAttrMask specifies a valid mask for setattr.
+type SetAttrMask struct {
+	Permissions        bool
+	UID                bool
+	GID                bool
+	Size               bool
+	ATime              bool
+	MTime              bool
+	CTime              bool
+	ATimeNotSystemTime bool
+	MTimeNotSystemTime bool
+}
+
+// IsSubsetOf returns whether s is a subset of m.
+func (s SetAttrMask) IsSubsetOf(m SetAttrMask) bool {
+	sb := s.bitmask()
+	sm := m.bitmask()
+	return sm|sb == sm
+}
+
+// String implements fmt.Stringer.
+func (s SetAttrMask) String() string {
+	var masks []string
+	if s.Permissions {
+		masks = append(masks, "Permissions")
+	}
+	if s.UID {
+		masks = append(masks, "UID")
+	}
+	if s.GID {
+		masks = append(masks, "GID")
+	}
+	if s.Size {
+		masks = append(masks, "Size")
+	}
+	if s.ATime {
+		masks = append(masks, "ATime")
+	}
+	if s.MTime {
+		masks = append(masks, "MTime")
+	}
+	if s.CTime {
+		masks = append(masks, "CTime")
+	}
+	if s.ATimeNotSystemTime {
+		masks = append(masks, "ATimeNotSystemTime")
+	}
+	if s.MTimeNotSystemTime {
+		masks = append(masks, "MTimeNotSystemTime")
+	}
+	return fmt.Sprintf("SetAttrMask{with: %s}", strings.Join(masks, " "))
+}
+
+// Empty returns true if no fields are masked.
+func (s SetAttrMask) Empty() bool {
+	return !s.Permissions && !s.UID && !s.GID && !s.Size && !s.ATime && !s.MTime && !s.CTime && !s.ATimeNotSystemTime && !s.MTimeNotSystemTime
+}
+
+// decode implements encoder.decode.
+func (s *SetAttrMask) decode(b *buffer) {
+	mask := b.Read32()
+	s.Permissions = mask&0x00000001 != 0
+	s.UID = mask&0x00000002 != 0
+	s.GID = mask&0x00000004 != 0
+	s.Size = mask&0x00000008 != 0
+	s.ATime = mask&0x00000010 != 0
+	s.MTime = mask&0x00000020 != 0
+	s.CTime = mask&0x00000040 != 0
+	s.ATimeNotSystemTime = mask&0x00000080 != 0
+	s.MTimeNotSystemTime = mask&0x00000100 != 0
+}
+
+func (s SetAttrMask) bitmask() uint32 {
+	var mask uint32
+	if s.Permissions {
+		mask |= 0x00000001
+	}
+	if s.UID {
+		mask |= 0x00000002
+	}
+	if s.GID {
+		mask |= 0x00000004
+	}
+	if s.Size {
+		mask |= 0x00000008
+	}
+	if s.ATime {
+		mask |= 0x00000010
+	}
+	if s.MTime {
+		mask |= 0x00000020
+	}
+	if s.CTime {
+		mask |= 0x00000040
+	}
+	if s.ATimeNotSystemTime {
+		mask |= 0x00000080
+	}
+	if s.MTimeNotSystemTime {
+		mask |= 0x00000100
+	}
+	return mask
+}
+
+// encode implements encoder.encode.
+func (s *SetAttrMask) encode(b *buffer) {
+	b.Write32(s.bitmask())
+}
+
+// SetAttr specifies a set of attributes for a setattr.
+type SetAttr struct {
+	Permissions      FileMode
+	UID              UID
+	GID              GID
+	Size             uint64
+	ATimeSeconds     uint64
+	ATimeNanoSeconds uint64
+	MTimeSeconds     uint64
+	MTimeNanoSeconds uint64
+}
+
+// String implements fmt.Stringer.
+func (s SetAttr) String() string {
+	return fmt.Sprintf("SetAttr{Permissions: 0o%o, UID: %d, GID: %d, Size: %d, ATime: {Sec: %d, NanoSec: %d}, MTime: {Sec: %d, NanoSec: %d}}", s.Permissions, s.UID, s.GID, s.Size, s.ATimeSeconds, s.ATimeNanoSeconds, s.MTimeSeconds, s.MTimeNanoSeconds)
+}
+
+// decode implements encoder.decode.
+func (s *SetAttr) decode(b *buffer) {
+	s.Permissions = b.ReadPermissions()
+	s.UID = b.ReadUID()
+	s.GID = b.ReadGID()
+	s.Size = b.Read64()
+	s.ATimeSeconds = b.Read64()
+	s.ATimeNanoSeconds = b.Read64()
+	s.MTimeSeconds = b.Read64()
+	s.MTimeNanoSeconds = b.Read64()
+}
+
+// encode implements encoder.encode.
+func (s *SetAttr) encode(b *buffer) {
+	b.WritePermissions(s.Permissions)
+	b.WriteUID(s.UID)
+	b.WriteGID(s.GID)
+	b.Write64(s.Size)
+	b.Write64(s.ATimeSeconds)
+	b.Write64(s.ATimeNanoSeconds)
+	b.Write64(s.MTimeSeconds)
+	b.Write64(s.MTimeNanoSeconds)
+}
+
+// Apply applies this to the given Attr.
+func (a *Attr) Apply(mask SetAttrMask, attr SetAttr) {
+	if mask.Permissions {
+		a.Mode = a.Mode&^permissionsMask | (attr.Permissions & permissionsMask)
+	}
+	if mask.UID {
+		a.UID = attr.UID
+	}
+	if mask.GID {
+		a.GID = attr.GID
+	}
+	if mask.Size {
+		a.Size = attr.Size
+	}
+	if mask.ATime {
+		a.ATimeSeconds = attr.ATimeSeconds
+		a.ATimeNanoSeconds = attr.ATimeNanoSeconds
+	}
+	if mask.MTime {
+		a.MTimeSeconds = attr.MTimeSeconds
+		a.MTimeNanoSeconds = attr.MTimeNanoSeconds
+	}
+}
+
+// Dirent is used for readdir.
+type Dirent struct {
+	// QID is the entry QID.
+	QID QID
+
+	// Offset is the offset in the directory.
+	//
+	// This will be communicated back the original caller.
+	Offset uint64
+
+	// Type is the 9P type.
+	Type QIDType
+
+	// Name is the name of the entry (i.e. basename).
+	Name string
+}
+
+// String implements fmt.Stringer.
+func (d Dirent) String() string {
+	return fmt.Sprintf("Dirent{QID: %d, Offset: %d, Type: 0x%X, Name: %s}", d.QID, d.Offset, d.Type, d.Name)
+}
+
+// decode implements encoder.decode.
+func (d *Dirent) decode(b *buffer) {
+	d.QID.decode(b)
+	d.Offset = b.Read64()
+	d.Type = b.ReadQIDType()
+	d.Name = b.ReadString()
+}
+
+// encode implements encoder.encode.
+func (d *Dirent) encode(b *buffer) {
+	d.QID.encode(b)
+	b.Write64(d.Offset)
+	b.WriteQIDType(d.Type)
+	b.WriteString(d.Name)
+}
+
+// AllocateMode are possible modes to p9.File.Allocate().
+type AllocateMode struct {
+	KeepSize      bool
+	PunchHole     bool
+	NoHideStale   bool
+	CollapseRange bool
+	ZeroRange     bool
+	InsertRange   bool
+	Unshare       bool
+}
+
+// ToLinux converts to a value compatible with fallocate(2)'s mode.
+func (a *AllocateMode) ToLinux() uint32 {
+	rv := uint32(0)
+	if a.KeepSize {
+		rv |= unix.FALLOC_FL_KEEP_SIZE
+	}
+	if a.PunchHole {
+		rv |= unix.FALLOC_FL_PUNCH_HOLE
+	}
+	if a.NoHideStale {
+		rv |= unix.FALLOC_FL_NO_HIDE_STALE
+	}
+	if a.CollapseRange {
+		rv |= unix.FALLOC_FL_COLLAPSE_RANGE
+	}
+	if a.ZeroRange {
+		rv |= unix.FALLOC_FL_ZERO_RANGE
+	}
+	if a.InsertRange {
+		rv |= unix.FALLOC_FL_INSERT_RANGE
+	}
+	if a.Unshare {
+		rv |= unix.FALLOC_FL_UNSHARE_RANGE
+	}
+	return rv
+}
+
+// decode implements encoder.decode.
+func (a *AllocateMode) decode(b *buffer) {
+	mask := b.Read32()
+	a.KeepSize = mask&0x01 != 0
+	a.PunchHole = mask&0x02 != 0
+	a.NoHideStale = mask&0x04 != 0
+	a.CollapseRange = mask&0x08 != 0
+	a.ZeroRange = mask&0x10 != 0
+	a.InsertRange = mask&0x20 != 0
+	a.Unshare = mask&0x40 != 0
+}
+
+// encode implements encoder.encode.
+func (a *AllocateMode) encode(b *buffer) {
+	mask := uint32(0)
+	if a.KeepSize {
+		mask |= 0x01
+	}
+	if a.PunchHole {
+		mask |= 0x02
+	}
+	if a.NoHideStale {
+		mask |= 0x04
+	}
+	if a.CollapseRange {
+		mask |= 0x08
+	}
+	if a.ZeroRange {
+		mask |= 0x10
+	}
+	if a.InsertRange {
+		mask |= 0x20
+	}
+	if a.Unshare {
+		mask |= 0x40
+	}
+	b.Write32(mask)
+}

--- a/vendor/github.com/hugelgupf/p9/p9/path_tree.go
+++ b/vendor/github.com/hugelgupf/p9/p9/path_tree.go
@@ -1,0 +1,221 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"fmt"
+	"sync"
+)
+
+// pathNode is a single node in a path traversal.
+//
+// These are shared by all fidRefs that point to the same path.
+//
+// Lock ordering:
+//   opMu
+//     childMu
+//
+//   Two different pathNodes may only be locked if Server.renameMu is held for
+//   write, in which case they can be acquired in any order.
+type pathNode struct {
+	// opMu synchronizes high-level, sematic operations, such as the
+	// simultaneous creation and deletion of a file.
+	//
+	// opMu does not directly protect any fields in pathNode.
+	opMu sync.RWMutex
+
+	// childMu protects the fields below.
+	childMu sync.RWMutex
+
+	// childNodes maps child path component names to their pathNode.
+	childNodes map[string]*pathNode
+
+	// childRefs maps child path component names to all of the their
+	// references.
+	childRefs map[string]map[*fidRef]struct{}
+
+	// childRefNames maps child references back to their path component
+	// name.
+	childRefNames map[*fidRef]string
+}
+
+func newPathNode() *pathNode {
+	return &pathNode{
+		childNodes:    make(map[string]*pathNode),
+		childRefs:     make(map[string]map[*fidRef]struct{}),
+		childRefNames: make(map[*fidRef]string),
+	}
+}
+
+// forEachChildRef calls fn for each child reference.
+func (p *pathNode) forEachChildRef(fn func(ref *fidRef, name string)) {
+	p.childMu.RLock()
+	defer p.childMu.RUnlock()
+
+	for name, m := range p.childRefs {
+		for ref := range m {
+			fn(ref, name)
+		}
+	}
+}
+
+// forEachChildNode calls fn for each child pathNode.
+func (p *pathNode) forEachChildNode(fn func(pn *pathNode)) {
+	p.childMu.RLock()
+	defer p.childMu.RUnlock()
+
+	for _, pn := range p.childNodes {
+		fn(pn)
+	}
+}
+
+// pathNodeFor returns the path node for the given name, or a new one.
+func (p *pathNode) pathNodeFor(name string) *pathNode {
+	p.childMu.RLock()
+	// Fast path, node already exists.
+	if pn, ok := p.childNodes[name]; ok {
+		p.childMu.RUnlock()
+		return pn
+	}
+	p.childMu.RUnlock()
+
+	// Slow path, create a new pathNode for shared use.
+	p.childMu.Lock()
+
+	// Re-check after re-lock.
+	if pn, ok := p.childNodes[name]; ok {
+		p.childMu.Unlock()
+		return pn
+	}
+
+	pn := newPathNode()
+	p.childNodes[name] = pn
+	p.childMu.Unlock()
+	return pn
+}
+
+// nameFor returns the name for the given fidRef.
+//
+// Precondition: addChild is called for ref before nameFor.
+func (p *pathNode) nameFor(ref *fidRef) string {
+	p.childMu.RLock()
+	n, ok := p.childRefNames[ref]
+	p.childMu.RUnlock()
+
+	if !ok {
+		// This should not happen, don't proceed.
+		panic(fmt.Sprintf("expected name for %+v, none found", ref))
+	}
+
+	return n
+}
+
+// addChildLocked adds a child reference to p.
+//
+// Precondition: As addChild, plus childMu is locked for write.
+func (p *pathNode) addChildLocked(ref *fidRef, name string) {
+	if n, ok := p.childRefNames[ref]; ok {
+		// This should not happen, don't proceed.
+		panic(fmt.Sprintf("unexpected fidRef %+v with path %q, wanted %q", ref, n, name))
+	}
+
+	p.childRefNames[ref] = name
+
+	m, ok := p.childRefs[name]
+	if !ok {
+		m = make(map[*fidRef]struct{})
+		p.childRefs[name] = m
+	}
+
+	m[ref] = struct{}{}
+}
+
+// addChild adds a child reference to p.
+//
+// Precondition: ref may only be added once at a time.
+func (p *pathNode) addChild(ref *fidRef, name string) {
+	p.childMu.Lock()
+	p.addChildLocked(ref, name)
+	p.childMu.Unlock()
+}
+
+// removeChild removes the given child.
+//
+// This applies only to an individual fidRef, which is not required to exist.
+func (p *pathNode) removeChild(ref *fidRef) {
+	p.childMu.Lock()
+
+	// This ref may not exist anymore. This can occur, e.g., in unlink,
+	// where a removeWithName removes the ref, and then a DecRef on the ref
+	// attempts to remove again.
+	if name, ok := p.childRefNames[ref]; ok {
+		m, ok := p.childRefs[name]
+		if !ok {
+			// This should not happen, don't proceed.
+			p.childMu.Unlock()
+			panic(fmt.Sprintf("name %s missing from childfidRefs", name))
+		}
+
+		delete(m, ref)
+		if len(m) == 0 {
+			delete(p.childRefs, name)
+		}
+	}
+
+	delete(p.childRefNames, ref)
+
+	p.childMu.Unlock()
+}
+
+// addPathNodeFor adds an existing pathNode as the node for name.
+//
+// Preconditions: newName does not exist.
+func (p *pathNode) addPathNodeFor(name string, pn *pathNode) {
+	p.childMu.Lock()
+
+	if opn, ok := p.childNodes[name]; ok {
+		p.childMu.Unlock()
+		panic(fmt.Sprintf("unexpected pathNode %+v with path %q", opn, name))
+	}
+
+	p.childNodes[name] = pn
+	p.childMu.Unlock()
+}
+
+// removeWithName removes all references with the given name.
+//
+// The provided function is executed after reference removal. The only method
+// it may (transitively) call on this pathNode is addChildLocked.
+//
+// If a child pathNode for name exists, it is removed from this pathNode and
+// returned by this function. Any operations on the removed tree must use this
+// value.
+func (p *pathNode) removeWithName(name string, fn func(ref *fidRef)) *pathNode {
+	p.childMu.Lock()
+	defer p.childMu.Unlock()
+
+	if m, ok := p.childRefs[name]; ok {
+		for ref := range m {
+			delete(m, ref)
+			delete(p.childRefNames, ref)
+			fn(ref)
+		}
+	}
+
+	// Return the original path node, if it exists.
+	origPathNode := p.childNodes[name]
+	delete(p.childNodes, name)
+	return origPathNode
+}

--- a/vendor/github.com/hugelgupf/p9/p9/pool.go
+++ b/vendor/github.com/hugelgupf/p9/p9/pool.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"sync"
+)
+
+// pool is a simple allocator.
+//
+// It is used for both tags and FIDs.
+type pool struct {
+	mu sync.Mutex
+
+	// cache is the set of returned values.
+	cache []uint64
+
+	// start is the starting value (if needed).
+	start uint64
+
+	// max is the current maximum issued.
+	max uint64
+
+	// limit is the upper limit.
+	limit uint64
+}
+
+// Get gets a value from the pool.
+func (p *pool) Get() (uint64, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Anything cached?
+	if len(p.cache) > 0 {
+		v := p.cache[len(p.cache)-1]
+		p.cache = p.cache[:len(p.cache)-1]
+		return v, true
+	}
+
+	// Over the limit?
+	if p.start == p.limit {
+		return 0, false
+	}
+
+	// Generate a new value.
+	v := p.start
+	p.start++
+	return v, true
+}
+
+// Put returns a value to the pool.
+func (p *pool) Put(v uint64) {
+	p.mu.Lock()
+	p.cache = append(p.cache, v)
+	p.mu.Unlock()
+}

--- a/vendor/github.com/hugelgupf/p9/p9/server.go
+++ b/vendor/github.com/hugelgupf/p9/p9/server.go
@@ -1,0 +1,576 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"io"
+	"log"
+	"net"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"syscall"
+)
+
+// Server is a 9p2000.L server.
+type Server struct {
+	// attacher provides the attach function.
+	attacher Attacher
+
+	// pathTree is the full set of paths opened on this server.
+	//
+	// These may be across different connections, but rename operations
+	// must be serialized globally for safely. There is a single pathTree
+	// for the entire server, and not per connection.
+	pathTree *pathNode
+
+	// renameMu is a global lock protecting rename operations. With this
+	// lock, we can be certain that any given rename operation can safely
+	// acquire two path nodes in any order, as all other concurrent
+	// operations acquire at most a single node.
+	renameMu sync.RWMutex
+}
+
+// NewServer returns a new server.
+//
+func NewServer(attacher Attacher) *Server {
+	return &Server{
+		attacher: attacher,
+		pathTree: newPathNode(),
+	}
+}
+
+// connState is the state for a single connection.
+type connState struct {
+	// server is the backing server.
+	server *Server
+
+	// sendMu is the send lock.
+	sendMu sync.Mutex
+
+	// conn is the connection.
+	conn net.Conn
+
+	// fids is the set of active fids.
+	//
+	// This is used to find fids for files.
+	fidMu sync.Mutex
+	fids  map[fid]*fidRef
+
+	// tags is the set of active tags.
+	//
+	// The given channel is closed when the
+	// tag is finished with processing.
+	tagMu sync.Mutex
+	tags  map[tag]chan struct{}
+
+	// messageSize is the maximum message size. The server does not
+	// do automatic splitting of messages.
+	messageSize uint32
+
+	// version is the agreed upon version X of 9P2000.L.Google.X.
+	// version 0 implies 9P2000.L.
+	version uint32
+
+	// recvOkay indicates that a receive may start.
+	recvOkay chan bool
+
+	// recvDone is signalled when a message is received.
+	recvDone chan error
+
+	// sendDone is signalled when a send is finished.
+	sendDone chan error
+}
+
+// fidRef wraps a node and tracks references.
+type fidRef struct {
+	// server is the associated server.
+	server *Server
+
+	// file is the associated File.
+	file File
+
+	// refs is an active refence count.
+	//
+	// The node above will be closed only when refs reaches zero.
+	refs int64
+
+	// openedMu protects opened and openFlags.
+	openedMu sync.Mutex
+
+	// opened indicates whether this has been opened already.
+	//
+	// This is updated in handlers.go.
+	opened bool
+
+	// mode is the fidRef's mode from the walk. Only the type bits are
+	// valid, the permissions may change. This is used to sanity check
+	// operations on this element, and prevent walks across
+	// non-directories.
+	mode FileMode
+
+	// openFlags is the mode used in the open.
+	//
+	// This is updated in handlers.go.
+	openFlags OpenFlags
+
+	// pathNode is the current pathNode for this fid.
+	pathNode *pathNode
+
+	// parent is the parent fidRef. We hold on to a parent reference to
+	// ensure that hooks, such as Renamed, can be executed safely by the
+	// server code.
+	//
+	// Note that parent cannot be changed without holding both the global
+	// rename lock and a writable lock on the associated pathNode for this
+	// fidRef. Holding either of these locks is sufficient to examine
+	// parent safely.
+	//
+	// The parent will be nil for root fidRefs, and non-nil otherwise. The
+	// method maybeParent can be used to return a cyclical reference, and
+	// isRoot should be used to check for root over looking at parent
+	// directly.
+	parent *fidRef
+
+	// deleted indicates that the backing file has been deleted. We stop
+	// many operations at the API level if they are incompatible with a
+	// file that has already been unlinked.
+	deleted uint32
+}
+
+// OpenFlags returns the flags the file was opened with and true iff the fid was opened previously.
+func (f *fidRef) OpenFlags() (OpenFlags, bool) {
+	f.openedMu.Lock()
+	defer f.openedMu.Unlock()
+	return f.openFlags, f.opened
+}
+
+// IncRef increases the references on a fid.
+func (f *fidRef) IncRef() {
+	atomic.AddInt64(&f.refs, 1)
+}
+
+// DecRef should be called when you're finished with a fid.
+func (f *fidRef) DecRef() {
+	if atomic.AddInt64(&f.refs, -1) == 0 {
+		f.file.Close()
+
+		// Drop the parent reference.
+		//
+		// Since this fidRef is guaranteed to be non-discoverable when
+		// the references reach zero, we don't need to worry about
+		// clearing the parent.
+		if f.parent != nil {
+			// If we've been previously deleted, this removing this
+			// ref is a no-op. That's expected.
+			f.parent.pathNode.removeChild(f)
+			f.parent.DecRef()
+		}
+	}
+}
+
+// isDeleted returns true if this fidRef has been deleted.
+func (f *fidRef) isDeleted() bool {
+	return atomic.LoadUint32(&f.deleted) != 0
+}
+
+// isRoot indicates whether this is a root fid.
+func (f *fidRef) isRoot() bool {
+	return f.parent == nil
+}
+
+// maybeParent returns a cyclic reference for roots, and the parent otherwise.
+func (f *fidRef) maybeParent() *fidRef {
+	if f.parent != nil {
+		return f.parent
+	}
+	return f // Root has itself.
+}
+
+// notifyDelete marks all fidRefs as deleted.
+//
+// Precondition: this must be called via safelyWrite or safelyGlobal.
+func notifyDelete(pn *pathNode) {
+	// Call on all local references.
+	pn.forEachChildRef(func(ref *fidRef, _ string) {
+		atomic.StoreUint32(&ref.deleted, 1)
+	})
+
+	// Call on all subtrees.
+	pn.forEachChildNode(func(pn *pathNode) {
+		notifyDelete(pn)
+	})
+}
+
+// markChildDeleted marks all children below the given name as deleted.
+//
+// Precondition: this must be called via safelyWrite or safelyGlobal.
+func (f *fidRef) markChildDeleted(name string) {
+	origPathNode := f.pathNode.removeWithName(name, func(ref *fidRef) {
+		atomic.StoreUint32(&ref.deleted, 1)
+	})
+
+	if origPathNode != nil {
+		// Mark all children as deleted.
+		notifyDelete(origPathNode)
+	}
+}
+
+// notifyNameChange calls the relevant Renamed method on all nodes in the path,
+// recursively. Note that this applies only for subtrees, as these
+// notifications do not apply to the actual file whose name has changed.
+//
+// Precondition: this must be called via safelyGlobal.
+func notifyNameChange(pn *pathNode) {
+	// Call on all local references.
+	pn.forEachChildRef(func(ref *fidRef, name string) {
+		ref.file.Renamed(ref.parent.file, name)
+	})
+
+	// Call on all subtrees.
+	pn.forEachChildNode(func(pn *pathNode) {
+		notifyNameChange(pn)
+	})
+}
+
+// renameChildTo renames the given child to the target.
+//
+// Precondition: this must be called via safelyGlobal.
+func (f *fidRef) renameChildTo(oldName string, target *fidRef, newName string) {
+	target.markChildDeleted(newName)
+	origPathNode := f.pathNode.removeWithName(oldName, func(ref *fidRef) {
+		// N.B. DecRef can take f.pathNode's parent's childMu. This is
+		// allowed because renameMu is held for write via safelyGlobal.
+		ref.parent.DecRef() // Drop original reference.
+		ref.parent = target // Change parent.
+		ref.parent.IncRef() // Acquire new one.
+		if f.pathNode == target.pathNode {
+			target.pathNode.addChildLocked(ref, newName)
+		} else {
+			target.pathNode.addChild(ref, newName)
+		}
+		ref.file.Renamed(target.file, newName)
+	})
+
+	if origPathNode != nil {
+		// Replace the previous (now deleted) path node.
+		target.pathNode.addPathNodeFor(newName, origPathNode)
+		// Call Renamed on all children.
+		notifyNameChange(origPathNode)
+	}
+}
+
+// safelyRead executes the given operation with the local path node locked.
+// This implies that paths will not change during the operation.
+func (f *fidRef) safelyRead(fn func() error) (err error) {
+	f.server.renameMu.RLock()
+	defer f.server.renameMu.RUnlock()
+	f.pathNode.opMu.RLock()
+	defer f.pathNode.opMu.RUnlock()
+	return fn()
+}
+
+// safelyWrite executes the given operation with the local path node locked in
+// a writable fashion. This implies some paths may change.
+func (f *fidRef) safelyWrite(fn func() error) (err error) {
+	f.server.renameMu.RLock()
+	defer f.server.renameMu.RUnlock()
+	f.pathNode.opMu.Lock()
+	defer f.pathNode.opMu.Unlock()
+	return fn()
+}
+
+// safelyGlobal executes the given operation with the global path lock held.
+func (f *fidRef) safelyGlobal(fn func() error) (err error) {
+	f.server.renameMu.Lock()
+	defer f.server.renameMu.Unlock()
+	return fn()
+}
+
+// Lookupfid finds the given fid.
+//
+// You should call fid.DecRef when you are finished using the fid.
+func (cs *connState) LookupFID(fid fid) (*fidRef, bool) {
+	cs.fidMu.Lock()
+	defer cs.fidMu.Unlock()
+	fidRef, ok := cs.fids[fid]
+	if ok {
+		fidRef.IncRef()
+		return fidRef, true
+	}
+	return nil, false
+}
+
+// Insertfid installs the given fid.
+//
+// This fid starts with a reference count of one. If a fid exists in
+// the slot already it is closed, per the specification.
+func (cs *connState) InsertFID(fid fid, newRef *fidRef) {
+	cs.fidMu.Lock()
+	defer cs.fidMu.Unlock()
+	origRef, ok := cs.fids[fid]
+	if ok {
+		defer origRef.DecRef()
+	}
+	newRef.IncRef()
+	cs.fids[fid] = newRef
+}
+
+// Deletefid removes the given fid.
+//
+// This simply removes it from the map and drops a reference.
+func (cs *connState) DeleteFID(fid fid) bool {
+	cs.fidMu.Lock()
+	defer cs.fidMu.Unlock()
+	fidRef, ok := cs.fids[fid]
+	if !ok {
+		return false
+	}
+	delete(cs.fids, fid)
+	fidRef.DecRef()
+	return true
+}
+
+// StartTag starts handling the tag.
+//
+// False is returned if this tag is already active.
+func (cs *connState) StartTag(t tag) bool {
+	cs.tagMu.Lock()
+	defer cs.tagMu.Unlock()
+	_, ok := cs.tags[t]
+	if ok {
+		return false
+	}
+	cs.tags[t] = make(chan struct{})
+	return true
+}
+
+// ClearTag finishes handling a tag.
+func (cs *connState) ClearTag(t tag) {
+	cs.tagMu.Lock()
+	defer cs.tagMu.Unlock()
+	ch, ok := cs.tags[t]
+	if !ok {
+		// Should never happen.
+		panic("unused tag cleared")
+	}
+	delete(cs.tags, t)
+
+	// Notify.
+	close(ch)
+}
+
+// Waittag waits for a tag to finish.
+func (cs *connState) WaitTag(t tag) {
+	cs.tagMu.Lock()
+	ch, ok := cs.tags[t]
+	cs.tagMu.Unlock()
+	if !ok {
+		return
+	}
+
+	// Wait for close.
+	<-ch
+}
+
+// handleRequest handles a single request.
+//
+// The recvDone channel is signaled when recv is done (with a error if
+// necessary). The sendDone channel is signaled with the result of the send.
+func (cs *connState) handleRequest() {
+	messageSize := atomic.LoadUint32(&cs.messageSize)
+	if messageSize == 0 {
+		// Default or not yet negotiated.
+		messageSize = maximumLength
+	}
+
+	// Receive a message.
+	tag, m, err := recv(cs.conn, messageSize, msgRegistry.get)
+	if errSocket, ok := err.(ErrSocket); ok {
+		// Connection problem; stop serving.
+		cs.recvDone <- errSocket.error
+		return
+	}
+
+	// Signal receive is done.
+	cs.recvDone <- nil
+
+	// Deal with other errors.
+	if err != nil && err != io.EOF {
+		// If it's not a connection error, but some other protocol error,
+		// we can send a response immediately.
+		cs.sendMu.Lock()
+		err := send(cs.conn, tag, newErr(err))
+		cs.sendMu.Unlock()
+		cs.sendDone <- err
+		return
+	}
+
+	// Try to start the tag.
+	if !cs.StartTag(tag) {
+		// Nothing we can do at this point; client is bogus.
+		cs.sendDone <- ErrNoValidMessage
+		return
+	}
+
+	// Handle the message.
+	var r message // r is the response.
+	defer func() {
+		if r == nil {
+			// Don't allow a panic to propagate.
+			recover()
+
+			// Include a useful log message.
+			log.Printf("panic in handler: %s", debug.Stack())
+
+			// Wrap in an EFAULT error; we don't really have a
+			// better way to describe this kind of error. It will
+			// usually manifest as a result of the test framework.
+			r = newErr(syscall.EFAULT)
+		}
+
+		// Clear the tag before sending. That's because as soon as this
+		// hits the wire, the client can legally send another message
+		// with the same tag.
+		cs.ClearTag(tag)
+
+		// Send back the result.
+		cs.sendMu.Lock()
+		err = send(cs.conn, tag, r)
+		cs.sendMu.Unlock()
+		cs.sendDone <- err
+	}()
+	if handler, ok := m.(handler); ok {
+		// Call the message handler.
+		r = handler.handle(cs)
+	} else {
+		// Produce an ENOSYS error.
+		r = newErr(syscall.ENOSYS)
+	}
+	msgRegistry.put(m)
+	m = nil // 'm' should not be touched after this point.
+}
+
+func (cs *connState) handleRequests() {
+	for range cs.recvOkay {
+		cs.handleRequest()
+	}
+}
+
+func (cs *connState) stop() {
+	// Close all channels.
+	close(cs.recvOkay)
+	close(cs.recvDone)
+	close(cs.sendDone)
+
+	for _, fidRef := range cs.fids {
+		// Drop final reference in the fid table. Note this should
+		// always close the file, since we've ensured that there are no
+		// handlers running via the wait for Pending => 0 below.
+		fidRef.DecRef()
+	}
+
+	// Ensure the connection is closed.
+	cs.conn.Close()
+}
+
+// service services requests concurrently.
+func (cs *connState) service() error {
+	// Pending is the number of handlers that have finished receiving but
+	// not finished processing requests. These must be waiting on properly
+	// below. See the next comment for an explanation of the loop.
+	pending := 0
+
+	// Start the first request handler.
+	go cs.handleRequests() // S/R-SAFE: Irrelevant.
+	cs.recvOkay <- true
+
+	// We loop and make sure there's always one goroutine waiting for a new
+	// request. We process all the data for a single request in one
+	// goroutine however, to ensure the best turnaround time possible.
+	for {
+		select {
+		case err := <-cs.recvDone:
+			if err != nil {
+				// Wait for pending handlers.
+				for i := 0; i < pending; i++ {
+					<-cs.sendDone
+				}
+				return err
+			}
+
+			// This handler is now pending.
+			pending++
+
+			// Kick the next receiver, or start a new handler
+			// if no receiver is currently waiting.
+			select {
+			case cs.recvOkay <- true:
+			default:
+				go cs.handleRequests() // S/R-SAFE: Irrelevant.
+				cs.recvOkay <- true
+			}
+
+		case <-cs.sendDone:
+			// This handler is finished.
+			pending--
+
+			// Error sending a response? Nothing can be done.
+			//
+			// We don't terminate on a send error though, since
+			// we still have a pending receive. The error would
+			// have been logged above, we just ignore it here.
+		}
+	}
+}
+
+// Handle handles a single connection.
+func (s *Server) Handle(conn net.Conn) error {
+	cs := &connState{
+		server:   s,
+		conn:     conn,
+		fids:     make(map[fid]*fidRef),
+		tags:     make(map[tag]chan struct{}),
+		recvOkay: make(chan bool),
+		recvDone: make(chan error, 10),
+		sendDone: make(chan error, 10),
+	}
+	defer cs.stop()
+	return cs.service()
+}
+
+// Serve handles requests from the bound socket.
+//
+// The passed serverSocket _must_ be created in packet mode.
+func (s *Server) Serve(serverSocket net.Listener) error {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	for {
+		conn, err := serverSocket.Accept()
+		if err != nil {
+			// Something went wrong.
+			//
+			// Socket closed?
+			return err
+		}
+
+		wg.Add(1)
+		go func(conn net.Conn) { // S/R-SAFE: Irrelevant.
+			s.Handle(conn)
+			wg.Done()
+		}(conn)
+	}
+}

--- a/vendor/github.com/hugelgupf/p9/p9/transport.go
+++ b/vendor/github.com/hugelgupf/p9/p9/transport.go
@@ -1,0 +1,246 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"sync"
+
+	"github.com/hugelgupf/p9/vecnet"
+)
+
+// ErrSocket is returned in cases of a socket issue.
+//
+// This may be treated differently than other errors.
+type ErrSocket struct {
+	// error is the socket error.
+	error
+}
+
+func (e ErrSocket) Error() string {
+	return fmt.Sprintf("socket error: %v", e.error)
+}
+
+// ErrMessageTooLarge indicates the size was larger than reasonable.
+type ErrMessageTooLarge struct {
+	size  uint32
+	msize uint32
+}
+
+// Error returns a sensible error.
+func (e *ErrMessageTooLarge) Error() string {
+	return fmt.Sprintf("message too large for fixed buffer: size is %d, limit is %d", e.size, e.msize)
+}
+
+// ErrNoValidMessage indicates no valid message could be decoded.
+var ErrNoValidMessage = errors.New("buffer contained no valid message")
+
+const (
+	// headerLength is the number of bytes required for a header.
+	headerLength uint32 = 7
+
+	// maximumLength is the largest possible message.
+	maximumLength uint32 = 4 * 1024 * 1024
+
+	// initialBufferLength is the initial data buffer we allocate.
+	initialBufferLength uint32 = 64
+)
+
+var dataPool = sync.Pool{
+	New: func() interface{} {
+		// These buffers are used for decoding without a payload.
+		return make([]byte, initialBufferLength)
+	},
+}
+
+// send sends the given message over the socket.
+func send(conn net.Conn, tag tag, m message) error {
+	data := dataPool.Get().([]byte)
+	dataBuf := buffer{data: data[:0]}
+
+	Debug("send [conn %p] [Tag %06d] %s", conn, tag, m)
+
+	// Encode the message. The buffer will grow automatically.
+	m.encode(&dataBuf)
+
+	// Get our vectors to send.
+	var hdr [headerLength]byte
+	vecs := make(net.Buffers, 0, 3)
+	vecs = append(vecs, hdr[:])
+	if len(dataBuf.data) > 0 {
+		vecs = append(vecs, dataBuf.data)
+	}
+	totalLength := headerLength + uint32(len(dataBuf.data))
+
+	// Is there a payload?
+	if payloader, ok := m.(payloader); ok {
+		p := payloader.Payload()
+		if len(p) > 0 {
+			vecs = append(vecs, p)
+			totalLength += uint32(len(p))
+		}
+	}
+
+	// Construct the header.
+	headerBuf := buffer{data: hdr[:0]}
+	headerBuf.Write32(totalLength)
+	headerBuf.WriteMsgType(m.typ())
+	headerBuf.WriteTag(tag)
+
+	if _, err := vecs.WriteTo(conn); err != nil {
+		return ErrSocket{err}
+	}
+
+	// All set.
+	dataPool.Put(dataBuf.data)
+	return nil
+}
+
+// lookupTagAndType looks up an existing message or creates a new one.
+//
+// This is called by recv after decoding the header. Any error returned will be
+// propagating back to the caller. You may use messageByType directly as a
+// lookupTagAndType function (by design).
+type lookupTagAndType func(tag tag, t msgType) (message, error)
+
+// recv decodes a message from the socket.
+//
+// This is done in two parts, and is thus not safe for multiple callers.
+//
+// On a socket error, the special error type ErrSocket is returned.
+//
+// The tag value NoTag will always be returned if err is non-nil.
+func recv(conn net.Conn, msize uint32, lookup lookupTagAndType) (tag, message, error) {
+	// Read a header.
+	var hdr [headerLength]byte
+
+	if _, err := io.ReadAtLeast(conn, hdr[:], int(headerLength)); err != nil {
+		return noTag, nil, ErrSocket{err}
+	}
+
+	// Decode the header.
+	headerBuf := buffer{data: hdr[:]}
+	size := headerBuf.Read32()
+	t := headerBuf.ReadMsgType()
+	tag := headerBuf.ReadTag()
+	if size < headerLength {
+		// The message is too small.
+		//
+		// See above: it's probably screwed.
+		return noTag, nil, ErrSocket{ErrNoValidMessage}
+	}
+	if size > maximumLength || size > msize {
+		// The message is too big.
+		return noTag, nil, ErrSocket{&ErrMessageTooLarge{size, msize}}
+	}
+	remaining := size - headerLength
+
+	// Find our message to decode.
+	m, err := lookup(tag, t)
+	if err != nil {
+		// Throw away the contents of this message.
+		if remaining > 0 {
+			io.Copy(ioutil.Discard, io.LimitReader(conn, int64(remaining)))
+		}
+		return tag, nil, err
+	}
+
+	// Not yet initialized.
+	var dataBuf buffer
+
+	// Read the rest of the payload.
+	//
+	// This requires some special care to ensure that the vectors all line
+	// up the way they should. We do this to minimize copying data around.
+	var vecs vecnet.Buffers
+	if payloader, ok := m.(payloader); ok {
+		fixedSize := payloader.FixedSize()
+
+		// Do we need more than there is?
+		if fixedSize > remaining {
+			// This is not a valid message.
+			if remaining > 0 {
+				io.Copy(ioutil.Discard, io.LimitReader(conn, int64(remaining)))
+			}
+			return noTag, nil, ErrNoValidMessage
+		}
+
+		if fixedSize != 0 {
+			// Pull a data buffer from the pool.
+			data := dataPool.Get().([]byte)
+			if int(fixedSize) > len(data) {
+				// Create a larger data buffer, ensuring
+				// sufficient capicity for the message.
+				data = make([]byte, fixedSize)
+				defer dataPool.Put(data)
+				dataBuf = buffer{data: data}
+				vecs = append(vecs, data)
+			} else {
+				// Limit the data buffer, and make sure it
+				// gets filled before the payload buffer.
+				defer dataPool.Put(data)
+				dataBuf = buffer{data: data[:fixedSize]}
+				vecs = append(vecs, data[:fixedSize])
+			}
+		}
+
+		// Include the payload.
+		p := payloader.Payload()
+		if p == nil || len(p) != int(remaining-fixedSize) {
+			p = make([]byte, remaining-fixedSize)
+			payloader.SetPayload(p)
+		}
+		if len(p) > 0 {
+			vecs = append(vecs, p)
+		}
+	} else if remaining != 0 {
+		// Pull a data buffer from the pool.
+		data := dataPool.Get().([]byte)
+		if int(remaining) > len(data) {
+			// Create a larger data buffer.
+			data = make([]byte, remaining)
+			defer dataPool.Put(data)
+			dataBuf = buffer{data: data}
+			vecs = append(vecs, data)
+		} else {
+			// Limit the data buffer.
+			defer dataPool.Put(data)
+			dataBuf = buffer{data: data[:remaining]}
+			vecs = append(vecs, data[:remaining])
+		}
+	}
+
+	if len(vecs) > 0 {
+		if _, err := vecs.ReadFrom(conn); err != nil {
+			return noTag, nil, ErrSocket{err}
+		}
+	}
+
+	// Decode the message data.
+	m.decode(&dataBuf)
+	if dataBuf.isOverrun() {
+		// No need to drain the socket.
+		return noTag, nil, ErrNoValidMessage
+	}
+
+	Debug("recv [conn %p] [Tag %06d] %s", conn, tag, m)
+
+	// All set.
+	return tag, m, nil
+}

--- a/vendor/github.com/hugelgupf/p9/p9/version.go
+++ b/vendor/github.com/hugelgupf/p9/p9/version.go
@@ -1,0 +1,135 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package p9
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	// highestSupportedVersion is the highest supported version X in a
+	// version string of the format 9P2000.L.Google.X.
+	//
+	// Clients are expected to start requesting this version number and
+	// to continuously decrement it until a Tversion request succeeds.
+	highestSupportedVersion uint32 = 7
+
+	// lowestSupportedVersion is the lowest supported version X in a
+	// version string of the format 9P2000.L.Google.X.
+	//
+	// Clients are free to send a Tversion request at a version below this
+	// value but are expected to encounter an Rlerror in response.
+	lowestSupportedVersion uint32 = 0
+
+	// baseVersion is the base version of 9P that this package must always
+	// support.  It is equivalent to 9P2000.L.Google.0.
+	baseVersion = "9P2000.L"
+)
+
+// HighestVersionString returns the highest possible version string that a client
+// may request or a server may support.
+func HighestVersionString() string {
+	return versionString(highestSupportedVersion)
+}
+
+// parseVersion parses a Tversion version string into a numeric version number
+// if the version string is supported by p9.  Otherwise returns (0, false).
+//
+// From Tversion(9P): "Version strings are defined such that, if the client string
+// contains one or more period characters, the initial substring up to but not
+// including any single period in the version string defines a version of the protocol."
+//
+// p9 intentionally diverges from this and always requires that the version string
+// start with 9P2000.L to express that it is always compatible with 9P2000.L.  The
+// only supported versions extensions are of the format 9p2000.L.Google.X where X
+// is an ever increasing version counter.
+//
+// Version 9P2000.L.Google.0 implies 9P2000.L.
+//
+// New versions must always be a strict superset of 9P2000.L. A version increase must
+// define a predicate representing the feature extension introduced by that version. The
+// predicate must be commented and should take the format:
+//
+// // VersionSupportsX returns true if version v supports X and must be checked when ...
+// func VersionSupportsX(v int32) bool {
+//	...
+// )
+func parseVersion(str string) (uint32, bool) {
+	// Special case the base version which lacks the ".Google.X" suffix.  This
+	// version always means version 0.
+	if str == baseVersion {
+		return 0, true
+	}
+	substr := strings.Split(str, ".")
+	if len(substr) != 4 {
+		return 0, false
+	}
+	if substr[0] != "9P2000" || substr[1] != "L" || substr[2] != "Google" || len(substr[3]) == 0 {
+		return 0, false
+	}
+	version, err := strconv.ParseUint(substr[3], 10, 32)
+	if err != nil {
+		return 0, false
+	}
+	return uint32(version), true
+}
+
+// versionString formats a p9 version number into a Tversion version string.
+func versionString(version uint32) string {
+	// Special case the base version so that clients expecting this string
+	// instead of the 9P2000.L.Google.0 equivalent get it.  This is important
+	// for backwards compatibility with legacy servers that check for exactly
+	// the baseVersion and allow nothing else.
+	if version == 0 {
+		return baseVersion
+	}
+	return fmt.Sprintf("9P2000.L.Google.%d", version)
+}
+
+// VersionSupportsTflushf returns true if version v supports the Tflushf message.
+// This predicate must be checked by clients before attempting to make a Tflushf
+// request.  If this predicate returns false, then clients may safely no-op.
+func VersionSupportsTflushf(v uint32) bool {
+	return v >= 1
+}
+
+// versionSupportsTwalkgetattr returns true if version v supports the
+// Twalkgetattr message. This predicate must be checked by clients before
+// attempting to make a Twalkgetattr request.
+func versionSupportsTwalkgetattr(v uint32) bool {
+	return v >= 2
+}
+
+// versionSupportsTucreation returns true if version v supports the Tucreation
+// messages (Tucreate, Tusymlink, Tumkdir, Tumknod). This predicate must be
+// checked by clients before attempting to make a Tucreation request.
+// If Tucreation messages are not supported, their non-UID supporting
+// counterparts (Tlcreate, Tsymlink, Tmkdir, Tmknod) should be used.
+func versionSupportsTucreation(v uint32) bool {
+	return v >= 3
+}
+
+// VersionSupportsMultiUser returns true if version v supports multi-user fake
+// directory permissions and ID values.
+func VersionSupportsMultiUser(v uint32) bool {
+	return v >= 6
+}
+
+// versionSupportsTallocate returns true if version v supports Allocate().
+func versionSupportsTallocate(v uint32) bool {
+	return v >= 7
+}

--- a/vendor/github.com/hugelgupf/p9/unimplfs/unimplfs.go
+++ b/vendor/github.com/hugelgupf/p9/unimplfs/unimplfs.go
@@ -1,0 +1,150 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package unimplfs provides an p9.File template that returns ENOSYS for all
+// methods.
+//
+// This can be used to leave some methods unimplemented in incomplete p9.File
+// implementations.
+package unimplfs
+
+import (
+	"syscall"
+
+	"github.com/hugelgupf/p9/p9"
+)
+
+// NoopFile is a p9.File that returns ENOSYS for every method.
+type NoopFile struct {
+	p9.DefaultWalkGetAttr
+}
+
+var (
+	_ p9.File = &NoopFile{}
+)
+
+// Walk implements p9.File.Walk.
+func (NoopFile) Walk(names []string) ([]p9.QID, p9.File, error) {
+	return nil, nil, syscall.ENOSYS
+}
+
+// StatFS implements p9.File.StatFS.
+//
+// Not implemented.
+func (NoopFile) StatFS() (p9.FSStat, error) {
+	return p9.FSStat{}, syscall.ENOSYS
+}
+
+// FSync implements p9.File.FSync.
+func (NoopFile) FSync() error {
+	return syscall.ENOSYS
+}
+
+// GetAttr implements p9.File.GetAttr.
+func (NoopFile) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+	return p9.QID{}, p9.AttrMask{}, p9.Attr{}, syscall.ENOSYS
+}
+
+// SetAttr implements p9.File.SetAttr.
+func (NoopFile) SetAttr(valid p9.SetAttrMask, attr p9.SetAttr) error {
+	return syscall.ENOSYS
+}
+
+// Remove implements p9.File.Remove.
+func (NoopFile) Remove() error {
+	return syscall.ENOSYS
+}
+
+// Rename implements p9.File.Rename.
+func (NoopFile) Rename(directory p9.File, name string) error {
+	return syscall.ENOSYS
+}
+
+// Close implements p9.File.Close.
+func (NoopFile) Close() error {
+	return nil
+}
+
+// Open implements p9.File.Open.
+func (NoopFile) Open(mode p9.OpenFlags) (p9.QID, uint32, error) {
+	return p9.QID{}, 0, syscall.ENOSYS
+}
+
+// Read implements p9.File.Read.
+func (NoopFile) ReadAt(p []byte, offset uint64) (int, error) {
+	return 0, syscall.ENOSYS
+}
+
+// Write implements p9.File.Write.
+func (NoopFile) WriteAt(p []byte, offset uint64) (int, error) {
+	return 0, syscall.ENOSYS
+}
+
+// Create implements p9.File.Create.
+func (NoopFile) Create(name string, mode p9.OpenFlags, permissions p9.FileMode, _ p9.UID, _ p9.GID) (p9.File, p9.QID, uint32, error) {
+	return nil, p9.QID{}, 0, syscall.ENOSYS
+}
+
+// Mkdir implements p9.File.Mkdir.
+func (NoopFile) Mkdir(name string, permissions p9.FileMode, _ p9.UID, _ p9.GID) (p9.QID, error) {
+	return p9.QID{}, syscall.ENOSYS
+}
+
+// Symlink implements p9.File.Symlink.
+func (NoopFile) Symlink(oldname string, newname string, _ p9.UID, _ p9.GID) (p9.QID, error) {
+	return p9.QID{}, syscall.ENOSYS
+}
+
+// Link implements p9.File.Link.
+func (NoopFile) Link(target p9.File, newname string) error {
+	return syscall.ENOSYS
+}
+
+// Mknod implements p9.File.Mknod.
+func (NoopFile) Mknod(name string, mode p9.FileMode, major uint32, minor uint32, _ p9.UID, _ p9.GID) (p9.QID, error) {
+	return p9.QID{}, syscall.ENOSYS
+}
+
+// RenameAt implements p9.File.RenameAt.
+func (NoopFile) RenameAt(oldname string, newdir p9.File, newname string) error {
+	return syscall.ENOSYS
+}
+
+// UnlinkAt implements p9.File.UnlinkAt.
+func (NoopFile) UnlinkAt(name string, flags uint32) error {
+	return syscall.ENOSYS
+}
+
+// Readdir implements p9.File.Readdir.
+func (NoopFile) Readdir(offset uint64, count uint32) ([]p9.Dirent, error) {
+	return nil, syscall.ENOSYS
+}
+
+// Readlink implements p9.File.Readlink.
+func (NoopFile) Readlink() (string, error) {
+	return "", syscall.ENOSYS
+}
+
+// Flush implements p9.File.Flush.
+func (NoopFile) Flush() error {
+	return nil
+}
+
+// Renamed implements p9.File.Renamed.
+func (NoopFile) Renamed(parent p9.File, newName string) {}
+
+// Allocate implements p9.File.Allocate.
+func (NoopFile) Allocate(mode p9.AllocateMode, offset, length uint64) error {
+	return syscall.ENOSYS
+}

--- a/vendor/github.com/hugelgupf/p9/vecnet/vecnet.go
+++ b/vendor/github.com/hugelgupf/p9/vecnet/vecnet.go
@@ -1,0 +1,54 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package vecnet provides access to recvmsg syscalls on net.Conns.
+package vecnet
+
+import (
+	"io"
+	"net"
+	"syscall"
+)
+
+// Buffers points to zero or more buffers to read into.
+//
+// On connections that support it, ReadFrom is optimized into the batch read
+// operation recvmsg.
+type Buffers net.Buffers
+
+// ReadFrom reads into the pre-allocated bufs. Returns bytes read.
+//
+// ReadFrom keeps reading until all bufs are filled or EOF is received.
+//
+// The pre-allocatted space used by ReadFrom is based upon slice lengths.
+func (bufs Buffers) ReadFrom(r io.Reader) (int64, error) {
+	if conn, ok := r.(syscall.Conn); ok && readFromBuffers != nil {
+		return readFromBuffers(bufs, conn)
+	}
+
+	var total int64
+	for _, buf := range bufs {
+		for filled := 0; filled < len(buf); {
+			n, err := r.Read(buf[filled:])
+			total += int64(n)
+			filled += n
+			if (n == 0 && err == nil) || err == io.EOF {
+				return total, io.EOF
+			} else if err != nil {
+				return total, err
+			}
+		}
+	}
+	return total, nil
+}

--- a/vendor/github.com/hugelgupf/p9/vecnet/vecnet_linux.go
+++ b/vendor/github.com/hugelgupf/p9/vecnet/vecnet_linux.go
@@ -1,0 +1,109 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vecnet
+
+import (
+	"io"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+var readFromBuffers = readFromBuffersLinux
+
+func readFromBuffersLinux(bufs Buffers, conn syscall.Conn) (int64, error) {
+	rc, err := conn.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+
+	length := int64(0)
+	for _, buf := range bufs {
+		length += int64(len(buf))
+	}
+
+	for n := int64(0); n < length; {
+		cur, err := recvmsg(bufs, rc)
+		if err != nil && (cur == 0 || err != io.EOF) {
+			return n, err
+		}
+		n += int64(cur)
+
+		// Consume iovecs to retry.
+		for consumed := 0; consumed < cur; {
+			if len(bufs[0]) <= cur-consumed {
+				consumed += len(bufs[0])
+				bufs = bufs[1:]
+			} else {
+				bufs[0] = bufs[0][cur-consumed:]
+				break
+			}
+		}
+	}
+	return length, nil
+}
+
+// buildIovec builds an iovec slice from the given []byte slice.
+//
+// iovecs is used as an initial slice, to avoid excessive allocations.
+func buildIovec(bufs Buffers, iovecs []syscall.Iovec) ([]syscall.Iovec, int) {
+	var length int
+	for _, buf := range bufs {
+		if l := len(buf); l > 0 {
+			iovecs = append(iovecs, syscall.Iovec{
+				Base: &buf[0],
+				Len:  uint64(l),
+			})
+			length += l
+		}
+	}
+	return iovecs, length
+}
+
+func recvmsg(bufs Buffers, rc syscall.RawConn) (int, error) {
+	iovecs, length := buildIovec(bufs, make([]syscall.Iovec, 0, 2))
+
+	var msg syscall.Msghdr
+	if len(iovecs) != 0 {
+		msg.Iov = &iovecs[0]
+		msg.Iovlen = uint64(len(iovecs))
+	}
+
+	// n is the bytes received.
+	var n uintptr
+	var e syscall.Errno
+	err := rc.Read(func(fd uintptr) bool {
+		n, _, e = syscall.Syscall(syscall.SYS_RECVMSG, fd, uintptr(unsafe.Pointer(&msg)), syscall.MSG_DONTWAIT)
+		// Return false if EINTR, EAGAIN, or EWOULDBLOCK to retry.
+		return !(e == syscall.EINTR || e == syscall.EAGAIN || e == syscall.EWOULDBLOCK)
+	})
+	runtime.KeepAlive(iovecs)
+	if err != nil {
+		return 0, err
+	}
+	if e != 0 {
+		return 0, e
+	}
+
+	// The other end is closed by returning a 0 length read with no error.
+	if n == 0 {
+		return 0, io.EOF
+	}
+
+	if int(n) > length {
+		return length, io.ErrShortBuffer
+	}
+	return int(n), nil
+}

--- a/vendor/github.com/hugelgupf/p9/vecnet/vecnet_other.go
+++ b/vendor/github.com/hugelgupf/p9/vecnet/vecnet_other.go
@@ -1,0 +1,23 @@
+// Copyright 2018 The gVisor Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !linux
+
+package vecnet
+
+import (
+	"syscall"
+)
+
+var readFromBuffers func(bufs Buffers, conn syscall.Conn) (int64, error)


### PR DESCRIPTION
cpu will now by default use a builtin 9p server.

You still have the option of using an external program,
which is very useful for debugging.

Note this does not work at present b/c the ssh channel is
not backed by a syscall.Conn and the 9p package expects that it is.

It will, again, still work with an external 9p server.