### PR TITLE
RunBSD!

### DIFF
--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -159,12 +159,12 @@ func CreateFileInRoot(f Record, rootDir string, forcePriv bool) error {
 		}
 
 	case os.ModeDevice:
-		if err := syscall.Mknod(f.Name, perm(f)|syscall.S_IFBLK, dev(f)); err != nil && forcePriv {
+		if err := mknod(f.Name, perm(f)|syscall.S_IFBLK, dev(f)); err != nil && forcePriv {
 			return err
 		}
 
 	case os.ModeCharDevice:
-		if err := syscall.Mknod(f.Name, perm(f)|syscall.S_IFCHR, dev(f)); err != nil && forcePriv {
+		if err := mknod(f.Name, perm(f)|syscall.S_IFCHR, dev(f)); err != nil && forcePriv {
 			return err
 		}
 

--- a/pkg/cpio/mknod_freebsd.go
+++ b/pkg/cpio/mknod_freebsd.go
@@ -1,0 +1,13 @@
+// Copyright 2013-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cpio
+
+import (
+	"syscall"
+)
+
+func mknod(path string, mode uint32, dev int) (err error) {
+	return syscall.Mknod(path, mode, uint64(dev))
+}

--- a/pkg/cpio/mknod_unix.go
+++ b/pkg/cpio/mknod_unix.go
@@ -1,0 +1,15 @@
+// Copyright 2013-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !freebsd
+
+package cpio
+
+import (
+	"syscall"
+)
+
+func mknod(path string, mode uint32, dev int) (err error) {
+	return syscall.Mknod(path, mode, dev)
+}

--- a/pkg/cpio/sysinfo_freebsd.go
+++ b/pkg/cpio/sysinfo_freebsd.go
@@ -1,0 +1,25 @@
+// Copyright 2013-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cpio
+
+import (
+	"syscall"
+)
+
+func sysInfo(n string, sys *syscall.Stat_t) Info {
+	return Info{
+		Ino:      sys.Ino,
+		Mode:     uint64(sys.Mode),
+		UID:      uint64(sys.Uid),
+		GID:      uint64(sys.Gid),
+		NLink:    sys.Nlink,
+		FileSize: uint64(sys.Size),
+		Major:    sys.Dev >> 8,
+		Minor:    sys.Dev & 0xff,
+		Rmajor:   sys.Rdev >> 8,
+		Rminor:   sys.Rdev & 0xff,
+		Name:     n,
+	}
+}

--- a/pkg/ldd/ldso_freebsd.go
+++ b/pkg/ldd/ldso_freebsd.go
@@ -1,0 +1,26 @@
+// Copyright 2017-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ldd
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// LdSo finds the loader binary.
+func LdSo(bit64 bool) (string, error) {
+	path := "/libexec/ld-elf32.so.*"
+	if bit64 {
+		path = "/libexec/ld-elf.so.*"
+	}
+	n, err := filepath.Glob(path)
+	if err != nil {
+		return "", err
+	}
+	if len(n) > 0 {
+		return n[0], nil
+	}
+	return "", fmt.Errorf("could not find ld.so in %v", path)
+}


### PR DESCRIPTION
That's all it takes to build on FreeBSD. :) I'm not entirely happy about `mknod_{linux,darwin}.go` being the same. Bear with me, I'm new to Gopherland. Does it even work like that on Darwin? It is just a comment here: https://golang.org/src/syscall/syscall_darwin.go?s=3188:3245#L293