### PR TITLE
add a simple pager

### DIFF
--- a/cmds/exp/page/main.go
+++ b/cmds/exp/page/main.go
@@ -1,0 +1,106 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Synopsis:
+//     page [file]
+//
+// Description:
+// page prints a page at a time to stdout from either stdin or a named file.
+// It stops every x rows, where x is the number of rows determined from gtty.
+// Single character commands tell it what to do next. Currently the only ones
+// are return and q.
+//
+// Options:
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	"github.com/u-root/u-root/pkg/termios"
+)
+
+func page(t *termios.TTY, r io.Reader, w io.Writer) error {
+	rows := int64(24)
+	if w, err := t.GetWinSize(); err != nil {
+		log.Printf("Could not get win size: %v; continuing assuming %d rows", err, rows)
+	} else {
+		rows = int64(w.Row)
+	}
+
+	l := int64(1)
+	scanner := bufio.NewScanner(r)
+	for {
+		cur := l
+		for {
+			if !scanner.Scan() {
+				return scanner.Err()
+			}
+			line := scanner.Text()
+			if _, err := fmt.Fprintf(w, "%s\r\n", string(line)); err != nil {
+				return err
+			}
+			cur++
+			if cur > l+rows {
+				break
+			}
+		}
+		if cur == l {
+			break
+		}
+		l = cur
+		if _, err := fmt.Fprintf(t, ":"); err != nil {
+			return err
+		}
+		var cmd [1]byte
+		if _, err := t.Read(cmd[:]); err != nil {
+			return err
+		}
+		switch cmd[0] {
+		default:
+			fmt.Printf("%q:unknown\n", cmd[0])
+		case '\n', ' ':
+		case 'q':
+			return nil
+		}
+		fmt.Fprintf(w, "\r")
+	}
+
+	return nil
+}
+
+func main() {
+	t, err := termios.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	in := os.Stdin
+
+	switch len(os.Args) {
+	case 1:
+	case 2:
+		f, err := os.Open(os.Args[1])
+		if err != nil {
+			log.Fatal(err)
+		}
+		in = f
+	default:
+		log.Fatal("Usage: page [file]")
+	}
+	c, err := t.Raw()
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer func() {
+		if err := t.Set(c); err != nil {
+			log.Printf("Restoring modes failed; sorry (%v)", err)
+		}
+	}()
+	if err := page(t, in, os.Stdout); err != nil {
+		log.Fatal(err)
+	}
+}


### PR DESCRIPTION
The u-root less program has a lot of issues that make it
'less' useful, especially in firmware environments:

1) can't read from a pipe
2) can't read from any file that can't be mmap'ed
3) can't be in a pipeline
4) needs builtin terminfo support and environment variables
5) at least for me, has a weird error that won't let it read commands at all,
   so I'm always stuck seeing just one page of text

page is a dead simple pager modeled on the one from Plan 9.
It's already more useful to me than our less program.

And it's got far less footprint: 2.22M vs. 3.38M