### PR TITLE
elvish: Do not use reflect.Call

### DIFF
--- a/cmds/core/elvish/edit/api.go
+++ b/cmds/core/elvish/edit/api.go
@@ -90,17 +90,43 @@ func makeNs(ed *editor) eval.Ns {
 
 	// Functions.
 	fns := map[string]interface{}{
-		"binding-table": eddefs.MakeBindingMap,
 		"insert-at-dot": ed.InsertAtDot,
 		"replace-input": ed.replaceInput,
-		"styled":        styled,
-		"key":           ui.ToKey,
 		"wordify":       wordifyBuiltin,
 		"-dump-buf":     ed.dumpBuf,
 	}
 	ns.AddBuiltinFns("edit:", fns)
 
+	ns.AddBuiltinFnCustom("edit:", "binding-table", eddefs.MakeBindingMapCallable())
+	ns.AddBuiltinFnCustom("edit:", "styled", &styledCallable{})
+	ns.AddBuiltinFnCustom("edit:", "key", &uiToKeyCallable{})
+
 	return ns
+}
+
+type styledCallable struct {
+}
+
+func (*styledCallable) Target() interface{} {
+	return styled
+}
+
+func (*styledCallable) Call(
+	f *eval.Frame, args []interface{}, opts eval.RawOptions, inputs eval.Inputs) ([]interface{}, error) {
+	out, err := styled(args[0].(string), args[1])
+	return []interface{}{out}, err
+}
+
+type uiToKeyCallable struct {
+}
+
+func (*uiToKeyCallable) Target() interface{} {
+	return ui.ToKey
+}
+
+func (*uiToKeyCallable) Call(f *eval.Frame, args []interface{}, opts eval.RawOptions, inputs eval.Inputs) ([]interface{}, error) {
+	out := ui.ToKey(args[0])
+	return []interface{}{out}, nil
 }
 
 // CallFn calls an Fn, displaying its outputs and possible errors as editor

