### PR TITLE
bb: if bb is invoked directly, list commands and symlinks

### DIFF
--- a/pkg/bb/bbmain/cmd/main.go
+++ b/pkg/bb/bbmain/cmd/main.go
@@ -36,6 +36,6 @@ func init() {
 		os.Args = os.Args[1:]
 		run()
 	}
-	bbmain.Register("bb", bbmain.Noop, m)
+	bbmain.Register("bb", bbmain.Noop, bbmain.ListCmds)
 	bbmain.RegisterDefault(bbmain.Noop, m)
 }


### PR DESCRIPTION
The bb command exits silently when invoked directly, e.g.
/bbin/bb
just exits.

Sometimes due to build system problems an initramfs is built
either with missing symlinks or missing compiled-in commands.
These problems are difficult to diagnose.

With this change, bb invoked directly will create a listing
of the command, formed from either the basename of the /bbin/
symlink or the list of compiled-in commands; the symlink;
and the compiled-in command name.

If the symlink is missing or there is a symlink with no compiled-in
command, a diagnostic is shown, e.g. if we have an image with a bogus
symlink, in this ccat; or a missing symlink, in this case cat, we
would see (among a listing of all correct commands)

cat:	NO SYMLINK	cat
ccat:	"/bbin/ccat"	NO COMMAND

N.B. this command does not sort output, to avoid bringing
in sort just for this use. Plus, in the Unix model, programs
should not necessarily include sorted output. For sorted output,
bb | sort
will do.