### PR TITLE
pox: just use the list of names retured by ldd.Ldd()

### DIFF
--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -120,20 +120,20 @@ var chrootMounts = []struct {
 	{"/dev", "/dev", "", mount.MS_BIND, "", 0755},
 }
 
-func poxCreate(names []string) error {
-	if len(names) == 0 {
+func poxCreate(bin []string) error {
+	if len(bin) == 0 {
 		return fmt.Errorf(usage)
 	}
-	l, err := ldd.Ldd(names)
+	l, err := ldd.Ldd(bin)
 	if err != nil {
 		var stderr []byte
 		if eerr, ok := err.(*exec.ExitError); ok {
 			stderr = eerr.Stderr
 		}
-		return fmt.Errorf("Running ldd on %v: %v %s", names,
-			err, stderr)
+		return fmt.Errorf("Running ldd on %v: %v %s", bin, err, stderr)
 	}
 
+	var names []string
 	for _, dep := range l {
 		v("%s", dep.FullName)
 		names = append(names, dep.FullName)


### PR DESCRIPTION
ldd.Ldd returns ALL the names, including the names of
the input files. We appended the ldd.Ldd results
to the file names, resulting in us adding the binary
names twice.

This has not been a problem in several years, until we hit
a weird case today where adding a file twice failed.

Just use the ldd.Ldd() list.