### PR TITLE
ts: Add option for times relative to first line

### DIFF
--- a/cmds/core/ts/ts.go
+++ b/cmds/core/ts/ts.go
@@ -17,13 +17,17 @@ import (
 	"github.com/u-root/u-root/pkg/ts"
 )
 
+var first = flag.Bool("f", false, "All timestamps are relative to the first character")
+
 func main() {
 	flag.Parse()
 	if flag.NArg() != 0 {
 		log.Fatal("Usage: ts")
 	}
 
-	_, err := io.Copy(os.Stdout, ts.New(os.Stdin))
+	t := ts.New(os.Stdin)
+	t.ResetTimeOnNextRead = *first
+	_, err := io.Copy(os.Stdout, t)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/ts/ts.go
+++ b/pkg/ts/ts.go
@@ -18,6 +18,11 @@ type PrependTimestamp struct {
 	StartTime time.Time
 	Format    func(startTime time.Time) string
 
+	// ResetTimeOnNextRead is set to force the StartTime to reset to the
+	// current time when data is next read. It is useful to set this to
+	// true initially for all times to be relative to the first line.
+	ResetTimeOnNextRead bool
+
 	// noPrintTS is true to indicate the timestamp should be printed
 	// in front of the next byte.
 	noPrintTS bool
@@ -61,6 +66,10 @@ func (t *PrependTimestamp) Read(p []byte) (n int, err error) {
 	scratch = scratch[:m]
 	if m == 0 {
 		return
+	}
+	if t.ResetTimeOnNextRead {
+		t.StartTime = time.Now()
+		t.ResetTimeOnNextRead = false
 	}
 	if err == io.EOF {
 		// Do not return EOF immediately because there may be more than


### PR DESCRIPTION
When the -f argument is set, the first line printed will always be
prefixed with "[0.0000s]" all other lines are relative to this.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>