### PR TITLE
WIP: disable GO111MODULE for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,14 @@ templates:
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - CGO_ENABLED: 0
+      - GO111MODULE: off
       # Double all timeouts for QEMU VM tests since they run without KVM.
       - UROOT_QEMU_TIMEOUT_X: 2
   integration-template: &integration-template
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - CGO_ENABLED: 0
+      - GO111MODULE: off
       # Double all timeouts for QEMU VM tests since they run without KVM.
       - UROOT_QEMU_TIMEOUT_X: 2
     steps:
@@ -116,6 +118,7 @@ jobs:
     <<: *golang-template
     environment:
       - CGO_ENABLED: 1
+      - GO111MODULE: off
     steps:
       - checkout
       - run:

--- a/pkg/golang/build.go
+++ b/pkg/golang/build.go
@@ -114,7 +114,7 @@ func (c Environ) Env() []string {
 	if c.CgoEnabled {
 		cgo = 1
 	}
-	env = append(env, fmt.Sprintf("CGO_ENABLED=%d", cgo))
+	env = append(env, fmt.Sprintf("CGO_ENABLED=%d", cgo), "GO111MODULE=off")
 	return env
 }
 

--- a/pkg/libinit/root_linux.go
+++ b/pkg/libinit/root_linux.go
@@ -175,6 +175,7 @@ func SetEnv() {
 		"GOPATH":          "/",
 		"GOBIN":           "/ubin",
 		"CGO_ENABLED":     "0",
+		"GO111MODULE":     "off",
 	}
 
 	// Not all these paths may be populated or even exist but OTOH they might.

--- a/pkg/vmtest/gotest.go
+++ b/pkg/vmtest/gotest.go
@@ -49,6 +49,7 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 	// Statically build tests and add them to the temporary directory.
 	var tests []string
 	os.Setenv("CGO_ENABLED", "0")
+	os.Setenv("GO111MODULE", "off")
 	testDir := filepath.Join(o.TmpDir, "tests")
 	for _, pkg := range pkgs {
 		pkgDir := filepath.Join(testDir, pkg)


### PR DESCRIPTION
we're having trouble building in certain cases. Until we know what to do
with go modules, maybe we should leave them off?