### PR TITLE
pkg/boot/netboot: Check for error in looking up the name instead of returning a nil pointer that will cause callers to panic

### DIFF
--- a/pkg/boot/netboot/netboot.go
+++ b/pkg/boot/netboot/netboot.go
@@ -76,6 +76,9 @@ func getBootImage(schemes curl.Schemes, uri *url.URL, mac net.HardwareAddr, ip n
 		return nil, fmt.Errorf("failed to parse pxelinux config: %v", err)
 	}
 
-	label := pc.Entries[pc.DefaultEntry]
+	label, ok := pc.Entries[pc.DefaultEntry]
+	if !ok {
+		return nil, fmt.Errorf("Could not find %q from entries %v", pc.DefaultEntry, pc.Entries)
+	}
 	return label, nil
 }


### PR DESCRIPTION
The hack is what to do if DefaultEntry is not set: use "LinuxImage"
as the name.

The good fix is to correctly detect nothing was found, and return
an error, instead of returning nil, nil, which was causing pxeboot
to explode.