### PR TITLE
Fix option parsing for dhcp6 package

### DIFF
--- a/pkg/dhclient/dhcp6.go
+++ b/pkg/dhclient/dhcp6.go
@@ -114,7 +114,7 @@ func (p *Packet6) DNS() []net.IP {
 // in the packet.
 func (p *Packet6) Boot() (*url.URL, error) {
 	uriOpt := p.p.GetOneOption(dhcpv6.OptionBootfileURL)
-	uri, ok := uriOpt.(*dhcpv6.OptBootFileURL)
+	uri, ok := uriOpt.(dhcpv6.OptBootFileURL)
 	if !ok {
 		return nil, fmt.Errorf("packet does not contain boot file URL")
 	}
@@ -129,7 +129,7 @@ func (p *Packet6) Boot() (*url.URL, error) {
 // 4173 and RFC 5970.
 func (p *Packet6) ISCSIBoot() (*net.TCPAddr, string, error) {
 	uriOpt := p.p.GetOneOption(dhcpv6.OptionBootfileURL)
-	uri, ok := uriOpt.(*dhcpv6.OptBootFileURL)
+	uri, ok := uriOpt.(dhcpv6.OptBootFileURL)
 	if !ok {
 		return nil, "", fmt.Errorf("packet does not contain boot file URL")
 	}


### PR DESCRIPTION
The return value is an Option, not an option pointer.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>