### PR TITLE
Fix issues in boot2

### DIFF
--- a/cmds/boot/boot2/boot.go
+++ b/cmds/boot/boot2/boot.go
@@ -40,13 +40,13 @@ func getDevice() (*diskboot.Device, error) {
 		return nil, errors.New("No devices found")
 	}
 
-	verbose("Got devices: %#v", devices)
+	verbose("Got devices: %v", devices)
 	var err error
 	deviceIndex := 0
 	if len(devices) > 1 {
 		if *sDeviceIndex == "" {
 			for i, device := range devices {
-				log.Printf("Device #%v: %s", i, device)
+				log.Printf("Device %v: %s", i, device)
 			}
 			return nil, errors.New("multiple devices found - must specify a device index")
 		}
@@ -64,13 +64,13 @@ func getConfig(device *diskboot.Device) (*diskboot.Config, error) {
 		return nil, errors.New("No config found")
 	}
 
-	verbose("Got configs: %#v", configs)
+	verbose("Got configs: %v", configs)
 	var err error
 	configIndex := 0
 	if len(configs) > 1 {
 		if *sConfigIndex == "" {
 			for i, config := range configs {
-				log.Printf("Config #%v: path: %v", i, config.ConfigPath)
+				log.Printf("Config %v: path: %v", i, config.ConfigPath)
 			}
 			return nil, errors.New("Multiple configs found - must specify a config index")
 		}
@@ -83,7 +83,7 @@ func getConfig(device *diskboot.Device) (*diskboot.Config, error) {
 }
 
 func getEntry(config *diskboot.Config) (*diskboot.Entry, error) {
-	verbose("Got entries: %#v", config.Entries)
+	verbose("Got entries: %v", config.Entries)
 	var err error
 	entryIndex := 0
 	if *sEntryIndex != "" {
@@ -95,7 +95,7 @@ func getEntry(config *diskboot.Config) (*diskboot.Entry, error) {
 		entryIndex = config.DefaultEntry
 	} else {
 		for i, entry := range config.Entries {
-			log.Printf("Entry #%v: %#v", i, entry)
+			log.Printf("Entry %v: %v", i, entry)
 		}
 		return nil, errors.New("No entry specified")
 	}

--- a/pkg/boot/diskboot/config.go
+++ b/pkg/boot/diskboot/config.go
@@ -26,6 +26,16 @@ type Config struct {
 	DefaultEntry int
 }
 
+func (c Config) String() string {
+	return fmt.Sprintf(`
+		Config {
+			MountPath: %s,
+			ConfigPath: %s,
+			Entries: %v,
+			DefaultEntry: %d
+		}`, c.MountPath, c.ConfigPath, c.Entries, c.DefaultEntry)
+}
+
 // EntryType dictates the method by which kexec should use to load
 // the new kernel
 type EntryType int
@@ -60,6 +70,16 @@ type Entry struct {
 	Name    string
 	Type    EntryType
 	Modules []Module
+}
+
+func (e Entry) String() string {
+	return fmt.Sprintf(`
+		Entry {
+			Name: %s,
+			Type: %s,
+			Modules: %v
+	  }
+  `, e.Name, e.Type.String(), e.Modules)
 }
 
 // KexecLoad calls the appropriate kexec load routines based on the


### PR DESCRIPTION
When trying to boot RHEL 7.8, we noticed that parsing the GRUB
config failed. This is because diskboot/parser.go expected to find
the exact string "linux" and "initrd", and the RHEL config had
"linux16" and "initrd16". The changes here make it so we can
parse that correctly, and make debug messages a little more informative.

Tested in QEMU by booting the RHEL image.

Signed-off-by: pallaud <plaud@google.com>