### PR TITLE
Add support for custom build tags and add tag `nohwrng` to random

### DIFF
--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -181,6 +181,8 @@ func (v *VM) CmdlineQuoted() string {
 func (v *VM) Close() {
 	v.gExpect.Close()
 	v.gExpect = nil
+	// Ensure the logs are closed by waiting the complete end
+	<-v.errCh
 }
 
 // Send sends a string to QEMU's serial.

--- a/pkg/rand/random_linux.go
+++ b/pkg/rand/random_linux.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !nohwrng
+
 package rand
 
 import (

--- a/pkg/rand/random_unix.go
+++ b/pkg/rand/random_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris
+// +build darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris linux,nohwrng
 
 package rand
 

--- a/u-root.go
+++ b/u-root.go
@@ -40,6 +40,7 @@ var (
 	fourbins                                *bool
 	noCommands                              *bool
 	extraFiles                              multiFlag
+	buildTags                               *string
 )
 
 func init() {
@@ -58,6 +59,7 @@ func init() {
 	noCommands = flag.Bool("nocmd", false, "Build no Go commands; initramfs only")
 
 	flag.Var(&extraFiles, "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be speficified multiple times.")
+	buildTags = flag.String("build-tags", "", "a space-separated list of build tags to consider satisfied during the build.")
 }
 
 func main() {
@@ -98,6 +100,12 @@ func Main() error {
 	log.Printf("Build environment: %s", env)
 	if env.GOOS != "linux" {
 		log.Printf("GOOS is not linux. Did you mean to set GOOS=linux?")
+	}
+
+	if *buildTags != "" {
+		tagList := strings.Split(*buildTags, " ")
+		env.BuildTags = append(env.BuildTags, tagList...)
+		log.Printf("Build tags: %s", env.BuildTags)
 	}
 
 	v, err := env.Version()


### PR DESCRIPTION
This is basically to solve the issue that dhcp (and pxe) cannot work on platform with no hardware source of entropy.

This should not be used when the system will require some cryptographically safe random number