### PR TITLE
pxeboot: continue to boot when lease failed.

### DIFF
--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -78,7 +78,10 @@ func Netboot(ifaceNames string) error {
 
 			if err := result.Lease.Configure(); err != nil {
 				log.Printf("Failed to configure lease %s: %v", result.Lease, err)
-				continue
+				// Boot further regardless of lease configuration result.
+				//
+				// If lease failed, fall back to use locally configured
+				// ip/ipv6 address.
 			}
 			img, err := netboot.BootImage(urlfetch.DefaultSchemes, result.Lease)
 			if err != nil {


### PR DESCRIPTION
- When lease configuration failed, there is
  still a default ip/ipv6 address available
  locally, which was auto configured before
  pexclient can send request packet. There
  are usecases where DHCP server does not
  assign IP and prefer local hardware based
  address to be picked up. So updating pxeboot
  to acommendate that.
- Arguably, it may be good to always have IP
  assigned from server. This CL does not intend
  to address the ask/argument about what is
  best, but to update pxeboot to provide the
  flexibility to the particular usecase mentioned
  above.
- On a separate note, it maybe good to retry
  lease configuration a few times upon failures
  and then give up to boot further.

Signed-off-by: David Hu <xuehaohu@google.com>