### PR TITLE
Rename MaskBits to TestAndSet and write only if changed

### DIFF
--- a/cmds/core/lockmsrs/lockmsrs.go
+++ b/cmds/core/lockmsrs/lockmsrs.go
@@ -87,7 +87,7 @@ func main() {
 		if *verbose {
 			log.Printf("Locking MSR %v on cpus %v, clearmask 0x%8x, setmask 0x%8x", m.msrAdd, cpus, m.clearMask, m.setMask)
 		}
-		errs := m.msrAdd.MaskBits(cpus, m.clearMask, m.setMask)
+		errs := m.msrAdd.TestAndSet(cpus, m.clearMask, m.setMask)
 		for i, e := range errs {
 			if e != nil {
 				// Hope no one ever modifies this slice.


### PR DESCRIPTION
This helps when we happen to be trying to lock MSRs
that are already locked. This avoids the resulting io error. If we
really want to rewrite the same value you can do so using read followed
by write.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>