### PR TITLE
u-root: default to build=bb

### DIFF
--- a/u-root.go
+++ b/u-root.go
@@ -44,7 +44,7 @@ var (
 
 func init() {
 	fourbins = flag.Bool("fourbins", false, "build installcommand on boot, no ahead of time, so we have only four binares")
-	build = flag.String("build", "source", "u-root build format (e.g. bb or source).")
+	build = flag.String("build", "bb", "u-root build format (e.g. bb or source).")
 	format = flag.String("format", "cpio", "Archival format.")
 
 	tmpDir = flag.String("tmpdir", "", "Temporary directory to put binaries in.")


### PR DESCRIPTION
When we started u-root in 2011, on Go 1.2, the toolchain was
based on Ken's Plan 9 C compiler toolchain (in fact, the amd64
toolchain was derived from the DOE-funded C toolchain created
by Vita Nuova for DOE Fast-OS).

That compiler was so fast that I ran, by mistake, with commands always
being compiled and it was months before I noticed it.

Time flies. Go is not as fast as it was. Commands take many seconds to compile.
It's not really viable to have a Go compiler in FLASH at this point.
Even little disks are very big, so the space argument no longer holds for root
file systems. Almost no one (and maybe no one) uses source mode any more.

Make the default be bb, which everyone uses.