### PR TITLE
Lock documented MSRs.

### DIFF
--- a/cmds/core/lockmsrs/lockmsrs.go
+++ b/cmds/core/lockmsrs/lockmsrs.go
@@ -2,68 +2,74 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// lock-msrs locks a bunch of intel MSRs, all specified in the Intel
-// Software developer's manual. This seems like a good set of bits to
-// lock down when booting through NERF/LINUXBOOT to some other OS.
-// When locked, these MSRs generally prevent further modifications until
-// reset.
+// lockmsrs locks important intel MSRs.
+//
+// All MSRs are specified in the Intel Software developer's manual.
+// This seems like a good set of bits to lock down when booting through NERF/LINUXBOOT
+// to some other OS. When locked, these MSRs generally prevent
+// further modifications until reset.
 package main
 
 import (
+	"flag"
 	"log"
 
 	"github.com/intel-go/cpuid"
 	"github.com/u-root/u-root/pkg/msr"
 )
 
-const MSR_IA32_FEATURE_CONTROL uint32 = 0x3A
-const MSR_PKG_CST_CONFIG_CONTROL uint32 = 0xE2
-const MSR_FEATURE_CONFIG uint32 = 0x13C
-const MSR_DRAM_POWER_LIMIT uint32 = 0x618
-const MSR_CONFIG_TDP_CONTROL uint32 = 0x64B
-const IA32_DEBUG_INTERFACE uint32 = 0xC80
+const (
+	msrIA32FeatureControl  msr.MSR = 0x3A  // MSR_IA32_FEATURE_CONTROL
+	msrPkgCstConfigControl msr.MSR = 0xE2  // MSR_PKG_CST_CONFIG_CONTROL
+	msrFeatureConfig       msr.MSR = 0x13C // MSR_FEATURE_CONFIG
+	msrDramPowerLimit      msr.MSR = 0x618 // MSR_DRAM_POWER_LIMIT
+	msrConfigTDPControl    msr.MSR = 0x64B // MSR_CONFIG_TDP_CONTROL
+	ia32DebugInterface     msr.MSR = 0xC80 // IA32_DEBUG_INTERFACE
+)
+
+var verbose = flag.Bool("v", false, "verbose mode")
 
 var msrList = []struct {
-	msrAdd    uint32
+	msrAdd    msr.MSR
 	clearMask uint64
 	setMask   uint64
 }{
 	{
 		// Architectural MSR. All systems.
 		// Enables features like VMX.
-		msrAdd:  MSR_IA32_FEATURE_CONTROL,
+		msrAdd:  msrIA32FeatureControl,
 		setMask: 1 << 0, // Locks this register.
 	},
 	{
 		// Silvermont, Airmont, Nehalem...
 		// Controls Processor C States.
-		msrAdd:  MSR_PKG_CST_CONFIG_CONTROL,
+		msrAdd:  msrPkgCstConfigControl,
 		setMask: 1 << 15, // Locks this register.
 	},
 	{
 		// Westmere onwards.
 		// Note that this turns on AES instructions, however
 		// 3 will turn off AES until reset.
-		msrAdd:  MSR_FEATURE_CONFIG,
+		msrAdd:  msrFeatureConfig,
 		setMask: 1 << 0,
 	},
 	{
 		// Goldmont, SandyBridge
 		// Controls DRAM power limits. See Intel SDM
-		msrAdd:  MSR_DRAM_POWER_LIMIT,
+		msrAdd:  msrDramPowerLimit,
 		setMask: 1 << 31, // Locks this register.
 	},
 	{
 		// IvyBridge Onwards.
 		// Not much information in the SDM, seems to control power limits
-		msrAdd:  MSR_CONFIG_TDP_CONTROL,
+		msrAdd:  msrConfigTDPControl,
 		setMask: 1 << 31, // Locks this register.
 	},
 	{
 		// Architectural MSR. All systems.
 		// This is the actual spelling of the MSR in the manual.
 		// Controls availability of silicon debug interfaces
-		msrAdd:  IA32_DEBUG_INTERFACE,
+		msrAdd:  ia32DebugInterface,
 		setMask: 1 << 30, // Locks this register.
 	},
 }
