### PR TITLE
fix testramfs

### DIFF
--- a/pkg/pty/pty_linux.go
+++ b/pkg/pty/pty_linux.go
@@ -23,6 +23,15 @@ import (
 // pty support. We used to import github.com/kr/pty but what we need is not that complex.
 // Thanks to keith rarick for these functions.
 func New() (*Pty, error) {
+	tty, err := termios.New()
+	if err != nil {
+		return nil, err
+	}
+	restorer, err := tty.Get()
+	if err != nil {
+		return nil, err
+	}
+
 	ptm, err := os.OpenFile("/dev/ptmx", os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
@@ -45,15 +54,6 @@ func New() (*Pty, error) {
 		if err == nil {
 			break
 		}
-	}
-
-	tty, err := termios.NewWithDev(sname)
-	if err != nil {
-		return nil, err
-	}
-	restorer, err := tty.Get()
-	if err != nil {
-		return nil, err
 	}
 
 	pts, err := os.OpenFile(sname, os.O_RDWR|syscall.O_NOCTTY, 0)

--- a/tools/testramfs/testramfs.go
+++ b/tools/testramfs/testramfs.go
@@ -129,8 +129,10 @@ func main() {
 
 	// At this point you could use an array of commands/output templates to
 	// drive the test, and end with the exit command shown nere.
-	if n, err := cmd.Ptm.Write([]byte("exit\n")); err != nil {
-		log.Printf("Writing exit: want (5, nil); got (%d, %v)\n", n, err)
+	for _, c := range []string{"date\n", "exit\n", "exit\n", "exit\n"} {
+		if _, err := cmd.Ptm.Write([]byte(c)); err != nil {
+			log.Printf("Writing %s: %v", c, err)
+		}
 	}
 	if err := cmd.Wait(); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
testramfs was broken by a series of changes culminating in 8483665f289e261c7e6ada8bd24803c473ae5950

I can't get the noninteractive test working again, but this does fix interactive usage.

I'll try to figure out what broke noninteractive later this week.

A further question: why did our CI no catch this? No idea.

Signed-off-by: Ronald Minnich <rminnich@gmail.com>