### PR TITLE
docs/index.md: Use same go version as in README.md

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
 <h1 id="u-root">u-root</h1>
 <p>u-root is an embeddable root file system intended to be placed in a flash device as part of the firmware image, along with a Linux kernel. Unlike most embedded root file systems, which consist of large binaries, u-root only has five: an init program and four Go compiler binaries.</p>
 <h2 id="setup">Setup</h2>
-<p>On an Ubuntu system, install prerequisites and ensure Go is at least version 1.11:</p>
+<p>On an Ubuntu system, install prerequisites and ensure Go is at least version 1.12:</p>
 <div class="sourceCode" id="cb1"><pre class="sourceCode sh"><code class="sourceCode bash"><a class="sourceLine" id="cb1-1" title="1"><span class="fu">sudo</span> apt-get install git golang build-essential</a>
 <a class="sourceLine" id="cb1-2" title="2"><span class="ex">go</span> version</a></code></pre></div>
 <p>Set your <code>GOPATH</code>:</p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,7 @@ init program and four Go compiler binaries.
 
 ## Setup
 
-On an Ubuntu system, install prerequisites and ensure Go is at least version
-1.12:
+On an Ubuntu system, install prerequisites and ensure Go is at least version 1.12:
 
 ```sh
 sudo apt-get install git golang build-essential


### PR DESCRIPTION
Somehow the index.html was not updated after #1591,
perhaps because of the linebreak.. dunno.

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>