### PR TITLE
Add 'checker' for netbooting into cmds/boot

### DIFF
--- a/cmds/boot/fixmynetboot/main.go
+++ b/cmds/boot/fixmynetboot/main.go
@@ -1,0 +1,115 @@
+// Copyright 2017-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/u-root/u-root/pkg/checker"
+)
+
+// fixmynetboot is a troubleshooting tool that can help you identify issues that
+// won't let your system boot over the network.
+// NOTE: this is a DEMO tool. It's here only to show you how to write your own
+// checks and remediations. Don't use it in production.
+
+var emergencyShellBanner = `
+**************************************************************************
+** Interface checks failed, see the output above to debug the issue.     *
+** Entering the emergency shell, where you can run "fixmynetboot" again, *
+** or any other LinuxBoot command.                                       *
+**************************************************************************
+`
+
+var (
+	doEmergencyShell = flag.Bool("shell", false, "Run emergency shell if checks fail")
+)
+
+func checkInterface(ifname string) error {
+	checklist := []checker.Check{
+		{
+			Name:        fmt.Sprintf("%s exists", ifname),
+			Run:         checker.InterfaceExists(ifname),
+			Remediate:   checker.InterfaceRemediate(ifname),
+			StopOnError: true,
+		},
+		{
+			Name:        fmt.Sprintf("%s link speed", ifname),
+			Run:         checker.LinkSpeed(ifname, 100),
+			Remediate:   nil,
+			StopOnError: false},
+		{
+			Name:        fmt.Sprintf("%s link autoneg", ifname),
+			Run:         checker.LinkAutoneg(ifname, true),
+			Remediate:   nil,
+			StopOnError: false,
+		},
+		{
+			Name:        fmt.Sprintf("%s has link-local", ifname),
+			Run:         checker.InterfaceHasLinkLocalAddress(ifname),
+			Remediate:   nil,
+			StopOnError: true,
+		},
+		{
+			Name:        fmt.Sprintf("%s has global addresses", ifname),
+			Run:         checker.InterfaceHasGlobalAddresses(ifname),
+			Remediate:   nil,
+			StopOnError: true,
+		},
+		{
+			Name:        fmt.Sprintf("%s can do netboot", ifname),
+			Run:         checker.InterfaceCanDoDHCPv6(ifname),
+			Remediate:   checker.RunNTPDate(),
+			StopOnError: true,
+		},
+	}
+
+	return checker.Run(checklist)
+}
+
+func getNonLoopbackInterfaces() ([]string, error) {
+	var interfaces []string
+	allInterfaces, err := net.Interfaces()
+	if err != nil {
+		return nil, err
+	}
+	for _, iface := range allInterfaces {
+		if iface.Flags&net.FlagLoopback == 0 {
+			interfaces = append(interfaces, iface.Name)
+		}
+	}
+	return interfaces, nil
+}
+
+func main() {
+	flag.Parse()
+	var (
+		interfaces []string
+		err        error
+	)
+	ifname := flag.Arg(0)
+	if ifname == "" {
+		interfaces, err = getNonLoopbackInterfaces()
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		interfaces = []string{ifname}
+	}
+
+	for _, ifname := range interfaces {
+		if err := checkInterface(ifname); err != nil {
+			if !*doEmergencyShell {
+				log.Fatal(err)
+			}
+			if err := checker.EmergencyShell(emergencyShellBanner)(); err != nil {
+				log.Fatal(err)
+			}
+		}
+	}
+}

--- a/cmds/boot/uinit/main.go
+++ b/cmds/boot/uinit/main.go
@@ -25,7 +25,7 @@ var (
 )
 
 var defaultBootsequence = [][]string{
-	{"fbnetboot", "-userclass", "linuxboot"},
+	{"fbnetboot", "-userclass", "linuxboot", "-fix"},
 	{"localboot", "-grub"},
 }
 

--- a/pkg/checker/interfaces.go
+++ b/pkg/checker/interfaces.go
@@ -147,7 +147,7 @@ func InterfaceCanDoDHCPv6(ifname string) Checker {
 		if err != nil {
 			return err
 		}
-		_, err = netboot.ConversationToNetconf(conv)
+		_, _, err = netboot.ConversationToNetconf(conv)
 		return err
 	}
 }


### PR DESCRIPTION
The 'checker' framework was built by Andrea. This just adds a specific use case we need; that if we fail to get a kernel/ramdisk over http, try run 'ntpdate'.

This fixes a specific, and possibly common, problem with hardware clocks - there is a good chance the clock can be set to something older than the creation date of the certs.

And before anyone asks, no, we'ed rather not trust any old cert to get around this problem. It's nice to know the kernel you are running came from your org.