### PR TITLE
Add ts command

### DIFF
--- a/cmds/core/ts/ts.go
+++ b/cmds/core/ts/ts.go
@@ -1,0 +1,30 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// ts prepends each line of stdin with a timestamp.
+//
+// Synopsis:
+//     ts
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+
+	flag "github.com/spf13/pflag"
+	"github.com/u-root/u-root/pkg/ts"
+)
+
+func main() {
+	flag.Parse()
+	if flag.NArg() != 0 {
+		log.Fatal("Usage: ts")
+	}
+
+	_, err := io.Copy(os.Stdout, ts.New(os.Stdin))
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/ts/ts.go
+++ b/pkg/ts/ts.go
@@ -1,0 +1,103 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package ts contains a Transform to prepend a timestamp in front of each line.
+package ts
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"time"
+)
+
+// PrependTimestamp is an io.Reader which prepends a timestamp on each line.
+type PrependTimestamp struct {
+	R         io.Reader
+	StartTime time.Time
+	Format    func(startTime time.Time) string
+
+	// noPrintTS is true to indicate the timestamp should be printed
+	// in front of the next byte.
+	noPrintTS bool
+
+	// buf is a Buffer to store data in case the buffer passed to
+	// PrependTimestamp.Read is not large enough.
+	buf []byte
+
+	// isEOF indicates the wrapped reader R returned an io.EOF. All future
+	// calls to PrependTimestamp.Read should just read from buf until it is
+	// empty, then return io.EOF.
+	isEOF bool
+}
+
+// New creates a PrependTimestamp with default settings.
+func New(r io.Reader) *PrependTimestamp {
+	return &PrependTimestamp{
+		R:         r,
+		StartTime: time.Now(),
+		Format:    DefaultFormat,
+	}
+}
+
+// Read prepends a timestamp on each line.
+func (t *PrependTimestamp) Read(p []byte) (n int, err error) {
+	// Empty the buffer first.
+	n = copy(p, t.buf)
+	t.buf = t.buf[n:]
+	if len(t.buf) != 0 {
+		return // Buffer not yet empty.
+	}
+	if t.isEOF {
+		err = io.EOF
+		return // Buffer empty and reached EOF.
+	}
+
+	// Read new data.
+	var m int
+	scratch := p[n:]
+	m, err = t.R.Read(scratch)
+	scratch = scratch[:m]
+	if m == 0 {
+		return
+	}
+	if err == io.EOF {
+		// Do not return EOF immediately because there may be more than
+		// one calls to PrependTimestamp.Read.
+		t.isEOF = true
+		err = nil
+	}
+
+	// Generate the timestamp.
+	lfts := []byte("\n" + t.Format(t.StartTime))
+	ts := lfts[1:]
+
+	// Insert timestamps after newlines.
+	t.buf = bytes.ReplaceAll(scratch, []byte{'\n'}, lfts)
+
+	// If the input ends in a newline, defer the insertion of the timestamp
+	// until the next byte is read.
+	if !t.noPrintTS {
+		t.buf = append(ts, t.buf...)
+		t.noPrintTS = true
+	}
+	if scratch[len(scratch)-1] == '\n' {
+		t.buf = t.buf[:len(t.buf)-len(ts)]
+		t.noPrintTS = false
+	}
+
+	// Empty new data from the buffer.
+	m = copy(p[n:], t.buf)
+	n += m
+	t.buf = t.buf[m:]
+	if len(t.buf) == 0 && t.isEOF {
+		err = io.EOF // Buffer empty and reached EOF.
+	}
+	return
+}
+
+// DefaultFormat formats in seconds since the startTime. Ex: [12.3456s]
+func DefaultFormat(startTime time.Time) string {
+	return fmt.Sprintf("[%06.4fs] ", time.Since(startTime).Seconds())
+}

