### PR TITLE
Update circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,4 +171,4 @@ jobs:
   test-integration-arm:
     <<: *integration-template
     docker:
-      - image: uroottest/test-image-arm:3.0.2
+      - image: uroottest/test-image-arm:v3.0.3

--- a/.circleci/images/test-image-arm/Dockerfile
+++ b/.circleci/images/test-image-arm/Dockerfile
@@ -19,6 +19,8 @@ RUN sudo apt-get update &&                          \
         libfdt-dev                                  \
         libpixman-1-dev                             \
         zlib1g-dev                                  \
+	libcap-dev                                  \
+	libattr1-dev                                \
         `# Linux kernel build deps`                 \
         libelf-dev &&                               \
     sudo rm -rf /var/lib/apt/lists/*
@@ -48,6 +50,7 @@ RUN set -eux;                                                          \
     cd build;                                                          \
     ../configure                                                       \
         --target-list=arm-softmmu                                      \
+        --enable-virtfs                                                \
         --disable-docs                                                 \
         --disable-sdl                                                  \
         --disable-kvm;                                                 \


### PR DESCRIPTION
We want to update the ARM QEMUused in our circleci tests to
have 9p support (since we are changing our vm tests to always use 9p).
This updates the configs and Dockerfile to reflect that.

Signed-off-by: pallaud <plaud@google.com>