### PR TITLE
pkg/rand: add AIX support

### DIFF
--- a/pkg/rand/random_unix.go
+++ b/pkg/rand/random_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris
+// +build aix darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris
 
 package rand
 

--- a/pkg/rand/random_urandom.go
+++ b/pkg/rand/random_urandom.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris linux
+// +build aix darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris linux
 
 // Package rand implements cancelable reads from a cryptographically safe
 // random number source.


### PR DESCRIPTION
This package is sometimes used by other projects, at least
"github.com/insomniacslk/dhcp/dhcpv4".
Therefore, it must be ported even if the whole u-root project isn't
available on AIX.