### PR TITLE
Enable kexec on arm64 architecture.

### DIFF
--- a/pkg/kexec/kexec_linux_implemented.go
+++ b/pkg/kexec/kexec_linux_implemented.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build linux,amd64 linux,arm64
+
 package kexec
 
 import (
@@ -14,7 +16,7 @@ import (
 // FileLoad loads the given kernel as the new kernel with the given ramfs and
 // cmdline.
 //
-// The kexec_file_load(2) syscall is x86-64 bit only.
+// The kexec_file_load(2) syscall is x86-64 and arm64 only.
 func FileLoad(kernel, ramfs *os.File, cmdline string) error {
 	var flags int
 	var ramfsfd int

--- a/pkg/kexec/kexec_linux_other.go
+++ b/pkg/kexec/kexec_linux_other.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build linux,!amd64
+// +build linux,!amd64,!arm64
 
 package kexec
 


### PR DESCRIPTION
Recent kernels now support it.

Signed-off-by: Jean-Marc Eurin <jmeurin@google.com>