### PR TITLE
test-image-amd64/Dockerfile: Bump QEMU to version v4.2.0

### DIFF
--- a/.circleci/images/test-image-amd64/Dockerfile
+++ b/.circleci/images/test-image-amd64/Dockerfile
@@ -46,7 +46,7 @@ RUN set -eux;                                                             \
 
 # Build QEMU
 RUN set -eux;                                                          \
-    git clone --depth=1 --branch=v2.12.0 https://github.com/qemu/qemu; \
+    git clone --depth=1 --branch=v4.2.0 https://github.com/qemu/qemu;  \
     cd qemu;                                                           \
     mkdir build;                                                       \
     cd build;                                                          \


### PR DESCRIPTION
Fixes #1298

As comparison: test-image-arm runs QEMU v3.1.0 from 2018.
v4.2.0 builds well locally on amd64, I hope this doesn't break
any integration. If all works well I will also update the arm image if wanted.

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>