### PR TITLE
cmds/core/fusermount: restore privs correctly

### DIFF
--- a/cmds/core/fusermount/fusermount_linux.go
+++ b/cmds/core/fusermount/fusermount_linux.go
@@ -4,29 +4,29 @@
 
 package main
 
-import (
-	"os"
-
-	"golang.org/x/sys/unix"
-)
+import "golang.org/x/sys/unix"
 
 var (
 	fileSystemUID, fileSystemGID int
 )
 
 func dropPrivs() error {
-	if fileSystemUID = unix.Getuid(); fileSystemUID == 0 {
+	uid := unix.Getuid()
+	if uid == 0 {
 		return nil
 	}
-	fileSystemGID = unix.Getgid()
-	if err := unix.Setfsuid(fileSystemUID); err != nil {
+
+	var err error
+	fileSystemUID, err = unix.SetfsuidRetUid(uid)
+	if err != nil {
 		return err
 	}
-	return unix.Setfsgid(fileSystemGID)
+	fileSystemGID, err = unix.SetfsgidRetGid(unix.Getgid())
+	return err
 }
 
 func restorePrivs() {
-	if os.Getuid() == 0 {
+	if unix.Getuid() == 0 {
 		return
 	}
 	// We're exiting, if there's an error, not much to do.


### PR DESCRIPTION
`Setfsuid`/`Setfsgid` from `x/sys/unix` don't return the previous filesystem
uid/gid, so `restorePrivs` will be a no-op as it is just setting previous
`fileSystemUID` and `fileSystemGID` again.
    
golang/sys@e047566fdf introduced the `SetfsuidRetUid`/`SetfsgidRetGid`
wrappers for the `setfsuid`/`setfsgid` syscalls returning the previous
fileystem uid/gid. Use these and store the previous values, so they can
be used in `restorePrivs`.