### PR TITLE
cmd/fbsplash

### DIFF
--- a/cmds/exp/fbsplash/main.go
+++ b/cmds/exp/fbsplash/main.go
@@ -1,0 +1,52 @@
+// Copyright 2019-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// see the example at https://golang.org/pkg/image/png/#Decode
+
+package main
+
+import (
+	"encoding/base64"
+	"flag"
+	"fmt"
+	"image"
+	"image/png"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/u-root/u-root/pkg/fb"
+)
+
+const gopher = `iVBORw0KGgoAAAANSUhEUgAAAEsAAAA8CAAAAAALAhhPAAAFfUlEQVRYw62XeWwUVRzHf2+OPbo9d7tsWyiyaZti6eWGAhISoIGKECEKCAiJJkYTiUgTMYSIosYYBBIUIxoSPIINEBDi2VhwkQrVsj1ESgu9doHWdrul7ba73WNm3vOPtsseM9MdwvvrzTs+8/t95ze/33sI5BqiabU6m9En8oNjduLnAEDLUsQXFF8tQ5oxK3vmnNmDSMtrncks9Hhtt/qeWZapHb1ha3UqYSWVl2ZmpWgaXMXGohQAvmeop3bjTRtv6SgaK/Pb9/bFzUrYslbFAmHPp+3WhAYdr+7GN/YnpN46Opv55VDsJkoEpMrY/vO2BIYQ6LLvm0ThY3MzDzzeSJeeWNyTkgnIE5ePKsvKlcg/0T9QMzXalwXMlj54z4c0rh/mzEfr+FgWEz2w6uk8dkzFAgcARAgNp1ZYef8bH2AgvuStbc2/i6CiWGj98y2tw2l4FAXKkQBIf+exyRnteY83LfEwDQAYCoK+P6bxkZm/0966LxcAAILHB56kgD95PPxltuYcMtFTWw/FKkY/6Opf3GGd9ZF+Qp6mzJxzuRSractOmJrH1u8XTvWFHINNkLQLMR+XHXvfPPHw967raE1xxwtA36IMRfkAAG29/7mLuQcb2WOnsJReZGfpiHsSBX81cvMKywYZHhX5hFPtOqPGWZCXnhWGAu6lX91ElKXSalcLXu3UaOXVay57ZSe5f6Gpx7J2MXAsi7EqSp09b/MirKSyJfnfEEgeDjl8FgDAfvewP03zZ+AJ0m9aFRM8eEHBDRKjfcreDXnZdQuAxXpT2NRJ7xl3UkLBhuVGU16gZiGOgZmrSbRdqkILuL/yYoSXHHkl9KXgqNu3PB8oRg0geC5vFmLjad6mUyTKLmF3OtraWDIfACyXqmephaDABawfpi6tqqBZytfQMqOz6S09iWXhktrRaB8Xz4Yi/8gyABDm5NVe6qq/3VzPrcjELWrebVuyY2T7ar4zQyybUCtsQ5Es1FGaZVrRVQwAgHGW2ZCRZshI5bGQi7HesyE972pOSeMM0dSktlzxRdrlqb3Osa6CCS8IJoQQQgBAbTAa5l5epO34rJszibJI8rxLfGzcp1dRosutGeb2VDNgqYrwTiPNsLxXiPi3dz7LiS1WBRBDBOnqEjyy3aQb+/bLiJzz9dIkscVBBLxMfSEac7kO4Fpkngi0ruNBeSOal+u8jgOuqPz12nryMLCniEjtOOOmpt+KEIqsEdocJjYXwrh9OZqWJQyPCTo67LNS/TdxLAv6R5ZNK9npEjbYdT33gRo4o5oTqR34R+OmaSzDBWsAIPhuRcgyoteNi9gF0KzNYWVItPf2TLoXEg+7isNC7uJkgo1iQWOfRSP9NR11RtbZZ3OMG/VhL6jvx+J1m87+RCfJChAtEBQkSBX2PnSiihc/Twh3j0h7qdYQAoRVsRGmq7HU2QRbaxVGa1D6nIOqaIWRjyRZpHMQKWKpZM5feA+lzC4ZFultV8S6T0mzQGhQohi5I8iw+CsqBSxhFMuwyLgSwbghGb0AiIKkSDmGZVmJSiKihsiyOAUs70UkywooYP0bii9GdH4sfr1UNysd3fUyLLMQN+rsmo3grHl9VNJHbbwxoa47Vw5gupIqrZcjPh9R4Nye3nRDk199V+aetmvVtDRE8/+cbgAAgMIWGb3UA0MGLE9SCbWX670TDy1y98c3D27eppUjsZ6fql3jcd5rUe7+ZIlLNQny3Rd+E5Tct3WVhTM5RBCEdiEK0b6B+/ca2gYU393nFj/n1AygRQxPIUA043M42u85+z2SnssKrPl8Mx76NL3E6eXc3be7OD+H4WHbJkKI8AU8irbITQjZ+0hQcPEgId/Fn/pl9crKH02+5o2b9T/eMx7pKoskYgAAAABJRU5ErkJggg==`
+
+// gopherPNG creates an io.Reader by decoding the base64 encoded image data string in the gopher constant.
+func gopherPNG() io.Reader { return base64.NewDecoder(base64.StdEncoding, strings.NewReader(gopher)) }
+
+var pngFile string
+
+func init() {
+	flag.StringVar(&pngFile, "file", "", "path to a PNG file")
+}
+
+func main() {
+	flag.Parse()
+	var img image.Image
+	var err error
+	// If no file is provided, draw the gopher as a fallback :)
+	if len(pngFile) > 0 {
+		imageFile, _ := os.Open(pngFile)
+		defer imageFile.Close()
+		img, err = png.Decode(imageFile)
+	} else {
+		imageFile := gopherPNG()
+		img, err = png.Decode(imageFile)
+	}
+	if err != nil {
+		fmt.Println(err)
+	}
+	if err = fb.DrawImageAt(img, 0, 0); err != nil {
+		fmt.Println(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -17,10 +17,12 @@ require (
 	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f
 	github.com/insomniacslk/dhcp v0.0.0-20210314223004-28f74147e2e8
 	github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2
+	github.com/kaey/framebuffer v0.0.0-20140402104929-7b385489a1ff // indirect
 	github.com/klauspost/compress v1.10.6 // indirect
 	github.com/klauspost/pgzip v1.2.4
 	github.com/kr/pty v1.1.8
 	github.com/mattn/go-isatty v0.0.12
+	github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/rck/unit v0.0.3
 	github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc

--- a/go.sum
+++ b/go.sum
@@ -86,6 +86,8 @@ github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c/go.mod h1:huN
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kaey/framebuffer v0.0.0-20140402104929-7b385489a1ff h1:eK9dwGbaOkNQ44GPFD571d+51Qa2AGIYAR3kpjsrhLE=
+github.com/kaey/framebuffer v0.0.0-20140402104929-7b385489a1ff/go.mod h1:tS4qtlcKqtt3tCIHUflVSqeP3CLH5Qtv2szX9X2SyhU=
 github.com/klauspost/compress v1.10.6 h1:SP6zavvTG3YjOosWePXFDlExpKIWMTO4SE/Y8MZB2vI=
 github.com/klauspost/compress v1.10.6/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/pgzip v1.2.4 h1:TQ7CNpYKovDOmqzRHKxJh0BeaBI7UdQZYc6p7pMQh1A=
@@ -115,6 +117,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330 h1:zJBTzBuTR7EdFzmCGx0xp0pbOOb82sAh0+YUK4JTDEI=
+github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330/go.mod h1:3Myb/UszJY32F2G7yGkUtcW/ejHpjlGfYLim7cv2uKA=
 github.com/pborman/getopt/v2 v2.1.0 h1:eNfR+r+dWLdWmV8g5OlpyrTYHkhVNxHBdN2cCrJmOEA=
 github.com/pborman/getopt/v2 v2.1.0/go.mod h1:4NtW75ny4eBw9fO1bhtNdYTlZKYX5/tBLtsOpwKIKd0=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -182,7 +186,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/exp v0.0.0-20190121172915-509febef88a4 h1:c2HOrn5iMezYjSlGPncknSEr/8x5LELb/ilJbXi9DEA=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -203,7 +206,6 @@ golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201010224723-4f7140c49acb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 h1:4nGaVu0QrbjT/AK2PRLuQfQuh6DJve+pELhqTdAj3x0=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
@@ -274,7 +276,6 @@ google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
-gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/fb/fb.go
+++ b/pkg/fb/fb.go
@@ -1,0 +1,111 @@
+// Copyright 2019-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fb
+
+import (
+	"fmt"
+	"image"
+	"io/ioutil"
+	"os"
+
+	"github.com/orangecms/go-framebuffer/framebuffer"
+)
+
+const fbdev = "/dev/fb0"
+
+func DrawOnBufAt(
+	buf []byte,
+	img image.Image,
+	posx int,
+	posy int,
+	stride int,
+	bpp int,
+) {
+	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
+		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
+			r, g, b, a := img.At(x, y).RGBA()
+			offset := bpp * ((posy+y)*stride + posx + x)
+			// framebuffer is BGR(A)
+			buf[offset+0] = byte(b)
+			buf[offset+1] = byte(g)
+			buf[offset+2] = byte(r)
+			if bpp >= 4 {
+				buf[offset+3] = byte(a)
+			}
+		}
+	}
+}
+
+// FbInit initializes a frambuffer by querying ioctls and returns the width and
+// height in pixels, the stride, and the bytes per pixel
+func FbInit() (int, int, int, int, error) {
+	fbo, err := framebuffer.Init(fbdev)
+
+	if err != nil {
+		return 0, 0, 0, 0, err
+	}
+	width, height := fbo.Size()
+	stride := fbo.Stride()
+	bpp := fbo.Bpp()
+	fmt.Fprintf(os.Stdout, "Framebuffer resolution: %v %v %v %v\n", width, height, stride, bpp)
+	return width, height, stride, bpp, nil
+}
+
+func DrawImageAt(img image.Image, posx int, posy int) error {
+	width, height, stride, bpp, err := FbInit()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Framebuffer init error: %v\n", err)
+		// fallback values, probably a bad assumption
+		width, height, stride, bpp = 1920, 1080, 1920*4, 4
+	}
+	buf := make([]byte, width*height*bpp)
+	DrawOnBufAt(buf, img, posx, posy, stride, bpp)
+	err = ioutil.WriteFile(fbdev, buf, 0600)
+	if err != nil {
+		return fmt.Errorf("Error writing to framebuffer: %v", err)
+	}
+	return nil
+}
+
+func DrawScaledOnBufAt(
+	buf []byte,
+	img image.Image,
+	posx int,
+	posy int,
+	factor int,
+	stride int,
+	bpp int,
+) {
+	for y := img.Bounds().Min.Y; y < img.Bounds().Max.Y; y++ {
+		for x := img.Bounds().Min.X; x < img.Bounds().Max.X; x++ {
+			r, g, b, a := img.At(x, y).RGBA()
+			for sx := 1; sx <= factor; sx++ {
+				for sy := 1; sy <= factor; sy++ {
+					offset := bpp * ((posy+y*factor+sy)*stride + posx + x*factor + sx)
+					buf[offset+0] = byte(b)
+					buf[offset+1] = byte(g)
+					buf[offset+2] = byte(r)
+					if bpp == 4 {
+						buf[offset+3] = byte(a)
+					}
+				}
+			}
+		}
+	}
+}
+
+func DrawScaledImageAt(img image.Image, posx int, posy int, factor int) error {
+	width, height, stride, bpp, err := FbInit()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Framebuffer init error: %v\n", err)
+	}
+	buf := make([]byte, width*height*bpp)
+	DrawScaledOnBufAt(buf, img, posx, posy, factor, stride, bpp)
+	err = ioutil.WriteFile(fbdev, buf, 0600)
+	if err != nil {
+		return fmt.Errorf("Error writing to framebuffer: %v", err)
+	}
+	return nil
+}

