### PR TITLE
Docker image that lends itself to local testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,17 +5,21 @@ templates:
     working_directory: /go/src/github.com/u-root/u-root
     docker:
       - image: circleci/golang:1.12
+    environment:
+      - IS_CIRCLECI: 1
   test-template: &test-template
     working_directory: /go/src/github.com/u-root/u-root
     docker:
       - image: uroottest/test-image-amd64:chris-v3.2.8-test
     environment:
+      - IS_CIRCLECI: 1
       - CGO_ENABLED: 0
       # Double all timeouts for QEMU VM tests since they run without KVM.
       - UROOT_QEMU_TIMEOUT_X: 2
   integration-template: &integration-template
     working_directory: /go/src/github.com/u-root/u-root
     environment:
+      - IS_CIRCLECI: 1
       - CGO_ENABLED: 0
       # Double all timeouts for QEMU VM tests since they run without KVM.
       - UROOT_QEMU_TIMEOUT_X: 2
@@ -113,6 +117,7 @@ jobs:
     <<: *base-template
     environment:
       - CGO_ENABLED: 1
+      - IS_CIRCLECI: 1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,14 @@
 version: 2
 
 templates:
-  golang-template: &golang-template
-    docker:
-      - image: uroottest/test-image-amd64:v3.2.7
+  base-template: &base-template
     working_directory: /go/src/github.com/u-root/u-root
+    docker:
+      - image: circleci/golang:1.12
+  test-template: &test-template
+    working_directory: /go/src/github.com/u-root/u-root
+    docker:
+      - image: uroottest/test-image-amd64:chris-v3.2.8-test
     environment:
       - CGO_ENABLED: 0
       # Double all timeouts for QEMU VM tests since they run without KVM.
@@ -23,38 +27,31 @@ templates:
 
 workflows:
   version: 2
-  build_and_test:
+  clean_stuff:
     jobs:
       - clean-code
-      - test:
-          requires:
-            - clean-code
-      - test-integration-amd64:
-          requires:
-            - clean-code
-      - test-integration-arm:
-          requires:
-            - clean-code
-      - race:
-          requires:
-            - clean-code
-      - compile_cmds:
-          requires:
-            - clean-code
-      - check_licenses:
-          requires:
-            - clean-code
+      - check_licenses
+  build_and_test:
+    jobs:
+      - test
+      - test-integration-amd64
+      - test-integration-arm
+      - compile_cmds
+  race:
+    jobs:
+      - race
 jobs:
   clean-code:
-    <<: *golang-template
+    <<: *base-template
     steps:
       - checkout
       - run:
           name: Install dep
           command: |
+            #go build ./cmds/core/wget
             wget https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
             mv dep-linux-amd64 dep
-            chmod +x dep
+            chmod 0755 dep
       - run:
           name: Install gometalinter
           command: |
@@ -101,8 +98,28 @@ jobs:
       - run:
           name: ineffassign
           command: ineffassign .
+  check_licenses:
+    <<: *base-template
+    steps:
+      - checkout
+      - run:
+          name: Check licenses
+          command: go run tools/checklicenses/checklicenses.go -c tools/checklicenses/config.json
+  race:
+    # This intentionally does not use the template that has integration stuff
+    # available.
+    #
+    # The integration tests should not run under the race detector.
+    <<: *base-template
+    environment:
+      - CGO_ENABLED: 1
+    steps:
+      - checkout
+      - run:
+          name: Race detector
+          command: go test -race ./cmds/... ./pkg/...
   test:
-    <<: *golang-template
+    <<: *test-template
     steps:
       - checkout
       - run:
@@ -112,17 +129,8 @@ jobs:
       - run:
           name: Test coverage
           command: go test -cover ./cmds/... ./pkg/...
-  race:
-    <<: *golang-template
-    environment:
-      - CGO_ENABLED: 1
-    steps:
-      - checkout
-      - run:
-          name: Race detector
-          command: go test -race ./cmds/... ./pkg/...
   compile_cmds:
-    <<: *golang-template
+    <<: *test-template
     steps:
       - checkout
       - run:
@@ -132,22 +140,18 @@ jobs:
             go install -a ./...
             cd ../tools
             go install -a ./...
-  check_licenses:
-    <<: *golang-template
-    steps:
-      - checkout
-      - run:
-          name: Check licenses
-          command: go run tools/checklicenses/checklicenses.go -c tools/checklicenses/config.json
   check_symlinks:
-    <<: *golang-template
+    <<: *test-template
     steps:
       - checkout
       - run:
           name: Symbol tests to ensure we do not break symlink handling
-          command: mkdir /tmp/usr && ln -s /tmp/usr/x /tmp/usr/y && go run u-root.go -build=bb -files /tmp/usr minimal
+          command: |
+            mkdir /tmp/usr
+            ln -s /tmp/usr/x /tmp/usr/y
+            go run u-root.go -build=bb -files /tmp/usr minimal
   check_templates:
-    <<: *golang-template
+    <<: *test-template
     steps:
       - checkout
       - run:
@@ -167,7 +171,7 @@ jobs:
   test-integration-amd64:
     <<: *integration-template
     docker:
