### PR TITLE
dhclient: fix negative -retry flag

### DIFF
--- a/cmds/core/dhclient/dhclient.go
+++ b/cmds/core/dhclient/dhclient.go
@@ -53,8 +53,12 @@ func main() {
 func configureAll(ifs []netlink.Link) {
 	packetTimeout := time.Duration(*timeout) * time.Second
 
-	ctx, cancel := context.WithTimeout(context.Background(), packetTimeout*time.Duration(1<<uint(*retry)))
-	defer cancel()
+	ctx := context.Background()
+	if *retry >= 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, packetTimeout*time.Duration(1<<uint(*retry)))
+		defer cancel()
+	}
 
 	c := dhclient.Config{
 		Timeout: packetTimeout,


### PR DESCRIPTION
This PR fixes infinite retry (as implied by the negative retry value).

```
dhclient -retry=-1
```
- Expected behavior: enters infinite retry loop.
- Actual behavior: context deadline exceeded.