### PR TITLE
pkg/ldd: add build constraints

### DIFF
--- a/pkg/ldd/ldd_test.go
+++ b/pkg/ldd/ldd_test.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build freebsd linux
+
 package ldd
 
 import (

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build freebsd linux
+
 // ldd returns all the library dependencies of an executable.
 //
 // The way this is done on GNU-based systems is interesting. For each ELF, one


### PR DESCRIPTION
go get github.com/u-root/u-root on darwin fails with
```
  # github.com/u-root/u-root/pkg/ldd
  u-root/u-root/pkg/ldd/ldd_unix.go:156:18: undefined: LdSo
```
Fix this by adding build constraints for freebsd and linux which are
currently the only supported platforms for pkg/ldd

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>