### PR TITLE
dhcp6: extend link timeout

### DIFF
--- a/pkg/dhclient/dhclient.go
+++ b/pkg/dhclient/dhclient.go
@@ -171,7 +171,9 @@ func lease6(ctx context.Context, iface netlink.Link, c Config) (Lease, error) {
 
 	// If the link is never going to be ready, don't wait forever.
 	// (The user may not have configured a ctx with a timeout.)
-	linkTimeout := time.After(c.Timeout)
+	//
+	// Hardcode the timeout to 30s for now.
+	linkTimeout := time.After(linkUpAttempt)
 	for {
 		if ready, err := isIpv6LinkReady(iface); err != nil {
 			return nil, err


### PR DESCRIPTION
Extends the timeout waiting for a non-tentative IPv6 address.

If c.Timeout is too short, no DHCPv6 lease will be attempted at all. Internally, this messed us up at 3 seconds. For now, let's just give a default timeout.