### PR TITLE
Rework MultibootImage to use ReaderAt instead of filename

### DIFF
--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -21,7 +21,6 @@ package main
 import (
 	"log"
 	"os"
-	"strings"
 
 	flag "github.com/spf13/pflag"
 
@@ -92,19 +91,11 @@ func main() {
 		defer mbkernel.Close()
 		var image boot.OSImage
 		if err := multiboot.Probe(mbkernel); err == nil {
-
-			modules := make([]multiboot.Module, len(opts.modules))
-			for i, cmd := range opts.modules {
-				modules[i].CmdLine = cmd
-				name := strings.Fields(cmd)[0]
-				f, err := os.Open(name)
-				if err != nil {
-					log.Fatalf("error opening module %v: %v", name, err)
-				}
-				defer f.Close()
-				modules[i].Module = f
+			modules, err := multiboot.OpenModules(opts.modules, true)
+			if err != nil {
+				log.Fatalf("%v", err)
 			}
-
+			defer modules.Close()
 			image = &boot.MultibootImage{
 				Modules: modules,
 				Kernel:  mbkernel,

--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -21,6 +21,7 @@ package main
 import (
 	"log"
 	"os"
+	"strings"
 
 	flag "github.com/spf13/pflag"
 
@@ -91,9 +92,22 @@ func main() {
 		defer mbkernel.Close()
 		var image boot.OSImage
 		if err := multiboot.Probe(mbkernel); err == nil {
+
+			modules := make([]multiboot.Module, len(opts.modules))
+			for i, cmd := range opts.modules {
+				modules[i].CmdLine = cmd
+				name := strings.Fields(cmd)[0]
+				f, err := os.Open(name)
+				if err != nil {
+					log.Fatalf("error opening module %v: %v", name, err)
+				}
+				defer f.Close()
+				modules[i].Module = f
+			}
+
 			image = &boot.MultibootImage{
-				Modules: opts.modules,
-				Path:    kernelpath,
+				Modules: modules,
+				Kernel:  mbkernel,
 				Cmdline: newCmdline,
 			}
 		} else {

--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -20,6 +20,7 @@ package main
 
 import (
 	"log"
+	"os"
 
 	flag "github.com/spf13/pflag"
 
@@ -83,8 +84,13 @@ func main() {
 
 	if opts.load {
 		kernelpath := flag.Arg(0)
+		mbkernel, err := os.Open(kernelpath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer mbkernel.Close()
 		var image boot.OSImage
-		if err := multiboot.Probe(kernelpath); err == nil {
+		if err := multiboot.Probe(mbkernel); err == nil {
 			image = &boot.MultibootImage{
 				Modules: opts.modules,
 				Path:    kernelpath,

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -6,6 +6,7 @@ package boot
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/u-root/u-root/pkg/boot/ibft"
@@ -25,7 +26,13 @@ var _ OSImage = &MultibootImage{}
 
 // Load implements OSImage.Load.
 func (mi *MultibootImage) Load(verbose bool) error {
-	return multiboot.Load(verbose, mi.Path, mi.Cmdline, mi.Modules, mi.IBFT)
+	mbkernel, err := os.Open(mi.Path)
+	if err != nil {
+		return err
+	}
+	defer mbkernel.Close()
+
+	return multiboot.Load(verbose, mbkernel, mi.Cmdline, mi.Modules, mi.IBFT)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -31,8 +31,19 @@ func (mi *MultibootImage) Load(verbose bool) error {
 		return err
 	}
 	defer mbkernel.Close()
+	modules := make([]multiboot.Module, len(mi.Modules))
+	for i, cmd := range mi.Modules {
+		modules[i].CmdLine = cmd
+		name := strings.Fields(cmd)[0]
+		f, err := os.Open(name)
+		if err != nil {
+			return fmt.Errorf("error opening module %v: %v", name, err)
+		}
+		defer f.Close()
+		modules[i].Module = f
+	}
 
-	return multiboot.Load(verbose, mbkernel, mi.Cmdline, mi.Modules, mi.IBFT)
+	return multiboot.Load(verbose, mbkernel, mi.Cmdline, modules, mi.IBFT)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/boot/multiboot/description.go
+++ b/pkg/boot/multiboot/description.go
@@ -10,7 +10,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // DebugPrefix is a prefix that some messages are printed with for tests to parse.
@@ -40,8 +41,7 @@ type Description struct {
 func (m multiboot) description() (string, error) {
 	var modules []ModuleDesc
 	for i, mod := range m.loadedModules {
-		name := strings.Fields(m.modules[i])[0]
-		b, err := readFile(name)
+		b, err := uio.ReadAll(m.modules[i].Module)
 		if err != nil {
 			return "", nil
 		}
@@ -49,7 +49,7 @@ func (m multiboot) description() (string, error) {
 		modules = append(modules, ModuleDesc{
 			Start:   mod.Start,
 			End:     mod.End,
-			CmdLine: m.modules[i],
+			CmdLine: m.modules[i].CmdLine,
 			SHA256:  fmt.Sprintf("%x", hash),
 		})
 

--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -107,20 +107,17 @@ func alignUp(buf *bytes.Buffer) error {
 func (m *module) loadModule(buf *bytes.Buffer, r io.ReaderAt, name string) error {
 	log.Printf("Adding module %v", name)
 
-	b, err := uio.ReadAll(r)
-	if err != nil {
-		return err
-	}
-
 	// place start of each module to a beginning of a page.
 	if err := alignUp(buf); err != nil {
 		return err
 	}
 
 	m.Start = uint32(buf.Len())
-	if _, err := buf.Write(b); err != nil {
+
+	if _, err := io.Copy(buf, uio.Reader(r)); err != nil {
 		return err
 	}
+
 	m.End = uint32(buf.Len())
 
 	return nil

--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -11,7 +11,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/u-root/u-root/pkg/ubinary"
 	"github.com/u-root/u-root/pkg/uio"
@@ -87,9 +86,8 @@ func loadModules(rmods []Module) (loaded modules, data []byte, err error) {
 	}
 
 	for i, rmod := range rmods {
-		name := strings.Fields(rmod.CmdLine)[0]
-		if err := loaded[i].loadModule(&buf, rmod.Module, name); err != nil {
-			return nil, nil, fmt.Errorf("error adding module %v: %v", name, err)
+		if err := loaded[i].loadModule(&buf, rmod.Module, rmod.Name); err != nil {
+			return nil, nil, fmt.Errorf("error adding module %v: %v", rmod.Name, err)
 		}
 	}
 

--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -8,11 +8,13 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"strings"
 
 	"github.com/u-root/u-root/pkg/ubinary"
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 // A module represents a module to be loaded along with the kernel.
@@ -74,19 +76,19 @@ func (m *multiboot) addModules() (uintptr, error) {
 //			modules_n
 //
 // <padding> aligns the start of each module to a page beginning.
-func loadModules(cmds []string) (loaded modules, data []byte, err error) {
-	loaded = make(modules, len(cmds))
+func loadModules(rmods []Module) (loaded modules, data []byte, err error) {
+	loaded = make(modules, len(rmods))
 	buf := bytes.Buffer{}
 
-	for i, cmd := range cmds {
-		if err := loaded[i].setCmdLine(&buf, cmd); err != nil {
+	for i, rmod := range rmods {
+		if err := loaded[i].setCmdLine(&buf, rmod.CmdLine); err != nil {
 			return nil, nil, err
 		}
 	}
 
-	for i, cmd := range cmds {
-		name := strings.Fields(cmd)[0]
-		if err := loaded[i].loadModule(&buf, name); err != nil {
+	for i, rmod := range rmods {
+		name := strings.Fields(rmod.CmdLine)[0]
+		if err := loaded[i].loadModule(&buf, rmod.Module, name); err != nil {
 			return nil, nil, fmt.Errorf("error adding module %v: %v", name, err)
 		}
 	}
@@ -102,10 +104,10 @@ func alignUp(buf *bytes.Buffer) error {
 	return err
 }
 
-func (m *module) loadModule(buf *bytes.Buffer, name string) error {
+func (m *module) loadModule(buf *bytes.Buffer, r io.ReaderAt, name string) error {
 	log.Printf("Adding module %v", name)
 
-	b, err := readFile(name)
+	b, err := uio.ReadAll(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -29,12 +29,18 @@ import (
 
 const bootloader = "u-root kexec"
 
+// Module describe a module by a ReaderAt and a `CmdLine`
+type Module struct {
+	Module  io.ReaderAt
+	CmdLine string
+}
+
 // multiboot defines parameters for working with multiboot kernels.
 type multiboot struct {
 	mem kexec.Memory
 
 	kernel  io.ReaderAt
-	modules []string
+	modules []Module
 
 	cmdLine    string
 	bootloader string
@@ -105,7 +111,7 @@ func Probe(kernel io.ReaderAt) error {
 }
 
 // newMB returns a new multiboot instance.
-func newMB(kernel io.ReaderAt, cmdLine string, modules []string) (*multiboot, error) {
+func newMB(kernel io.ReaderAt, cmdLine string, modules []Module) (*multiboot, error) {
 	// Trampoline should be a part of current binary.
 	p, err := os.Executable()
 	if err != nil {
@@ -140,7 +146,19 @@ func newMB(kernel io.ReaderAt, cmdLine string, modules []string) (*multiboot, er
 // Linux and execute the loaded kernel.
 func Load(debug bool, kernel io.ReaderAt, cmdline string, modules []string, ibft *ibft.IBFT) error {
 	kernel = tryGzipFilter(kernel)
-	m, err := newMB(kernel, cmdline, modules)
+	readableModules := make([]Module, len(modules))
+	for i, cmd := range modules {
+		readableModules[i].CmdLine = cmd
+		name := strings.Fields(cmd)[0]
+		f, err := os.Open(name)
+		if err != nil {
+			return fmt.Errorf("error adding module %v: %v", name, err)
+		}
+		defer f.Close()
+		readableModules[i].Module = tryGzipFilter(f)
+	}
+
+	m, err := newMB(kernel, cmdline, readableModules)
 	if err != nil {
 		return err
 	}

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -32,6 +32,7 @@ const bootloader = "u-root kexec"
 // Module describe a module by a ReaderAt and a `CmdLine`
 type Module struct {
 	Module  io.ReaderAt
+	Name    string
 	CmdLine string
 }
 
@@ -171,6 +172,7 @@ func OpenModules(cmds []string, uncompress bool) (Modules, error) {
 	for i, cmd := range cmds {
 		modules[i].CmdLine = cmd
 		name := strings.Fields(cmd)[0]
+		modules[i].Name = name
 		f, err := os.Open(name)
 		if err != nil {
 			// TODO close already open files

--- a/pkg/boot/multiboot/reader.go
+++ b/pkg/boot/multiboot/reader.go
@@ -37,6 +37,11 @@ func (kr *kernelReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
+// implement inMemReaderAt interface
+func (kr kernelReader) Bytes() []byte {
+	return kr.buf
+}
+
 func readGzip(r io.Reader) ([]byte, error) {
 	z, err := gzip.NewReader(r)
 	if err != nil {

--- a/pkg/boot/multiboot/reader.go
+++ b/pkg/boot/multiboot/reader.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/u-root/u-root/pkg/uio"
 )
 
 type kernelReader struct {
@@ -59,4 +61,15 @@ func readFile(name string) ([]byte, error) {
 	}
 
 	return ioutil.ReadAll(f)
+}
+
+// TODO: could be tryCompressionFilters, grub support gz,xz and lzop
+// TODO: do we want to keep the filter inside multiboot? This could be the responsibility of the caller...
+func tryGzipFilter(r io.ReaderAt) io.ReaderAt {
+	b, err := readGzip(uio.Reader(r))
+	if err == nil {
+		kernel := kernelReader{buf: b}
+		return kernel
+	}
+	return r
 }

--- a/pkg/boot/multiboot/reader.go
+++ b/pkg/boot/multiboot/reader.go
@@ -5,42 +5,13 @@
 package multiboot
 
 import (
+	"bytes"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"io/ioutil"
-	"os"
 
 	"github.com/u-root/u-root/pkg/uio"
 )
-
-type kernelReader struct {
-	buf []byte
-	off int
-}
-
-func (kr kernelReader) ReadAt(p []byte, off int64) (n int, err error) {
-	if off < 0 || off > int64(len(kr.buf)) {
-		return 0, fmt.Errorf("bad offset %v", off)
-	}
-	if n = copy(p, kr.buf[off:]); n < len(p) {
-		err = io.EOF
-	}
-	return n, err
-}
-
-func (kr *kernelReader) Read(p []byte) (n int, err error) {
-	if n = copy(p, kr.buf[kr.off:]); n < len(p) {
-		err = io.EOF
-	}
-	kr.off += n
-	return n, err
-}
-
-// implement inMemReaderAt interface
-func (kr kernelReader) Bytes() []byte {
-	return kr.buf
-}
 
 func readGzip(r io.Reader) ([]byte, error) {
 	z, err := gzip.NewReader(r)
@@ -51,30 +22,12 @@ func readGzip(r io.Reader) ([]byte, error) {
 	return ioutil.ReadAll(z)
 }
 
-func readFile(name string) ([]byte, error) {
-	f, err := os.Open(name)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-	b, err := readGzip(f)
-	if err == nil {
-		return b, err
-	}
-	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		return nil, fmt.Errorf("cannot rewind file: %v", err)
-	}
-
-	return ioutil.ReadAll(f)
-}
-
 // TODO: could be tryCompressionFilters, grub support gz,xz and lzop
 // TODO: do we want to keep the filter inside multiboot? This could be the responsibility of the caller...
 func tryGzipFilter(r io.ReaderAt) io.ReaderAt {
 	b, err := readGzip(uio.Reader(r))
 	if err == nil {
-		kernel := kernelReader{buf: b}
-		return kernel
+		return bytes.NewReader(b)
 	}
 	return r
 }

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -87,12 +87,19 @@ func (bc *BootConfig) Boot() error {
 			return err
 		}
 	} else if bc.Multiboot != "" {
+		mbkernel, err := os.Open(bc.Multiboot)
+		if err != nil {
+			log.Printf("Error opening multiboot kernel file: %v", err)
+			return err
+		}
+		defer mbkernel.Close()
+
 		// check multiboot header
-		if err := multiboot.Probe(bc.Multiboot); err != nil {
+		if err := multiboot.Probe(mbkernel); err != nil {
 			log.Printf("Error parsing multiboot header: %v", err)
 			return err
 		}
-		if err := multiboot.Load(true, bc.Multiboot, bc.MultibootArgs, bc.Modules, nil); err != nil {
+		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, bc.Modules, nil); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}
 	}

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/u-root/u-root/pkg/boot/kexec"
 	"github.com/u-root/u-root/pkg/boot/multiboot"
@@ -100,18 +99,11 @@ func (bc *BootConfig) Boot() error {
 			log.Printf("Error parsing multiboot header: %v", err)
 			return err
 		}
-		modules := make([]multiboot.Module, len(bc.Modules))
-		for i, cmd := range bc.Modules {
-			modules[i].CmdLine = cmd
-			name := strings.Fields(cmd)[0]
-			f, err := os.Open(name)
-			if err != nil {
-				return fmt.Errorf("error opening module %v: %v", name, err)
-			}
-			defer f.Close()
-			modules[i].Module = f
+		modules, err := multiboot.OpenModules(bc.Modules, true)
+		if err != nil {
+			return err
 		}
-
+		defer modules.Close()
 		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, modules, nil); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/u-root/u-root/pkg/boot/kexec"
 	"github.com/u-root/u-root/pkg/boot/multiboot"
@@ -99,7 +100,19 @@ func (bc *BootConfig) Boot() error {
 			log.Printf("Error parsing multiboot header: %v", err)
 			return err
 		}
-		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, bc.Modules, nil); err != nil {
+		modules := make([]multiboot.Module, len(bc.Modules))
+		for i, cmd := range bc.Modules {
+			modules[i].CmdLine = cmd
+			name := strings.Fields(cmd)[0]
+			f, err := os.Open(name)
+			if err != nil {
+				return fmt.Errorf("error opening module %v: %v", name, err)
+			}
+			defer f.Close()
+			modules[i].Module = f
+		}
+
+		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, modules, nil); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}
 	}


### PR DESCRIPTION
The goal is to unify the interface with LinuxImage and hopefully allow to PXE boot multiboot kernel