### PR TITLE
pkg/esxi: boot 'upgrading' partitions, not 'dirty' ones

### DIFF
--- a/pkg/esxi/esxi.go
+++ b/pkg/esxi/esxi.go
@@ -131,9 +131,20 @@ func mountPartition(dev string) (*options, error) {
 }
 
 func getBootImage(opts options, device string, partition int) (*boot.MultibootImage, error) {
-	// esx-boot/safeboot/bootbank.c:bank_scan says only "valid" and "dirty"
-	// are bootable partitions.
-	if opts.bootstate != bootValid && opts.bootstate != bootDirty {
+	// Only valid and upgrading are bootable partitions.
+	//
+	// We are supposed to support the following two state transitions (only
+	// one transition every boot!):
+	//
+	// upgrading -> dirty
+	// dirty -> invalid
+	//
+	// A validly booted system will set its own bootstate to "valid" from
+	// "dirty".
+	//
+	// We currently don't support writing the state back to disk, which is
+	// fine in our manual testing.
+	if opts.bootstate != bootValid && opts.bootstate != bootUpgrading {
 		return nil, fmt.Errorf("boot state %d invalid", opts.bootstate)
 	}
 


### PR DESCRIPTION
I misread
https://github.com/vmware/esx-boot/blob/abe46c4b2edb507e5486c3996075d9bd7ade4ba1/safeboot/bootbank.c#L194
because it checks the bank->bootstate *AFTER* it has been updated (see
the call to bank_set_bootstate a couple lines before).

The only bootable states are "valid" and "upgrading".

State transitions (which we do not implement) are supposed to be:

valid -> upgrading (done by upgrader)
upgrading -> dirty (done by bootloader)
dirty -> valid     (done by booted OS)
dirty -> invalid   (done by bootloader)

Signed-off-by: Chris Koch <chrisko@google.com>