### PR TITLE
madeye: create Multi Architecture Disk Images

### DIFF
--- a/cmds/exp/madeye/doc.go
+++ b/cmds/exp/madeye/doc.go
@@ -1,0 +1,22 @@
+// Copyright 2013-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// u-root was intended to be capable of function as a universal root, i.e. a root
+// file system that you could boot from different architectures.
+// We call this Multiple Architecture Device Image, or MADI, pronounced Mad-Eye.
+// Apologies to Harry Potter.
+// This command implements MADI and works as follows:
+// Given a set of images, e.g.
+// initramfs.linux_<arch>.cpio it derives the architecture from the name.
+// It then reads the cpio in.
+// For all symlinks which resolve to absolute paths, it records the file they point to.
+// For a distinguished set of directories, it relocates them from / to /<arch>/, a la Plan 9.
+// If there is a /init, it moves to /<arch>/init.
+// It adjusts absolute path symlinks.
+// future: it looks for conflicting dev entries.
+// It then writes it out.
+// To boot a kernel with a MadEye, one must adjust the init= arg to prepend the architecture.
+// For example, /init on arm would become /arm/init
+// For now, this only works for bb mode.
+package main

--- a/cmds/exp/madeye/madeye.go
+++ b/cmds/exp/madeye/madeye.go
@@ -1,0 +1,152 @@
+// Copyright 2013-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// madeye merges u-root initramfs to form a single universal initramfs.
+// Synopsis:
+//     madeye initramfs [initramfs...]
+//
+// Description:
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/u-root/u-root/pkg/cpio"
+	"github.com/u-root/u-root/pkg/uio"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	debug = func(string, ...interface{}) {}
+	d     = flag.Bool("v", false, "Debug prints")
+	arch  = map[string]string{
+		"initramfs.linux_amd64.cpio": "amd64",
+		"initramfs.linux_arm.cpio":   "arm",
+	}
+	out = map[string]*cpio.Record{}
+)
+
+func usage() {
+	log.Fatalf("Usage: madeye")
+}
+
+func file(archiver cpio.RecordFormat, n string, f io.ReaderAt) ([]cpio.Record, error) {
+	var r []cpio.Record
+	rr := archiver.Reader(f)
+	a, ok := arch[filepath.Base(n)]
+	if !ok {
+		return r, fmt.Errorf("%s: don't know about this", n)
+	}
+	debug("arch is %s", a)
+	for {
+		rec, err := rr.ReadRecord()
+		if err == io.EOF {
+			break
+		}
+		debug("Read %v", rec)
+		if err != nil {
+			log.Fatalf("error reading records: %v", err)
+		}
+		d := filepath.Dir(rec.Name)
+		switch d {
+		case "bbin", "bin":
+			rec.Name = filepath.Join(a, rec.Name)
+			debug("Change to %v", rec)
+		default:
+			debug("dir is %v, ignore", d)
+		}
+		switch rec.Name {
+		case "init", "bbin", "bin":
+			rec.Name = filepath.Join(a, rec.Name)
+		}
+		// TODO: make this use os constants, not unix constants.
+		switch rec.Mode & unix.S_IFMT {
+		case unix.S_IFLNK:
+			content, err := ioutil.ReadAll(uio.Reader(rec))
+			if err != nil {
+				return nil, err
+			}
+			switch string(content) {
+			case "bbin", "bin":
+				content = []byte(filepath.Join(a, string(content)))
+				debug("Change to %v", rec)
+			default:
+				debug("dir is %v, ignore", d)
+			}
+			rec.ReaderAt = bytes.NewReader(content)
+		}
+
+		if _, ok := out[rec.Name]; ok {
+			continue
+		}
+		out[rec.Name] = &rec
+		r = append(r, rec)
+	}
+	return r, nil
+}
+func main() {
+	flag.Parse()
+	if *d {
+		debug = log.Printf
+	}
+
+	a := flag.Args()
+	debug("Args %v", a)
+	if len(a) < 1 {
+		usage()
+	}
+
+	archiver, err := cpio.Format("newc")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var rr []cpio.Record
+	for _, a := range flag.Args() {
+		f, err := os.Open(a)
+		if err != nil {
+			log.Fatal(err)
+		}
+		r, err := file(archiver, a, f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		// Why not a defer? Because that would happen
+		// outside the for loop. Not that it really matters:
+		// any kind of explicit close is a bit silly here, we're
+		// never going to have more than MAXFD arguments anyway,
+		// but better safe than sorry.
+		if err := f.Close(); err != nil {
+			log.Fatal(err)
+		}
+		rr = append(rr, r...)
+	}
+	// process ...
+	archiver, err = cpio.Format("newc")
+	if err != nil {
+		log.Fatal(err)
+	}
+	rw := archiver.Writer(os.Stdout)
+	for _, r := range rr {
+		if *d {
+			log.Printf("%s", r)
+			continue
+		}
+		if err := rw.WriteRecord(r); err != nil {
+			log.Fatal(err)
+		}
+	}
+	if !*d {
+		if err := cpio.WriteTrailer(rw); err != nil {
+			log.Fatalf("Error writing trailer record: %v", err)
+		}
+	}
+}


### PR DESCRIPTION
This is an original goal of u-root: that we could build a root file system
and use it on different architectures.

This is called MADI: Multi Architecture Disk Image. It has binaries for several
architectures, rooted at, e.g., /amd64, /arm, and so on; with binaries in, e.g.,
/amd64/bbin, and init in /amd64/init.
To boot on, e.g., x86_64, you set init=/amd64/init

It's spelled madeye so people know how to say and, because, some might think it mad.

This idea is not original with u-root; it's how Plan 9 works. It was the reason for the
"source mode" in original u-root: four binaries only, the rest source. Busybox mode
did not come until 2015 or so, and it turns out it lets us do the same thing with
one binary or five; we can have both busybox and source mode MADIs.

Source mode and busybox mode can share a single root file system, so I'm starting out
supporting just busybox mode.

Rather than complicate the u-root command with a bunch of options for multiple architectures,
we take the approach here of implementing a tool that concatenates u-root cpio's, which
is neat as it allows after-the-fact construction of MADI. Names are translated as needed,
as are symlink targets.

This is a WIP for a bit longer, but the driver was the class we're putting together, where
we want lightweight pxe servers and we don't much care about architecture. madeye will let
us construct USB sticks that boot on atomic pi or raspberry pi, with a very simple root
file system.