### PR TITLE
Load modules in Init before userland

### DIFF
--- a/cmds/core/init/init_linux.go
+++ b/cmds/core/init/init_linux.go
@@ -7,17 +7,57 @@ package main
 import (
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 
 	"github.com/u-root/u-root/pkg/cmdline"
+	"github.com/u-root/u-root/pkg/kmodule"
 )
+
+// installModules installs kernel modules (.ko files) from /lib/modules.
+// Useful for modules that need to be loaded for boot (ie a network
+// driver needed for netboot)
+func installModules() {
+	modulePattern := "/lib/modules/*.ko"
+	files, err := filepath.Glob(modulePattern)
+	if err != nil {
+		log.Printf("installModules: %v", err)
+		return
+	}
+	if len(files) == 0 {
+		// Since it is common for users to not have modules, no need to error or
+		// print if there are none to install
+		return
+	}
+
+	for _, filename := range files {
+		f, err := os.Open(filename)
+		if err != nil {
+			log.Printf("installModules: can't open %q: %v", filename, err)
+			continue
+		}
+		// Module flags are passed to the command line in the form modulename.flag=val
+		// And must be passed to FileInit as flag=val to be installed properly
+		moduleName := strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
+		flags := cmdline.FlagsForModule(moduleName)
+		err = kmodule.FileInit(f, flags, 0)
+		f.Close()
+		if err != nil {
+			log.Printf("installModules: can't install %q: %v", filename, err)
+		}
+	}
+}
 
 func init() {
 	osInitGo = runOSInitGo
 }
 
 func runOSInitGo() {
+	// Install modules before exec-ing into user mode below
+	installModules()
+
 	// systemd is "special". If we are supposed to run systemd, we're
 	// going to exec, and if we're going to exec, we're done here.
 	// systemd uber alles.

--- a/pkg/cmdline/cmdline_test.go
+++ b/pkg/cmdline/cmdline_test.go
@@ -72,3 +72,32 @@ func TestCmdline(t *testing.T) {
 	}
 
 }
+
+func TestCmdlineModules(t *testing.T) {
+	exampleCmdlineModules := `BOOT_IMAGE=/vmlinuz-4.11.2 ro ` +
+		`my_module.flag1=8 my-module.flag2-string=hello ` +
+		`otherMod.opt1=world otherMod.opt_2=22-22`
+
+	once.Do(cmdLineOpener)
+	cmdLineReader := strings.NewReader(exampleCmdlineModules)
+	procCmdLine = parse(cmdLineReader)
+
+	if procCmdLine.Err != nil {
+		t.Errorf("procCmdLine threw an error: %v", procCmdLine.Err)
+	}
+
+	// Check flags using contains to not rely on map iteration order
+	flags := FlagsForModule("my-module")
+	if !strings.Contains(flags, "flag1=8 ") || !strings.Contains(flags, "flag2_string=hello ") {
+		t.Errorf("my-module flags got: %v, want flag1=8 flag2_string=hello ", flags)
+	}
+	flags = FlagsForModule("my_module")
+	if !strings.Contains(flags, "flag1=8 ") || !strings.Contains(flags, "flag2_string=hello ") {
+		t.Errorf("my_module flags got: %v, want flag1=8 flag2_string=hello ", flags)
+	}
+
+	flags = FlagsForModule("otherMod")
+	if !strings.Contains(flags, "opt1=world ") || !strings.Contains(flags, "opt_2=22-22 ") {
+		t.Errorf("my_module flags got: %v, want opt1=world opt_2=22-22 ", flags)
+	}
+}


### PR DESCRIPTION
Update init_linux.go to load modules from /lib/modules before exec-ing into userland

Signed-off-by: Jake Saferstein <jsaf@google.com>