### PR TITLE
msr: move definitions to package, add Test function, add -verify to lockmsr

### DIFF
--- a/cmds/core/lockmsrs/lockmsrs.go
+++ b/cmds/core/lockmsrs/lockmsrs.go
@@ -13,85 +13,45 @@ package main
 import (
 	"flag"
 	"log"
+	"os"
 
-	"github.com/intel-go/cpuid"
 	"github.com/u-root/u-root/pkg/msr"
 )
 
-const (
-	msrIA32FeatureControl  msr.MSR = 0x3A  // MSR_IA32_FEATURE_CONTROL
-	msrPkgCstConfigControl msr.MSR = 0xE2  // MSR_PKG_CST_CONFIG_CONTROL
-	msrFeatureConfig       msr.MSR = 0x13C // MSR_FEATURE_CONFIG
-	msrDramPowerLimit      msr.MSR = 0x618 // MSR_DRAM_POWER_LIMIT
-	msrConfigTDPControl    msr.MSR = 0x64B // MSR_CONFIG_TDP_CONTROL
-	ia32DebugInterface     msr.MSR = 0xC80 // IA32_DEBUG_INTERFACE
+var (
+	verbose = flag.Bool("v", false, "verbose mode")
+	verify  = flag.Bool("V", false, "Verify, do not write")
+	debug   = func(string, ...interface{}) {}
 )
 
-var verbose = flag.Bool("v", false, "verbose mode")
-
-var msrList = []struct {
-	msrAdd    msr.MSR
-	clearMask uint64
-	setMask   uint64
-}{
-	{
-		// Architectural MSR. All systems.
-		// Enables features like VMX.
-		msrAdd:  msrIA32FeatureControl,
-		setMask: 1 << 0, // Locks this register.
-	},
-	{
-		// Silvermont, Airmont, Nehalem...
-		// Controls Processor C States.
-		msrAdd:  msrPkgCstConfigControl,
-		setMask: 1 << 15, // Locks this register.
-	},
-	{
-		// Westmere onwards.
-		// Note that this turns on AES instructions, however
-		// 3 will turn off AES until reset.
-		msrAdd:  msrFeatureConfig,
-		setMask: 1 << 0,
-	},
-	{
-		// Goldmont, SandyBridge
-		// Controls DRAM power limits. See Intel SDM
-		msrAdd:  msrDramPowerLimit,
-		setMask: 1 << 31, // Locks this register.
-	},
-	{
-		// IvyBridge Onwards.
-		// Not much information in the SDM, seems to control power limits
-		msrAdd:  msrConfigTDPControl,
-		setMask: 1 << 31, // Locks this register.
-	},
-	{
-		// Architectural MSR. All systems.
-		// This is the actual spelling of the MSR in the manual.
-		// Controls availability of silicon debug interfaces
-		msrAdd:  ia32DebugInterface,
-		setMask: 1 << 30, // Locks this register.
-	},
-}
-
 func main() {
-	if cpuid.VendorIdentificatorString != "GenuineIntel" {
-		log.Fatalf("Only Intel CPUs supported, expected GenuineIntel, got %v", cpuid.VendorIdentificatorString)
+	flag.Parse()
+
+	if *verbose {
+		debug = log.Printf
+	}
+
+	msr.Debug = debug
+
+	if *verify {
+		if err := msr.Verify(); err != nil {
+			log.Fatal(err)
+		}
+		os.Exit(0)
 	}
 
 	cpus, err := msr.AllCPUs()
 	if err != nil {
 		log.Fatal(err)
 	}
-	for _, m := range msrList {
-		if *verbose {
-			log.Printf("Locking MSR %v on cpus %v, clearmask 0x%8x, setmask 0x%8x", m.msrAdd, cpus, m.clearMask, m.setMask)
-		}
-		errs := m.msrAdd.TestAndSet(cpus, m.clearMask, m.setMask)
+	for _, m := range msr.Intel {
+		debug("Lock MSR %s on cpus %v, clearmask %#08x, setmask %#08x", m.String(), cpus, m.Clear, m.Set)
+		errs := m.Addr.TestAndSet(cpus, m.Clear, m.Set)
+
 		for i, e := range errs {
 			if e != nil {
 				// Hope no one ever modifies this slice.
-				log.Printf("Error locking msr %v on cpu %v: %v\n", m.msrAdd.String(), cpus[i], e)
+				log.Printf("Error locking msr %v on cpu %v: %v\n", m.Addr.String(), cpus[i], e)
 			}
 		}
 	}

--- a/pkg/msr/intel.go
+++ b/pkg/msr/intel.go
@@ -1,0 +1,63 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package msr
+
+const (
+	// This is Intel's name. It makes no sense: this register is present
+	// in 64-bit CPUs.
+	IntelIA32FeatureControl  MSR = 0x3A
+	IntelPkgCstConfigControl MSR = 0xE2
+	IntelFeatureConfig       MSR = 0x13
+	IntelDramPowerLimit      MSR = 0x61
+	IntelConfigTDPControl    MSR = 0x64B
+	IntelIA32DebugInterface  MSR = 0xC80
+)
+
+var Intel = []MSRVal{
+	{
+		// Architectural MSR. All systems.
+		// Enables features like VMX.
+		Addr: IntelIA32FeatureControl,
+		Name: "IntelIA32FeatureControl",
+		Set:  1 << 0, // Locks this register.
+	},
+	{
+		// Silvermont, Airmont, Nehalem...
+		// Controls Processor C States.
+		Addr: IntelPkgCstConfigControl,
+		Name: "IntelPkgCstConfigControl",
+		Set:  1 << 15, // Locks this register.
+	},
+	{
+		// Westmere onwards.
+		// Note that this turns on AES instructions, however
+		// 3 will turn off AES until reset.
+		Addr: IntelFeatureConfig,
+		Name: "IntelFeatureConfig",
+		Set:  1 << 0,
+	},
+	{
+		// Goldmont, SandyBridge
+		// Controls DRAM power limits. See Intel SDM
+		Addr: IntelDramPowerLimit,
+		Name: "IntelDramPowerLimit",
+		Set:  1 << 31, // Locks this register.
+	},
+	{
+		// IvyBridge Onwards.
+		// Not much information in the SDM, seems to control power limits
+		Addr: IntelConfigTDPControl,
+		Name: "IntelConfigTDPControl",
+		Set:  1 << 31, // Locks this register.
+	},
+	{
+		// Architectural MSR. All systems.
+		// This is the actual spelling of the MSR in the manual.
+		// Controls availability of silicon debug interfaces
+		Addr: IntelIA32DebugInterface,
+		Name: "IntelIA32DebugInterface",
+		Set:  1 << 30, // Locks this register.
+	},
+}

--- a/pkg/msr/msr.go
+++ b/pkg/msr/msr.go
@@ -1,0 +1,18 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package msr
+
+type MSRVal struct {
+	Addr  MSR
+	Name  string
+	Clear uint64
+	Set   uint64
+}
+
+func (m MSRVal) String() string {
+	return m.Name
+}
+
+var Debug = func(string, ...interface{}) {}


### PR DESCRIPTION
There were constants defined in lockmsr that are
useful to have in the msr package; move them. Place the
Intel-specific MSR settings in an array.
Add a Test function to verify settings.

Add test code, now that constants and a Test function
are available.

Add -verify option to lockmsr.