### PR TITLE
Disable function inlining

### DIFF
--- a/pkg/golang/build.go
+++ b/pkg/golang/build.go
@@ -147,6 +147,7 @@ func (c Environ) BuildDir(dirPath string, binaryPath string, opts BuildOpts) err
 		"-a", // Force rebuilding of packages.
 		"-o", binaryPath,
 		"-installsuffix", "uroot",
+		"-gcflags=all=-l",   // Disable "function inlining" to get a smaller binary
 		"-ldflags", "-s -w", // Strip all symbols.
 	}
 	if len(c.BuildTags) > 0 {

--- a/pkg/vmtest/gotest.go
+++ b/pkg/vmtest/gotest.go
@@ -59,6 +59,7 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 		testFile := filepath.Join(pkgDir, fmt.Sprintf("%s.test", path.Base(pkg)))
 
 		cmd := exec.Command("go", "test",
+			"-gcflags=all=-l",
 			"-ldflags", "-s -w",
 			"-c", pkg,
 			"-o", testFile,


### PR DESCRIPTION
It appears function inlining was enabled and it was taking a lot of space. So flag `-gcflags=all=-l` was added to reduce the size of the initrd image.  The size of the image was reduced on 15% in the compressed state.

Before:

    $ stat -c %s /tmp/initramfs.linux_amd64.cpio.inline
    16399044

    $ stat -c %s initramfs.linux_amd64.cpio.inline.xz
    4613328

    $ stat -c %s stat /tmp/extracted/inline/bbin/bb
    16384000

    $ go tool objdump bb | awk '{print $1}' | sort | uniq -c | sort -rn | head -10
     102193 <autogenerated>:1
      15791 TEXT
      15790
      13388 nl_linux.go:271
      11954 nl_linux.go:290
       8860 nl_linux.go:376
       6805 errors.go:59
       5571 data.go:12
       4949 builder.go:298
       3413 buffer.go:92

After:

    $ stat -c %s /tmp/initramfs.linux_amd64.cpio.noinline
    14887620

    $ stat -c %s /tmp/initramfs.linux_amd64.cpio.noinline.xz
    3933256

    $ stat -c %s /tmp/extracted/noinline/bbin/bb
    14872576

    $ go tool objdump bb | awk '{print $1}' | sort | uniq -c | sort -rn | head -10
     111407 <autogenerated>:1
      18629 TEXT
      18628
       7118 syscall_linux_amd64.go:30
       5571 data.go:12
       2841 types.go:301
       2375 tables.go:3522
       2363 list_linux.go:92
       1932 sha1block_amd64.s:1456
       1221 :-1