### PR TITLE
dhclient: remove broken Classless Static Route option

### DIFF
--- a/pkg/dhclient/dhcp4.go
+++ b/pkg/dhclient/dhcp4.go
@@ -66,25 +66,7 @@ func (p *Packet4) Configure() error {
 		return fmt.Errorf("add/replace %s to %v: %v", dst, p.iface, err)
 	}
 
-	// RFC 3442 notes that if classless static routes are available, they
-	// have priority. You have to ignore the Route Option.
-	if routes := p.P.ClasslessStaticRoute(); routes != nil {
-		for _, route := range routes {
-			r := &netlink.Route{
-				LinkIndex: p.iface.Attrs().Index,
-				Dst:       route.Dest,
-				Gw:        route.Router,
-			}
-			// If no gateway is specified, the destination must be link-local.
-			if r.Gw == nil || r.Gw.Equal(net.IPv4zero) {
-				r.Scope = netlink.SCOPE_LINK
-			}
-
-			if err := netlink.RouteReplace(r); err != nil {
-				return fmt.Errorf("%s: add %s: %v", p.iface.Attrs().Name, r, err)
-			}
-		}
-	} else if gw := p.P.Router(); gw != nil && len(gw) > 0 {
+	if gw := p.P.Router(); gw != nil && len(gw) > 0 {
 		r := &netlink.Route{
 			LinkIndex: p.iface.Attrs().Index,
 			Gw:        gw[0],


### PR DESCRIPTION
Rolling back 'cause it's broken, and I don't have the time to fix it,
but I also need it to not be in the way for an internal project.

It works for a /32 IP, but any non-/32 IP with the following classless
static routes fails to have routes configured correctly:

Subnet Mask: ffffff00
Router: 10.0.0.1
Classless Static Route:
  route to 10.0.0.1/32 via 0.0.0.0; route to 0.0.0.0/0 via 10.0.0.1

(Rejected by RTNETLINK.)

They're so simple, yet so hard.

cc @insomniacslk and @tfg13 who may know WTF I'm doing wrong here