### PR TITLE
Add audible feature to cmds/core/ping

### DIFF
--- a/cmds/core/ping/ping.go
+++ b/cmds/core/ping/ping.go
@@ -14,6 +14,7 @@
 //     -i: interval in milliseconds (default: 1000)
 //     -V: version
 //     -w: wait time in milliseconds (default: 100)
+//     -a: Audible rings a bell when a packet is received
 //     -h: help
 package main
 
@@ -34,6 +35,7 @@ var (
 	intv       = flag.Int("i", 1000, "interval in milliseconds")
 	version    = flag.Bool("V", false, "version")
 	wtf        = flag.Int("w", 100, "wait time in milliseconds")
+	audible    = flat.Bool("a", false, "Audible rings a bell when a packet is received")
 )
 
 const (
@@ -44,7 +46,7 @@ const (
 )
 
 func usage() {
-	fmt.Fprintf(os.Stdout, "ping [-V] [-c count] [-i interval] [-s packetsize] [-w deadline] destination\n")
+	fmt.Fprintf(os.Stdout, "ping [-V] [-a] [-c count] [-i interval] [-s packetsize] [-w deadline] destination\n")
 	os.Exit(0)
 }
 
@@ -157,6 +159,9 @@ func main() {
 		msg, err := ping1(netname, host, i)
 		if err != nil {
 			log.Fatalf("ping failed: %v", err)
+		}
+		if *audible {
+			fmt.Print("\a")
 		}
 		log.Print(msg)
 		time.Sleep(time.Millisecond * interval)


### PR DESCRIPTION
This PR adds an optional (-a) audible flag to cmds/core/ping.
This was a todo-feature on the roadmap for which I opened issue #1445 

Signed-off-by: Tim Rots tim.rots@protonmail.ch

