### PR TITLE
pci: alloc NewBusReader to take a []string

### DIFF
--- a/cmds/core/pci/pci.go
+++ b/cmds/core/pci/pci.go
@@ -107,7 +107,7 @@ func registers(d pci.Devices, cmds ...string) {
 }
 func main() {
 	flag.Parse()
-	r, err := pci.NewBusReader(*devs)
+	r, err := pci.NewBusReader(strings.Split(*devs, ",")...)
 	if err != nil {
 		log.Fatalf("%v", err)
 	}

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -1,0 +1,29 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pci
+
+import (
+	"testing"
+)
+
+func TestNewBusReaderNoGlob(t *testing.T) {
+	n, err := NewBusReader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	g, err := NewBusReader("*", "*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(n.(*bus).Devices) != len(g.(*bus).Devices) {
+		t.Fatalf("Got %v, want %v", len(n.(*bus).Devices), len(g.(*bus).Devices))
+	}
+
+	for i := range n.(*bus).Devices {
+		if n.(*bus).Devices[i] != g.(*bus).Devices[i] {
+			t.Errorf("%d: got %q, want %q", i, n.(*bus).Devices[i], g.(*bus).Devices[i])
+		}
+	}
+}


### PR DESCRIPTION
Also allow the pci command to take , separate globs, viz:

rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/pci$ ./pci -s *1[78]*
0000:00:17.0: VMware PCI Express Root Port
0000:00:17.1: VMware PCI Express Root Port
0000:00:17.2: VMware PCI Express Root Port
0000:00:17.3: VMware PCI Express Root Port
0000:00:17.4: VMware PCI Express Root Port
0000:00:17.5: VMware PCI Express Root Port
0000:00:17.6: VMware PCI Express Root Port
0000:00:17.7: VMware PCI Express Root Port
0000:00:18.0: VMware PCI Express Root Port
0000:00:18.1: VMware PCI Express Root Port
0000:00:18.2: VMware PCI Express Root Port
0000:00:18.3: VMware PCI Express Root Port
0000:00:18.4: VMware PCI Express Root Port
0000:00:18.5: VMware PCI Express Root Port
0000:00:18.6: VMware PCI Express Root Port
0000:00:18.7: VMware PCI Express Root Port
rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/pci$ ./pci -s *17*,*18*
0000:00:17.0: VMware PCI Express Root Port
0000:00:17.1: VMware PCI Express Root Port
0000:00:17.2: VMware PCI Express Root Port
0000:00:17.3: VMware PCI Express Root Port
0000:00:17.4: VMware PCI Express Root Port
0000:00:17.5: VMware PCI Express Root Port
0000:00:17.6: VMware PCI Express Root Port
0000:00:17.7: VMware PCI Express Root Port
0000:00:18.0: VMware PCI Express Root Port
0000:00:18.1: VMware PCI Express Root Port
0000:00:18.2: VMware PCI Express Root Port
0000:00:18.3: VMware PCI Express Root Port
0000:00:18.4: VMware PCI Express Root Port
0000:00:18.5: VMware PCI Express Root Port
0000:00:18.6: VMware PCI Express Root Port
0000:00:18.7: VMware PCI Express Root Port
rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/pci$ exit