### PR TITLE
.circleci/config.yml: use uroottest/test-image-amd64:latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 templates:
   golang-template: &golang-template
     docker:
-      - image: uroottest/test-image-amd64:v3.2.10
+      - image: uroottest/test-image-amd64:v3.2.11
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - CGO_ENABLED: 0
@@ -167,7 +167,7 @@ jobs:
   test-integration-amd64:
     <<: *integration-template
     docker:
-      - image: uroottest/test-image-amd64:v3.2.10
+      - image: uroottest/test-image-amd64:v3.2.11
   test-integration-arm:
     <<: *integration-template
     docker:


### PR DESCRIPTION
This PR updates .circleci/config.yml to use
uroottest/test-image-amd64:latest which uses QEMU v4.2.0

Signed-off-by: Tim Rots <tim.rots@protonmail.ch>