### PR TITLE
STBOOT: stconfig unpack deletes tmp folder

### DIFF
--- a/pkg/boot/stboot/bootball.go
+++ b/pkg/boot/stboot/bootball.go
@@ -321,9 +321,9 @@ func (ball *BootBall) getSignatures() error {
 	ball.signatures = make(map[string][]signature)
 	path := filepath.Join(ball.dir, signaturesDirName)
 
-	sigPool := make([]signature, 0)
 	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
 		ext := filepath.Ext(info.Name())
+		sigPool := make([]signature, 0)
 
 		if !info.IsDir() && (ext == ".signature") {
 			sigBytes, err := ioutil.ReadFile(path)

--- a/tools/stconfig/commands.go
+++ b/tools/stconfig/commands.go
@@ -51,6 +51,6 @@ func unpackBootBall(bootBall string) (err error) {
 		return err
 	}
 
-	log.Println("Archive unpacked into: " + ball.Dir())
-	return ball.Clean()
+	log.Println("Archive unpacked into: " + ball.Dir() + " Remember to delte folder afterwards")
+	return
 }


### PR DESCRIPTION
stconfig unpack doesn't delete the tmp folder now, so you can access it
Signed-off-by: Christopher Meis <christopher.meis@9elements.com>