### PR TITLE
Get completion rules right 

### DIFF
--- a/cmds/exp/ash/ash.go
+++ b/cmds/exp/ash/ash.go
@@ -5,10 +5,7 @@
 package main
 
 import (
-	"bufio"
-	"bytes"
 	"flag"
-	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -19,35 +16,13 @@ import (
 )
 
 var (
-	debug   = flag.Bool("d", false, "enable debug prints")
-	userush = flag.Bool("R", false, "Use the rush interpreter for commands")
-	v       = func(string, ...interface{}) {}
+	debug = flag.Bool("d", false, "enable debug prints")
+	test  = flag.Bool("t", false, "test mode -- do completions, don't run commands")
+	v     = func(string, ...interface{}) {}
 )
 
 func verbose(f string, a ...interface{}) {
 	v(f+"\r\n", a...)
-}
-
-func output(s chan string, w io.Writer) {
-	for l := range s {
-		if _, err := w.Write([]byte("\r")); err != nil {
-			log.Printf("output write: %v", err)
-		}
-		for _, b := range l {
-			var o string
-			switch b {
-			default:
-				o = string(b)
-			case '\b', 127:
-				o = "\b \b"
-			case '\r', '\n':
-				o = "\r\n"
-			}
-			if _, err := w.Write([]byte(o)); err != nil {
-				log.Printf("output write: %v", err)
-			}
-		}
-	}
 }
 
 func main() {
@@ -65,101 +40,56 @@ func main() {
 	if err != nil {
 		log.Printf("non-fatal cannot get tty: %v", err)
 	}
-	defer t.Set(r)
-	_, cw, err := os.Pipe()
-	if err != nil {
-		log.Fatal(err)
-	}
+	defer func() {
+		if err := t.Set(r); err != nil {
+			log.Print(err)
+		}
+	}()
+
+	f := complete.NewFileCompleter("")
 	p, err := complete.NewPathCompleter()
 	if err != nil {
 		log.Fatal(err)
 	}
-	f := complete.NewFileCompleter("/")
-	bin := complete.NewMultiCompleter(complete.NewStringCompleter([]string{"exit"}), p)
-	rest := f
-	l := complete.NewLineReader(bin, t, cw)
-	lines := make(chan string)
-	go output(lines, os.Stdout)
-	var lineComplete bool
+
+	bin := complete.NewMultiCompleter(complete.NewStringCompleter([]string{"exit"}), p, f)
+	l := complete.NewNewerLineReader(bin, f)
+	l.Prompt = "% "
 	for !l.EOF {
-		lineComplete = false
-		l.C = bin
-		if l.Fields > 1 {
-			l.C = rest
-		}
-		// Read one byte, run it through the completer, then print the string
-		// as we have it.
-		v("start with %v", l)
-		var b [1]byte
-		n, err := l.R.Read(b[:])
-		if err != nil {
-			break
-		}
-		v("ReadLine: got %s, %v, %v", b, n, err)
-
-		if err := l.ReadChar(b[0]); err != nil {
-			v("ERR -> %v (%v)", l, err)
-			if err == io.EOF || err != complete.ErrEOL {
-				v("%v", err)
-				lines <- l.Line
-				continue
-			}
-			v("set linecomplete")
-			lineComplete = true
-		}
-
-		v("back from ReadChar, l is %v", l)
-		if l.Line == "exit" {
-			break
-		}
-		if lineComplete && l.Line != "" {
-			v("ash: Done reading args: line %q", l.Line)
-			// here we go.
-			lines <- "\n"
-			t.Set(r)
-			if !*userush {
-				f := strings.Fields(l.Line)
-				var args []string
-				if l.Exact != "" {
-					args = append(args, l.Exact)
-				}
-				args = append(args, l.Candidates...)
-				if len(f) > 1 && len(args) > 1 {
-					f = append(f[:len(f)-1], args...)
-				}
-
-				cmd := exec.Command(f[0], f[1:]...)
-				cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
-
-				if err := cmd.Run(); err != nil {
-					log.Print(err)
-				}
-
-			} else {
-				b := bufio.NewReader(bytes.NewBufferString(l.Line))
-				if err := rush(b); err != nil {
-					log.Print(err)
-				}
-			}
-			foreground()
-			t.Raw()
-
-			l.Line = ""
-			l.Candidates = []string{}
-			l.C = bin
-			l.Fields = 0
-			l.Exact = ""
+		if err := l.ReadLine(t, t); err != nil {
+			log.Printf("looperr: %v", err)
 			continue
 		}
-		if l.Exact != "" {
-			lines <- "\n" + l.Exact
+		if _, err := t.Write([]byte("\r\n")); err != nil {
+			log.Print(err)
 		}
-		if len(l.Candidates) > 0 {
-			for _, ln := range l.Candidates {
-				lines <- "\n" + ln
+		if l.FullLine == "" {
+			continue
+		}
+		if l.Exact == "" {
+			f := strings.Fields(l.FullLine)
+			if *test {
+				log.Printf("%v", f)
+				if _, err := t.Write([]byte("\r\n")); err != nil {
+					log.Print(err)
+				}
+				continue
 			}
-			lines <- "\n"
+
+			if err := t.Set(r); err != nil {
+				log.Print(err)
+			}
+			cmd := exec.Command(f[0], f[1:]...)
+			cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+			if err := cmd.Run(); err != nil {
+				log.Print(err)
+			}
+
+			foreground()
+			if _, err := t.Raw(); err != nil {
+				log.Print(err)
+			}
 		}
-		lines <- l.Line
 	}
 }

--- a/pkg/complete/file.go
+++ b/pkg/complete/file.go
@@ -34,7 +34,12 @@ func (f *FileCompleter) Complete(s string) (string, []string, error) {
 	g, err = filepath.Glob(p)
 	Debug("FileCompleter: %s*: matches %v, err %v", s, g, err)
 	if err != nil || len(g) == 0 {
-		return x, nil, err
+		// one last test: directory?
+		p = filepath.Join(f.Root, s, "*")
+		g, err = filepath.Glob(p)
+		if err != nil || len(g) == 0 {
+			return x, nil, err
+		}
 	}
 	// Here's a complication: we don't want to repeat
 	// the exact match in the g array

--- a/pkg/complete/line_test.go
+++ b/pkg/complete/line_test.go
@@ -1,0 +1,55 @@
+// Copyright 2012-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package complete
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/termios"
+)
+
+// TestSh tests a bash-like line completer.
+// It is intended to be used interactively for now
+// and will exit if INTERACTIVE is not set.
+func TestSh(t *testing.T) {
+	if os.Getenv("INTERACTIVE") == "" {
+		t.Skip()
+	}
+	Debug = t.Logf
+	tty, err := termios.New()
+	if err != nil {
+		log.Fatal(err)
+	}
+	r, err := tty.Raw()
+	if err != nil {
+		log.Printf("non-fatal cannot get tty: %v", err)
+	}
+	defer func() {
+		if err := tty.Set(r); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	f := NewFileCompleter("")
+	p, err := NewPathCompleter()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	bin := NewMultiCompleter(NewStringCompleter([]string{"exit"}), p, f)
+	l := NewNewerLineReader(bin, f)
+	l.Prompt = "Prompt% "
+	for !l.EOF {
+		if err := l.ReadLine(tty, tty); err != nil {
+			t.Logf("looperr: %v", err)
+		}
+		if _, err := tty.Write([]byte("\r\n")); err != nil {
+			t.Error(err)
+		}
+	}
+	t.Log("All done!")
+}

--- a/pkg/complete/newline.go
+++ b/pkg/complete/newline.go
@@ -1,0 +1,185 @@
+// Copyright 2012-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package complete
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// NewerLineReader reads a char and changes state. It does no I/O.
+// It maintains information such that a caller can figure out
+// what to do with a line.
+type NewerLineReader struct {
+	// Completer for this LineReader
+	C Completer
+	F Completer
+	// Prompt is a prompt
+	Prompt string
+	// Lines holds data as it is read.
+	Line string
+	// FullLine holds the last full line read
+	FullLine string
+	// Exact is the exact match.
+	// It can be "" if there is not one.
+	Exact string
+	// Candidates are any completion candidates.
+	// The UI can decide how to handle them.
+	Candidates []string
+	EOF        bool
+	Fields     int
+	// we only try to do completions if Tabbed is true
+	Tabbed bool
+}
+
+// NewNewerLineReader returns a LineReader.
+func NewNewerLineReader(c, f Completer) *NewerLineReader {
+	return &NewerLineReader{C: c, F: f}
+}
+
+// ReadChar reads one character and processes it. It is inflexible by design.
+func (l *NewerLineReader) ReadChar(b byte) (err error) {
+	defer func() {
+		l.Fields = len(strings.Fields(l.Line))
+	}()
+	c := l.C
+	Debug("l.Fields %d", l.Fields)
+	if l.Fields > 1 || strings.Trim(l.Line, " ") != l.Line {
+		c = l.F
+	}
+	Debug("NewerLineReader: start with %v", l)
+	l.Exact, l.Candidates = "", []string{}
+	switch b {
+	case '\t':
+		if !l.Tabbed {
+			l.Tabbed = true
+			return nil
+		}
+	default:
+		l.Tabbed = false
+	}
+	switch b {
+	default:
+		Debug("NewerLineReader.Just add it to line and pipe")
+		l.Line += string(b)
+	case controlD:
+		l.EOF = true
+		return io.EOF
+	case backSpace, del:
+		s := l.Line
+		if len(s) > 0 {
+			s = s[:len(s)-1]
+			l.Line = s
+		}
+	case '\n', '\r':
+		Debug("ERREOL")
+		return ErrEOL
+	case ' ':
+		l.Line += string(b)
+		return nil
+	case '\t':
+		ll := len(l.Line)
+		// Special case: if there's nothing in the line yet,
+		// just return.
+		if ll == 0 {
+			return nil
+		}
+		s := l.Line
+		bl := strings.LastIndexAny(s, " ")
+		flds := strings.Fields(s)
+		Debug("fields of %q is %v", s, flds)
+		var cc string
+		// The rules are complex.
+		// It might be zero length.
+		// It might end in whitespace
+		// It might be one or more things
+		switch {
+		case ll == 0 || bl == ll-1:
+		case len(flds) == 0:
+			cc = flds[0]
+		default:
+			cc = flds[len(flds)-1]
+		}
+
+		Debug("ReadChar.Try complete with %s", cc)
+		x, cmpl, err := c.Complete(cc)
+		Debug("ReadChar.Complete returns %q, %v, %v", x, cmpl, err)
+		if err != nil {
+			return err
+		}
+		if len(cmpl) == 1 && x == "" {
+			Debug("Readchar: only one candidate, so use it")
+			x, cmpl = cmpl[0], []string{}
+		}
+		l.Exact = x
+		l.Candidates = cmpl
+		if x != "" && filepath.Clean(cc) != x {
+			// Paste the completion over where we found the candidate.
+			Debug("ReadChar: l.Line %q bl %d cmpl[0] %q", l.Line, bl, x)
+			// In the case of multicompleters, x might have multiple
+			// matches. So return the base, not the whole thing.
+			if !filepath.IsAbs(cc) {
+				x = filepath.Base(x)
+			}
+			l.Line = l.Line[:bl+1] + x
+			Debug("Return is %v", l)
+			l.Exact = x
+			return nil
+		}
+	}
+	return nil
+}
+
+// ReadLine reads until an error occurs
+func (l *NewerLineReader) ReadLine(r io.Reader, w io.Writer) error {
+	fmt.Print(l.Prompt)
+	for {
+		Debug("ReadLine: start with %v", l)
+		var b [1]byte
+		n, err := r.Read(b[:])
+		if err != nil && err != io.EOF {
+			return err
+		}
+		Debug("ReadLine: got %s, %v, %v", b, n, err)
+		if n == 0 {
+			return io.EOF
+		}
+		p := l.Line
+		if err := l.ReadChar(b[0]); err != nil {
+			Debug("Readline: %v", l)
+			if err == io.EOF || err == ErrEOL {
+				Debug("Readline: %v", err)
+				l.FullLine = l.Line
+				l.Line = ""
+				return nil
+			}
+			return err
+		}
+		Debug("readline, exact %q, cand %q", l.Exact, l.Candidates)
+		if len(l.Candidates) > 1 {
+			c := l.Candidates
+			if l.Exact != "" {
+				c = append([]string{l.Exact}, l.Candidates...)
+			}
+			if _, err := fmt.Fprintf(w, "\r\n%s\r\n%s%s", c, l.Prompt, l.Line); err != nil {
+				log.Printf("Showing completions: %v", err)
+			}
+			continue
+		}
+		// How we handle this depends on whether it is a directory
+		if s, err := os.Stat(l.Exact); err == nil && s.IsDir() {
+			l.Line += "/"
+		}
+		if p != l.Line {
+			if _, err := w.Write([]byte("\r" + strings.Repeat(" ", len(l.Prompt+p)) + "\r" + l.Prompt + l.Line)); err != nil {
+				log.Print(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
If you run
INTERACTIVE=1 go test -run TestSh

you can try what I think may be a good enough completer.

The first arg on the line will be determined from $PATH;
then we switch to a file completer.

ash is also modified to work with this. It seems to work
fine SAVE there is not  prompt yet; WIP.

Try this if you can and see if it is close.

If it works,  we have an advantage:
- much smaller code and binary: 2.7M vs. 5.1M for elvish
- code is easier (for me) to understand
- completer package is useful in other programs