### PR TITLE
pkg/ulog: move test logger in a sub package

### DIFF
--- a/pkg/ulog/log.go
+++ b/pkg/ulog/log.go
@@ -7,12 +7,12 @@
 // ulog has three implementations of the Logger interface: a Go standard
 // library "log" package Logger, a kernel syslog (dmesg) Logger, and a test
 // Logger that logs via a test's testing.TB.Logf.
+// To use the test logger import "ulog/ulogtest".
 package ulog
 
 import (
 	"log"
 	"os"
-	"testing"
 )
 
 // Logger is a log receptacle.
@@ -25,18 +25,3 @@ type Logger interface {
 
 // Log is a Logger that prints to stderr, like the default log package.
 var Log = log.New(os.Stderr, "", log.LstdFlags)
-
-// TestLogger is a Logger implementation that logs to testing.TB.Logf.
-type TestLogger struct {
-	TB testing.TB
-}
-
-// Printf formats according to the format specifier and prints to a unit test's log.
-func (tl TestLogger) Printf(format string, v ...interface{}) {
-	tl.TB.Logf(format, v...)
-}
-
-// Print formats according the default formats for v and prints to a unit test's log.
-func (tl TestLogger) Print(v ...interface{}) {
-	tl.TB.Log(v...)
-}

--- a/pkg/ulog/ulogtest/log.go
+++ b/pkg/ulog/ulogtest/log.go
@@ -1,0 +1,25 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package ulogtest implement the Logger interface via a test's testing.TB.Logf.
+package ulogtest
+
+import (
+	"testing"
+)
+
+// Logger is a Logger implementation that logs to testing.TB.Logf.
+type Logger struct {
+	TB testing.TB
+}
+
+// Printf formats according to the format specifier and prints to a unit test's log.
+func (tl Logger) Printf(format string, v ...interface{}) {
+	tl.TB.Logf(format, v...)
+}
+
+// Print formats according the default formats for v and prints to a unit test's log.
+func (tl Logger) Print(v ...interface{}) {
+	tl.TB.Log(v...)
+}

--- a/pkg/vmtest/integration.go
+++ b/pkg/vmtest/integration.go
@@ -19,6 +19,7 @@ import (
 	"github.com/u-root/u-root/pkg/qemu"
 	"github.com/u-root/u-root/pkg/uio"
 	"github.com/u-root/u-root/pkg/ulog"
+	"github.com/u-root/u-root/pkg/ulog/ulogtest"
 	"github.com/u-root/u-root/pkg/uroot"
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
 )
@@ -148,7 +149,7 @@ func QEMUTest(t *testing.T, o *Options) (*qemu.VM, func()) {
 		o.Name = callerName(2)
 	}
 	if o.Logger == nil {
-		o.Logger = &ulog.TestLogger{t}
+		o.Logger = &ulogtest.Logger{TB: t}
 	}
 	if o.QEMUOpts.SerialOutput == nil {
 		o.QEMUOpts.SerialOutput = TestLineWriter(t, "serial")


### PR DESCRIPTION
While using u-root in bb mode I noticed that commands using the "flag"
package got all the -test.* flags in their help message.
Removing the "testing" package from the default build fixes this.

Signed-off-by: Julien Viard de Galbert <julien.viard-de-galbert@itrenew.com>