### PR TITLE
Set more reasonable defaults for urlfetch tftp scheme

### DIFF
--- a/pkg/urlfetch/schemes.go
+++ b/pkg/urlfetch/schemes.go
@@ -52,7 +52,7 @@ var (
 	DefaultHTTPClient = NewHTTPClient(http.DefaultClient)
 
 	// DefaultTFTPClient is the default TFTP FileScheme.
-	DefaultTFTPClient = NewTFTPClient()
+	DefaultTFTPClient = NewTFTPClient(tftp.ClientMode(tftp.ModeOctet), tftp.ClientBlocksize(1450), tftp.ClientWindowsize(65535))
 
 	// DefaultSchemes are the schemes supported by default.
 	DefaultSchemes = Schemes{


### PR DESCRIPTION
RFC7440:
   TFTP is virtually unused for Internet transfers today, TFTP is still
   massively used in network boot/installation scenarios including EFI
   (Extensible Firmware Interface).

UEFI continues to put the legacy in legacy boot and the
backwards in backwards compatibility :-)

Anyway, since we are booting over networks that are essentially
error free (having a BER better than disk in some cases!) it makes
sense to boost the block and window sizes. Do so.

While we're at it, fetch in ModeOctet. ModeAscii is a legacy of the PDP10
and other machines with 7 bit bytes. Or 6. Or even 5. Not kidding. The
PDP10 byte pointer had a 6 bit field for byte length.