### PR TITLE
Change: templates.go

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -1,12 +1,12 @@
-// Copyright 2015-2018 the u-root Authors. All rights reserved
+// Copyright 2015-2020 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
 package main
 
 // TODO: make templates able to include other templates.
-// e.g. "all" below should just say "core" and "boot"
-// and "systemboot" should say "core", "boot", "github.com/u-root/u-root/cmds/boot/uinit"
+// e.g. "all" below should just say "core" and "boot". Use it to replace
+// the old 'systemboot' template.
 // Or just call it a day, now that we have the new directory structure, and dump the templates
 // completely; that may be our best bet.
 var templates = map[string][]string{
@@ -16,10 +16,6 @@ var templates = map[string][]string{
 	},
 	"boot": {
 		"github.com/u-root/u-root/cmds/boot/*boot*",
-	},
-	"systemboot": {
-		"github.com/u-root/u-root/cmds/boot/*boot*",
-		"github.com/u-root/u-root/cmds/boot/uinit",
 	},
 	// Core should be things you don't want to live without.
 	"core": {


### PR DESCRIPTION
In current master uinit is deprecated. The systemboot template
is referencing it still and breaking the build consequently.
Therefore systemboot is discarded in favor of the all-template

Signed-off-by: Patrik Tesarik <mail@patrik-tesarik.de>

For more background information check the u-root slack channel [here](https://u-root.slack.com/archives/CAJUM8MF1/p1586425897025100) and following.