### PR TITLE
Fix some forth eval fun

### DIFF
--- a/pkg/forth/forth_test.go
+++ b/pkg/forth/forth_test.go
@@ -142,3 +142,30 @@ func TestNewWord(t *testing.T) {
 	}
 	t.Logf("stack %v", f.Stack())
 }
+
+// make sure that if we die in an Eval nested in an Eval, we fall all the way
+// back out.
+func TestEvalPanic(t *testing.T) {
+	f := New()
+	Debug = t.Logf
+	err := Eval(f, "0", "'+", "2", "p", "newword")
+	if err != nil {
+		t.Fatalf("newword: got %v, nil", err)
+	}
+	t.Logf("p created, now try problems")
+	err = Eval(f, "0", uint8(0), "+")
+	if err == nil {
+		t.Fatal("Got nil, want error")
+	}
+	t.Logf("Test plus with wrong types: %v", err)
+	f.Reset()
+	err = Eval(f, "p")
+	if err == nil {
+		t.Fatal("P with too few args: Got nil, want error")
+	}
+	t.Logf("p with too few args: %v", err)
+	err2 := Eval(f, "p", "0", uint8(0), "+")
+	if err2.Error() != err.Error() {
+		t.Fatalf("Got %v, want %v", err2, err)
+	}
+}


### PR DESCRIPTION
The forth eval loop as broken for 8 years and nobody noticed -- and, weirdly, this
code was used.

If two Eval's were nested, the inner one would catch panics and the outer one would return
no error. This hid a broken forth test (for 8 years) and broke the msr command.

This now works right:
rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr  READ_IA32_FEATURE_CONTROL
2020/03/14 06:26:40 [open /dev/cpu/0/msr: permission denied open /dev/cpu/1/msr: permission denied open /dev/cpu/2/msr: permission denied open /dev/cpu/3/msr: permission denied]

and

rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ sudo ./msr  READ_IA32_FEATURE_CONTROL
[5 5 5 5]