@@ -72,15 +78,18 @@ func main() {
 	if cpuid.VendorIdentificatorString != "GenuineIntel" {
 		log.Fatalf("Only Intel CPUs supported, expected GenuineIntel, got %v", cpuid.VendorIdentificatorString)
 	}
-	p := msr.Paths("*")
-	var errs []error
 
+	cpus := msr.AllCPUs
 	for _, m := range msrList {
-		errs = msr.MaskBits(p, m.msrAdd, m.clearMask, m.setMask)
-	}
-	for i, e := range errs {
-		if e != nil {
-			log.Printf("%v: %v\n", p[i], e)
+		if *verbose {
+			log.Printf("Locking MSR %v on cpus %v, clearmask 0x%8x, setmask 0x%8x", m.msrAdd, cpus, m.clearMask, m.setMask)
+		}
+		errs := m.msrAdd.MaskBits(cpus, m.clearMask, m.setMask)
+		for i, e := range errs {
+			if e != nil {
+				// Hope no one ever modifies this slice.
+				log.Printf("Error locking msr %v on cpu %v: %v\n", m.msrAdd.String(), cpus[i], e)
+			}
 		}
 	}
 }

--- a/cmds/core/lockmsrs/lockmsrs.go
+++ b/cmds/core/lockmsrs/lockmsrs.go
@@ -1,0 +1,86 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// lock-msrs locks a bunch of intel MSRs, all specified in the Intel
+// Software developer's manual. This seems like a good set of bits to
+// lock down when booting through NERF/LINUXBOOT to some other OS.
+// When locked, these MSRs generally prevent further modifications until
+// reset.
+package main
+
+import (
+	"log"
+
+	"github.com/intel-go/cpuid"
+	"github.com/u-root/u-root/pkg/msr"
+)
+
+const MSR_IA32_FEATURE_CONTROL uint32 = 0x3A
+const MSR_PKG_CST_CONFIG_CONTROL uint32 = 0xE2
+const MSR_FEATURE_CONFIG uint32 = 0x13C
+const MSR_DRAM_POWER_LIMIT uint32 = 0x618
+const MSR_CONFIG_TDP_CONTROL uint32 = 0x64B
+const IA32_DEBUG_INTERFACE uint32 = 0xC80
+
+var msrList = []struct {
+	msrAdd    uint32
+	clearMask uint64
+	setMask   uint64
+}{
+	{
+		// Architectural MSR. All systems.
+		// Enables features like VMX.
+		msrAdd:  MSR_IA32_FEATURE_CONTROL,
+		setMask: 1 << 0, // Locks this register.
+	},
+	{
+		// Silvermont, Airmont, Nehalem...
+		// Controls Processor C States.
+		msrAdd:  MSR_PKG_CST_CONFIG_CONTROL,
+		setMask: 1 << 15, // Locks this register.
+	},
+	{
+		// Westmere onwards.
+		// Note that this turns on AES instructions, however
+		// 3 will turn off AES until reset.
+		msrAdd:  MSR_FEATURE_CONFIG,
+		setMask: 1 << 0,
+	},
+	{
+		// Goldmont, SandyBridge
+		// Controls DRAM power limits. See Intel SDM
+		msrAdd:  MSR_DRAM_POWER_LIMIT,
+		setMask: 1 << 31, // Locks this register.
+	},
+	{
+		// IvyBridge Onwards.
+		// Not much information in the SDM, seems to control power limits
+		msrAdd:  MSR_CONFIG_TDP_CONTROL,
+		setMask: 1 << 31, // Locks this register.
+	},
+	{
+		// Architectural MSR. All systems.
+		// This is the actual spelling of the MSR in the manual.
+		// Controls availability of silicon debug interfaces
+		msrAdd:  IA32_DEBUG_INTERFACE,
+		setMask: 1 << 30, // Locks this register.
+	},
+}
+
+func main() {
+	if cpuid.VendorIdentificatorString != "GenuineIntel" {
+		log.Fatalf("Only Intel CPUs supported, expected GenuineIntel, got %v", cpuid.VendorIdentificatorString)
+	}
+	p := msr.Paths("*")
+	var errs []error
+
+	for _, m := range msrList {
+		errs = msr.MaskBits(p, m.msrAdd, m.clearMask, m.setMask)
+	}
+	for i, e := range errs {
+		if e != nil {
+			log.Printf("%v: %v\n", p[i], e)
+		}
+	}
+}

--- a/cmds/core/msr/msr.go
+++ b/cmds/core/msr/msr.go
@@ -55,9 +55,40 @@ var (
 		name string
 		w    []forth.Cell
 	}{
-		{name: "IA32_FEATURE_CONTROL", w: []forth.Cell{"'*", "msr", "0x3a", "reg"}},
-		{name: "READ_IA32_FEATURE_CONTROL", w: []forth.Cell{"IA32_FEATURE_CONTROL", "rd"}},
-		{name: "LOCK_IA32_FEATURE_CONTROL", w: []forth.Cell{"IA32_FEATURE_CONTROL", "READ_IA32_FEATURE_CONTROL", "1", "u64", "or", "wr"}},
+		// Architectural MSR. All systems.
+		// Enables features like VMX.
+		{name: "MSR_IA32_FEATURE_CONTROL", w: []forth.Cell{"'*", "msr", "0x3a", "reg"}},
+		{name: "READ_MSR_IA32_FEATURE_CONTROL", w: []forth.Cell{"MSR_IA32_FEATURE_CONTROL", "rd"}},
+		{name: "LOCK_MSR_IA32_FEATURE_CONTROL", w: []forth.Cell{"MSR_IA32_FEATURE_CONTROL", "READ_MSR_IA32_FEATURE_CONTROL", "1", "u64", "or", "wr"}},
+		// Silvermont, Airmont, Nehalem...
+		// Controls Processor C States.
+		{name: "MSR_PKG_CST_CONFIG_CONTROL", w: []forth.Cell{"'*", "msr", "0xe2", "reg"}},
+		{name: "READ_MSR_PKG_CST_CONFIG_CONTROL", w: []forth.Cell{"MSR_PKG_CST_CONFIG_CONTROL", "rd"}},
+		{name: "LOCK_MSR_PKG_CST_CONFIG_CONTROL", w: []forth.Cell{"MSR_PKG_CST_CONFIG_CONTROL", "READ_MSR_PKG_CST_CONFIG_CONTROL", uint64(1 << 15), "or", "wr"}},
+		// Westmere onwards.
+		// Note that this turns on AES instructions, however
+		// 3 will turn off AES until reset.
+		{name: "MSR_FEATURE_CONFIG", w: []forth.Cell{"'*", "msr", "0x13c", "reg"}},
+		{name: "READ_MSR_FEATURE_CONFIG", w: []forth.Cell{"MSR_FEATURE_CONFIG", "rd"}},
+		{name: "LOCK_MSR_FEATURE_CONFIG", w: []forth.Cell{"MSR_FEATURE_CONFIG", "READ_MSR_FEATURE_CONFIG", uint64(1 << 0), "or", "wr"}},
+		// Goldmont, SandyBridge
+		// Controls DRAM power limits. See Intel SDM
+		{name: "MSR_DRAM_POWER_LIMIT", w: []forth.Cell{"'*", "msr", "0x618", "reg"}},
+		{name: "READ_MSR_DRAM_POWER_LIMIT", w: []forth.Cell{"MSR_DRAM_POWER_LIMIT", "rd"}},
+		{name: "LOCK_MSR_DRAM_POWER_LIMIT", w: []forth.Cell{"MSR_DRAM_POWER_LIMIT", "READ_MSR_DRAM_POWER_LIMIT", uint64(1 << 31), "or", "wr"}},
+		// IvyBridge Onwards.
+		// Not much information in the SDM, seems to control power limits
+		{name: "MSR_CONFIG_TDP_CONTROL", w: []forth.Cell{"'*", "msr", "0xe2", "reg"}},
+		{name: "READ_MSR_CONFIG_TDP_CONTROL", w: []forth.Cell{"MSR_CONFIG_TDP_CONTROL", "rd"}},
+		{name: "LOCK_MSR_CONFIG_TDP_CONTROL", w: []forth.Cell{"MSR_CONFIG_TDP_CONTROL", "READ_MSR_CONFIG_TDP_CONTROL", uint64(1 << 31), "or", "wr"}},
+		// Architectural MSR. All systems.
+		// This is the actual spelling of the MSR in the manual.
+		// Controls availability of silicon debug interfaces
+		{name: "IA32_DEBUG_INTERFACE", w: []forth.Cell{"'*", "msr", "0xe2", "reg"}},
+		{name: "READ_IA32_DEBUG_INTERFACE", w: []forth.Cell{"IA32_DEBUG_INTERFACE", "rd"}},
+		{name: "LOCK_IA32_DEBUG_INTERFACE", w: []forth.Cell{"IA32_DEBUG_INTERFACE", "READ_IA32_DEBUG_INTERFACE", uint64(1 << 15), "or", "wr"}},
+		// Locks all known msrs to lock
+		{name: "LOCK_KNOWN_MSRS", w: []forth.Cell{"LOCK_MSR_IA32_FEATURE_CONTROL", "LOCK_MSR_PKG_CST_CONFIG_CONTROL", "LOCK_MSR_FEATURE_CONFIG", "LOCK_MSR_DRAM_POWER_LIMIT", "LOCK_MSR_CONFIG_TDP_CONTROL", "LOCK_IA32_DEBUG_INTERFACE"}},
 	}
 	ops = []struct {
 		name string

--- a/pkg/msr/msr_linux.go
+++ b/pkg/msr/msr_linux.go
@@ -11,30 +11,38 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 )
 
-// Paths returns the paths to all instances of a specific msr
-func Paths(n string) []string {
-	m, err := filepath.Glob(filepath.Join("/dev/cpu", n, "msr"))
-	// This err will be if the glob was bad.
-	if err != nil {
-		log.Fatalf("No MSRs matched %v: %v", n, err)
+// CPUs is a slice of the various cpus to read or write the MSR to.
+type CPUs []uint64
+
+// AllCPUs is a helper variable that lists all the cpus available on the machine.
+var AllCPUs CPUs
+
+func init() {
+	var errs []error
+
+	if AllCPUs, errs = getAllCPUs(); errs != nil {
+		// Should I fatal here? panic?
+		log.Print("Failed to find all CPUs from /dev/cpu")
+		log.Print(errs)
 	}
-	// len will be zero for any of a number of reasons.
-	if len(m) == 0 {
-		log.Fatalf("No msrs found. Make sure your kernel is compiled with msrs, and you may need to 'sudo modprobe msr'. To see available msrs, ls /dev/cpu.")
-	}
-	return m
 }
 
-func openAll(m []string, o int) ([]*os.File, []error) {
-	var (
-		f      = make([]*os.File, len(m))
-		errs   = make([]error, len(m))
-		hadErr bool
-	)
-	for i := range m {
-		f[i], errs[i] = os.OpenFile(m[i], o, 0)
+// GlobCPUs allow the user to specify CPUs using a glob as one would in /dev/cpu
+func GlobCPUs(g string) (CPUs, []error) {
+	var hadErr bool
+
+	f, err := filepath.Glob(filepath.Join("/dev/cpu", g))
+	if err != nil {
+		return nil, []error{err}
+	}
+
+	c := make([]uint64, len(f))
+	errs := make([]error, len(f))
+	for i, v := range f {
+		c[i], errs[i] = strconv.ParseUint(filepath.Base(v), 0, 64)
 		if errs[i] != nil {
 			hadErr = true
 		}
@@ -42,28 +50,42 @@ func openAll(m []string, o int) ([]*os.File, []error) {
 	if hadErr {
 		return nil, errs
 	}
-	return f, nil
+	return c, nil
 }
 
-func doIO(msr *os.File, addr uint32, f func(*os.File) error) error {
-	if _, err := msr.Seek(int64(addr), 0); err != nil {
-		return fmt.Errorf("bad address %v: %v", addr, err)
+func getAllCPUs() (CPUs, []error) {
+	return GlobCPUs("*")
+}
+
+// MSR is the address of the MSR we want to target.
+type MSR uint32
+
+func (m MSR) String() string {
+	return fmt.Sprintf("%#x", uint32(m))
+}
+
+func (c CPUs) paths() []string {
+	var p = make([]string, len(c))
+
+	for i, v := range c {
+		p[i] = filepath.Join("/dev/cpu", strconv.Itoa(int(v)), "msr")
 	}
-	return f(msr)
+	return p
 }
 
-// Read reads from the msrs paths specified in m.
-func Read(m []string, addr uint32) ([]uint64, []error) {
+func (m MSR) Read(c CPUs) ([]uint64, []error) {
 	var hadErr bool
-	var regs = make([]uint64, len(m))
+	var regs = make([]uint64, len(c))
 
-	f, errs := openAll(m, os.O_RDONLY)
+	paths := c.paths()
+	f, errs := openAll(paths, os.O_RDONLY)
 	if errs != nil {
 		return nil, errs
 	}
 	errs = make([]error, len(f))
 	for i := range f {
-		errs[i] = doIO(f[i], addr, func(port *os.File) error {
+		defer f[i].Close()
+		errs[i] = doIO(f[i], m, func(port *os.File) error {
 			return binary.Read(port, binary.LittleEndian, &regs[i])
 		})
 		if errs[i] != nil {
@@ -78,16 +100,23 @@ func Read(m []string, addr uint32) ([]uint64, []error) {
 }
 
 // Write writes the corresponding data to their specified msrs
-func Write(m []string, addr uint32, data []uint64) []error {
+func (m MSR) Write(c CPUs, data ...uint64) []error {
 	var hadErr bool
-	f, errs := openAll(m, os.O_RDWR)
+
+	if len(data) != len(c) && len(data) != 1 {
+		return []error{fmt.Errorf("mismatched lengths: cpus %v, data %v", c, data)}
+	}
+
+	paths := c.paths()
+	f, errs := openAll(paths, os.O_RDWR)
 
 	if errs != nil {
 		return errs
 	}
 	errs = make([]error, len(f))
-	for i := range m {
-		errs[i] = doIO(f[i], addr, func(port *os.File) error {
+	for i := range f {
+		defer f[i].Close()
+		errs[i] = doIO(f[i], m, func(port *os.File) error {
 			return binary.Write(port, binary.LittleEndian, data[i])
 		})
 		if errs[i] != nil {
@@ -102,14 +131,17 @@ func Write(m []string, addr uint32, data []uint64) []error {
 
 // MaskBits takes a mask of bits to clear and to set, and applies them to the specified MSR in
 // each of the CPUs.
-func MaskBits(m []string, addr uint32, clearMask uint64, setMask uint64) []error {
-	f, errs := openAll(m, os.O_RDWR)
+func (m MSR) MaskBits(c CPUs, clearMask uint64, setMask uint64) []error {
+	paths := c.paths()
+	f, errs := openAll(paths, os.O_RDWR)
 
-	for i := range m {
-		if errs[i] != nil {
-			continue
-		}
-		errs[i] = doIO(f[i], addr, func(port *os.File) error {
+	if errs != nil {
+		return errs
+	}
+	errs = make([]error, len(f))
+	for i := range f {
+		defer f[i].Close()
+		errs[i] = doIO(f[i], m, func(port *os.File) error {
 			var v uint64
 			err := binary.Read(port, binary.LittleEndian, &v)
 			if err != nil {
@@ -121,4 +153,35 @@ func MaskBits(m []string, addr uint32, clearMask uint64, setMask uint64) []error
 		})
 	}
 	return errs
+}
+
+func openAll(m []string, o int) ([]*os.File, []error) {
+	var (
+		f      = make([]*os.File, len(m))
+		errs   = make([]error, len(m))
+		hadErr bool
+	)
+	for i := range m {
+		f[i], errs[i] = os.OpenFile(m[i], o, 0)
+		if errs[i] != nil {
+			hadErr = true
+			f[i] = nil // Not sure if I need to do this, it doesn't seem guaranteed.
+		}
+	}
+	if hadErr {
+		for i := range f {
+			if f[i] != nil {
+				f[i].Close()
+			}
+		}
+		return nil, errs
+	}
+	return f, nil
+}
+
+func doIO(msr *os.File, addr MSR, f func(*os.File) error) error {
+	if _, err := msr.Seek(int64(addr), 0); err != nil {
+		return fmt.Errorf("bad address %v: %v", addr, err)
+	}
+	return f(msr)
 }

--- a/pkg/msr/msr_linux.go
+++ b/pkg/msr/msr_linux.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 )
 
+// Paths returns the paths to all instances of a specific msr
 func Paths(n string) []string {
 	m, err := filepath.Glob(filepath.Join("/dev/cpu", n, "msr"))
 	// This err will be if the glob was bad.
@@ -51,6 +52,7 @@ func doIO(msr *os.File, addr uint32, f func(*os.File) error) error {
 	return f(msr)
 }
 
+// Read reads from the msrs paths specified in m.
 func Read(m []string, addr uint32) ([]uint64, []error) {
 	var hadErr bool
 	var regs = make([]uint64, len(m))
@@ -75,6 +77,7 @@ func Read(m []string, addr uint32) ([]uint64, []error) {
 	return regs, nil
 }
 
+// Write writes the corresponding data to their specified msrs
 func Write(m []string, addr uint32, data []uint64) []error {
 	var hadErr bool
 	f, errs := openAll(m, os.O_RDWR)


### PR DESCRIPTION
These are all MSRs in the Intel SDM, Lock them as part of Linuxboot.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>