### PR TITLE
scuzz: add ATA identify command

### DIFF
--- a/pkg/scuzz/ata.go
+++ b/pkg/scuzz/ata.go
@@ -14,8 +14,8 @@ const (
 	// don't work and are ugly.
 	// Sure, you can add a nolint tag, but as your
 	//	bidi int8 = -4  nolint:golint,unused
-	//from direction = -3
-	to direction = -2
+	from direction = -3
+	to   direction = -2
 	//none direction = -1
 
 	oldSchoolBlockLen = 512
@@ -54,13 +54,15 @@ const (
 	//	tlenBytes   = 0 << 2  nolint:golint,unused
 	tlenSectors = 1 << 2
 
-	tdirTo = 0 << 3
-	//	tdirFrom  = 1 << 3  nolint:golint,unused
+	tdirTo    = 0 << 3
+	tdirFrom  = 1 << 3
 	checkCond = 1 << 5
 )
 
 // Commands. We only export those we implement.
 const (
+	// identify gets identify information
+	identify = 0xec
 	// securityUnlock unlocks the drive with a given 32-byte password
 	securityUnlock = 0xf2
 )

--- a/pkg/scuzz/control.go
+++ b/pkg/scuzz/control.go
@@ -4,28 +4,11 @@
 
 package scuzz
 
-// Request is an interface for scuzz requests.
-// Different kernels have different ways of defining
-// a request. The most common is ioctl, and will require
-// a Cmd and a Packet, passed as uintptr.
-// Some systems, e.g. Plan9, will require a string.
-type Request interface {
-	Cmd() uintptr
-	Packet() uintptr
-	String() string
-}
-
 // Disk is the interface to a disk, with operations
 // to create packets and operate on them.
 type Disk interface {
-	// UnlockRequest generates an unlock Request
-	UnlockRequest(string, uint, bool) Request
-	// Operate performs the operation defined in Request on the Disk.
-	Operate(Request) error
-}
-
-// Unlock unlocks a disk using a password and timeout.
-func Unlock(d Disk, password string, timeout uint, master bool) error {
-	p := d.UnlockRequest(password, timeout, master)
-	return d.Operate(p)
+	// Unlock unlocks the drive, given a password
+	Unlock(string, uint, bool) error
+	// Identify returns drive identity information
+	Identify(timeout uint) error
 }

--- a/pkg/scuzz/sg_linux_test.go
+++ b/pkg/scuzz/sg_linux_test.go
@@ -100,7 +100,7 @@ func TestSizes(t *testing.T) {
 	}
 }
 
-func TestWriteUnlock(t *testing.T) {
+func TestUnlock(t *testing.T) {
 	Debug = t.Logf
 	// This command: ./hdparm --security-unlock 12345678901234567890123456789012 /dev/null
 	// yields this header and data to ioctl(fd, SECURITY_UNLOCK, ...)
@@ -139,7 +139,47 @@ func TestWriteUnlock(t *testing.T) {
 				0x31, 0x32,
 			},
 		}
+		//sb statusBlock
 	)
-	r := (&SGDisk{dev: 0x40}).UnlockRequest("12345678901234567890123456789012", 15000, true)
-	check(t, r.(*sgRequest).packet, want)
+	p := (&SGDisk{dev: 0x40}).unlockPacket("12345678901234567890123456789012", 15000, true)
+	check(t, p, want)
+}
+
+func TestIdentify(t *testing.T) {
+	Debug = t.Logf
+	// The 'want' data is derived from a modified version of hdparm (github.com/rminnich/hdparmm)
+	// which prints the ioctl parameters as initialized go structs.
+	var (
+		want = &packet{
+			packetHeader: packetHeader{
+				interfaceID:       'S',
+				direction:         -3,
+				cmdLen:            16,
+				maxStatusBlockLen: 32,
+				iovCount:          0,
+				dataLen:           512,
+				data:              0,
+				cdb:               0,
+				sb:                0,
+				timeout:           15000,
+				flags:             0,
+				packID:            0,
+				usrPtr:            0,
+				status:            0,
+				maskedStatus:      0,
+				msgStatus:         0,
+				sbLen:             0,
+				hostStatus:        0,
+				driverStatus:      0,
+				resID:             0,
+				duration:          0,
+				info:              0,
+			},
+			command: commandDataBlock{0x85, 0x08, 0x0e, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0xec, 0x00},
+		}
+		// TODO: check status block. Requires a qemu device that supports these operations.
+		//sb = statusBlock{0x70, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+	)
+	p := (&SGDisk{dev: 0x40}).identifyPacket(15000)
+	check(t, p, want)
 }


### PR DESCRIPTION
The ATA identify reads information from those disks
which support the command.

This PR adds the Response interface, which allows programs
to query the result.

We separate what look like transport errors, i.e. the system
call failed for some reason, from target errors, i.e. the system
call worked but the drive rejected the command. The kernel does
not make such a seperation, which calls our seperation into
question.

Error determination from the status block is a work in progress,
not expected to be completed quickly.

This is nevertheless a basic starting point for an identify.