### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ for system firmwares.
 
 More detailed information about the build process for a full LinuxBoot firmware
 image using u-root/systemboot and coreboot can be found in the
-[LinuxBoot book](https://github.com/linuxboot/book) chapter 11,
-[LinuxBoot using coreboot, u-root and systemboot](https://github.com/linuxboot/book/blob/master/11.coreboot.u-root.systemboot/README.md).
+[LinuxBoot book](https://github.com/linuxboot/book) chapter 10,
+[LinuxBoot using coreboot, u-root and systemboot](https://github.com/linuxboot/book/blob/master/coreboot.u-root.systemboot/README.md).
 
 # Usage
 


### PR DESCRIPTION
LinuxBoot book chapter 11 changed to chapter 10 which resulted in broken link.