-      - image: uroottest/test-image-amd64:v3.2.7
+      - image: uroottest/test-image-amd64:chris-v3.2.8-test
   test-integration-arm:
     <<: *integration-template
     docker:

--- a/.circleci/images/test-image-amd64/Dockerfile
+++ b/.circleci/images/test-image-amd64/Dockerfile
@@ -19,13 +19,15 @@ RUN sudo apt-get update &&                          \
         libfdt-dev                                  \
         libpixman-1-dev                             \
         zlib1g-dev                                  \
-	libcap-dev                                  \
-	libattr1-dev                                \
+        libcap-dev                                  \
+        libattr1-dev                                \
         `# Linux kernel build deps`                 \
         libelf-dev                                  \
         `# Multiboot kernel build deps`             \
         gcc-multilib                                \
-        gzip &&                                     \
+        gzip                                        \
+        `# sane debugging`                          \
+        bash &&                                     \
     sudo rm -rf /var/lib/apt/lists/*
 
 # Create working directory
@@ -72,7 +74,31 @@ RUN set -eux;                                                          \
     gzip -k kernel;                                                    \
     rm -rf multiboot-test-kernel/
 
+RUN set -eux;                                                          \
+    go get -u github.com/u-root/u-root;                                \
+    mkdir rootfs;                                                      \
+    u-root -build=bb -format=dir -o ./rootfs                           \
+      -defaultsh /bin/bash                                             \
+      -files /usr/local/go -files /usr/local/go/bin/go                 \
+      -files /home/circleci -files /home/circleci/qemu-system-x86_64   \
+      -files /bin/bash
+
+# We used the above to build everything. Let's build a tiny image that just has
+# the things we need to survive.
+FROM scratch AS release
+
+# unpack u-root initramfs at the root
+COPY --from=0 /home/circleci/rootfs /
+
 # Export paths to binaries.
+ENV GOPATH /go
+ENV GOROOT /usr/local/go
+ENV CGO_ENABLED 0
+ENV PATH /bbin:/bin:/usr/local/go/bin:/home/circleci/.local/bin:/usr/bin
+ENV HOME /home/circleci
+
 ENV UROOT_KERNEL /home/circleci/bzImage
 ENV UROOT_QEMU "/home/circleci/qemu-system-x86_64 -L /home/circleci/pc-bios -m 1G"
 ENV UROOT_TESTARCH amd64
+
+CMD ["elvish"]

--- a/cmds/core/dmesg/dmesg_test.go
+++ b/cmds/core/dmesg/dmesg_test.go
@@ -12,13 +12,14 @@ import (
 )
 
 func TestDmesg(t *testing.T) {
-	if uid := os.Getuid(); uid != 0 {
-		t.Skipf("test requires root on CircleCI, your uid is %d", uid)
+	if os.Getenv("IS_CIRCLECI") == "1" {
+		t.Skipf("test skipped on circleci, which doesn't allow access to dmesg at all")
 	}
 
 	cmd := testutil.Command(t)
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 	if err != nil || len(out) == 0 {
+		t.Logf("Output: %s", string(out))
 		t.Fatal(err)
 	}
 }

--- a/cmds/core/wget/wget.go
+++ b/cmds/core/wget/wget.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"io"
@@ -31,11 +32,17 @@ import (
 )
 
 var (
-	outPath = flag.String("O", "", "output file")
+	noCheckCert = flag.Bool("no-check-certificate", false, "Disables checking HTTPS certificates")
+	outPath     = flag.String("O", "", "output file")
 )
 
 func wget(arg, fileName string) error {
-	resp, err := http.Get(arg)
+	transCfg := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: *noCheckCert},
+	}
+	client := &http.Client{Transport: transCfg}
+
+	resp, err := client.Get(arg)
 	if err != nil {
 		return err
 	}

--- a/integration/multiboot_test.go
+++ b/integration/multiboot_test.go
@@ -25,7 +25,7 @@ func testMultiboot(t *testing.T, kernel string) {
 
 	src := fmt.Sprintf("/home/circleci/%v", kernel)
 	if _, err := os.Stat(src); err != nil && os.IsNotExist(err) {
-		t.Skip("multiboot kernel is not present")
+		t.Skipf("multiboot kernel %q is not present", src)
 	}
 
 	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -239,8 +239,11 @@ func CreateInitramfs(logger logger.Logger, opts Opts) error {
 			if err := archive.AddRecord(cpio.Symlink("bin/defaultsh", filepath.Join("..", rtarget))); err != nil {
 				return err
 			}
-			if err := archive.AddRecord(cpio.Symlink("bin/sh", filepath.Join("..", rtarget))); err != nil {
-				return err
+			// Don't try to symlink to yourself.
+			if rtarget != "bin/sh" {
+				if err := archive.AddRecord(cpio.Symlink("bin/sh", filepath.Join("..", rtarget))); err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Use with

```sh
docker run -it \
  -w /go/src/github.com/u-root/u-root \
  --mount type=bind,source=$(pwd),target=/go/src/github.com/u-root/u-root \
  uroottest/test-image-amd64:chris-v3.2.8-test
```

we should start using :latest tags for released images so we can just retag rather than having to merge a thing