### PR TITLE
docs/index.md: Use same go version as in README.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@ init program and four Go compiler binaries.
 ## Setup
 
 On an Ubuntu system, install prerequisites and ensure Go is at least version
-1.11:
+1.12:
 
 ```sh
 sudo apt-get install git golang build-essential


### PR DESCRIPTION
v1.11 > v1.12 as per README.md

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>