### PR TITLE
Integration tests: separate test from initramfs

### DIFF
--- a/integration/dhclient_test.go
+++ b/integration/dhclient_test.go
@@ -28,7 +28,6 @@ func TestDhclient(t *testing.T) {
 			Commands: uroot.BusyBoxCmds(
 				"github.com/u-root/u-root/cmds/core/echo",
 				"github.com/u-root/u-root/cmds/core/ip",
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/sleep",
 				"github.com/u-root/u-root/cmds/core/shutdown",
 				"github.com/u-root/u-root/cmds/exp/pxeserver",
@@ -40,7 +39,7 @@ func TestDhclient(t *testing.T) {
 				network.NewVM(),
 			},
 		},
-		Uinit: []string{
+		TestCmds: []string{
 			"ip link set eth0 up",
 			"ip addr add 192.168.0.1/24 dev eth0",
 			"ip route add 0.0.0.0/0 dev eth0",
@@ -54,7 +53,6 @@ func TestDhclient(t *testing.T) {
 		BuildOpts: uroot.Opts{
 			Commands: uroot.BusyBoxCmds(
 				"github.com/u-root/u-root/cmds/core/ip",
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/dhclient",
 				"github.com/u-root/u-root/cmds/core/shutdown",
 			),
@@ -66,7 +64,7 @@ func TestDhclient(t *testing.T) {
 				network.NewVM(),
 			},
 		},
-		Uinit: []string{
+		TestCmds: []string{
 			"dhclient -ipv6=false -v",
 			"ip a",
 			// Sleep so serial console output gets flushed. The expect library is racy.
@@ -98,7 +96,6 @@ func TestPxeboot(t *testing.T) {
 		Name: "TestPxeboot_Server",
 		BuildOpts: uroot.Opts{
 			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/ip",
 				"github.com/u-root/u-root/cmds/core/ls",
 				"github.com/u-root/u-root/cmds/exp/pxeserver",
@@ -107,7 +104,7 @@ func TestPxeboot(t *testing.T) {
 				"./testdata/pxe:pxeroot",
 			},
 		},
-		Uinit: []string{
+		TestCmds: []string{
 			"ip addr add 192.168.0.1/24 dev eth0",
 			"ip link set eth0 up",
 			"ip route add 0.0.0.0/0 dev eth0",
@@ -128,14 +125,13 @@ func TestPxeboot(t *testing.T) {
 		Name: "TestPxeboot_Client",
 		BuildOpts: uroot.Opts{
 			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/ip",
 				"github.com/u-root/u-root/cmds/core/shutdown",
 				"github.com/u-root/u-root/cmds/core/sleep",
 				"github.com/u-root/u-root/cmds/boot/pxeboot",
 			),
 		},
-		Uinit: []string{
+		TestCmds: []string{
 			"pxeboot --dry-run --no-load -v",
 			// Sleep so serial console output gets flushed. The expect library is racy.
 			"sleep 5",
@@ -172,7 +168,6 @@ func TestQEMUDHCPTimesOut(t *testing.T) {
 		Name: "TestQEMUDHCPTimesOut",
 		BuildOpts: uroot.Opts{
 			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/echo",
 				"github.com/u-root/u-root/cmds/core/dhclient",
 				"github.com/u-root/u-root/cmds/core/sleep",
@@ -183,7 +178,7 @@ func TestQEMUDHCPTimesOut(t *testing.T) {
 			SerialOutput: vmtest.TestLineWriter(t, "client"),
 			Timeout:      40 * time.Second,
 		},
-		Uinit: []string{
+		TestCmds: []string{
 			// loopback should time out and it can't have configured anything.
 			"dhclient -v -retry 1 -timeout 10 lo",
 			"echo \"DHCP timed out\"",

--- a/integration/io_test.go
+++ b/integration/io_test.go
@@ -24,11 +24,10 @@ func TestIO(t *testing.T) {
 	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{
 		BuildOpts: uroot.Opts{
 			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/integration/testcmd/io/uinit",
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/io",
 			),
 		},
+		Uinit: "github.com/u-root/u-root/integration/testcmd/io/uinit",
 	})
 	defer cleanup()
 

--- a/integration/kexec_test.go
+++ b/integration/kexec_test.go
@@ -26,12 +26,11 @@ func TestMountKexec(t *testing.T) {
 	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{
 		BuildOpts: uroot.Opts{
 			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/integration/testcmd/kexec/uinit",
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/mount",
 				"github.com/u-root/u-root/cmds/core/kexec",
 			),
 		},
+		Uinit: "github.com/u-root/u-root/integration/testcmd/kexec/uinit",
 		QEMUOpts: qemu.Options{
 			Timeout: 30 * time.Second,
 		},

--- a/integration/multiboot_test.go
+++ b/integration/multiboot_test.go
@@ -35,14 +35,13 @@ func testMultiboot(t *testing.T, kernel string) {
 	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{
 		BuildOpts: uroot.Opts{
 			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/kexec",
 			),
 			ExtraFiles: []string{
 				src + ":kernel",
 			},
 		},
-		Uinit: []string{
+		TestCmds: []string{
 			`kexec -l kernel -e -d --module="/kernel foo=bar" --module="/bbin/bb"`,
 		},
 		QEMUOpts: qemu.Options{

--- a/integration/tcz_test.go
+++ b/integration/tcz_test.go
@@ -43,7 +43,7 @@ func TestTczclient(t *testing.T) {
 					"./testdata/tczserver:tcz",
 				},
 			},
-			Uinit: []string{
+			TestCmds: []string{
 				"dmesg",
 				"ip l",
 				"echo NOW DO IT",
@@ -89,7 +89,7 @@ func TestTczclient(t *testing.T) {
 				"./testdata/tczclient:tcz",
 			},
 		},
-		Uinit: []string{
+		TestCmds: []string{
 			"ip addr add 192.168.0.2/24 dev eth0",
 			"ip link set eth0 up",
 			//"ip route add 255.255.255.255/32 dev eth0",

--- a/integration/testcmd/generic/uinit/generic.go
+++ b/integration/testcmd/generic/uinit/generic.go
@@ -1,0 +1,56 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/u-root/u-root/pkg/mount"
+	"golang.org/x/sys/unix"
+)
+
+func main() {
+	if err := os.MkdirAll("/testdata", 0755); err != nil {
+		log.Fatalf("Couldn't create testdata: %v", err)
+	}
+
+	// Mount a vfat volume and run the tests within.
+	var err error
+	if os.Getenv("UROOT_USE_9P") == "1" {
+		err = mount.Mount("tmpdir", "/testdata", "9p", "", 0)
+	} else {
+		err = mount.Mount("/dev/sda1", "/testdata", "vfat", "", unix.MS_RDONLY)
+	}
+	if err != nil {
+		log.Fatalf("Failed to mount test directory: %v", err)
+	}
+
+	// Run the test script test.elv
+	test := filepath.Join("/testdata", "test.elv")
+	if os.Stat(test); os.IsNotExist(err) {
+		log.Fatalf("Could not find any test script to run.")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 25000*time.Millisecond)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "elvish", test)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	// TODO(plaud) start test in its own dir so that testdata is available as a
+	// relative directory?
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("test.elv ran unsuccessfully: %v", err)
+	}
+
+	if err := unix.Reboot(unix.LINUX_REBOOT_CMD_POWER_OFF); err != nil {
+		log.Fatalf("Failed to reboot: %v", err)
+	}
+}

--- a/integration/testcmd/generic/uinit/generic.go
+++ b/integration/testcmd/generic/uinit/generic.go
@@ -5,12 +5,10 @@
 package main
 
 import (
-	"context"
 	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"time"
 
 	"github.com/u-root/u-root/pkg/mount"
 	"golang.org/x/sys/unix"
@@ -34,18 +32,13 @@ func main() {
 
 	// Run the test script test.elv
 	test := filepath.Join("/testdata", "test.elv")
-	if os.Stat(test); os.IsNotExist(err) {
+	if _, err := os.Stat(test); os.IsNotExist(err) {
 		log.Fatalf("Could not find any test script to run.")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 25000*time.Millisecond)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "elvish", test)
+	cmd := exec.Command("elvish", test)
 	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 
-	// TODO(plaud) start test in its own dir so that testdata is available as a
-	// relative directory?
 	if err := cmd.Run(); err != nil {
 		log.Fatalf("test.elv ran unsuccessfully: %v", err)
 	}

--- a/integration/testcmd/gotest/uinit/gotest.go
+++ b/integration/testcmd/gotest/uinit/gotest.go
@@ -46,7 +46,7 @@ func main() {
 		err = mount.Mount("/dev/sda1", "/testdata", "vfat", "", unix.MS_RDONLY)
 	}
 	if err != nil {
-		log.Fatalf("Couldn't mount /dev/sda1: %v", err)
+		log.Fatalf("Failed to mount test directory: %v", err)
 	}
 
 	walkTests("/testdata/tests", func(path, pkgName string) {

--- a/integration/uinit_test.go
+++ b/integration/uinit_test.go
@@ -16,12 +16,7 @@ import (
 // TestHelloWorld runs an init which prints the string "HELLO WORLD" and exits.
 func TestHelloWorld(t *testing.T) {
 	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{
-		BuildOpts: uroot.Opts{
-			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/integration/testcmd/helloworld/uinit",
-				"github.com/u-root/u-root/cmds/core/init",
-			),
-		},
+		Uinit: "github.com/u-root/u-root/integration/testcmd/helloworld/uinit",
 	})
 	defer cleanup()
 
@@ -33,12 +28,7 @@ func TestHelloWorld(t *testing.T) {
 // TestHelloWorldNegative runs an init which does not print the string "HELLO WORLD".
 func TestHelloWorldNegative(t *testing.T) {
 	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{
-		BuildOpts: uroot.Opts{
-			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/integration/testcmd/helloworld/uinit",
-				"github.com/u-root/u-root/cmds/core/init",
-			),
-		},
+		Uinit: "github.com/u-root/u-root/integration/testcmd/helloworld/uinit",
 	})
 	defer cleanup()
 
@@ -52,12 +42,11 @@ func TestScript(t *testing.T) {
 		Name: "ShellScript",
 		BuildOpts: uroot.Opts{
 			Commands: uroot.BusyBoxCmds(
-				"github.com/u-root/u-root/cmds/core/init",
 				"github.com/u-root/u-root/cmds/core/shutdown",
 				"github.com/u-root/u-root/cmds/core/echo",
 			),
 		},
-		Uinit: []string{
+		TestCmds: []string{
 			"echo HELLO WORLD",
 			"shutdown -h",
 		},

--- a/pkg/vmtest/gotest.go
+++ b/pkg/vmtest/gotest.go
@@ -33,12 +33,12 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 	}
 
 	// Create a temporary directory.
-	if len(o.BuildOpts.TempDir) == 0 {
+	if len(o.TmpDir) == 0 {
 		tmpDir, err := ioutil.TempDir("", "uroot-integration")
 		if err != nil {
 			t.Fatal(err)
 		}
-		o.BuildOpts.TempDir = tmpDir
+		o.TmpDir = tmpDir
 	}
 
 	env := golang.Default()
@@ -49,7 +49,7 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 	// Statically build tests and add them to the temporary directory.
 	var tests []string
 	os.Setenv("CGO_ENABLED", "0")
-	testDir := filepath.Join(o.BuildOpts.TempDir, "tests")
+	testDir := filepath.Join(o.TmpDir, "tests")
 	for _, pkg := range pkgs {
 		pkgDir := filepath.Join(testDir, pkg)
 		if err := os.MkdirAll(pkgDir, 0755); err != nil {
@@ -87,10 +87,9 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 
 	// Create the CPIO and start QEMU.
 	o.BuildOpts.AddCommands(uroot.BinaryCmds("cmd/test2json")...)
-	o.BuildOpts.AddBusyBoxCommands(
-		"github.com/u-root/u-root/integration/testcmd/gotest/uinit",
-		"github.com/u-root/u-root/cmds/core/init",
-	)
+
+	// Specify the custom gotest uinit.
+	o.Uinit = "github.com/u-root/u-root/integration/testcmd/gotest/uinit"
 
 	tc := json2test.NewTestCollector()
 	serial := []io.Writer{

--- a/pkg/vmtest/integration.go
+++ b/pkg/vmtest/integration.go
@@ -5,12 +5,10 @@
 package vmtest
 
 import (
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
 	"os"
-	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -25,33 +23,11 @@ import (
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
 )
 
-const template = `
-package main
-
-import (
-	"log"
-	"os"
-	"os/exec"
-)
-
-func main() {
-	for _, cmds := range %#v {
-		cmd := exec.Command(cmds[0], cmds[1:]...)
-		log.Printf("Execing %%#v", cmds)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		err := cmd.Run()
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-}
-`
-
 // Options are integration test options.
 type Options struct {
 	// BuildOpts are u-root initramfs options.
 	//
+	// They are used if the test needs to generate an initramfs.
 	// Fields that are not set are populated by QEMU and QEMUTest as
 	// possible.
 	BuildOpts uroot.Opts
@@ -73,11 +49,20 @@ type Options struct {
 	// used as determined by runtime.Caller.
 	Name string
 
-	// Uinit are commands to execute after init.
+	// Uinit is the uinit that should be added to a generated initramfs.
 	//
-	// If populated, a uinit.go will be generated from these and added to
-	// the busybox generated in BuildOpts.Commands.
-	Uinit []string
+	// If none is specified, the generic uinit will be used, which searches for
+	// and runs the script generated from TestCmds.
+	Uinit string
+
+	// TestCmds are commands to execute after init.
+	//
+	// QEMUTest generates an Elvish script with these commands. The script is
+	// shared with the VM, and is run from the generic uinit.
+	TestCmds []string
+
+	// TmpDir is the temporary directory exposed to the QEMU VM.
+	TmpDir string
 
 	// Logger logs build statements.
 	Logger ulog.Logger
@@ -173,7 +158,16 @@ func QEMUTest(t *testing.T, o *Options) (*qemu.VM, func()) {
 		o.UseVVFAT = true
 	}
 
-	qOpts, tmpDir, err := QEMU(o)
+	// Create or reuse a temporary directory. This is exposed to the VM.
+	if o.TmpDir == "" {
+		tmpDir, err := ioutil.TempDir("", "uroot-integration")
+		if err != nil {
+			t.Fatalf("Failed to create temp dir: %v", err)
+		}
+		o.TmpDir = tmpDir
+	}
+
+	qOpts, err := QEMU(o)
 	if err != nil {
 		t.Fatalf("Failed to create QEMU VM %s: %v", o.Name, err)
 	}
@@ -187,10 +181,10 @@ func QEMUTest(t *testing.T, o *Options) (*qemu.VM, func()) {
 	return vm, func() {
 		vm.Close()
 		if t.Failed() {
-			t.Log("Keeping temp dir: ", tmpDir)
-		} else if len(o.BuildOpts.TempDir) == 0 {
-			if err := os.RemoveAll(o.BuildOpts.TempDir); err != nil {
-				t.Logf("failed to remove temporary directory %s: %v", o.BuildOpts.TempDir, err)
+			t.Log("Keeping temp dir: ", o.TmpDir)
+		} else if len(o.TmpDir) == 0 {
+			if err := os.RemoveAll(o.TmpDir); err != nil {
+				t.Logf("failed to remove temporary directory %s: %v", o.TmpDir, err)
 			}
 		}
 	}
@@ -203,13 +197,23 @@ func QEMUTest(t *testing.T, o *Options) (*qemu.VM, func()) {
 // caller either requested (through the Options.Uinit field, for example) or
 // that the caller did not set.
 //
-// QEMU returns the QEMU launch options, the temporary directory exposed to the
-// QEMU VM, or an error.
-func QEMU(o *Options) (*qemu.Options, string, error) {
+// QEMU returns the QEMU launch options or an error.
+func QEMU(o *Options) (*qemu.Options, error) {
 	if len(o.Name) == 0 {
 		o.Name = callerName(2)
 	}
 
+	// Generate Elvish shell script of test commands in o.TmpDir.
+	if len(o.TestCmds) > 0 {
+		testFile := filepath.Join(o.TmpDir, "test.elv")
+
+		if err := ioutil.WriteFile(
+			testFile, []byte(strings.Join(o.TestCmds, "\n")), 0777); err != nil {
+			return nil, err
+		}
+	}
+
+	// Create initramfs if caller did not provide one.
 	if len(o.QEMUOpts.Initramfs) == 0 {
 		if !o.DontSetEnv {
 			env := golang.Default()
@@ -218,54 +222,24 @@ func QEMU(o *Options) (*qemu.Options, string, error) {
 			o.BuildOpts.Env = env
 		}
 
-		var cmds []string
+		cmds := []string{
+			"github.com/u-root/u-root/cmds/core/init",
+			"github.com/u-root/u-root/cmds/core/elvish",
+		}
 		if len(o.BuildOpts.Commands) == 0 {
 			cmds = append(cmds, "github.com/u-root/u-root/cmds/*")
 		}
-		// Create a uinit from the commands given.
-		if len(o.Uinit) > 0 {
-			urootPkg, err := o.BuildOpts.Env.Package("github.com/u-root/u-root/integration")
-			if err != nil {
-				return nil, "", err
-			}
-			testDir := filepath.Join(urootPkg.Dir, "testcmd")
 
-			dirpath, err := ioutil.TempDir(testDir, "uinit-")
-			if err != nil {
-				return nil, "", err
-			}
-			defer os.RemoveAll(dirpath)
-
-			if err := os.MkdirAll(filepath.Join(dirpath, "uinit"), 0755); err != nil {
-				return nil, "", err
-			}
-
-			var realUinit [][]string
-			for _, cmd := range o.Uinit {
-				realUinit = append(realUinit, fields(cmd))
-			}
-
-			if err := ioutil.WriteFile(
-				filepath.Join(dirpath, "uinit", "uinit.go"),
-				[]byte(fmt.Sprintf(template, realUinit)),
-				0755); err != nil {
-				return nil, "", err
-			}
-			cmds = append(cmds, path.Join("github.com/u-root/u-root/integration/testcmd", filepath.Base(dirpath), "uinit"))
+		// If a custom uinit was not provided, use the generic test uinit. This will
+		// try to find and run the test commands shell script.
+		if len(o.Uinit) == 0 {
+			o.Uinit = "github.com/u-root/u-root/integration/testcmd/generic/uinit"
 		}
+		cmds = append(cmds, o.Uinit)
+
 		// Add our commands to the build opts.
-		if len(cmds) > 0 {
-			o.BuildOpts.AddBusyBoxCommands(cmds...)
-		}
+		o.BuildOpts.AddBusyBoxCommands(cmds...)
 
-		// Create or reuse a temporary directory.
-		if len(o.BuildOpts.TempDir) == 0 {
-			tmpDir, err := ioutil.TempDir("", "uroot-integration")
-			if err != nil {
-				return nil, "", err
-			}
-			o.BuildOpts.TempDir = tmpDir
-		}
 		if o.BuildOpts.BaseArchive == nil {
 			o.BuildOpts.BaseArchive = uroot.DefaultRamfs.Reader()
 		}
@@ -278,35 +252,40 @@ func QEMU(o *Options) (*qemu.Options, string, error) {
 			// We need to add elvish so the build will succeed.
 			o.BuildOpts.AddBusyBoxCommands("github.com/u-root/u-root/cmds/core/elvish")
 		}
+		if len(o.BuildOpts.TempDir) == 0 {
+			o.BuildOpts.TempDir = o.TmpDir
+		}
 
 		if o.Logger == nil {
 			o.Logger = log.New(os.Stderr, "", 0)
 		}
 
-		// OutputFile
+		// Set OutputFile so that the initramfs is written to o.TmpDir.
+		// TODO(plaud) what if its non-empty, QEMUOpts initramfs would be ""?
 		var outputFile string
 		if o.BuildOpts.OutputFile == nil {
-			outputFile = filepath.Join(o.BuildOpts.TempDir, "initramfs.cpio")
+			outputFile = filepath.Join(o.TmpDir, "initramfs.cpio")
 			w, err := initramfs.CPIO.OpenWriter(o.Logger, outputFile, "", "")
 			if err != nil {
-				return nil, "", err
+				return nil, err
 			}
 			o.BuildOpts.OutputFile = w
 		}
 
 		// Finally, create an initramfs!
 		if err := uroot.CreateInitramfs(o.Logger, o.BuildOpts); err != nil {
-			return nil, "", err
+			return nil, err
 		}
 
 		o.QEMUOpts.Initramfs = outputFile
+
 	}
 
 	if len(o.QEMUOpts.Kernel) == 0 {
-		// Copy kernel to tmpDir for tests involving kexec.
-		kernel := filepath.Join(o.BuildOpts.TempDir, "kernel")
+		// Copy kernel to o.TmpDir for tests involving kexec.
+		kernel := filepath.Join(o.TmpDir, "kernel")
 		if err := cp.Copy(os.Getenv("UROOT_KERNEL"), kernel); err != nil {
-			return nil, "", err
+			return nil, err
 		}
 		o.QEMUOpts.Kernel = kernel
 	}
@@ -320,11 +299,11 @@ func QEMU(o *Options) (*qemu.Options, string, error) {
 
 	var dir qemu.Device
 	if o.UseVVFAT {
-		dir = qemu.ReadOnlyDirectory{Dir: o.BuildOpts.TempDir}
+		dir = qemu.ReadOnlyDirectory{Dir: o.TmpDir}
 	} else {
-		dir = qemu.P9Directory{Dir: o.BuildOpts.TempDir}
+		dir = qemu.P9Directory{Dir: o.TmpDir}
 	}
 	o.QEMUOpts.Devices = append(o.QEMUOpts.Devices, qemu.VirtioRandom{}, dir)
 
-	return &o.QEMUOpts, o.BuildOpts.TempDir, nil
+	return &o.QEMUOpts, nil
 }

--- a/pkg/vmtest/integration.go
+++ b/pkg/vmtest/integration.go
@@ -244,9 +244,6 @@ func QEMU(o *Options) (*qemu.Options, error) {
 		}
 		if len(o.BuildOpts.DefaultShell) == 0 {
 			o.BuildOpts.DefaultShell = "elvish"
-
-			// We need to add elvish so the build will succeed.
-			o.BuildOpts.AddBusyBoxCommands("github.com/u-root/u-root/cmds/core/elvish")
 		}
 		if len(o.BuildOpts.TempDir) == 0 {
 			o.BuildOpts.TempDir = o.TmpDir

--- a/pkg/vmtest/integration.go
+++ b/pkg/vmtest/integration.go
@@ -153,10 +153,6 @@ func QEMUTest(t *testing.T, o *Options) (*qemu.VM, func()) {
 	if o.QEMUOpts.SerialOutput == nil {
 		o.QEMUOpts.SerialOutput = TestLineWriter(t, "serial")
 	}
-	if TestArch() == "arm" {
-		//currently, 9p does not work on arm
-		o.UseVVFAT = true
-	}
 
 	// Create or reuse a temporary directory. This is exposed to the VM.
 	if o.TmpDir == "" {
@@ -301,7 +297,7 @@ func QEMU(o *Options) (*qemu.Options, error) {
 	if o.UseVVFAT {
 		dir = qemu.ReadOnlyDirectory{Dir: o.TmpDir}
 	} else {
-		dir = qemu.P9Directory{Dir: o.TmpDir}
+		dir = qemu.P9Directory{Dir: o.TmpDir, Arch: TestArch()}
 	}
 	o.QEMUOpts.Devices = append(o.QEMUOpts.Devices, qemu.VirtioRandom{}, dir)
 


### PR DESCRIPTION
Our current test infra builds the test itself into the initramfs, which
means that we cannot separating building and testing or test with a
custom initramfs. To solve this, we separate the test from the
initramfs as follows:

Instead of building a uinit.go with the caller's provided commands, have
a generic uinit.go that finds an Elvish shell script of test commands in
the P9 directory exposed to the VM. This way callers can either 1)
provide a custom uinit or 2) provide commands to run for testing.

As part of that, we add some options to vmtest.Options and change the
tmpDir to be easier to work with.

(I can break this into smaller commits if thats better)