### PR TITLE
Multiboot ReaderAt revert

### DIFF
--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -20,7 +20,6 @@ package main
 
 import (
 	"log"
-	"os"
 
 	flag "github.com/spf13/pflag"
 
@@ -84,13 +83,8 @@ func main() {
 
 	if opts.load {
 		kernelpath := flag.Arg(0)
-		mbkernel, err := os.Open(kernelpath)
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer mbkernel.Close()
 		var image boot.OSImage
-		if err := multiboot.Probe(mbkernel); err == nil {
+		if err := multiboot.Probe(kernelpath); err == nil {
 			image = &boot.MultibootImage{
 				Modules: opts.modules,
 				Path:    kernelpath,

--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -21,7 +21,6 @@ package main
 import (
 	"log"
 	"os"
-	"strings"
 
 	flag "github.com/spf13/pflag"
 
@@ -92,22 +91,9 @@ func main() {
 		defer mbkernel.Close()
 		var image boot.OSImage
 		if err := multiboot.Probe(mbkernel); err == nil {
-
-			modules := make([]multiboot.Module, len(opts.modules))
-			for i, cmd := range opts.modules {
-				modules[i].CmdLine = cmd
-				name := strings.Fields(cmd)[0]
-				f, err := os.Open(name)
-				if err != nil {
-					log.Fatalf("error opening module %v: %v", name, err)
-				}
-				defer f.Close()
-				modules[i].Module = f
-			}
-
 			image = &boot.MultibootImage{
-				Modules: modules,
-				Kernel:  mbkernel,
+				Modules: opts.modules,
+				Path:    kernelpath,
 				Cmdline: newCmdline,
 			}
 		} else {

--- a/pkg/boot/esxi/esxi.go
+++ b/pkg/boot/esxi/esxi.go
@@ -39,10 +39,8 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/u-root/u-root/pkg/boot"
-	"github.com/u-root/u-root/pkg/boot/multiboot"
 	"github.com/u-root/u-root/pkg/gpt"
 	"github.com/u-root/u-root/pkg/mount"
-	"github.com/u-root/u-root/pkg/uio"
 )
 
 // LoadDisk loads the right ESXi multiboot kernel from partitions 5 or 6 of the
@@ -132,9 +130,6 @@ func mountPartition(dev string) (*options, error) {
 	return &opts, nil
 }
 
-// So tests can replace this and don't have to open actual files.
-var fileOpener func(string) uio.ReadAtCloser = uio.NewLazyFile
-
 func getBootImage(opts options, device string, partition int) (*boot.MultibootImage, error) {
 	// Only valid and upgrading are bootable partitions.
 	//
@@ -158,17 +153,10 @@ func getBootImage(opts options, device string, partition int) (*boot.MultibootIm
 			return nil, fmt.Errorf("cannot add boot uuid of %s: %v", device, err)
 		}
 	}
-	modules := make([]multiboot.Module, len(opts.modules))
-	for i, cmd := range opts.modules {
-		modules[i].CmdLine = cmd
-		name := strings.Fields(cmd)[0]
-		modules[i].Module = fileOpener(name)
-	}
-
 	return &boot.MultibootImage{
-		Kernel:  fileOpener(opts.kernel),
+		Path:    opts.kernel,
 		Cmdline: opts.args,
-		Modules: modules,
+		Modules: opts.modules,
 	}, nil
 }
 

--- a/pkg/boot/esxi/esxi_test.go
+++ b/pkg/boot/esxi/esxi_test.go
@@ -6,14 +6,11 @@ package esxi
 
 import (
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"reflect"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/boot"
-	"github.com/u-root/u-root/pkg/boot/multiboot"
-	"github.com/u-root/u-root/pkg/uio"
 )
 
 func TestParse(t *testing.T) {
@@ -148,35 +145,11 @@ var (
 	device   = "testdata/dev"
 )
 
-// use that in test and pass it instead of the uio.NewLazyFile to getBootImage
-type testReaderAt struct {
-	Path string
-}
-
-// ReadAt implements io.ReaderAt.ReadAt.
-func (tra *testReaderAt) ReadAt(p []byte, off int64) (int, error) {
-	return 0, errors.New("not implemented")
-}
-
-// Close implements io.Closer.Close.
-func (tra *testReaderAt) Close() error {
-	return nil
-}
-
-func newTestReaderAt(path string) uio.ReadAtCloser {
-	return &testReaderAt{Path: path}
-}
-
 func TestDev5Valid(t *testing.T) {
-	prevFileOpener := fileOpener
-	defer func() { fileOpener = prevFileOpener }()
-	fileOpener = newTestReaderAt
-
 	want := []*boot.MultibootImage{
 		{
-			Kernel:  newTestReaderAt("testdata/k"),
+			Path:    "testdata/k",
 			Cmdline: fmt.Sprintf(" bootUUID=%s", uuid5),
-			Modules: []multiboot.Module{},
 		},
 	}
 
@@ -205,15 +178,10 @@ func TestDev5Valid(t *testing.T) {
 }
 
 func TestDev6Valid(t *testing.T) {
-	prevFileOpener := fileOpener
-	defer func() { fileOpener = prevFileOpener }()
-	fileOpener = newTestReaderAt
-
 	want := []*boot.MultibootImage{
 		{
-			Kernel:  newTestReaderAt("testdata/k"),
+			Path:    "testdata/k",
 			Cmdline: fmt.Sprintf(" bootUUID=%s", uuid6),
-			Modules: []multiboot.Module{},
 		},
 	}
 
@@ -242,14 +210,6 @@ func TestDev6Valid(t *testing.T) {
 }
 
 func TestImageOrder(t *testing.T) {
-	prevFileOpener := fileOpener
-	prevGetBlockSize := getBlockSize
-	defer func() {
-		fileOpener = prevFileOpener
-		getBlockSize = prevGetBlockSize
-	}()
-	fileOpener = newTestReaderAt
-
 	getBlockSize = func(dev string) (int, error) {
 		return 512, nil
 	}
@@ -260,9 +220,8 @@ func TestImageOrder(t *testing.T) {
 		bootstate: bootValid,
 	}
 	want5 := &boot.MultibootImage{
-		Kernel:  newTestReaderAt("foobar"),
+		Path:    "foobar",
 		Cmdline: fmt.Sprintf(" bootUUID=%s", uuid5),
-		Modules: []multiboot.Module{},
 	}
 
 	opt6 := &options{
@@ -271,9 +230,8 @@ func TestImageOrder(t *testing.T) {
 		bootstate: bootValid,
 	}
 	want6 := &boot.MultibootImage{
-		Kernel:  newTestReaderAt("testdata/k"),
+		Path:    "testdata/k",
 		Cmdline: fmt.Sprintf(" bootUUID=%s", uuid6),
-		Modules: []multiboot.Module{},
 	}
 
 	// Way 1.

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -31,19 +31,8 @@ func (mi *MultibootImage) Load(verbose bool) error {
 		return err
 	}
 	defer mbkernel.Close()
-	modules := make([]multiboot.Module, len(mi.Modules))
-	for i, cmd := range mi.Modules {
-		modules[i].CmdLine = cmd
-		name := strings.Fields(cmd)[0]
-		f, err := os.Open(name)
-		if err != nil {
-			return fmt.Errorf("error opening module %v: %v", name, err)
-		}
-		defer f.Close()
-		modules[i].Module = f
-	}
 
-	return multiboot.Load(verbose, mbkernel, mi.Cmdline, modules, mi.IBFT)
+	return multiboot.Load(verbose, mbkernel, mi.Cmdline, mi.Modules, mi.IBFT)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -6,7 +6,6 @@ package boot
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/u-root/u-root/pkg/boot/ibft"
@@ -26,13 +25,7 @@ var _ OSImage = &MultibootImage{}
 
 // Load implements OSImage.Load.
 func (mi *MultibootImage) Load(verbose bool) error {
-	mbkernel, err := os.Open(mi.Path)
-	if err != nil {
-		return err
-	}
-	defer mbkernel.Close()
-
-	return multiboot.Load(verbose, mbkernel, mi.Cmdline, mi.Modules, mi.IBFT)
+	return multiboot.Load(verbose, mi.Path, mi.Cmdline, mi.Modules, mi.IBFT)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/boot/multiboot/description.go
+++ b/pkg/boot/multiboot/description.go
@@ -10,8 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-
-	"github.com/u-root/u-root/pkg/uio"
+	"strings"
 )
 
 // DebugPrefix is a prefix that some messages are printed with for tests to parse.
@@ -41,7 +40,8 @@ type Description struct {
 func (m multiboot) description() (string, error) {
 	var modules []ModuleDesc
 	for i, mod := range m.loadedModules {
-		b, err := uio.ReadAll(m.modules[i].Module)
+		name := strings.Fields(m.modules[i])[0]
+		b, err := readFile(name)
 		if err != nil {
 			return "", nil
 		}
@@ -49,7 +49,7 @@ func (m multiboot) description() (string, error) {
 		modules = append(modules, ModuleDesc{
 			Start:   mod.Start,
 			End:     mod.End,
-			CmdLine: m.modules[i].CmdLine,
+			CmdLine: m.modules[i],
 			SHA256:  fmt.Sprintf("%x", hash),
 		})
 

--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -107,17 +107,20 @@ func alignUp(buf *bytes.Buffer) error {
 func (m *module) loadModule(buf *bytes.Buffer, r io.ReaderAt, name string) error {
 	log.Printf("Adding module %v", name)
 
+	b, err := uio.ReadAll(r)
+	if err != nil {
+		return err
+	}
+
 	// place start of each module to a beginning of a page.
 	if err := alignUp(buf); err != nil {
 		return err
 	}
 
 	m.Start = uint32(buf.Len())
-
-	if _, err := io.Copy(buf, uio.Reader(r)); err != nil {
+	if _, err := buf.Write(b); err != nil {
 		return err
 	}
-
 	m.End = uint32(buf.Len())
 
 	return nil

--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/u-root/u-root/pkg/ubinary"
 	"github.com/u-root/u-root/pkg/uio"
@@ -86,8 +87,9 @@ func loadModules(rmods []Module) (loaded modules, data []byte, err error) {
 	}
 
 	for i, rmod := range rmods {
-		if err := loaded[i].loadModule(&buf, rmod.Module, rmod.Name); err != nil {
-			return nil, nil, fmt.Errorf("error adding module %v: %v", rmod.Name, err)
+		name := strings.Fields(rmod.CmdLine)[0]
+		if err := loaded[i].loadModule(&buf, rmod.Module, name); err != nil {
+			return nil, nil, fmt.Errorf("error adding module %v: %v", name, err)
 		}
 	}
 

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -32,7 +32,6 @@ const bootloader = "u-root kexec"
 // Module describe a module by a ReaderAt and a `CmdLine`
 type Module struct {
 	Module  io.ReaderAt
-	Name    string
 	CmdLine string
 }
 
@@ -172,7 +171,6 @@ func OpenModules(cmds []string, uncompress bool) (Modules, error) {
 	for i, cmd := range cmds {
 		modules[i].CmdLine = cmd
 		name := strings.Fields(cmd)[0]
-		modules[i].Name = name
 		f, err := os.Open(name)
 		if err != nil {
 			// TODO close already open files

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -35,9 +35,6 @@ type Module struct {
 	CmdLine string
 }
 
-// Modules is a range of module with a Closer interface
-type Modules []Module
-
 // multiboot defines parameters for working with multiboot kernels.
 type multiboot struct {
 	mem kexec.Memory
@@ -137,6 +134,9 @@ func newMB(kernel io.ReaderAt, cmdLine string, modules []Module) (*multiboot, er
 
 // Load parses and loads a multiboot `kernel` using kexec_load.
 //
+// Each module is a path followed by optional command-line arguments, e.g.
+// []string{"./module arg1 arg2", "./module2 arg3 arg4"}.
+//
 // debug turns on debug logging.
 //
 // Load can set up an arbitrary number of modules, and takes care of the
@@ -146,6 +146,19 @@ func newMB(kernel io.ReaderAt, cmdLine string, modules []Module) (*multiboot, er
 // Linux and execute the loaded kernel.
 func Load(debug bool, kernel io.ReaderAt, cmdline string, modules []Module, ibft *ibft.IBFT) error {
 	kernel = tryGzipFilter(kernel)
+	for i, mod := range modules {
+		// try open modules as file... we loop for the filter anyway
+		if mod.Module == nil {
+			name := strings.Fields(mod.CmdLine)[0]
+			f, err := os.Open(name)
+			if err != nil {
+				return fmt.Errorf("error opening module %v: %v", name, err)
+			}
+			defer f.Close()
+			mod.Module = f
+		}
+		modules[i].Module = tryGzipFilter(mod.Module)
+	}
 
 	m, err := newMB(kernel, cmdline, modules)
 	if err != nil {
@@ -158,45 +171,6 @@ func Load(debug bool, kernel io.ReaderAt, cmdline string, modules []Module, ibft
 		return fmt.Errorf("kexec.Load() error: %v", err)
 	}
 	return nil
-}
-
-// OpenModules open modules as files and fill a range of `Module` struct
-//
-// Each module is a path followed by optional command-line arguments, e.g.
-// []string{"./module arg1 arg2", "./module2 arg3 arg4"}.
-//
-// uncompress when true will try to uncompress modules if needed
-func OpenModules(cmds []string, uncompress bool) (Modules, error) {
-	modules := make([]Module, len(cmds))
-	for i, cmd := range cmds {
-		modules[i].CmdLine = cmd
-		name := strings.Fields(cmd)[0]
-		f, err := os.Open(name)
-		if err != nil {
-			// TODO close already open files
-			return nil, fmt.Errorf("error opening module %v: %v", name, err)
-		}
-		if uncompress {
-			modules[i].Module = tryGzipFilter(f)
-		} else {
-			modules[i].Module = f
-		}
-	}
-	return modules, nil
-}
-
-// Close closes all Modules ReaderAt implementing the io.Closer interface
-func (m Modules) Close() error {
-	// poor error handling inspired from uio.multiCloser
-	var allErr error
-	for _, mod := range m {
-		if c, ok := mod.Module.(io.Closer); ok {
-			if err := c.Close(); err != nil {
-				allErr = err
-			}
-		}
-	}
-	return allErr
 }
 
 // load loads and parses multiboot information from m.kernel.

--- a/pkg/boot/multiboot/reader.go
+++ b/pkg/boot/multiboot/reader.go
@@ -5,13 +5,42 @@
 package multiboot
 
 import (
-	"bytes"
 	"compress/gzip"
+	"fmt"
 	"io"
 	"io/ioutil"
+	"os"
 
 	"github.com/u-root/u-root/pkg/uio"
 )
+
+type kernelReader struct {
+	buf []byte
+	off int
+}
+
+func (kr kernelReader) ReadAt(p []byte, off int64) (n int, err error) {
+	if off < 0 || off > int64(len(kr.buf)) {
+		return 0, fmt.Errorf("bad offset %v", off)
+	}
+	if n = copy(p, kr.buf[off:]); n < len(p) {
+		err = io.EOF
+	}
+	return n, err
+}
+
+func (kr *kernelReader) Read(p []byte) (n int, err error) {
+	if n = copy(p, kr.buf[kr.off:]); n < len(p) {
+		err = io.EOF
+	}
+	kr.off += n
+	return n, err
+}
+
+// implement inMemReaderAt interface
+func (kr kernelReader) Bytes() []byte {
+	return kr.buf
+}
 
 func readGzip(r io.Reader) ([]byte, error) {
 	z, err := gzip.NewReader(r)
@@ -22,12 +51,30 @@ func readGzip(r io.Reader) ([]byte, error) {
 	return ioutil.ReadAll(z)
 }
 
+func readFile(name string) ([]byte, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	b, err := readGzip(f)
+	if err == nil {
+		return b, err
+	}
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("cannot rewind file: %v", err)
+	}
+
+	return ioutil.ReadAll(f)
+}
+
 // TODO: could be tryCompressionFilters, grub support gz,xz and lzop
 // TODO: do we want to keep the filter inside multiboot? This could be the responsibility of the caller...
 func tryGzipFilter(r io.ReaderAt) io.ReaderAt {
 	b, err := readGzip(uio.Reader(r))
 	if err == nil {
-		return bytes.NewReader(b)
+		kernel := kernelReader{buf: b}
+		return kernel
 	}
 	return r
 }

--- a/pkg/boot/multiboot/reader.go
+++ b/pkg/boot/multiboot/reader.go
@@ -10,8 +10,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-
-	"github.com/u-root/u-root/pkg/uio"
 )
 
 type kernelReader struct {
@@ -61,15 +59,4 @@ func readFile(name string) ([]byte, error) {
 	}
 
 	return ioutil.ReadAll(f)
-}
-
-// TODO: could be tryCompressionFilters, grub support gz,xz and lzop
-// TODO: do we want to keep the filter inside multiboot? This could be the responsibility of the caller...
-func tryGzipFilter(r io.ReaderAt) io.ReaderAt {
-	b, err := readGzip(uio.Reader(r))
-	if err == nil {
-		kernel := kernelReader{buf: b}
-		return kernel
-	}
-	return r
 }

--- a/pkg/boot/multiboot/reader.go
+++ b/pkg/boot/multiboot/reader.go
@@ -37,11 +37,6 @@ func (kr *kernelReader) Read(p []byte) (n int, err error) {
 	return n, err
 }
 
-// implement inMemReaderAt interface
-func (kr kernelReader) Bytes() []byte {
-	return kr.buf
-}
-
 func readGzip(r io.Reader) ([]byte, error) {
 	z, err := gzip.NewReader(r)
 	if err != nil {

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/u-root/u-root/pkg/boot/kexec"
 	"github.com/u-root/u-root/pkg/boot/multiboot"
@@ -100,19 +99,7 @@ func (bc *BootConfig) Boot() error {
 			log.Printf("Error parsing multiboot header: %v", err)
 			return err
 		}
-		modules := make([]multiboot.Module, len(bc.Modules))
-		for i, cmd := range bc.Modules {
-			modules[i].CmdLine = cmd
-			name := strings.Fields(cmd)[0]
-			f, err := os.Open(name)
-			if err != nil {
-				return fmt.Errorf("error opening module %v: %v", name, err)
-			}
-			defer f.Close()
-			modules[i].Module = f
-		}
-
-		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, modules, nil); err != nil {
+		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, bc.Modules, nil); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}
 	}

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -87,19 +87,12 @@ func (bc *BootConfig) Boot() error {
 			return err
 		}
 	} else if bc.Multiboot != "" {
-		mbkernel, err := os.Open(bc.Multiboot)
-		if err != nil {
-			log.Printf("Error opening multiboot kernel file: %v", err)
-			return err
-		}
-		defer mbkernel.Close()
-
 		// check multiboot header
-		if err := multiboot.Probe(mbkernel); err != nil {
+		if err := multiboot.Probe(bc.Multiboot); err != nil {
 			log.Printf("Error parsing multiboot header: %v", err)
 			return err
 		}
-		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, bc.Modules, nil); err != nil {
+		if err := multiboot.Load(true, bc.Multiboot, bc.MultibootArgs, bc.Modules, nil); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}
 	}

--- a/pkg/bootconfig/bootconfig.go
+++ b/pkg/bootconfig/bootconfig.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/u-root/u-root/pkg/boot/kexec"
 	"github.com/u-root/u-root/pkg/boot/multiboot"
@@ -99,11 +100,18 @@ func (bc *BootConfig) Boot() error {
 			log.Printf("Error parsing multiboot header: %v", err)
 			return err
 		}
-		modules, err := multiboot.OpenModules(bc.Modules, true)
-		if err != nil {
-			return err
+		modules := make([]multiboot.Module, len(bc.Modules))
+		for i, cmd := range bc.Modules {
+			modules[i].CmdLine = cmd
+			name := strings.Fields(cmd)[0]
+			f, err := os.Open(name)
+			if err != nil {
+				return fmt.Errorf("error opening module %v: %v", name, err)
+			}
+			defer f.Close()
+			modules[i].Module = f
 		}
-		defer modules.Close()
+
 		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, modules, nil); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}


### PR DESCRIPTION
This has broken multiboot for ESXi kernels. I need to temporarily revert this for time constraints, I will fix forward later. cc @JulienVdG 

you can use the instructions at https://github.com/u-root/u-root/tree/master/cmds/exp/esxiboot to reproduce the failure. I'll be bisecting to test this.