### PR TITLE
Boot parsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ u-root embodies four different projects.
 *   Go bootloaders that use `kexec` to boot Linux or multiboot kernels such as
     ESXi, Xen, or tboot. They are meant to be used with
     [LinuxBoot](https://www.linuxboot.org). With that, parsers for
-    [GRUB config files](pkg/boot/diskboot) or
+    [GRUB config files](pkg/boot/grub) or
     [syslinux config files](pkg/boot/syslinux) are to make transition to
     LinuxBoot easier.
 

--- a/pkg/boot/grub/echo_test.go
+++ b/pkg/boot/grub/echo_test.go
@@ -1,0 +1,136 @@
+// Copyright 2017-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package grub
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/curl"
+)
+
+var update = flag.Bool("run-bash", false, "run bash and update golden file")
+
+// TestMain is used to warp a go utility in the same test binary
+// when the environment variable BE_ECHO is set to 1, the binary will echo its
+// parameters using the %#v format string, so the parameters are escaped and can
+// be recovered.
+func TestMain(m *testing.M) {
+	if os.Getenv("BE_ECHO") == "1" {
+		fmt.Printf("echo:%#v\n", os.Args[1:])
+		return
+	} // call flag.Parse() here if TestMain uses flags
+	os.Exit(m.Run())
+}
+
+// TestHelperEcho tests the echo wrapper in TestMain
+func TestHelperEcho(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "echothis")
+	cmd.Env = append(os.Environ(), "BE_ECHO=1")
+	out, err := cmd.Output()
+	t.Logf("%q\n", out)
+	if err != nil {
+		t.Fatalf("process ran with err %v", err)
+	}
+	want := "echo:[]string{\"echothis\"}\n"
+	if string(out) != want {
+		t.Fatalf("wrong process output got `%s` want `%s`", out, want)
+	}
+}
+
+// TestBashWrapper tests that the "./testdata/bash_wrapper.sh" works as expected
+// bash_wrapper.sh is a script that replace the internal command echo with its
+// first argument and source its second argument.
+// The goal is to be able to run grub's tests scripts, see TestGrubTests
+func TestBashWrapper(t *testing.T) {
+	if !*update {
+		t.Skip("use -run-bash flag to run this")
+	}
+	cmd := exec.Command("./testdata/bash_wrapper.sh", os.Args[0], "./testdata/test_bash_wrapper.sh")
+	cmd.Env = append(os.Environ(), "BE_ECHO=1")
+	out, err := cmd.Output()
+	t.Logf("%q\n", out)
+	if err != nil {
+		t.Fatalf("process ran with err %v", err)
+	}
+	want := "echo:[]string{\"param1\", \"param2\"}\n"
+	if string(out) != want {
+		t.Fatalf("wrong process output got `%s` want `%s`", out, want)
+	}
+}
+
+// TestGrubTests run tests imported from grub source to check our parser
+// grub has tests in for of scripts that are run both by grub and bash, they
+// mostly use echo and the test then compare the output of both runs.
+// In our case we don't want to compare the output of echo, but get the token
+// passed to echo. So we replace the echo command in bash with the wrapper (see
+// above). We can then compare the bash output to our parser output.
+// Also to avoid keeping the dependency on bash, the output are saved in the
+// golden files. One must run the test with '-run-bash' to update the golden
+// files in case new tests are added or the echo format is changed.
+func TestGrubTests(t *testing.T) {
+	files, err := filepath.Glob("testdata/*.in")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, file := range files {
+		name := strings.TrimSuffix(filepath.Base(file), ".in")
+		t.Run(name, func(t *testing.T) {
+			golden := strings.TrimSuffix(file, ".in") + ".out"
+			var out []byte
+			if *update {
+				cmd := exec.Command("./testdata/bash_wrapper.sh", os.Args[0], file)
+				cmd.Env = append(os.Environ(), "BE_ECHO=1")
+				out, err = cmd.Output()
+				//t.Logf("%s\n", out)
+				if err != nil {
+					t.Fatalf("process ran with err %v", err)
+				}
+			} else {
+				out, err = ioutil.ReadFile(golden)
+				if err != nil {
+					t.Fatalf("error loading file `%s`, %v", golden, err)
+				}
+			}
+			// parse with our parser and compare
+			var b bytes.Buffer
+			wd := &url.URL{
+				Scheme: "file",
+				Path:   "./testdata",
+			}
+			c := newParserWithSchemes(wd, curl.DefaultSchemes)
+			c.W = &b
+
+			script, err := ioutil.ReadFile(file)
+			if err != nil {
+				t.Fatalf("error loading file `%s`, %v", file, err)
+			}
+			err = c.append(string(script))
+			if err != nil {
+				t.Fatalf("error parsing file `%s`, %v", file, err)
+			}
+
+			if b.String() != string(out) {
+				t.Fatalf("wrong script parsing output got `%s` want `%s`", b.String(), string(out))
+			}
+			// update/create golden file on success
+			if *update {
+				err := ioutil.WriteFile(golden, out, 0644)
+				if err != nil {
+					t.Fatalf("error writing file `%s`, %v", file, err)
+				}
+			}
+		})
+
+	}
+}

