### PR TITLE
refactor boot commands to use pkg/boot and avoid unnecessary file copy

### DIFF
--- a/pkg/boot/linux.go
+++ b/pkg/boot/linux.go
@@ -72,6 +72,12 @@ func (li *LinuxImage) Load(verbose bool) error {
 		initrd = progress(initrd)
 	}
 
+	// It seams inefficient to always copy, in particular when the reader
+	// is an io.File but that's not sufficient, os.File could be a socket,
+	// a pipe or some other strange thing. Also kexec_file_load will fail
+	// (similar to execve) if anything as the file opened for writing.
+	// That's unfortunately something we can't guarantee here - unless we
+	// make a copy of the file and dump it somewhere.
 	k, err := copyToFile(kernel)
 	if err != nil {
 		return err


### PR DESCRIPTION
This relates to:
https://github.com/u-root/u-root/issues/751
https://github.com/u-root/u-root/issues/1054
https://github.com/u-root/u-root/pull/1283
https://github.com/u-root/u-root/pull/1241

I'm currently starting from the boot/boot command as it uses less packages so almost everything is in the same file.