### PR TITLE
Revert "Update godoc link to pkg.go.dev"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://circleci.com/gh/u-root/u-root/tree/master.png?style=shield&circle-token=8d9396e32f76f82bf4257b60b414743e57734244)](https://circleci.com/gh/u-root/u-root/tree/master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/u-root/u-root)](https://goreportcard.com/report/github.com/u-root/u-root)
-[![GoDoc](https://img.shields.io/static/v1?label=godoc&message=reference&color=blue)](https://pkg.go.dev/mod/github.com/u-root/u-root?tab=packages)
+[![GoDoc](https://godoc.org/github.com/u-root/u-root?status.svg)](https://godoc.org/github.com/u-root/u-root)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/u-root/u-root/blob/master/LICENSE)
 
 # Description


### PR DESCRIPTION
The default for pkg.go.dev is to show documentation for the last u-root
release, which happened last August. I'd rather we get our documentation
at HEAD.

This reverts commit ad45df693f3715dbc8f0a6a40586a43c2e7987e4.