### PR TITLE
cmds/boot/fbnetboot: use bootfile params if provided

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -115,7 +115,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:52e6f593faf5fd66e6ed7231655f79c3d657190ded4770ad32c93a29d13bbfd7"
+  digest = "1:25914b93e1d9e1f87d5d1c33d3bf5da74d904db7f5cf52d9c4f30b52f1eb8948"
   name = "github.com/insomniacslk/dhcp"
   packages = [
     "dhcpv4",
@@ -131,7 +131,7 @@
     "rfc1035label",
   ]
   pruneopts = "NUT"
-  revision = "3997b8a58c66233275ad9b26612ef733a63bd9d3"
+  revision = "b3fbc9f9fdd5ac725d73f2a9109e59d4947f067d"
 
 [[projects]]
   branch = "master"

--- a/pkg/checker/interfaces.go
+++ b/pkg/checker/interfaces.go
@@ -147,7 +147,7 @@ func InterfaceCanDoDHCPv6(ifname string) Checker {
 		if err != nil {
 			return err
 		}
-		_, _, err = netboot.ConversationToNetconf(conv)
+		_, err = netboot.ConversationToNetconf(conv)
 		return err
 	}
 }

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv6/client6/client.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv6/client6/client.go
@@ -177,6 +177,10 @@ func (c *Client) sendReceive(ifname string, packet dhcpv6.DHCPv6, expectedType d
 		adv, err = dhcpv6.FromBytes(buf[:n])
 		if err != nil {
 			// skip non-DHCP packets
+			//
+			// TODO: It also skips DHCP packets with any errors (for example
+			// if bootfile params are encoded incorrectly). We need to
+			// log such cases instead of silently skip them.
 			continue
 		}
 		if recvMsg, ok := adv.(*dhcpv6.Message); ok && isMessage {

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv6/option_bootfileparam.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv6/option_bootfileparam.go
@@ -1,0 +1,60 @@
+package dhcpv6
+
+import (
+	"fmt"
+
+	"github.com/u-root/u-root/pkg/uio"
+)
+
+// OptBootFileParam implements the OptionBootfileParam option
+//
+// This module defines the OPT_BOOTFILE_PARAM structure.
+// https://www.ietf.org/rfc/rfc5970.txt (section 3.2)
+type OptBootFileParam []string
+
+var _ Option = OptBootFileParam(nil)
+
+// Code returns the option code
+func (op OptBootFileParam) Code() OptionCode {
+	return OptionBootfileParam
+}
+
+// ToBytes serializes the option and returns it as a sequence of bytes
+func (op OptBootFileParam) ToBytes() []byte {
+	buf := uio.NewBigEndianBuffer(nil)
+	for _, param := range op {
+		if len(param) >= 1<<16 {
+			// TODO: say something here instead of silently ignoring a parameter
+			continue
+		}
+		buf.Write16(uint16(len(param)))
+		buf.WriteBytes([]byte(param))
+		/*if err := buf.Error(); err != nil {
+			// TODO: description of `WriteBytes` says it could return
+			// an error via `buf.Error()`. But a quick look into implementation of
+			// `WriteBytes` at the moment of this comment showed it does not set any
+			// errors to `Error()` output. It's required to make a decision:
+			// to fix `WriteBytes` or it's description or
+			// to find a way to handle an error here.
+		}*/
+	}
+	return buf.Data()
+}
+
+func (op OptBootFileParam) String() string {
+	return fmt.Sprintf("OptBootFileParam(%v)", ([]string)(op))
+}
+
+// ParseOptBootFileParam builds an OptBootFileParam structure from a sequence
+// of bytes. The input data does not include option code and length bytes.
+func ParseOptBootFileParam(data []byte) (result OptBootFileParam, err error) {
+	buf := uio.NewBigEndianBuffer(data)
+	for buf.Has(2) {
+		length := buf.Read16()
+		result = append(result, string(buf.CopyN(int(length))))
+	}
+	if err := buf.FinError(); err != nil {
+		return nil, err
+	}
+	return
+}

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv6/options.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv6/options.go
@@ -75,6 +75,8 @@ func ParseOption(code OptionCode, optData []byte) (Option, error) {
 		opt, err = ParseOptRemoteId(optData)
 	case OptionBootfileURL:
 		opt, err = ParseOptBootFileURL(optData)
+	case OptionBootfileParam:
+		opt, err = ParseOptBootFileParam(optData)
 	case OptionClientArchType:
 		opt, err = ParseOptClientArchType(optData)
 	case OptionNII:


### PR DESCRIPTION
Added support of DHCP option 60 on IPv6 to define arguments (cmdline) to the loading kernel.

Task: https://github.com/u-root/u-root/issues/1384

~~Depends on: https://github.com/insomniacslk/dhcp/pull/340~~

~~Update: The build is failed because of the dependency above.~~