--- a/cmds/core/elvish/edit/completion/completion_mode.go
+++ b/cmds/core/elvish/edit/completion/completion_mode.go
@@ -77,10 +77,21 @@ func Init(ed eddefs.Editor, ns eval.Ns) {
 	ns.AddFn("match-subseq", matchSubseq)
 
 	// Other functions.
-	ns.AddBuiltinFns("edit:", map[string]interface{}{
-		"complete-getopt":   complGetopt,
-		"complex-candidate": makeComplexCandidate,
-	})
+	ns.AddBuiltinFn("edit:", "complete-getopt", complGetopt)
+	ns.AddBuiltinFnCustom("edit:", "complete-candidate", &makeComplexCandidateCallable{})
+}
+
+type makeComplexCandidateCallable struct {
+}
+
+func (*makeComplexCandidateCallable) Target() interface{} {
+	return makeComplexCandidate
+}
+
+func (*makeComplexCandidateCallable) Call(
+	f *eval.Frame, args []interface{}, opts eval.RawOptions, inputs eval.Inputs) ([]interface{}, error) {
+	out := makeComplexCandidate(opts, args[0].(string))
+	return []interface{}{out}, nil
 }
 
 func makeArgCompleter() hashmap.Map {

--- a/cmds/core/elvish/edit/eddefs/binding_map.go
+++ b/cmds/core/elvish/edit/eddefs/binding_map.go
@@ -88,7 +88,12 @@ func (bt BindingMap) Dissoc(k interface{}) interface{} {
 	return BindingMap{bt.Map.Dissoc(ui.ToKey(k))}
 }
 
-func MakeBindingMap(raw hashmap.Map) (BindingMap, error) {
+// MakeBindingMapCallable implements eval.CustomCallable interface for makeBindingMap.
+func MakeBindingMapCallable() eval.CustomCallable {
+	return &makeBindingMapCallable{}
+}
+
+func makeBindingMap(raw hashmap.Map) (BindingMap, error) {
 	converted := vals.EmptyMap
 	for it := raw.Iterator(); it.HasElem(); it.Next() {
 		k, v := it.Elem()
@@ -100,4 +105,16 @@ func MakeBindingMap(raw hashmap.Map) (BindingMap, error) {
 	}
 
 	return BindingMap{converted}, nil
+}
+
+type makeBindingMapCallable struct {
+}
+
+func (*makeBindingMapCallable) Target() interface{} {
+	return makeBindingMap
+}
+
+func (*makeBindingMapCallable) Call(f *eval.Frame, args []interface{}, opts eval.RawOptions, inputs eval.Inputs) ([]interface{}, error) {
+	out, err := makeBindingMap(args[0].(hashmap.Map))
+	return []interface{}{out}, err
 }

--- a/cmds/core/elvish/eval/builtin_fn_test.go
+++ b/cmds/core/elvish/eval/builtin_fn_test.go
@@ -8,8 +8,10 @@ import (
 )
 
 func TestReflectBuiltinFnCall(t *testing.T) {
+	called := false
 	theFrame := new(Frame)
 	theOptions := map[string]interface{}{}
+	theError := errors.New("the error")
 
 	var f Callable
 	callGood := func(fm *Frame, args []interface{}, opts map[string]interface{}) {
@@ -24,25 +26,193 @@ func TestReflectBuiltinFnCall(t *testing.T) {
 			t.Errorf("Calling f didn't return error")
 		}
 	}
+	callBad2 := func(fm *Frame, args []interface{}, opts map[string]interface{}) {
+		err := f.Call(fm, args, opts)
+		if err == nil {
+			t.Errorf("Calling f didn't return error")
+		}
+		if err != theError {
+			t.Errorf("Calling f didn't return the right error")
+		}
+	}
 
-	// *Frame parameter gets the Frame.
-	f = NewBuiltinFn("f", func(f *Frame) {
+	// func()
+	called = false
+	f = NewBuiltinFn("f1", func() {
+		called = true
+	})
+	callGood(theFrame, nil, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
+
+	// func(float64)
+	called = false
+	f = NewBuiltinFn("f2", func(a float64) {
+		called = true
+		if a != 123.456 {
+			t.Errorf("arg1 not passed")
+		}
+	})
+	callGood(theFrame, []interface{}{"123.456"}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
+
+	// func(int)
+	called = false
+	f = NewBuiltinFn("f3", func(a int) {
+		called = true
+		if a != 123 {
+			t.Errorf("arg1 not passed")
+		}
+	})
+	callGood(theFrame, []interface{}{"123"}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
+
+	// func(...int) error
+	f = NewBuiltinFn("f4", func(va ...int) error {
+		if va[0] != 123 {
+			t.Errorf("arg1 not passed")
+		}
+		if va[1] != 456 {
+			t.Errorf("arg2 not passed")
+		}
+		return theError
+	})
+	callBad2(theFrame, []interface{}{"123", "456"}, theOptions)
+
+	// func() error
+	f = NewBuiltinFn("f5", func() error {
+		called = true
+		return theError
+	})
+	callBad2(theFrame, nil, theOptions)
+
+	// func(*eval.Frame)
+	called = false
+	f = NewBuiltinFn("f10", func(f *Frame) {
+		called = true
 		if f != theFrame {
 			t.Errorf("*Frame parameter doesn't get current frame")
 		}
 	})
 	callGood(theFrame, nil, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
+
+	// func(*eval.Frame, ...interface {}) error
+	f = NewBuiltinFn("f12", func(f *Frame, va ...interface{}) error {
+		if f != theFrame {
+			t.Errorf("*Frame parameter doesn't get current frame")
+		}
+		if va[0].(int) != 123 {
+			t.Errorf("arg1 not passed")
+		}
+		if va[1].(string) != "abc" {
+			t.Errorf("arg2 not passed")
+		}
+		if va[2].(error) != theError {
+			t.Errorf("arg3 not passed")
+		}
+		return theError
+	})
+	callBad2(theFrame, []interface{}{123, "abc", theError}, theOptions)
+
+	// func(*eval.Frame, interface {}, interface {}, interface {})
+	called = false
+	f = NewBuiltinFn("f12", func(f *Frame, a1 interface{}, a2 interface{}, a3 interface{}) {
+		called = true
+		if f != theFrame {
+			t.Errorf("*Frame parameter doesn't get current frame")
+		}
+		if a1.(int) != 123 {
+			t.Errorf("arg1 not passed")
+		}
+		if a2.(string) != "abc" {
+			t.Errorf("arg2 not passed")
+		}
+		if a3.(error) != theError {
+			t.Errorf("arg3 not passed")
+		}
+	})
+	callGood(theFrame, []interface{}{123, "abc", theError}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
+
+	// func(*eval.Frame, ...int) error
+	f = NewBuiltinFn("f13", func(f *Frame, va ...int) error {
+		if f != theFrame {
+			t.Errorf("*Frame parameter doesn't get current frame")
+		}
+		if va[0] != 123 {
+			t.Errorf("arg1 not passed")
+		}
+		return theError
+	})
+	callBad2(theFrame, []interface{}{"123"}, theOptions)
+
+	// func(*eval.Frame, ...string) error
+	f = NewBuiltinFn("f13", func(f *Frame, va ...string) error {
+		if f != theFrame {
+			t.Errorf("*Frame parameter doesn't get current frame")
+		}
+		if va[0] != "abc" {
+			t.Errorf("arg1 not passed")
+		}
+		return theError
+	})
+	callBad2(theFrame, []interface{}{"abc"}, theOptions)
+
+	// func(*eval.Frame, string)
+	called = false
+	f = NewBuiltinFn("f14", func(f *Frame, s string) {
+		called = true
+		if f != theFrame {
+			t.Errorf("*Frame parameter doesn't get current frame")
+		}
+		if s != "abc" {
+			t.Errorf("arg1 not passed")
+		}
+	})
+	callGood(theFrame, []interface{}{"abc"}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
+
+	// func(*eval.Frame, string) error
+	f = NewBuiltinFn("f15", func(f *Frame, s string) error {
+		if f != theFrame {
+			t.Errorf("*Frame parameter doesn't get current frame")
+		}
+		if s != "abc" {
+			t.Errorf("arg1 not passed")
+		}
+		return theError
+	})
+	callBad2(theFrame, []interface{}{"abc"}, theOptions)
 
 	// Options parameter gets options.
-	f = NewBuiltinFn("f", func(opts RawOptions) {
+	called = false
+	f = NewBuiltinFn("f20", func(opts RawOptions) {
+		called = true
 		if opts["foo"] != "bar" {
 			t.Errorf("Options parameter doesn't get options")
 		}
 	})
 	callGood(theFrame, nil, RawOptions{"foo": "bar"})
+	if !called {
+		t.Errorf("not called")
+	}
 
 	// Combination of Frame and Options.
-	f = NewBuiltinFn("f", func(f *Frame, opts RawOptions) {
+	called = false
+	f = NewBuiltinFn("f30", func(f *Frame, opts RawOptions) {
+		called = true
 		if f != theFrame {
 			t.Errorf("*Frame parameter doesn't get current frame")
 		}
@@ -51,28 +221,64 @@ func TestReflectBuiltinFnCall(t *testing.T) {
 		}
 	})
 	callGood(theFrame, nil, RawOptions{"foo": "bar"})
+	if !called {
+		t.Errorf("not called")
+	}
+
+	// func(*eval.Frame, eval.RawOptions, eval.Callable, eval.Callable)
+	called = false
+	theCallable1 := &BuiltinFn{}
+	theCallable2 := &BuiltinFn{}
+	f = NewBuiltinFn("f35", func(f *Frame, opts RawOptions, a1 Callable, a2 Callable) {
+		called = true
+		if f != theFrame {
+			t.Errorf("*Frame parameter doesn't get current frame")
+		}
+		if opts["foo"] != "bar" {
+			t.Errorf("Options parameter doesn't get options")
+		}
+		if a1 != theCallable1 {
+			t.Errorf("arg1 not passed")
+		}
+		if a2 != theCallable2 {
+			t.Errorf("arg2 not passed")
+		}
+	})
+	callGood(theFrame, []interface{}{theCallable1, theCallable2}, RawOptions{"foo": "bar"})
+	if !called {
+		t.Errorf("not called")
+	}
 
 	// Argument passing.
-	f = NewBuiltinFn("f", func(x, y string) {
+	called = false
+	f = NewBuiltinFn("f40", func(x string) {
+		called = true
 		if x != "lorem" {
 			t.Errorf("Argument x not passed")
 		}
-		if y != "ipsum" {
-			t.Errorf("Argument y not passed")
-		}
 	})
-	callGood(theFrame, []interface{}{"lorem", "ipsum"}, theOptions)
+	callGood(theFrame, []interface{}{"lorem"}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
 
 	// Variadic arguments.
-	f = NewBuiltinFn("f", func(x ...string) {
-		if len(x) != 2 || x[0] != "lorem" || x[1] != "ipsum" {
+	called = false
+	f = NewBuiltinFn("f50", func(f *Frame, x ...int) {
+		called = true
+		if len(x) != 2 || x[0] != 123 || x[1] != 456 {
 			t.Errorf("Variadic argument not passed")
 		}
 	})
-	callGood(theFrame, []interface{}{"lorem", "ipsum"}, theOptions)
+	callGood(theFrame, []interface{}{"123", "456"}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
 
 	// Conversion into int and float64.
-	f = NewBuiltinFn("f", func(i int, f float64) {
+	called = false
+	f = NewBuiltinFn("f60", func(i int, f float64) {
+		called = true
 		if i != 314 {
 			t.Errorf("Integer argument i not passed")
 		}
@@ -81,9 +287,30 @@ func TestReflectBuiltinFnCall(t *testing.T) {
 		}
 	})
 	callGood(theFrame, []interface{}{"314", "1.25"}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
+
+	// func(string, ...string)
+	called = false
+	f = NewBuiltinFn("f65", func(a string, va ...string) {
+		called = true
+		if a != "lorem" {
+			t.Errorf("arg1 not passed")
+		}
+		if va[0] != "ipsum" {
+			t.Errorf("arg2 not passed")
+		}
+	})
+	callGood(theFrame, []interface{}{"lorem", "ipsum"}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
 
 	// Conversion of supplied inputs.
-	f = NewBuiltinFn("f", func(i Inputs) {
+	called = false
+	f = NewBuiltinFn("f70", func(i Inputs) {
+		called = true
 		var values []interface{}
 		i(func(x interface{}) {
 			values = append(values, x)
@@ -93,6 +320,9 @@ func TestReflectBuiltinFnCall(t *testing.T) {
 		}
 	})
 	callGood(theFrame, []interface{}{vals.MakeList("foo", "bar")}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
 
 	// Conversion of implicit inputs.
 	inFrame := &Frame{ports: make([]*Port, 3)}
@@ -101,26 +331,34 @@ func TestReflectBuiltinFnCall(t *testing.T) {
 	ch <- "bar"
 	close(ch)
 	inFrame.ports[0] = &Port{Chan: ch}
-	f = NewBuiltinFn("f", func(i Inputs) {
+	called = false
+	f = NewBuiltinFn("f80", func(f *Frame, opts RawOptions, s string, i Inputs) {
+		called = true
 		var values []interface{}
 		i(func(x interface{}) {
 			values = append(values, x)
 		})
+		if s != "s" {
+			t.Errorf("Explicit argument not passed")
+		}
 		if len(values) != 2 || values[0] != "foo" || values[1] != "bar" {
 			t.Errorf("Inputs parameter didn't get implicit inputs")
 		}
 	})
-	callGood(inFrame, []interface{}{vals.MakeList("foo", "bar")}, theOptions)
+	callGood(inFrame, []interface{}{"s", vals.MakeList("foo", "bar")}, theOptions)
+	if !called {
+		t.Errorf("not called")
+	}
 
 	// Outputting of return values.
 	outFrame := &Frame{ports: make([]*Port, 3)}
 	ch = make(chan interface{}, 10)
 	outFrame.ports[1] = &Port{Chan: ch}
-	f = NewBuiltinFn("f", func() string { return "ret" })
-	callGood(outFrame, nil, theOptions)
+	f = NewBuiltinFn("f90", func(s string) string { return s + "-ret" })
+	callGood(outFrame, []interface{}{"arg"}, theOptions)
 	select {
 	case ret := <-ch:
-		if ret != "ret" {
+		if ret != "arg-ret" {
 			t.Errorf("Output is not the same as return value")
 		}
 	default:
@@ -128,7 +366,7 @@ func TestReflectBuiltinFnCall(t *testing.T) {
 	}
 
 	// Conversion of return values.
-	f = NewBuiltinFn("f", func() int { return 314 })
+	f = NewBuiltinFn("f100", func() int { return 314 })
 	callGood(outFrame, nil, theOptions)
 	select {
 	case ret := <-ch:
@@ -140,9 +378,8 @@ func TestReflectBuiltinFnCall(t *testing.T) {
 	}
 
 	// Passing of error return value.
-	theError := errors.New("the error")
-	f = NewBuiltinFn("f", func() (string, error) {
-		return "x", theError
+	f = NewBuiltinFn("f110", func() error {
+		return theError
 	})
 	if f.Call(outFrame, nil, theOptions) != theError {
 		t.Errorf("Returned error is not passed")
@@ -154,41 +391,41 @@ func TestReflectBuiltinFnCall(t *testing.T) {
 	}
 
 	// Too many arguments.
-	f = NewBuiltinFn("f", func() {
+	f = NewBuiltinFn("f120", func() {
 		t.Errorf("Function called when there are too many arguments")
 	})
 	callBad(theFrame, []interface{}{"x"}, theOptions)
 
 	// Too few arguments.
-	f = NewBuiltinFn("f", func(x string) {
+	f = NewBuiltinFn("f130", func(x string) {
 		t.Errorf("Function called when there are too few arguments")
 	})
 	callBad(theFrame, nil, theOptions)
-	f = NewBuiltinFn("f", func(x string, y ...string) {
+	f = NewBuiltinFn("f140", func(x string, y ...string) {
 		t.Errorf("Function called when there are too few arguments")
 	})
 	callBad(theFrame, nil, theOptions)
 
 	// Options when the function does not accept options.
-	f = NewBuiltinFn("f", func() {
+	f = NewBuiltinFn("f150", func() {
 		t.Errorf("Function called when there are extra options")
 	})
 	callBad(theFrame, nil, RawOptions{"foo": "bar"})
 
 	// Wrong argument type.
-	f = NewBuiltinFn("f", func(x string) {
+	f = NewBuiltinFn("f160", func(x string) {
 		t.Errorf("Function called when arguments have wrong type")
 	})
 	callBad(theFrame, []interface{}{1}, theOptions)
 
 	// Wrong argument type: cannot convert to int.
-	f = NewBuiltinFn("f", func(x int) {
+	f = NewBuiltinFn("f170", func(x int) {
 		t.Errorf("Function called when arguments have wrong type")
 	})
 	callBad(theFrame, []interface{}{"x"}, theOptions)
 
 	// Wrong argument type: cannot convert to float64.
-	f = NewBuiltinFn("f", func(x float64) {
+	f = NewBuiltinFn("f180", func(x float64) {
 		t.Errorf("Function called when arguments have wrong type")
 	})
 	callBad(theFrame, []interface{}{"x"}, theOptions)

--- a/cmds/core/elvish/eval/ns.go
+++ b/cmds/core/elvish/eval/ns.go
@@ -98,6 +98,12 @@ func (ns Ns) AddBuiltinFn(nsName, name string, impl interface{}) Ns {
 	return ns.AddFn(name, NewBuiltinFn(nsName+name, impl))
 }
 
+// AddBuiltinFnCustom adds a builtin function to a namespace.
+// It returns the namespace itself.
+func (ns Ns) AddBuiltinFnCustom(nsName, name string, impl CustomCallable) Ns {
+	return ns.AddFn(name, NewBuiltinFnCustom(nsName+name, impl))
+}
+
 // AddBuiltinFns adds builtin functions to a namespace. It returns the namespace
 // itself.
 func (ns Ns) AddBuiltinFns(nsName string, fns map[string]interface{}) Ns {


### PR DESCRIPTION
Use of `reflect.Value.Call` disables unused public method elimination at build time,
which leaves unused code in the resulting binary,
see https://github.com/u-root/u-root/issues/1477.

Elvish uses `reflect.Value.Call` to invoke builtin functions.
Replace its use with a static set of possible function signatures:
these cover all existing use cases and can be extended if needed.

Saves approx. 3.2M on amd64 (go 1.13.5 + text/template patch):
```
[rojer9@rojer9-t470 ~/go/src/github.com/u-root/u-root/bb master]$ GOROOT=$HOME/go_210284 go build && ls -l bb
-rwxrwxr-x. 1 rojer9 rojer9 20645771 Dec 16 16:40 bb
[rojer9@rojer9-t470 ~/go/src/github.com/u-root/u-root/bb master]$ gc elvish_noreflect
Switched to branch 'elvish_noreflect'
[rojer9@rojer9-t470 ~/go/src/github.com/u-root/u-root/bb elvish_noreflect]$ GOROOT=$HOME/go_210284 go build && ls -l bb
-rwxrwxr-x. 1 rojer9 rojer9 17257671 Dec 16 16:41 bb
```

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>