### PR TITLE
add a prefix function

### DIFF
--- a/pkg/complete/newline.go
+++ b/pkg/complete/newline.go
@@ -132,6 +132,13 @@ func (l *NewerLineReader) ReadChar(b byte) (err error) {
 			l.Exact = x
 			return nil
 		}
+		// see if there is enough for a common prefix.
+		if x == "" {
+			p := Prefix(cmpl)
+			if p != "" {
+				l.Line = l.Line[:bl+1] + p
+			}
+		}
 	}
 	return nil
 }

--- a/pkg/complete/prefix.go
+++ b/pkg/complete/prefix.go
@@ -1,0 +1,34 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package complete
+
+import "strings"
+
+// Prefix finds the longest common prefix string
+// from a []string.
+func Prefix(s []string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	var a string = s[0]
+	for _, h := range s {
+		if len(h) < len(a) {
+			a = h
+		}
+	}
+	var done bool
+	for !done && len(a) > 0 {
+		done = true
+		for _, h := range s {
+			if !strings.HasPrefix(h, a) {
+				a = a[:len(a)-1]
+				done = false
+				break
+			}
+
+		}
+	}
+	return a
+}

--- a/pkg/complete/prefix_test.go
+++ b/pkg/complete/prefix_test.go
@@ -1,0 +1,40 @@
+// Copyright 2012-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package complete
+
+import (
+	"testing"
+)
+
+func TestPrefix(t *testing.T) {
+	var tests = []string{
+		"/etc/hosts.allow",
+		"/etc/hosts.deny",
+		"/etc/hosts",
+		"/etc/host.conf",
+		"/etc/hostname",
+		"/etc",
+		"/a",
+		"",
+	}
+
+	var testsout = []string{
+		"/etc/hosts.allow",
+		"/etc/hosts.",
+		"/etc/hosts",
+		"/etc/host",
+		"/etc/host",
+		"/etc",
+		"/",
+		"",
+	}
+	for i := range tests {
+		test := tests[:i+1]
+		p := Prefix(test)
+		if p != testsout[i] {
+			t.Errorf("Test %d: %v: got %v, want %v", i, test, p, testsout[i])
+		}
+	}
+}


### PR DESCRIPTION
there may not be an exact match but there may be enough to fill out the completion more

This gives us nicer behavior:
% ls /etc/ho
[/etc/host.conf /etc/hostname /etc/hosts /etc/hosts.allow /etc/hosts.deny]
% ls /etc/host
[/etc/host.conf /etc/hostname /etc/hosts /etc/hosts.allow /etc/hosts.deny]

note that I hit /etc/ho<tab><tab> and it filled it out to the
longest common prefix.