### PR TITLE
Pox improvements

### DIFF
--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -73,7 +73,12 @@ func pox() error {
 	if *create {
 		l, err := ldd.Ldd(names)
 		if err != nil {
-			return fmt.Errorf("Running ldd on %v: %v", names, err)
+			var stderr []byte
+			if eerr, ok := err.(*exec.ExitError); ok {
+				stderr = eerr.Stderr
+			}
+			return fmt.Errorf("Running ldd on %v: %v %s", names,
+				err, stderr)
 		}
 
 		for _, dep := range l {

--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -49,15 +49,30 @@
 // Notes:
 // - When running a pox, you likely need sudo to chroot
 //
-// - Your binaries and programs show up in the TCZ using whatever path you
-// provided to pox.  For instance, if you are in /home/you/somedir/ and have
-// ./bin/foo, and you pox -c bin/foo, your TCZ will contain bin/foo.  If you
-// pox /home/you/somedir/bin/foo, your TCZ will contain the full path.
+// - Binaries run out of a chroot often need files you are unaware of.  For
+// instance, if bash can't find terminfo files, it won't know to handle
+// backspaces properly.  (They occur, but are not shown).  To fix this, pass pox
+// all of the files you need.  For bash: `find /lib/terminfo -type f`.
+//
+// Other programs rely on help functions, such as '/bin/man'.  If your program
+// has built-in help commands that trigger man pages, e.g. "git help foo",
+// you'll want to include /bin/man too.  But you'll also need everything that
+// man uses, such as /etc/manpath.config.  My advice: skip it.
+//
+// - When adding all files in a directory, the easiest thing to do is:
+// `find $DIR -type f`  (Note the ticks: this is a bash command execution).
 //
 // - When creating a pox with an executable with shared libraries that are not
 // installed on your system, such as for a project installed in your home
 // directory, run pox from the installation prefix directory, such that the
-// libraries and binaries are below pox's working directory.
+// lib/ and bin/ are in pox's working directory.  Pox will strip its working
+// directory from the paths of the files it builds.  Having bin/ in the root of
+// the pox file helps with PATH lookups, and not having the full path from your
+// machine in the pox file makes it easier to extract a pox file to /usr/local/.
+//
+// - Consider adding a --extract | -x option to install to the host.  One issue
+// would be how to handle collisions, e.g. libc.  Your app may not like the libc
+// on the system you run on.
 package main
 
 import (

--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -209,6 +209,14 @@ func poxRun(args []string) error {
 		defer mountPoint.Unmount(0) //nolint:errcheck
 	}
 
+	// If you pass Command a path with no slashes, it'll use PATH from the
+	// parent to resolve the path to exec.  Once we chroot, whatever path we
+	// picked is undoubtably wrong.  Let's help them out: if they give us a
+	// program with no /, let's look in /bin/.  If they want the root of the
+	// chroot, they can use "./"
+	if filepath.Base(args[0]) == args[0] {
+		args[0] = filepath.Join(string(os.PathSeparator), "bin", args[0])
+	}
 	c := exec.Command(args[0], args[1:]...)
 	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
 	c.SysProcAttr = &syscall.SysProcAttr{

--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -225,10 +225,10 @@ func poxRun(args []string) error {
 	c.Env = append(os.Environ(), "PWD=.")
 
 	if err = c.Run(); err != nil {
-		log.Printf("Running test: %v", err)
+		v("pox command exited with: %v", err)
 	}
 
-	return err
+	return nil
 }
 
 func pox() error {

--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -67,6 +67,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	flag "github.com/spf13/pflag"
@@ -111,6 +112,10 @@ func poxCreate(names []string) error {
 	if !*debug {
 		defer os.RemoveAll(dir)
 	}
+	pwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
 	// We don't use defer() here to close files as
 	// that can cause open failures with a large enough number.
 	for _, f := range names {
@@ -123,6 +128,7 @@ func poxCreate(names []string) error {
 		if err != nil {
 			return err
 		}
+		f = strings.TrimPrefix(f, pwd)
 		dfile := filepath.Join(dir, f)
 		d := filepath.Dir(dfile)
 		if err := os.MkdirAll(d, 0755); err != nil {

--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -183,6 +183,7 @@ func poxRun(args []string) error {
 	c.SysProcAttr = &syscall.SysProcAttr{
 		Chroot: dir,
 	}
+	c.Env = append(os.Environ(), "PWD=.")
 
 	if err = c.Run(); err != nil {
 		log.Printf("Running test: %v", err)

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -96,6 +96,56 @@ type FileInfo struct {
 	os.FileInfo
 }
 
+func GetInterp(file string) (string, error) {
+	r, err := os.Open(file)
+	if err != nil {
+		return "fail", err
+	}
+	defer r.Close()
+	f, err := elf.NewFile(r)
+	if err != nil {
+		return "", nil
+	}
+	s := f.Section(".interp")
+	var interp string
+	if s != nil {
+		// If there is an interpreter section, it should be
+		// an error if we can't read it.
+		i, err := s.Data()
+		if err != nil {
+			return "fail", err
+		}
+		// Ignore #! interpreters
+		if len(i) > 1 && i[0] == '#' && i[1] == '!' {
+			return "", nil
+		}
+		// annoyingly, s.Data() seems to return the null at the end and,
+		// weirdly, that seems to confuse the kernel. Truncate it.
+		interp = string(i[:len(i)-1])
+	}
+	if interp == "" {
+		if f.Type != elf.ET_DYN || f.Class == elf.ELFCLASSNONE {
+			return "", nil
+		}
+		bit64 := true
+		if f.Class != elf.ELFCLASS64 {
+			bit64 = false
+		}
+
+		// This is a shared library. Turns out you can run an
+		// interpreter with --list and this shared library as an
+		// argument. What interpreter do we use? Well, there's no way to
+		// know. You have to guess.  I'm not sure why they could not
+		// just put an interp section in .so's but maybe that would
+		// cause trouble somewhere else.
+		interp, err = LdSo(bit64)
+		if err != nil {
+			return "fail", err
+		}
+	}
+	return interp, nil
+}
+
 // Ldd returns a list of all library dependencies for a set of files.
 //
 // If a file has no dependencies, that is not an error. The only possible error
@@ -115,50 +165,12 @@ func Ldd(names []string) ([]*FileInfo, error) {
 		}
 	}
 	for _, n := range names {
-		r, err := os.Open(n)
+		interp, err := GetInterp(n)
 		if err != nil {
 			return nil, err
 		}
-		defer r.Close()
-		f, err := elf.NewFile(r)
-		if err != nil {
-			continue
-		}
-		s := f.Section(".interp")
-		var interp string
-		if s != nil {
-			// If there is an interpreter section, it should be
-			// an error if we can't read it.
-			i, err := s.Data()
-			if err != nil {
-				return nil, err
-			}
-			// Ignore #! interpreters
-			if len(i) > 1 && i[0] == '#' && i[1] == '!' {
-				continue
-			}
-			// annoyingly, s.Data() seems to return the null at the end and,
-			// weirdly, that seems to confuse the kernel. Truncate it.
-			interp = string(i[:len(i)-1])
-		}
 		if interp == "" {
-			if f.Type != elf.ET_DYN || f.Class == elf.ELFCLASSNONE {
-				continue
-			}
-			bit64 := true
-			if f.Class != elf.ELFCLASS64 {
-				bit64 = false
-			}
-
-			// This is a shared library. Turns out you can run an interpreter with
-			// --list and this shared library as an argument. What interpreter
-			// do we use? Well, there's no way to know. You have to guess.
-			// I'm not sure why they could not just put an interp section in
-			// .so's but maybe that would cause trouble somewhere else.
-			interp, err = LdSo(bit64)
-			if err != nil {
-				return nil, err
-			}
+			continue
 		}
 		// We could just append the interp but people
 		// expect to see that first.


### PR DESCRIPTION
This patch series consists of a bunch of changes to pox that helped me run it on non-standard Linux machines.  Highlights include:
- Splits pox's creation (-c) from running (-r).  You can now do only one at a time.
- Allow passing arguments to your binary, with '--'
- Option to use zip (-z) instead of squashfs, for kernels without CONFIG_SQUASHFS built in

With these changes, I am able to pox-run a relatively complicated program (https://github.com/pmem/ndctl) that requires several shared libraries, including its own .sos, and runtime access to /proc and /sys.