--- a/vendor/github.com/orangecms/go-framebuffer/LICENSE
+++ b/vendor/github.com/orangecms/go-framebuffer/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Konstantin Kulikov. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/orangecms/go-framebuffer/framebuffer/_defs-source.go
+++ b/vendor/github.com/orangecms/go-framebuffer/framebuffer/_defs-source.go
@@ -1,0 +1,26 @@
+// Copyright 2013 Konstantin Kulikov. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package framebuffer
+
+/*
+#include <linux/fb.h>
+#include <sys/mman.h>
+*/
+import "C"
+
+type fixedScreenInfo C.struct_fb_fix_screeninfo
+type variableScreenInfo C.struct_fb_var_screeninfo
+type bitField C.struct_fb_bitfield
+
+const (
+	getFixedScreenInfo    uintptr = C.FBIOGET_FSCREENINFO
+	getVariableScreenInfo uintptr = C.FBIOGET_VSCREENINFO
+)
+
+const (
+	protocolRead  int = C.PROT_READ
+	protocolWrite int = C.PROT_WRITE
+	mapShared     int = C.MAP_SHARED
+)

--- a/vendor/github.com/orangecms/go-framebuffer/framebuffer/defs.go
+++ b/vendor/github.com/orangecms/go-framebuffer/framebuffer/defs.go
@@ -1,0 +1,72 @@
+// Created by cgo -godefs - DO NOT EDIT
+// cgo -godefs _defs-source.go
+
+package framebuffer
+
+type fixedScreenInfo struct {
+	Id           [16]int8
+	Smem_start   uint64
+	Smem_len     uint32
+	Type         uint32
+	Type_aux     uint32
+	Visual       uint32
+	Xpanstep     uint16
+	Ypanstep     uint16
+	Ywrapstep    uint16
+	Pad_cgo_0    [2]byte
+	Line_length  uint32
+	Pad_cgo_1    [4]byte
+	Mmio_start   uint64
+	Mmio_len     uint32
+	Accel        uint32
+	Capabilities uint16
+	Reserved     [2]uint16
+	Pad_cgo_2    [2]byte
+}
+type variableScreenInfo struct {
+	Xres           uint32
+	Yres           uint32
+	Xres_virtual   uint32
+	Yres_virtual   uint32
+	Xoffset        uint32
+	Yoffset        uint32
+	Bits_per_pixel uint32
+	Grayscale      uint32
+	Red            bitField
+	Green          bitField
+	Blue           bitField
+	Transp         bitField
+	Nonstd         uint32
+	Activate       uint32
+	Height         uint32
+	Width          uint32
+	Accel_flags    uint32
+	Pixclock       uint32
+	Left_margin    uint32
+	Right_margin   uint32
+	Upper_margin   uint32
+	Lower_margin   uint32
+	Hsync_len      uint32
+	Vsync_len      uint32
+	Sync           uint32
+	Vmode          uint32
+	Rotate         uint32
+	Colorspace     uint32
+	Reserved       [4]uint32
+}
+type bitField struct {
+	Offset uint32
+	Length uint32
+	Right  uint32
+}
+
+const (
+	getFixedScreenInfo    uintptr = 0x4602
+	getVariableScreenInfo uintptr = 0x4600
+)
+
+const (
+	protocolRead  int = 0x1
+	protocolWrite int = 0x2
+	mapShared     int = 0x1
+)

