### PR TITLE
Add config for automerge tool

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,0 +1,6 @@
+minApprovals:
+  COLLABORATOR: 1
+requiredLabels:
+- automerge
+mergeMethod: rebase
+reportStatus: true


### PR DESCRIPTION
If the 'automerge' label is added to the PR, This tool automatically
merges the PR once it has all the necessary approvals.

This is useful for trivial PRs such as
https://github.com/u-root/u-root/pull/1443 which are in an endless cycle
of bringing the branch up to date.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>