### PR TITLE
kexec: fix segv when no initramfs is specified

### DIFF
--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"io"
 	"log"
 	"os"
 
@@ -97,9 +98,13 @@ func main() {
 				Cmdline: newCmdline,
 			}
 		} else {
+			var i io.ReaderAt
+			if opts.initramfs != "" {
+				i = uio.NewLazyFile(opts.initramfs)
+			}
 			image = &boot.LinuxImage{
 				Kernel:  uio.NewLazyFile(kernelpath),
-				Initrd:  uio.NewLazyFile(opts.initramfs),
+				Initrd:  i,
 				Cmdline: newCmdline,
 			}
 		}


### PR DESCRIPTION
If you run kexec this way:
kexec -l /bzImage
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x953946]

goroutine 1 [running]:
google3/third_party/golang/uroot/pkg/uio/uio.(*LazyOpenerAt).ReadAt(0x0, 0xc000220000, 0x8000, 0x8000, 0x0, 0xcf51c0, 0xc000036d01, 0xc000220000)
	third_party/golang/uroot/pkg/uio/lazy.go:89 +0x26
io.(*SectionReader).Read(0xc0001c8840, 0xc000220000, 0x8000, 0x8000, 0x0, 0x0, 0xe8c93c)
	third_party/go/gc/src/io/io.go:478 +0x7c
io.copyBuffer(0x1073e20, 0xc00000e488, 0x1073860, 0xc0001c8840, 0xc000220000, 0x8000, 0x8000, 0x2f7d40, 0x0, 0x0)
	third_party/go/gc/src/io/io.go:405 +0x122
io.Copy(...)
	third_party/go/gc/src/io/io.go:364
google3/third_party/golang/uroot/pkg/boot/boot.copyToFile(0x1073860, 0xc0001c8840, 0x0, 0x0, 0x0)
	third_party/golang/uroot/pkg/boot/linux.go:49 +0xd6
google3/third_party/golang/uroot/pkg/boot/boot.(*LinuxImage).Load(0xc0000872c0, 0xc000087200, 0x0, 0x0)
	third_party/golang/uroot/pkg/boot/linux.go:99 +0x3fe
google3/third_party/golang/uroot/cmds/core/kexec/kexec_uroot.Main()
	blaze-out/k8-nocgo-fastbuild/bin/third_party/golang/uroot/cmds/core/kexec/kexec_uroot_rewrite_gen/kexec_linux.go:107 +0x3c5
google3/third_party/golang/uroot/pkg/bb/bbmain/bbmain.Run(0x7ffee0beaecc, 0x5, 0x7ffee0beaecc, 0x5)
	third_party/golang/uroot/pkg/bb/bbmain/register.go:62 +0x8e
main.run()
	blaze-out/k8-nocgo-fastbuild/bin/platforms/nerf/initramfs_shell_bb_gen_main_bbgen/main.go:94 +0x6f
main.main()
	blaze-out/k8-nocgo-fastbuild/bin/platforms/nerf/initramfs_shell_bb_gen_main_bbgen/main.go:102 +0x7b
Exception: kexec exited with 2
[tty], line 1: kexec -l /bzImage

The problem is that if you create a uio.LazyReaderAt with a file that can not be opened,
you get no error but the first ReadAt will segv.

IMHO uio.LazyReaderAt should not do this but it's kind of a hard problem: the whole point
of lazy is not to open the file ... an earlier PR I submitted to fix this problem
was never accepted. So ask kexec not to do things that upset the package :-)

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>