--- a/vendor/github.com/orangecms/go-framebuffer/framebuffer/framebuffer.go
+++ b/vendor/github.com/orangecms/go-framebuffer/framebuffer/framebuffer.go
@@ -1,0 +1,110 @@
+// Copyright 2013 Konstantin Kulikov. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package framebuffer is an interface to linux framebuffer device.
+package framebuffer
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Framebuffer contains information about framebuffer.
+type Framebuffer struct {
+	dev      *os.File
+	Finfo    fixedScreenInfo
+	Vinfo    variableScreenInfo
+	Data     []uint8
+	restData []uint8
+}
+
+// Init opens framebuffer device, maps it to memory and saves its current contents.
+func Init(dev string) (*Framebuffer, error) {
+	var (
+		fb  = new(Framebuffer)
+		err error
+	)
+
+	fb.dev, err = os.OpenFile(dev, os.O_RDWR, os.ModeDevice)
+	if err != nil {
+		return nil, err
+	}
+
+	err = ioctl(fb.dev.Fd(), getFixedScreenInfo, unsafe.Pointer(&fb.Finfo))
+	if err != nil {
+		fb.dev.Close()
+		return nil, err
+	}
+
+	err = ioctl(fb.dev.Fd(), getVariableScreenInfo, unsafe.Pointer(&fb.Vinfo))
+	if err != nil {
+		fb.dev.Close()
+		return nil, err
+	}
+
+	fb.Data, err = syscall.Mmap(int(fb.dev.Fd()), 0, int(fb.Finfo.Smem_len+uint32(fb.Finfo.Smem_start&uint64(syscall.Getpagesize()-1))), protocolRead|protocolWrite, mapShared)
+	if err != nil {
+		fb.dev.Close()
+		return nil, err
+	}
+
+	fb.restData = make([]byte, len(fb.Data))
+	for i := range fb.Data {
+		fb.restData[i] = fb.Data[i]
+	}
+
+	return fb, nil
+}
+
+// Close closes framebuffer device and restores its contents.
+func (fb *Framebuffer) Close() {
+	for i := range fb.restData {
+		fb.Data[i] = fb.restData[i]
+	}
+	syscall.Munmap(fb.Data)
+	fb.dev.Close()
+}
+
+// WritePixel changes pixel at x, y to specified color.
+func (fb *Framebuffer) WritePixel(x, y int, red, green, blue, alpha uint8) {
+	offset := (int(fb.Vinfo.Xoffset)+x)*(int(fb.Vinfo.Bits_per_pixel)/8) + (int(fb.Vinfo.Yoffset)+y)*int(fb.Finfo.Line_length)
+	fb.Data[offset] = blue
+	fb.Data[offset+1] = green
+	fb.Data[offset+2] = red
+	fb.Data[offset+3] = alpha
+}
+
+// Clear fills screen with specified color
+func (fb *Framebuffer) Clear(red, green, blue, alpha uint8) {
+	w, h := fb.Size()
+	for i := 0; i < w; i++ {
+		for j := 0; j < h; j++ {
+			fb.WritePixel(i, j, red, green, blue, alpha)
+		}
+	}
+}
+
+// Bpp returns bytes per pixel for a framebuffer.
+func (fb *Framebuffer) Bpp() (bpp int) {
+	return int(fb.Vinfo.Bits_per_pixel) / 8
+}
+
+// Stride returns line length of a framebuffer.
+func (fb *Framebuffer) Stride() (stride int) {
+	return int(fb.Finfo.Line_length) / fb.Bpp()
+}
+
+// Size returns dimensions of a framebuffer.
+func (fb *Framebuffer) Size() (width, height int) {
+	return int(fb.Vinfo.Xres), int(fb.Vinfo.Yres)
+}
+
+func ioctl(fd uintptr, cmd uintptr, data unsafe.Pointer) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, fd, cmd, uintptr(data))
+	if errno != 0 {
+		return os.NewSyscallError("IOCTL", errno)
+	}
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -63,6 +63,8 @@ github.com/mdlayher/netlink
 github.com/mdlayher/netlink/nlenc
 # github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
 github.com/mdlayher/raw
+# github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330
+github.com/orangecms/go-framebuffer/framebuffer
 # github.com/pborman/getopt/v2 v2.1.0
 github.com/pborman/getopt/v2
 # github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
This allows showing a splash screen image from a file, falling back to displaying the Golang gopher. :)

Through the `go-framebuffer` module, ioctls are implemented to determine the framebuffer dimensions. For now it's always using `/dev/fb0` and the `fbsplash` command would draw at a fixed position. The very basic `pkg/fb` will be extended to support `cmd/fbtotp` later on.