### PR TITLE
Package for manipulating Memory Technology Devices

### DIFF
--- a/pkg/mtd/badchip.go
+++ b/pkg/mtd/badchip.go
@@ -1,0 +1,38 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mtd
+
+import "fmt"
+
+type badChip string
+
+// ID returns the ChipID.
+func (c badChip) ID() ChipID {
+	return 0
+}
+
+// Name returns the canonical chip name.
+func (c badChip) Name() ChipName {
+	return ChipName(c)
+}
+
+// Synonyms returns all synonyms for a chip.
+func (c badChip) Synonyms() []ChipName {
+	return []ChipName{c.Name()}
+}
+
+// Size returns a ChipSize in bytes.
+func (c badChip) Size() ChipSize {
+	return 0
+}
+
+// String is a stringer for a badChip.
+func (c badChip) String() string {
+	return fmt.Sprintf("Unknown(%s)", string(c))
+}
+
+func newBadChip(c string) ChipInfo {
+	return badChip(c)
+}

--- a/pkg/mtd/chips.go
+++ b/pkg/mtd/chips.go
@@ -28,8 +28,8 @@ func VendorFromName(v VendorName) (Vendor, error) {
 	return nil, fmt.Errorf("%v: not a known vendor", v)
 }
 
-// Chip returns a Chip or error given a ChipID.
-func (v *vendor) Chip(id ChipID) (Chip, error) {
+// ChipInfo returns a Chip or error given a ChipID.
+func (v *vendor) ChipInfo(id ChipID) (ChipInfo, error) {
 	for _, d := range devices {
 		if d.vendor == v.names[0] && d.id == id {
 			return &d, nil
@@ -53,13 +53,13 @@ func (v *vendor) Synonyms() []VendorName {
 	return v.names[1:]
 }
 
-// ChipFromVIDDID will return a Chip struct, given a Vendor and Device ID.
-func ChipFromVIDDID(vid VendorID, did ChipID) (Chip, error) {
+// ChipInfoFromVIDDID will return a ChipInfo struct, given a Vendor and Device ID.
+func ChipInfoFromVIDDID(vid VendorID, did ChipID) (ChipInfo, error) {
 	v, err := VendorFromID(vid)
 	if err != nil {
 		return nil, err
 	}
-	return v.Chip(did)
+	return v.ChipInfo(did)
 }
 
 // ID returns the ChipID.
@@ -95,6 +95,6 @@ func (c *ChipDevice) String() string {
 }
 
 // Supported returns true if a chip is supported by this package.
-func Supported(c Chip) bool {
+func Supported(c ChipInfo) bool {
 	return c.Size() != 0
 }

--- a/pkg/mtd/chips_test.go
+++ b/pkg/mtd/chips_test.go
@@ -49,11 +49,11 @@ func TestFindDevice(t *testing.T) {
 
 	for _, tt := range tests {
 		v, err := VendorFromName(tt.v)
-		t.Logf("vformname %v", v)
+		t.Logf("vendorfromname %v", v)
 		if err != nil {
 			t.Errorf("VendorFromName(%v): got %v, want nil", tt.v, err)
 		}
-		d, err := v.Chip(tt.id)
+		d, err := v.ChipInfo(tt.id)
 		if fmt.Sprintf("%v", err) != fmt.Sprintf("%v", tt.e) {
 			t.Errorf("(%q,%v): got %v want %v", tt.v, tt.id, err, tt.e)
 		}

--- a/pkg/mtd/doc.go
+++ b/pkg/mtd/doc.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package mtd supports manipulation of Memory Technology
+// Device chips.
+//
 // Chips are made by vendors, and an individual vendor is
 // defined by a 1 to 8 byte vendor id stored in the chip.
 // An instance of a type of chip, with, e.g., a particular size,
@@ -60,6 +63,14 @@
 // to balance time costs of writing, expected costs of too many erase
 // cycles, and several other factors I can not recall just now. Watch
 // this space.
+//
+// A note on the separation of ChipInfo from Flasher:
+// A ChipInfo is intended to tell us all we need to know about a device.
+// It might be derived from the /dev/mtd, a dediprog, or a person
+// forcing the vendor and device id. A Flasher performs the act.
+// One might derive a ChipInfo from /dev/mtd, but use a dediprog
+// to flash it. Hence we keep these two items separate. A ChipInfo
+// is like an os.Info, a Flasher like os.File.
 //
 // TODO: figure out some minimum set of config options for Linux, with
 // the proviso that this will be very kernel version dependent.

--- a/pkg/mtd/linux_test.go
+++ b/pkg/mtd/linux_test.go
@@ -10,16 +10,17 @@ import (
 )
 
 func TestOpen(t *testing.T) {
-	// If there's no such device then don't bother with the
-	// test.
-	if _, err := os.Stat(DevName); err != nil {
+	Debug = t.Logf
+	d := DevName + "0"
+	if _, err := os.Stat(d); err != nil {
 		t.Skip("No device to test")
 	}
-	m, err := NewDev(DevName)
+	m, err := NewChipInfoFromDev(d)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := m.Close(); err != nil {
-		t.Fatal(err)
+	if m == nil {
+		t.Errorf("no ChipInfo found in sysfs")
 	}
+	t.Logf("Chip info: name %v string %v", m.Name(), m.String())
 }

--- a/pkg/mtd/mtd.go
+++ b/pkg/mtd/mtd.go
@@ -1,0 +1,8 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mtd
+
+// Debug allows users of this package to get debug output.
+var Debug = func(string, ...interface{}) {}

--- a/pkg/mtd/mtd_linux.go
+++ b/pkg/mtd/mtd_linux.go
@@ -1,0 +1,78 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package mtd
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"reflect"
+)
+
+// LinuxChip contains all the information the Linux
+// MTD driver provides for a single chip.
+// We ignore oobsize and oobavailable.
+// They are mentioned as obsolete in library and driver.
+type LinuxChip struct {
+	// ChipInfo is filled in assuming mtd provides info we can use
+	// about a chip that is in our tables. If no such table is found
+	// ChipInfo will be a badChipInfo. Bad ChipInfo! Bad! Bad!
+	ChipInfo
+	// Device name, e.g. mtd0
+	Dev string `mtd:"dev"`
+	// Chip name as reported by MTD
+	// If this is a synonym then the ChipInfo may return
+	// something else.
+	MTDName string `mtd:"name"`
+	// Chip type
+	ChipType string `mtd:"type"`
+	// Erase size. MTD presents one erase size.
+	// It is hard to tell if that is going to work out.
+	EraseSize string `mtd:"erasesize"`
+	// Part Size as reported by MTD. This should be the same as the
+	// ChipInfo, but you never know.
+	MTDSize string `mtd:"size"`
+	// Write Size, which, yes, can differ
+	// from EraseSize.
+	WriteSize string `mtd:"writesize"`
+	// SubPageSize. Is this the writeable fragment
+	// of an erase area?
+	SubPageSize string `mtd:"subpagesize"`
+	// Regions. Generally Size could equal subpagesize * regions.
+	Regions string `mtd:"numeraseregions"`
+	// Flags. Which of these we care about remains to be seen.
+	Flags string `mtd:"flags"`
+}
+
+// DevName is the path name, minus the unit number, of the Linux MTD device.
+var DevName = "/sys/devices/virtual/mtd/mtd"
+
+func (l *LinuxChip) String() string {
+	return l.MTDName
+}
+
+// NewChipInfoFromDev creates a LinuxChip given a file name.
+func NewChipInfoFromDev(name string) (ChipInfo, error) {
+	var l LinuxChip
+	Debug("NewChipInfoFromDev(%s)", name)
+	v := reflect.TypeOf(l)
+	for ix := 0; ix < v.NumField(); ix++ {
+		f := v.Field(ix)
+		n := f.Tag.Get("mtd")
+		Debug("Field %v, n %v", f, n)
+		if n == "" {
+			continue
+		}
+		mf := filepath.Join(name, n)
+		s, err := ioutil.ReadFile(mf)
+		Debug("Contents of %s is %s", mf, string(s))
+		if err != nil {
+			return nil, err
+		}
+		reflect.ValueOf(&l).Elem().Field(ix).SetString(string(s))
+	}
+	l.ChipInfo = newBadChip(name)
+	Debug("Chip is %v", l)
+	return &l, nil
+}

--- a/pkg/mtd/ops_linux.go
+++ b/pkg/mtd/ops_linux.go
@@ -5,26 +5,18 @@
 package mtd
 
 import (
+	"fmt"
 	"os"
 )
 
-// Dev contains information about ongoing MTD status and operation.
+// Dev is a Linux device to be used for operations on MTDs.
 type Dev struct {
 	*os.File
-	devName string
-	data    []byte
 }
 
-// DevName is the default name for the MTD device.
-var DevName = "/dev/mtd0"
-
-// NewDev creates a Dev, returning Flasher or error.
-func NewDev(n string) (Flasher, error) {
-	f, err := os.OpenFile(n, os.O_RDWR, 0)
-	if err != nil {
-		return nil, err
-	}
-	return &Dev{File: f, devName: n}, nil
+// NewFlasher returns a Flasher or an error
+func NewFlasher(n string) (Flasher, error) {
+	return nil, fmt.Errorf("not yet")
 }
 
 // QueueWrite adds a []byte to the pending write queue.
@@ -49,5 +41,5 @@ func (m *Dev) Close() error {
 
 // DevName returns the name of the flash device.
 func (m *Dev) DevName() string {
-	return m.devName
+	return m.File.Name()
 }

--- a/pkg/mtd/types.go
+++ b/pkg/mtd/types.go
@@ -5,15 +5,6 @@
 package mtd
 
 // Flasher defines the interface to flash drivers.
-//
-// Many devices must have lazy writes; SyncWrite should always be
-// called after a sequence of QueueWrite commands.  Close should
-// return an error if there are queued write commands. To erase a
-// device, one calls chip Blank(), QueueWrite(), and SyncWrite(). The
-// operators are deined for the Flasher, not the Chipper, since
-// flashing can involve driver-level operations such as unlocking
-// protection bits on a bridge that are more than just a chip
-// operation.
 type Flasher interface {
 	// ReadAt implements io.ReadAt for a flash device.
 	ReadAt([]byte, int64) (int, error)
@@ -46,7 +37,7 @@ type ChipSize uint
 // Vendor defines operations on vendor data.
 type Vendor interface {
 	// Chip returns a Chip, given a DeviceID
-	Chip(ChipID) (Chip, error)
+	ChipInfo(ChipID) (ChipInfo, error)
 	// ID Returns the VendorID
 	ID() VendorID
 	// Name() returns the canonical name
@@ -55,8 +46,10 @@ type Vendor interface {
 	Synonyms() []VendorName
 }
 
-// Chip defines operations on Chips.
-type Chip interface {
+// ChipInfo provides information about a chip, possibly derived from /dev/mtdx,
+// possibly from vendor and device ID read from a programmer, possibly from
+// vendor and device ID provided by a user.
+type ChipInfo interface {
 	// Name returns the chip name
 	Name() ChipName
 	// ID returns the chip ID
@@ -79,9 +72,10 @@ type vendor struct {
 	id    VendorID
 }
 
-// ChipDevice has information about a chip, include Vendor, Device,
-// sizes, and so on; and a reference to common properties.
-// As in Vendors, there are several names for a chip.
+// ChipDevice has information about a chip as found in a table,
+// including Vendor, Device, sizes, and so on; and a reference to
+// common properties.  As in Vendors, there are several names for a
+// chip.
 type ChipDevice struct {
 	vendor   VendorName
 	devices  []ChipName


### PR DESCRIPTION
Realistically, nowadays, that means "spi", but there can
be more to it.

This code is designed to compress efficiently for embedding
in FLASH parts (similar to what we did for the pci package)
and, given that the tables are basically one pass, we don't
build any maps as we might have.

The test passes on linux with an mtd test device.