### PR TITLE
.circleci/config.yml: Bump dep to v0.5.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
       - run:
           name: Install dep
           command: |
-            wget https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64
+            wget https://github.com/golang/dep/releases/download/v0.5.4/dep-linux-amd64
             mv dep-linux-amd64 dep
             chmod +x dep
       - run:


### PR DESCRIPTION
Bump dep v0.5.0 (Jul 2018) -> latest v0.5.4 (Jul 2019) in circleci/config.yml

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>