### PR TITLE
circleci/config.yml: Increase UROOT_QEMU_TIMEOUT_X fixes build failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,14 @@ templates:
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - CGO_ENABLED: 0
-      # Double all timeouts for QEMU VM tests since they run without KVM.
-      - UROOT_QEMU_TIMEOUT_X: 2
+      # Triple all timeouts for QEMU VM tests since they run without KVM.
+      - UROOT_QEMU_TIMEOUT_X: 3
   integration-template: &integration-template
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - CGO_ENABLED: 0
-      # Double all timeouts for QEMU VM tests since they run without KVM.
-      - UROOT_QEMU_TIMEOUT_X: 2
+      # Triple all timeouts for QEMU VM tests since they run without KVM.
+      - UROOT_QEMU_TIMEOUT_X: 3
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR will bump the UROOT_QEMU_TIMEOUT_X value to 3 for QEMU VM tests
in .circleci/config.yml.

Local `circleci build --job test` builds consistently failed for me before increasing 
the timeout value.

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>