### PR TITLE
cmds/core/truncate: Add optional -o flag

### DIFF
--- a/cmds/core/truncate/truncate.go
+++ b/cmds/core/truncate/truncate.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2017 the u-root Authors. All rights reserved
+// Copyright 2013-2020 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -10,6 +10,7 @@
 // Options:
 //     -s: size in bytes
 //     -c: do not create any files
+//     -o: treat SIZE as number of IO blocks instead of bytes
 //
 // Author:
 //     Roland Kammerer <dev.rck@gmail.com>
@@ -20,15 +21,17 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"syscall"
 
 	"github.com/rck/unit"
 )
 
-const cmd = "truncate [-c] -s size file..."
+const cmd = "truncate [-c] [-o] -s size file..."
 
 var (
-	create = flag.Bool("c", false, "Do not create files.")
-	size   = unit.MustNewUnit(unit.DefaultUnits).MustNewValue(1, unit.None)
+	create      = flag.Bool("c", false, "Do not create files.")
+	ioblocksize = flag.Bool("o", false, "treat SIZE as number of IO blocks instead of bytes")
+	size        = unit.MustNewUnit(unit.DefaultUnits).MustNewValue(1, unit.None)
 )
 
 func init() {
@@ -70,6 +73,23 @@ func main() {
 		}
 
 		final := size.Value // base case
+
+		if *ioblocksize {
+			// get the filedescriptor of the file that we are handling.
+			fd, err := syscall.Open(fname, syscall.O_RDONLY, 0664)
+			if err != nil {
+				log.Fatalf("truncate: ERROR: %s does not exist.", fname)
+			}
+			defer syscall.Close(fd)
+
+			// do statfs systemcall on fd to retrieve the filesystems blocksize.
+			var statfs syscall.Statfs_t
+			if err = syscall.Fstatfs(fd, &statfs); err != nil {
+				log.Fatalf("truncate: ERROR: Failed to get filesystem blocksize for %s [%s].", fname, err)
+			}
+			final = final * int64(statfs.Bsize)
+		}
+
 		if size.ExplicitSign != unit.None {
 			final += st.Size() // in case of '-', size.Value is already negative
 		}

--- a/roadmap.md
+++ b/roadmap.md
@@ -20,7 +20,7 @@ yourself.
 | sort           | -bcfmnRu        |                        |
 | srvfiles       |                 | Serve files with TLS   |
 | :x: time       | -p              |                        |
-| truncate       | -or             |                        |
+| truncate       | -r              |                        |
 | uniq           | -i              |                        |
 | unshare        |                 | Different flag names   |
 | wget           |                 | No args yet...         |


### PR DESCRIPTION
This PR will add an optional -o flag to cmds/core/truncate
which will treat SIZE as number of IO blocks instead of bytes.

```shell
$ ./truncate -h
Usage of truncate [-c] [-o] -s size file...:
  -c	Do not create files.
  -o	treat SIZE as number of IO blocks instead of bytes
  -s value
    	Size in bytes, prefixes +/- are allowed (default 1B)
$ for i in {1..4};{ ./truncate -o -s ${i} foo ;ls -l foo; }
-rw-r--r-- 1 x x 4096 Mar 13 00:55 foo
-rw-r--r-- 1 x x 8192 Mar 13 00:55 foo
-rw-r--r-- 1 x x 12288 Mar 13 00:55 foo
-rw-r--r-- 1 x x 16384 Mar 13 00:55 foo
$for i in 1 1 1 1;{ ./truncate -o -s -${i} foo ;ls -l foo; }
-rw-r--r-- 1 x x 12288 Mar 13 00:55 foo
-rw-r--r-- 1 x x 8192 Mar 13 00:55 foo
-rw-r--r-- 1 x x 4096 Mar 13 00:55 foo
-rw-r--r-- 1 x x 0 Mar 13 00:55 foo
```

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>