### PR TITLE
cp: non-recursively copying dir should error

### DIFF
--- a/cmds/core/cp/cp.go
+++ b/cmds/core/cp/cp.go
@@ -91,6 +91,12 @@ func cpArgs(args []string) error {
 		// (2) the user is asked about overwriting an existing file if
 		//     one is already there.
 		PreCallback: func(src, dst string, srcfi os.FileInfo) error {
+			// check if src is dir
+			if !flags.recursive && srcfi.IsDir() == true {
+				log.Printf("cp: -r not specified, omitting directory %s", src)
+				return cp.ErrSkip
+			}
+
 			dstfi, err := os.Stat(dst)
 			if err != nil && !os.IsNotExist(err) {
 				log.Printf("cp: %q: can't handle error %v", dst, err)


### PR DESCRIPTION
Patch for https://github.com/u-root/u-root/issues/1349
When copying from a source cp should print a skipped
error when the source is a directory and the recursive flag
is not set.

Signed-off-by: Brett Kochendorfer <brett.kochendorfer@gmail.com>