--- a/pkg/ts/ts_test.go
+++ b/pkg/ts/ts_test.go
@@ -1,0 +1,153 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ts
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPrependTimestamp(t *testing.T) {
+	format := func(time.Time) string { return "#" }
+	tests := []struct {
+		name, input, want string
+	}{
+		{
+			name:  "empty",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "single blank line",
+			input: "\n",
+			want:  "#\n",
+		},
+		{
+			name:  "blank lines",
+			input: "\n\n\n\n",
+			want:  "#\n#\n#\n#\n",
+		},
+		{
+			name:  "text",
+			input: "hello\nworld\n\n\n",
+			want:  "#hello\n#world\n#\n#\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt := &PrependTimestamp{
+				R:      bytes.NewBufferString(tt.input),
+				Format: format,
+			}
+			got := &bytes.Buffer{}
+			if _, err := io.Copy(got, pt); err != nil {
+				t.Errorf("io.Copy returned an error: %v", err)
+			}
+			if !bytes.Equal(got.Bytes(), []byte(tt.want)) {
+				t.Errorf("PrependTimestamp = %q; want %q", got.String(), tt.want)
+			}
+		})
+	}
+}
+
+// TestPrependTimestampBuffering ensures two important properties with regards
+// to buffering which would be easy to miss with just a readline implementation:
+//     1. Data is printed before the whole line is available.
+//     2. Timestamp is generated at the beginning of the line, not at the end
+//        of the previous line.
+func TestPrependTimestampBuffering(t *testing.T) {
+	// Mock out the format function.
+	i := 0
+	format := func(time.Time) string {
+		return fmt.Sprint(i)
+	}
+
+	// Control exactly how many bytes are returned with each call to data.Read.
+	data := &bytes.Buffer{}
+	pt := &PrependTimestamp{
+		R:      data,
+		Format: format,
+	}
+
+	// These tests must run sequentially, so no tt.Run().
+	for _, tt := range []struct {
+		i        int
+		text     string
+		buffer   []byte
+		wantText string
+		wantErr  error
+	}{
+		{
+			// Data is printed before the whole line is available.
+			i:        1,
+			text:     "Waiting...",
+			buffer:   make([]byte, 100),
+			wantErr:  nil,
+			wantText: "1Waiting...",
+		},
+		{
+			text:     "DONE\n",
+			buffer:   make([]byte, 100),
+			wantErr:  nil,
+			wantText: "DONE\n",
+		},
+		{
+			// Timestamp is generated at the beginning of the line.
+			i:        2,
+			text:     "Hello",
+			buffer:   make([]byte, 2),
+			wantErr:  nil,
+			wantText: "2H",
+		},
+		{
+			text:     "",
+			buffer:   make([]byte, 2),
+			wantErr:  nil,
+			wantText: "el",
+		},
+		{
+			text:     "",
+			buffer:   make([]byte, 2),
+			wantErr:  nil,
+			wantText: "lo",
+		},
+		{
+			text:     "",
+			buffer:   make([]byte, 2),
+			wantErr:  io.EOF,
+			wantText: "",
+		},
+	} {
+		data.Write([]byte(tt.text))
+		i = tt.i
+		n, err := pt.Read(tt.buffer)
+		if err != tt.wantErr {
+			t.Errorf("PrependTimestamp.Read(%q) err = %v; want %v",
+				tt.text, err, tt.wantErr)
+		}
+		if !bytes.Equal(tt.buffer[:n], []byte(tt.wantText)) {
+			t.Errorf("PrependTimestamp.Read(%q) buffer = %q; want %q",
+				tt.text, tt.buffer[:n], tt.wantText)
+		}
+	}
+}
+
+// BenchmarkPrependTime measures the throughput of PrependTime where N is
+// measured in bytes.
+func BenchmarkPrependTime(b *testing.B) {
+	line := "hello world\n"
+	data := strings.Repeat(line, (b.N+len(line))/len(line))[:b.N]
+	pt := New(bytes.NewBufferString(data))
+	b.ResetTimer()
+	if _, err := io.Copy(ioutil.Discard, pt); err != nil {
+		b.Fatal(err)
+	}
+}


### PR DESCRIPTION
This prepends a timestamp in front of each line of stdin. Useful for
measuring performance from logs.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>