--- a/pkg/boot/grub/grub.go
+++ b/pkg/boot/grub/grub.go
@@ -1,0 +1,405 @@
+// Copyright 2017-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package grub implements a grub config file parser.
+//
+// See the grub manual https://www.gnu.org/software/grub/manual/grub/ for
+// a reference of the configuration format
+// In particular the following pages:
+// - https://www.gnu.org/software/grub/manual/grub/html_node/Shell_002dlike-scripting.html
+// - https://www.gnu.org/software/grub/manual/grub/html_node/Commands.html
+//
+// Currently, only the linux[16|efi], initrd[16|efi], menuentry and set
+// directives are partially supported.
+package grub
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net/url"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/u-root/u-root/pkg/boot"
+	"github.com/u-root/u-root/pkg/boot/multiboot"
+	"github.com/u-root/u-root/pkg/curl"
+	"github.com/u-root/u-root/pkg/uio"
+)
+
+var (
+	// ErrDefaultEntryNotFound is returned when the configuration file
+	// names a default label that is not part of the configuration.
+	ErrDefaultEntryNotFound = errors.New("default variable not set in configuration")
+	// ErrInitrdUsedWithoutLinux is returned when an initrd directive is
+	// not following a linux directive in the same menu entry
+	ErrInitrdUsedWithoutLinux = errors.New("missing linux directive before initrd")
+	// ErrModuleUsedWithoutMultiboot is returned when a module directive is
+	// not following a multiboot directive in the same menu entry
+	ErrModuleUsedWithoutMultiboot = errors.New("missing multiboot directive before module")
+)
+
+// Config encapsulates a parsed grub configuration file.
+type Config struct {
+	// Entries is a map of label name -> label configuration.
+	Entries map[string]boot.OSImage
+
+	// DefaultEntry is the default label key to use.
+	//
+	// If DefaultEntry is non-empty, the label is guaranteed to exist in
+	// `Entries`.
+	DefaultEntry string
+}
+
+// ParseConfigFile parses a grub configuration as specified in
+// https://www.gnu.org/software/grub/manual/grub/
+//
+// Currently, only the linux[16|efi], initrd[16|efi], menuentry and set
+// directives are partially supported.
+//
+// curl.DefaultSchemes is used to fetch any files that must be parsed or
+// provided.
+//
+// `wd` is the default scheme, host, and path for any files named as a
+// relative path - e.g. kernel, include, and initramfs paths are requested
+// relative to the wd.
+func ParseConfigFile(url string, wd *url.URL) (*Config, error) {
+	return ParseConfigFileWithSchemes(curl.DefaultSchemes, url, wd)
+}
+
+// ParseConfigFileWithSchemes is like ParseConfigFile, but uses the given
+// schemes explicitly.
+func ParseConfigFileWithSchemes(s curl.Schemes, url string, wd *url.URL) (*Config, error) {
+	p := newParserWithSchemes(wd, s)
+	if err := p.appendFile(url); err != nil {
+		return nil, err
+	}
+	return p.config, nil
+}
+
+type parser struct {
+	config *Config
+	W      io.Writer
+
+	// parser internals.
+	scope    scope
+	numEntry int
+	curEntry string
+	curLabel string
+	wd       *url.URL
+	schemes  curl.Schemes
+}
+
+type scope uint8
+
+const (
+	scopeGlobal scope = iota
+	scopeEntry
+)
+
+// newParserWithSchemes returns a new grub parser using working directory `wd`
+// and schemes `s`.
+//
+// If a path encountered in a configuration file is relative instead of a full
+// URL, `wd` is used as the "working directory" of that relative path; the
+// resulting URL is roughly `wd.String()/path`.
+//
+// `s` is used to get files referred to by URLs.
+func newParserWithSchemes(wd *url.URL, s curl.Schemes) *parser {
+	return &parser{
+		config: &Config{
+			Entries: make(map[string]boot.OSImage),
+		},
+		scope:   scopeGlobal,
+		wd:      wd,
+		schemes: s,
+	}
+}
+
+func parseURL(surl string, wd *url.URL) (*url.URL, error) {
+	u, err := url.Parse(surl)
+	if err != nil {
+		return nil, fmt.Errorf("could not parse URL %q: %v", surl, err)
+	}
+
+	if len(u.Scheme) == 0 {
+		u.Scheme = wd.Scheme
+
+		if len(u.Host) == 0 {
+			// If this is not there, it was likely just a path.
+			u.Host = wd.Host
+			u.Path = filepath.Join(wd.Path, filepath.Clean(u.Path))
+		}
+	}
+	return u, nil
+}
+
+// getFile parses `url` relative to the config's working directory and returns
+// an io.Reader for the requested url.
+//
+// If url is just a relative path and not a full URL, c.wd is used as the
+// "working directory" of that relative path; the resulting URL is roughly
+// path.Join(wd.String(), url).
+func (c *parser) getFile(url string) (io.ReaderAt, error) {
+	u, err := parseURL(url, c.wd)
+	if err != nil {
+		return nil, err
+	}
+
+	return c.schemes.LazyFetch(u)
+}
+
+// appendFile parses the config file downloaded from `url` and adds it to `c`.
+func (c *parser) appendFile(url string) error {
+	r, err := c.getFile(url)
+	if err != nil {
+		return err
+	}
+	config, err := uio.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	if len(config) > 500 {
+		// Avoid flooding the console on real systems
+		// TODO: do we want to pass a verbose flag or a logger?
+		log.Printf("Got config file %s", r)
+	} else {
+		log.Printf("Got config file %s:\n%s\n", r, string(config))
+	}
+	return c.append(string(config))
+}
+
+func isWhitespace(b byte) bool {
+	return b == '\t' || b == '\n' || b == '\v' ||
+		b == '\f' || b == '\r' || b == ' '
+}
+
+type quote uint8
+
+const (
+	unquoted quote = iota
+	escape
+	singleQuote
+	doubleQuote
+	doubleQuoteEscape
+	comment
+)
+
+// Fields splits a grub line and unquote it's components according to
+// https://www.gnu.org/software/grub/manual/grub/grub.html#Quoting
+// except that the escaping of newline is not supported
+func fields(s string) []string {
+	var ret []string
+	var token []byte
+
+	var context quote
+	lastWhiteSpace := true
+	for i := range []byte(s) {
+		quotes := context != unquoted
+		switch context {
+		case unquoted:
+			switch s[i] {
+			case '\\':
+				context = escape
+				// strip out the quote
+				continue
+			case '\'':
+				context = singleQuote
+				// strip out the quote
+				continue
+			case '"':
+				context = doubleQuote
+				// strip out the quote
+				continue
+			case '#':
+				if lastWhiteSpace {
+					context = comment
+					// strip out the rest
+					continue
+				}
+			}
+
+		case escape:
+			context = unquoted
+
+		case singleQuote:
+			if s[i] == '\'' {
+				context = unquoted
+				// strip out the quote
+				continue
+			}
+
+		case doubleQuote:
+			switch s[i] {
+			case '\\':
+				context = doubleQuoteEscape
+				// strip out the quote
+				continue
+			case '"':
+				context = unquoted
+				// strip out the quote
+				continue
+			}
+
+		case doubleQuoteEscape:
+			switch s[i] {
+			case '$', '"', '\\', '\n': // or newline
+			default:
+				token = append(token, '\\')
+			}
+
+			context = doubleQuote
+
+		case comment:
+			// should end on newline
+
+			// strip out the rest
+			continue
+
+		}
+
+		lastWhiteSpace = isWhitespace(s[i])
+
+		if !isWhitespace(s[i]) || quotes {
+			token = append(token, s[i])
+		} else if len(token) > 0 {
+			ret = append(ret, string(token))
+			token = token[:0]
+		}
+	}
+
+	if len(token) > 0 {
+		ret = append(ret, string(token))
+	}
+	return ret
+}
+
+// CmdlineQuote quotes the command line as grub-core/lib/cmdline.c does
+func cmdlineQuote(args []string) string {
+	q := make([]string, len(args))
+	for i, s := range args {
+		s = strings.Replace(s, `\`, `\\`, -1)
+		s = strings.Replace(s, `'`, `\'`, -1)
+		s = strings.Replace(s, `"`, `\"`, -1)
+		if strings.ContainsRune(s, ' ') {
+			s = `"` + s + `"`
+		}
+		q[i] = s
+	}
+	return strings.Join(q, " ")
+}
+
+// Append parses `config` and adds the respective configuration to `c`.
+func (c *parser) append(config string) error {
+	// Here's a shitty parser.
+	for _, line := range strings.Split(config, "\n") {
+		kv := fields(line)
+		if len(kv) < 1 {
+			continue
+		}
+		directive := strings.ToLower(kv[0])
+		// Used by tests (allow no parameters here)
+		if c.W != nil && directive == "echo" {
+			fmt.Fprintf(c.W, "echo:%#v\n", kv[1:])
+		}
+
+		if len(kv) <= 1 {
+			continue
+		}
+		arg := kv[1]
+
+		switch directive {
+		case "set":
+			vals := strings.SplitN(arg, "=", 2)
+			if len(vals) == 2 {
+				//TODO handle vars? bootVars[vals[0]] = vals[1]
+				//log.Printf("grubvar: %s=%s", vals[0], vals[1])
+				if vals[0] == "default" {
+					c.config.DefaultEntry = vals[1]
+				}
+			}
+
+		case "configfile":
+			// TODO test that
+			if err := c.appendFile(arg); err != nil {
+				return err
+			}
+
+		case "menuentry":
+			c.scope = scopeEntry
+			c.curEntry = strconv.Itoa(c.numEntry)
+			c.curLabel = arg
+			c.numEntry++
+
+		case "linux", "linux16", "linuxefi":
+			k, err := c.getFile(arg)
+			if err != nil {
+				return err
+			}
+			// from grub manual: "Any initrd must be reloaded after using this command" so we can replace the entry
+			entry := &boot.LinuxImage{
+				Name:    c.curLabel,
+				Kernel:  k,
+				Cmdline: cmdlineQuote(kv[2:]),
+			}
+			c.config.Entries[c.curEntry] = entry
+			c.config.Entries[c.curLabel] = entry
+
+		case "initrd", "initrd16", "initrdefi":
+			i, err := c.getFile(arg)
+			if err != nil {
+				return err
+			}
+			entry, ok := c.config.Entries[c.curEntry].(*boot.LinuxImage)
+			if !ok {
+				return ErrInitrdUsedWithoutLinux
+			}
+			entry.Initrd = i
+
+		case "multiboot":
+			// TODO handle --quirk-* arguments ? (change parsing)
+			k, err := c.getFile(arg)
+			if err != nil {
+				return err
+			}
+			// from grub manual: "Any initrd must be reloaded after using this command" so we can replace the entry
+			entry := &boot.MultibootImage{
+				Name:    c.curLabel,
+				Kernel:  k,
+				Cmdline: cmdlineQuote(kv[2:]),
+			}
+			c.config.Entries[c.curEntry] = entry
+			c.config.Entries[c.curLabel] = entry
+
+		case "module":
+			// TODO handle --nounzip arguments ? (change parsing)
+			m, err := c.getFile(arg)
+			if err != nil {
+				return err
+			}
+			entry, ok := c.config.Entries[c.curEntry].(*boot.MultibootImage)
+			if !ok {
+				return ErrModuleUsedWithoutMultiboot
+			}
+			// TODO: Lasy tryGzipFilter(m)
+			mod := multiboot.Module{
+				Module:  m,
+				Name:    arg,
+				CmdLine: cmdlineQuote(kv[2:]),
+			}
+			entry.Modules = append(entry.Modules, mod)
+
+		}
+	}
+
+	if len(c.config.DefaultEntry) > 0 {
+		if _, ok := c.config.Entries[c.config.DefaultEntry]; !ok {
+			return ErrDefaultEntryNotFound
+		}
+	}
+	return nil
+
+}

--- a/pkg/boot/grub/grub_test.go
+++ b/pkg/boot/grub/grub_test.go
@@ -1,0 +1,100 @@
+// Copyright 2017-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package grub
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestFields(t *testing.T) {
+	for i, tt := range []struct {
+		desc string
+		in   string
+		want []string
+	}{
+		{
+			desc: "nothing to do",
+			in:   "stuff",
+			want: []string{"stuff"},
+		},
+		{
+			desc: "split",
+			in:   "stuff more stuff",
+			want: []string{"stuff", "more", "stuff"},
+		},
+		{
+			desc: "escape",
+			in:   "stuff\\ more stuff",
+			want: []string{"stuff more", "stuff"},
+		},
+		{
+			desc: "quote",
+			in:   "stuff var='more stuff'",
+			want: []string{"stuff", "var=more stuff"},
+		},
+		{
+			desc: "double quote",
+			in:   "stuff var=\"more stuff\"",
+			want: []string{"stuff", "var=more stuff"},
+		},
+		{
+			desc: "quote specials",
+			in:   "stuff var='more stuff $ \\ \\$ \" '",
+			want: []string{"stuff", "var=more stuff $ \\ \\$ \" "},
+		},
+		{
+			desc: "double quote",
+			in:   "stuff var=\"more stuff $ \\ \\$ \\\" \"",
+			want: []string{"stuff", "var=more stuff $ \\ $ \" "},
+		},
+	} {
+		t.Run(fmt.Sprintf("Test [%02d] %s", i, tt.desc), func(t *testing.T) {
+			got := fields(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("fields = %#v, want %#v", got, tt.want)
+			}
+
+		})
+	}
+}
+
+func TestCmdlineQuote(t *testing.T) {
+	for i, tt := range []struct {
+		desc string
+		in   []string
+		want string
+	}{
+		{
+			desc: "nothing to do",
+			in:   []string{"stuff"},
+			want: "stuff",
+		},
+		{
+			desc: "split",
+			in:   []string{"stuff", "more", "stuff"},
+			want: "stuff more stuff",
+		},
+		{
+			desc: "escape",
+			in:   []string{`escape\quote'double"`},
+			want: `escape\\quote\'double\"`,
+		},
+		{
+			desc: "quote spaced",
+			in:   []string{`some stuff`},
+			want: `"some stuff"`,
+		},
+	} {
+		t.Run(fmt.Sprintf("Test [%02d] %s", i, tt.desc), func(t *testing.T) {
+			got := cmdlineQuote(tt.in)
+			if got != tt.want {
+				t.Errorf("cmdlineQuote = %#v, want %#v", got, tt.want)
+			}
+
+		})
+	}
+}

--- a/pkg/boot/grub/testdata/bash_wrapper.sh
+++ b/pkg/boot/grub/testdata/bash_wrapper.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# this wrapper calls $1 instead of the buildin for echo while running $2
+echocmd=$1
+enable -n echo
+mkdir testdata/bin
+echo "#!/bin/bash" > testdata/bin/echo
+echo "$echocmd \"\$@\"" >> testdata/bin/echo
+chmod +x testdata/bin/echo
+export PATH=$(realpath testdata/bin):$PATH
+
+source $2

--- a/pkg/boot/grub/testdata/example_grub_script_test.in
+++ b/pkg/boot/grub/testdata/example_grub_script_test.in
@@ -1,0 +1,3 @@
+#! @builddir@/grub-shell-tester --modules=echo
+
+echo "hello world"

--- a/pkg/boot/grub/testdata/example_grub_script_test.out
+++ b/pkg/boot/grub/testdata/example_grub_script_test.out
@@ -1,0 +1,1 @@
+echo:[]string{"hello world"}

--- a/pkg/boot/grub/testdata/grub_cmd_echo.in
+++ b/pkg/boot/grub/testdata/grub_cmd_echo.in
@@ -1,0 +1,42 @@
+#! @builddir@/grub-shell-tester
+#
+# Copyright (C) 2010  Free Software Foundation, Inc.
+#
+# GRUB is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GRUB is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+
+echo
+echo -n
+
+echo foo
+echo foo   bar
+
+echo -n foo
+
+echo -e "foo\nbar"
+
+echo -n -e "foo\nbar"
+
+echo foo -n
+echo foo -n -e
+
+echo -------
+
+if test -n "$grubshell"; then insmod regexp; fi
+
+echo '*'
+echo "*"
+
+#JVDG removed this test, uroot grub parser does not handle variables
+#foo="*"
+#echo "$foo"

--- a/pkg/boot/grub/testdata/grub_cmd_echo.out
+++ b/pkg/boot/grub/testdata/grub_cmd_echo.out
@@ -1,0 +1,12 @@
+echo:[]string{}
+echo:[]string{"-n"}
+echo:[]string{"foo"}
+echo:[]string{"foo", "bar"}
+echo:[]string{"-n", "foo"}
+echo:[]string{"-e", "foo\\nbar"}
+echo:[]string{"-n", "-e", "foo\\nbar"}
+echo:[]string{"foo", "-n"}
+echo:[]string{"foo", "-n", "-e"}
+echo:[]string{"-------"}
+echo:[]string{"*"}
+echo:[]string{"*"}

--- a/pkg/boot/grub/testdata/grub_script_comments.in
+++ b/pkg/boot/grub/testdata/grub_script_comments.in
@@ -1,0 +1,28 @@
+#! @builddir@/grub-shell-tester
+#
+# Copyright (C) 2010  Free Software Foundation, Inc.
+#
+# GRUB is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# GRUB is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with GRUB.  If not, see <http://www.gnu.org/licenses/>.
+
+echo a###b
+echo a# #b
+
+echo #
+echo \#
+
+echo '#'
+echo "#"
+
+echo '\#'
+echo "\#"

--- a/pkg/boot/grub/testdata/grub_script_comments.out
+++ b/pkg/boot/grub/testdata/grub_script_comments.out
@@ -1,0 +1,8 @@
+echo:[]string{"a###b"}
+echo:[]string{"a#"}
+echo:[]string{}
+echo:[]string{"#"}
+echo:[]string{"#"}
+echo:[]string{"#"}
+echo:[]string{"\\#"}
+echo:[]string{"\\#"}

--- a/pkg/boot/grub/testdata/grub_script_echo_keywords.in
+++ b/pkg/boot/grub/testdata/grub_script_echo_keywords.in
@@ -1,0 +1,3 @@
+#! @builddir@/grub-shell-tester
+
+echo if then else fi for do done

--- a/pkg/boot/grub/testdata/grub_script_echo_keywords.out
+++ b/pkg/boot/grub/testdata/grub_script_echo_keywords.out
@@ -1,0 +1,1 @@
+echo:[]string{"if", "then", "else", "fi", "for", "do", "done"}

--- a/pkg/boot/grub/testdata/import_grub_tests.sh
+++ b/pkg/boot/grub/testdata/import_grub_tests.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+if [ -z "$1" ]; then
+	echo usage $0 path/to/grub_source_dir/
+	exit 1
+fi
+
+grubsrcdir=$1
+
+for f in $(grep -rnl grub-shell-tester $grubsrcdir/tests/*); do cp $f .; done

--- a/pkg/boot/grub/testdata/test_bash_wrapper.sh
+++ b/pkg/boot/grub/testdata/test_bash_wrapper.sh
@@ -1,0 +1,1 @@
+echo param1 param2

--- a/pkg/boot/syslinux/syslinux.go
+++ b/pkg/boot/syslinux/syslinux.go
@@ -194,6 +194,7 @@ func (c *parser) append(config string) error {
 			c.curEntry = arg
 			c.config.Entries[c.curEntry] = &boot.LinuxImage{}
 			c.config.Entries[c.curEntry].Cmdline = c.globalAppend
+			c.config.Entries[c.curEntry].Name = c.curEntry
 
 		case "kernel":
 			k, err := c.getFile(arg)


### PR DESCRIPTION
This is a work in progress parsers replacement.
I started in boot as it doesn't use packages. Basically the functions added at the end of boot.go should go to a new "diskboot" or "localboot" or whatever package.
Opening the PR now to show the work.