### PR TITLE
hostname: Add support to set system hostname

### DIFF
--- a/cmds/core/hostname/hostname.go
+++ b/cmds/core/hostname/hostname.go
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Print the system's hostname.
+// Print or set the system's hostname.
 //
 // Synopsis:
-//     hostname
+//     hostname [HOSTNAME]
 //
 // Author:
 //     Beletti <rhiguita@gmail.com>
@@ -15,13 +15,26 @@ import (
 	"fmt"
 	"log"
 	"os"
+
+	"golang.org/x/sys/unix"
 )
 
 func main() {
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Fatalf("could not obtain hostname: %v", err)
-	}
+	if len(os.Args) == 2 {
+		newHostname := os.Args[1]
 
-	fmt.Println(hostname)
+		err := unix.Sethostname([]byte(newHostname))
+		if err != nil {
+			log.Fatalf("could not set hostname: %v", err)
+		}
+	} else if len(os.Args) == 1 {
+		hostname, err := os.Hostname()
+		if err != nil {
+			log.Fatalf("could not obtain hostname: %v", err)
+		}
+
+		fmt.Println(hostname)
+	} else {
+		log.Fatalf("usage: hostname [HOSTNAME]")
+	}
 }


### PR DESCRIPTION
Add support to set system hostname, like the standard hostname command.

Signed-off-by: Martin Lucina <martin@lucina.net>