### PR TITLE
Remove annoying rc.elv error message on startup

### DIFF
--- a/cmds/core/elvish/program/shell/interact.go
+++ b/cmds/core/elvish/program/shell/interact.go
@@ -82,12 +82,12 @@ func interact(ev *eval.Evaler, dataDir string) {
 func sourceRC(ev *eval.Evaler, dataDir string) error {
 	absPath, err := filepath.Abs(filepath.Join(dataDir, "rc.elv"))
 	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
 		return fmt.Errorf("cannot get full path of rc.elv: %v", err)
 	}
 	code, err := readFileUTF8(absPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
elvish would print an error message on startup if rc.elv
did not exist.

Turns out this was an error in the original; the author
expected filepath.Abs to return an error if the file
did not exist, and that is not the job of Abs.

Move the error test to the right place; no more annoying
error message. This has been a surprisingly common source
of confusion over the years so it's nice to have it gone.