### PR TITLE
Run docker image as root

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 templates:
   golang-template: &golang-template
     docker:
-      - image: uroottest/test-image-amd64:v3.2.7
+      - image: uroottest/test-image-amd64:chris-test
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - CGO_ENABLED: 0
@@ -167,7 +167,7 @@ jobs:
   test-integration-amd64:
     <<: *integration-template
     docker:
-      - image: uroottest/test-image-amd64:v3.2.7
+      - image: uroottest/test-image-amd64:chris-test
   test-integration-arm:
     <<: *integration-template
     docker:

--- a/.circleci/images/test-image-amd64/Dockerfile
+++ b/.circleci/images/test-image-amd64/Dockerfile
@@ -8,6 +8,7 @@ FROM circleci/golang:1.12
 RUN sudo apt-get update &&                          \
     sudo apt-get install -y --no-install-recommends \
         `# Linux dependencies`                      \
+        bash                                        \
         git                                         \
         bc                                          \
         bison                                       \
@@ -19,8 +20,8 @@ RUN sudo apt-get update &&                          \
         libfdt-dev                                  \
         libpixman-1-dev                             \
         zlib1g-dev                                  \
-	libcap-dev                                  \
-	libattr1-dev                                \
+        libcap-dev                                  \
+        libattr1-dev                                \
         `# Linux kernel build deps`                 \
         libelf-dev                                  \
         `# Multiboot kernel build deps`             \
@@ -76,3 +77,6 @@ RUN set -eux;                                                          \
 ENV UROOT_KERNEL /home/circleci/bzImage
 ENV UROOT_QEMU "/home/circleci/qemu-system-x86_64 -L /home/circleci/pc-bios -m 1G"
 ENV UROOT_TESTARCH amd64
+
+USER root
+CMD ["/bin/bash"]


### PR DESCRIPTION
Honestly, this is the easiest way to get the integration tests to run locally.

```sh
cd u-root
docker run -it \
  -w /go/src/github.com/u-root/u-root \
  --mount type=bind,source=$(pwd),target=/go/src/github.com/u-root/u-root \
  uroottest/test-image-amd64:chris-test
```