### PR TITLE
VMware mutiboot support

### DIFF
--- a/integration/generic-tests/esxi_boot_test.go
+++ b/integration/generic-tests/esxi_boot_test.go
@@ -1,0 +1,64 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !race
+
+package integration
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	expect "github.com/google/goexpect"
+	"github.com/u-root/u-root/pkg/qemu"
+	"github.com/u-root/u-root/pkg/vmtest"
+)
+
+func TestESXi(t *testing.T) {
+	img := os.Getenv("UROOT_ESXI_IMAGE")
+	if _, err := os.Stat(img); err != nil && os.IsNotExist(err) {
+		t.Skip("ESXi disk image is not present. Please set UROOT_ESXI_IMAGE= to an installed ESXi disk image.")
+	}
+
+	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{
+		TestCmds: []string{
+			`esxiboot -d="/dev/sda" --append="vmkBootVerbose=TRUE vmbLog=TRUE debugLogToSerial=1 logPort=com1"`,
+		},
+		QEMUOpts: qemu.Options{
+			Devices: []qemu.Device{
+				qemu.IDEBlockDevice{File: img},
+				// If at some point we get virtio-net working
+				// again in ESXi, you may need to set num CPUs
+				// to 4.
+				qemu.ArbitraryArgs{"-smp", "2"},
+
+				// QEMU is not good enough to do ESXi without KVM. You'll get kernel panic.
+				qemu.ArbitraryArgs{"-enable-kvm"},
+
+				// IvyBridge is the lowest-common-denominator.
+				// ESXi 7.0 drops support for SandyBridge
+				// afaict.
+				qemu.ArbitraryArgs{"-cpu", "IvyBridge"},
+
+				// Min ESXi requirement is 4G of memory.
+				qemu.ArbitraryArgs{"-m", "4096"},
+			},
+		},
+	})
+	defer cleanup()
+
+	if out, err := q.ExpectBatch([]expect.Batcher{
+		// Last Linux print.
+		&expect.BExp{R: "kexec_core: Starting new kernel"},
+		// First b.b00 ESXi first-stage kernel print
+		&expect.BExp{R: "Serial port initialized..."},
+		// ~thirdish k.b00 ESXi second-stage kernel print
+		&expect.BExp{R: "Parsing command line boot options"},
+		// When we can be confident it's done.
+		&expect.BExp{R: "Boot Successful"},
+	}, 2*time.Minute); err != nil {
+		t.Fatalf("VM output did not match expectations: %v", out)
+	}
+}

--- a/integration/generic-tests/esxi_boot_test.go
+++ b/integration/generic-tests/esxi_boot_test.go
@@ -42,8 +42,11 @@ func TestESXi(t *testing.T) {
 				// afaict.
 				qemu.ArbitraryArgs{"-cpu", "IvyBridge"},
 
-				// Min ESXi requirement is 4G of memory.
-				qemu.ArbitraryArgs{"-m", "4096"},
+				// Min ESXi requirement is 4G of memory, but in
+				// ESXi 7.0 some plugins fail to load at 4G
+				// under memory pressure, and we never get to
+				// "Boot Successful"
+				qemu.ArbitraryArgs{"-m", "8192"},
 			},
 		},
 	})

--- a/pkg/boot/multiboot/header.go
+++ b/pkg/boot/multiboot/header.go
@@ -25,8 +25,11 @@ var (
 )
 
 const (
+	// headerMagic is the magic value found in a multiboot kernel header.
 	headerMagic = 0x1BADB002
-	bootMagic   = 0x2BADB002
+
+	// bootMagic is the magic expected by the loaded OS in EAX at boot handover.
+	bootMagic = 0x2BADB002
 )
 
 type headerFlag uint32

--- a/pkg/boot/multiboot/header.go
+++ b/pkg/boot/multiboot/header.go
@@ -65,6 +65,20 @@ type header struct {
 	optional
 }
 
+type imageType interface {
+	addInfo(m *multiboot) (uintptr, error)
+	name() string
+	bootMagic() uintptr
+}
+
+func (h *header) name() string {
+	return "multiboot"
+}
+
+func (h *header) bootMagic() uintptr {
+	return bootMagic
+}
+
 // parseHeader parses multiboot header as defined in
 // https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#OS-image-format
 func parseHeader(r io.Reader) (*header, error) {

--- a/pkg/boot/multiboot/header.go
+++ b/pkg/boot/multiboot/header.go
@@ -24,7 +24,10 @@ var (
 	ErrFlagsNotSupported = errors.New("multiboot header flags not supported	yet")
 )
 
-const headerMagic = 0x1BADB002
+const (
+	headerMagic = 0x1BADB002
+	bootMagic   = 0x2BADB002
+)
 
 type headerFlag uint32
 

--- a/pkg/boot/multiboot/info.go
+++ b/pkg/boot/multiboot/info.go
@@ -93,6 +93,7 @@ func (iw *infoWrapper) marshal(base uintptr) ([]byte, error) {
 	iw.info.CmdLine = offset
 	offset += uint32(len(iw.CmdLine)) + 1
 	iw.info.BootLoaderName = offset
+	iw.info.Flags |= flagInfoCmdLine | flagInfoBootLoaderName
 
 	buf := bytes.Buffer{}
 	if err := binary.Write(&buf, ubinary.NativeEndian, iw.info); err != nil {

--- a/pkg/boot/multiboot/internal/trampoline/trampoline.go
+++ b/pkg/boot/multiboot/internal/trampoline/trampoline.go
@@ -8,6 +8,6 @@ package trampoline
 
 import "errors"
 
-func Setup(path string, infoAddr, entryPoint uintptr) ([]byte, error) {
+func Setup(path string, magic, infoAddr, entryPoint uintptr) ([]byte, error) {
 	return nil, errors.New("not implemented yet")
 }

--- a/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.s
+++ b/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.s
@@ -16,8 +16,6 @@
 #define DATA_SEGMENT	0x00CF92000000FFFF
 #define CODE_SEGMENT	0x00CF9A000000FFFF
 
-#define MAGIC	0x2BADB002
-
 TEXT ·start(SB),NOSPLIT,$0
 	// Create GDT pointer on stack.
 	LEAQ	gdt(SB), CX
@@ -30,6 +28,10 @@ TEXT ·start(SB),NOSPLIT,$0
 	// Store value of multiboot info addr in BX.
 	// Don't modify BX.
 	MOVL	info(SB), BX
+
+	// Store value of mu(l)tiboot magic in SI.
+	// Don't modify SI.
+	MOVL	magic(SB), SI
 
 	// Far return doesn't work on QEMU in 64-bit mode,
 	// let's do far jump.
@@ -84,7 +86,8 @@ TEXT boot(SB),NOSPLIT,$0
 	BYTE	$0x8e; BYTE $0xe0 // MOVL AX, FS
 	BYTE	$0x8e; BYTE $0xe8 // MOVL AX, GS
 
-	MOVL	$MAGIC, AX
+	// We stored the magic in SI before the far jump.
+	MOVL	SI, AX
 	JMP	farjump32(SB)
 
 	// Unreachable code.
@@ -92,6 +95,7 @@ TEXT boot(SB),NOSPLIT,$0
 	// include them to a binary.
 	JMP	infotext(SB)
 	JMP	entrytext(SB)
+  JMP magictext(SB)
 
 TEXT farjump64(SB),NOSPLIT,$0
 	BYTE	$0xFF; BYTE $0x2D; LONG $0x0 // ljmp *(ip)
@@ -127,6 +131,14 @@ TEXT entrytext(SB),NOSPLIT,$0
 	BYTE $'r'; BYTE $'y'; BYTE $'-'; BYTE $'l'; BYTE $'o';
 	BYTE $'n'; BYTE $'g';
 TEXT entry(SB),NOSPLIT,$0
+	LONG	$0x0
+
+TEXT magictext(SB),NOSPLIT,$0
+	// u-root-mb-magic
+	BYTE $'u'; BYTE $'-'; BYTE $'r'; BYTE $'o'; BYTE $'o';
+	BYTE $'t'; BYTE $'-'; BYTE $'m'; BYTE $'b'; BYTE $'-';
+	BYTE $'m'; BYTE $'a'; BYTE $'g'; BYTE $'i'; BYTE $'c';
+TEXT magic(SB),NOSPLIT,$0
 	LONG	$0x0
 
 TEXT ·end(SB),NOSPLIT,$0

--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -33,21 +33,32 @@ type module struct {
 
 type modules []module
 
-func (m *multiboot) addModules() (uintptr, error) {
+func (m *multiboot) loadModules() (modules, error) {
 	loaded, data, err := loadModules(m.modules)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	cmdlineRange, err := m.mem.AddKexecSegment(data)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 
 	loaded.fix(uint32(cmdlineRange.Start))
-
 	m.loadedModules = loaded
 
+	for i, mod := range loaded {
+		log.Printf("Added module %s at [%#x, %#x)", m.modules[i].Name, mod.Start, mod.End)
+	}
+
+	return loaded, nil
+}
+
+func (m *multiboot) addMultibootModules() (uintptr, error) {
+	loaded, err := m.loadModules()
+	if err != nil {
+		return 0, err
+	}
 	b, err := loaded.marshal()
 	if err != nil {
 		return 0, err
@@ -77,7 +88,7 @@ func (m *multiboot) addModules() (uintptr, error) {
 // <padding> aligns the start of each module to a page beginning.
 func loadModules(rmods []Module) (loaded modules, data []byte, err error) {
 	loaded = make(modules, len(rmods))
-	buf := bytes.Buffer{}
+	var buf bytes.Buffer
 
 	for i, rmod := range rmods {
 		if err := loaded[i].setCmdLine(&buf, rmod.CmdLine); err != nil {
@@ -90,12 +101,16 @@ func loadModules(rmods []Module) (loaded modules, data []byte, err error) {
 			return nil, nil, fmt.Errorf("error adding module %v: %v", rmod.Name, err)
 		}
 	}
-
 	return loaded, buf.Bytes(), nil
 }
 
-// alignUp pads buf to a page boundary.
-func alignUp(buf *bytes.Buffer) error {
+func pageAlign(val uint32) uint32 {
+	mask := uint32(os.Getpagesize() - 1)
+	return (val + mask) &^ mask
+}
+
+// pageAlignBuf pads buf to a page boundary.
+func pageAlignBuf(buf *bytes.Buffer) error {
 	mask := (os.Getpagesize() - 1)
 	size := (buf.Len() + mask) &^ mask
 	_, err := buf.Write(bytes.Repeat([]byte{0}, size-buf.Len()))
@@ -103,10 +118,8 @@ func alignUp(buf *bytes.Buffer) error {
 }
 
 func (m *module) loadModule(buf *bytes.Buffer, r io.ReaderAt, name string) error {
-	log.Printf("Adding module %v", name)
-
 	// place start of each module to a beginning of a page.
-	if err := alignUp(buf); err != nil {
+	if err := pageAlignBuf(buf); err != nil {
 		return err
 	}
 
@@ -117,7 +130,6 @@ func (m *module) loadModule(buf *bytes.Buffer, r io.ReaderAt, name string) error
 	}
 
 	m.End = uint32(buf.Len())
-
 	return nil
 }
 
@@ -144,4 +156,22 @@ func (m modules) marshal() ([]byte, error) {
 	buf := bytes.Buffer{}
 	err := binary.Write(&buf, ubinary.NativeEndian, m)
 	return buf.Bytes(), err
+}
+
+// elems returns the elements expected by the mutiboot info header.
+func (m modules) elems() []elem {
+	var e []elem
+	for _, mm := range m {
+		e = append(e, &mutibootModule{
+			cmdline:    uint64(mm.CmdLine),
+			moduleSize: uint64(mm.End - mm.Start),
+			ranges: []mutibootModuleRange{
+				{
+					startPageNum: uint64(mm.Start / uint32(os.Getpagesize())),
+					numPages:     pageAlign(mm.End-mm.Start) / uint32(os.Getpagesize()),
+				},
+			},
+		})
+	}
+	return e
 }

--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -150,15 +150,16 @@ func (m modules) fix(base uint32) {
 	}
 }
 
-// marshal writes out the exact bytes of modules to be loaded
-// along with the kernel.
+// marshal writes out the module list in multiboot info format, as described in
+// https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Boot-information-format
 func (m modules) marshal() ([]byte, error) {
 	buf := bytes.Buffer{}
 	err := binary.Write(&buf, ubinary.NativeEndian, m)
 	return buf.Bytes(), err
 }
 
-// elems returns the elements expected by the mutiboot info header.
+// elems adds mutiboot info elements describing where to find each module and
+// its cmdline.
 func (m modules) elems() []elem {
 	var e []elem
 	for _, mm := range m {

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -39,6 +39,13 @@ type Module struct {
 // Modules is a range of module with a Closer interface
 type Modules []Module
 
+type ImageType uint8
+
+const (
+	MultibootImage ImageType = 1
+	MutibootImage  ImageType = 2
+)
+
 // multiboot defines parameters for working with multiboot kernels.
 type multiboot struct {
 	mem kexec.Memory
@@ -54,17 +61,11 @@ type multiboot struct {
 	// https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Machine-state.
 	trampoline string
 
-	header header
-
-	// infoAddr is a pointer to multiboot info.
-	infoAddr uintptr
-	// kernelEntry is a pointer to entry point of kernel.
-	kernelEntry uintptr
 	// EntryPoint is a pointer to trampoline.
 	entryPoint uintptr
 
 	info          info
-	loadedModules []module
+	loadedModules modules
 }
 
 var (
@@ -98,6 +99,28 @@ func (m MemoryMap) String() string {
 
 type memoryMaps []MemoryMap
 
+// marshal writes out the exact bytes expected by the multiboot info header
+// specified in
+// https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Boot-information-format.
+func (m memoryMaps) marshal() ([]byte, error) {
+	buf := bytes.Buffer{}
+	err := binary.Write(&buf, ubinary.NativeEndian, m)
+	return buf.Bytes(), err
+}
+
+// elems returns the info elements expected in the mutiboot info header.
+func (m memoryMaps) elems() []elem {
+	var e []elem
+	for _, mm := range m {
+		e = append(e, &mutibootMemRange{
+			startAddr: mm.BaseAddr,
+			length:    mm.Length,
+			memType:   mm.Type,
+		})
+	}
+	return e
+}
+
 // String returns a new-line-separated representation of the entire memory map.
 func (m memoryMaps) String() string {
 	var s []string
@@ -107,10 +130,13 @@ func (m memoryMaps) String() string {
 	return strings.Join(s, "\n")
 }
 
-// Probe checks if `kernel` is multiboot v1 kernel.
+// Probe checks if `kernel` is multiboot v1 or mutiboot kernel.
 func Probe(kernel io.ReaderAt) error {
 	r := tryGzipFilter(kernel)
 	_, err := parseHeader(uio.Reader(r))
+	if err == ErrHeaderNotFound {
+		_, err = parseMutiHeader(uio.Reader(r))
+	}
 	return err
 }
 
@@ -219,15 +245,30 @@ func (m Modules) Close() error {
 func (m *multiboot) load(debug bool, ibft *ibft.IBFT) error {
 	var err error
 	log.Println("Parsing multiboot header")
-	if m.header, err = parseHeader(uio.Reader(m.kernel)); err != nil {
+	// TODO: the kernel is opened like 4 separate times here. Just open it
+	// once and pass it around.
+
+	multibootHeader, err := parseHeader(uio.Reader(m.kernel))
+	if err == ErrHeaderNotFound {
+		// We don't even need the header at the moment. Just need to
+		// know it's there. Everything that matters is in the ELF.
+		_, err = parseMutiHeader(uio.Reader(m.kernel))
+	}
+	if err != nil {
 		return fmt.Errorf("error parsing headers: %v", err)
+	}
+	if multibootHeader != nil {
+		log.Printf("Found Multiboot image")
+	} else {
+		log.Printf("Found Mutiboot image")
 	}
 
 	log.Printf("Getting kernel entry point")
-	if m.kernelEntry, err = getEntryPoint(m.kernel); err != nil {
+	kernelEntry, err := getEntryPoint(m.kernel)
+	if err != nil {
 		return fmt.Errorf("error getting kernel entry point: %v", err)
 	}
-	log.Printf("Kernel entry point at %#x", m.kernelEntry)
+	log.Printf("Kernel entry point at %#x", kernelEntry)
 
 	log.Printf("Parsing ELF segments")
 	if err := m.mem.LoadElfSegments(m.kernel); err != nil {
@@ -258,13 +299,26 @@ func (m *multiboot) load(debug bool, ibft *ibft.IBFT) error {
 		m.mem.Segments.Insert(kexec.NewSegment(ibuf, r))
 	}
 
-	log.Printf("Preparing multiboot info")
-	if m.infoAddr, err = m.addInfo(); err != nil {
+	log.Printf("Preparing mu(l)tiboot info")
+	var infoAddr uintptr
+	if multibootHeader != nil {
+		infoAddr, err = m.addMultibootInfo(multibootHeader)
+	} else {
+		infoAddr, err = m.addMutibootInfo()
+	}
+	if err != nil {
 		return fmt.Errorf("error preparing multiboot info: %v", err)
 	}
 
+	var magic uintptr
+	if multibootHeader != nil {
+		magic = bootMagic
+	} else {
+		magic = mutibootMagic
+	}
+
 	log.Printf("Adding trampoline")
-	if m.entryPoint, err = m.addTrampoline(); err != nil {
+	if m.entryPoint, err = m.addTrampoline(magic, infoAddr, kernelEntry); err != nil {
 		return fmt.Errorf("error adding trampoline: %v", err)
 	}
 	log.Printf("Trampoline entry point at %#x", m.entryPoint)
@@ -288,8 +342,8 @@ func getEntryPoint(r io.ReaderAt) (uintptr, error) {
 	return uintptr(f.Entry), err
 }
 
-func (m *multiboot) addInfo() (addr uintptr, err error) {
-	iw, err := m.newMultibootInfo()
+func (m *multiboot) addMultibootInfo(h *header) (addr uintptr, err error) {
+	iw, err := m.newMultibootInfo(h)
 	if err != nil {
 		return 0, err
 	}
@@ -313,6 +367,41 @@ func (m *multiboot) addInfo() (addr uintptr, err error) {
 	return r.Start, nil
 }
 
+func (m *multiboot) addMutibootInfo() (addr uintptr, err error) {
+	var mi mutibootInfo
+
+	mi.elems = append(mi.elems, m.memoryMap().elems()...)
+	mods, err := m.loadModules()
+	if err != nil {
+		return 0, err
+	}
+	mi.elems = append(mi.elems, mods.elems()...)
+
+	// This marshals the mutiboot info with cmdline = 0. We're gonna append
+	// the cmdline, so we must know the size of the marshaled stuff first
+	// to be able to point to it.
+	//
+	// TODO: find a better place to put the cmdline so we don't do this
+	// bullshit.
+	b := mi.marshal()
+
+	// string + null-terminator
+	cmdlineLen := len(m.cmdLine) + 1
+
+	memRange, err := m.mem.FindSpace(uint(len(b) + cmdlineLen))
+	if err != nil {
+		return 0, err
+	}
+	mi.cmdline = uint64(memRange.Start + uintptr(len(b)))
+
+	// Re-marshal, now that the cmdline is set.
+	b = mi.marshal()
+	b = append(b, []byte(m.cmdLine)...)
+	b = append(b, 0)
+	m.mem.Segments.Insert(kexec.NewSegment(b, memRange))
+	return memRange.Start, nil
+}
+
 func (m multiboot) memoryMap() memoryMaps {
 	var ret memoryMaps
 	for _, r := range m.mem.Phys {
@@ -329,12 +418,12 @@ func (m multiboot) memoryMap() memoryMaps {
 		}
 		ret = append(ret, v)
 	}
+	log.Printf("Memory map: %v", ret)
 	return ret
 }
 
 func (m *multiboot) addMmap() (addr uintptr, size uint, err error) {
 	mmap := m.memoryMap()
-	log.Printf("Memory map:\n%s", mmap)
 	d, err := mmap.marshal()
 	if err != nil {
 		return 0, 0, err
@@ -375,13 +464,13 @@ func min(a, b uint32) uint32 {
 	return b
 }
 
-func (m *multiboot) newMultibootInfo() (*infoWrapper, error) {
+func (m *multiboot) newMultibootInfo(header *header) (*infoWrapper, error) {
 	mmapAddr, mmapSize, err := m.addMmap()
 	if err != nil {
 		return nil, err
 	}
 	var inf info
-	if m.header.Flags&flagHeaderMemoryInfo != 0 {
+	if header.Flags&flagHeaderMemoryInfo != 0 {
 		lower, upper := m.memoryBoundaries()
 		inf = info{
 			Flags:      flagInfoMemMap | flagInfoMemory,
@@ -393,7 +482,7 @@ func (m *multiboot) newMultibootInfo() (*infoWrapper, error) {
 	}
 
 	if len(m.modules) > 0 {
-		modAddr, err := m.addModules()
+		modAddr, err := m.addMultibootModules()
 		if err != nil {
 			return nil, err
 		}
@@ -402,9 +491,6 @@ func (m *multiboot) newMultibootInfo() (*infoWrapper, error) {
 		inf.ModsCount = uint32(len(m.modules))
 	}
 
-	inf.CmdLine = sizeofInfo
-	inf.BootLoaderName = sizeofInfo + uint32(len(m.cmdLine)) + 1
-	inf.Flags |= flagInfoCmdLine | flagInfoBootLoaderName
 	return &infoWrapper{
 		info:           inf,
 		CmdLine:        m.cmdLine,
@@ -412,19 +498,10 @@ func (m *multiboot) newMultibootInfo() (*infoWrapper, error) {
 	}, nil
 }
 
-// marshal writes out the exact bytes expected by the multiboot info header
-// specified in
-// https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Boot-information-format.
-func (m memoryMaps) marshal() ([]byte, error) {
-	buf := bytes.Buffer{}
-	err := binary.Write(&buf, ubinary.NativeEndian, m)
-	return buf.Bytes(), err
-}
-
-func (m *multiboot) addTrampoline() (entry uintptr, err error) {
+func (m *multiboot) addTrampoline(magic, infoAddr, kernelEntry uintptr) (entry uintptr, err error) {
 	// Trampoline setups the machine registers to desired state
 	// and executes the loaded kernel.
-	d, err := trampoline.Setup(m.trampoline, bootMagic, m.infoAddr, m.kernelEntry)
+	d, err := trampoline.Setup(m.trampoline, magic, infoAddr, kernelEntry)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -101,7 +101,7 @@ func (m memoryMaps) marshal() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-// elems returns the info elements expected in the mutiboot info header.
+// elems adds mutiboot info elements describing the memory map of the system.
 func (m memoryMaps) elems() []elem {
 	var e []elem
 	for _, mm := range m {
@@ -324,6 +324,12 @@ func getEntryPoint(r io.ReaderAt) (uintptr, error) {
 	return uintptr(f.Entry), err
 }
 
+// addInfo collects and adds multiboot info into the relocations/segments.
+//
+// addInfo marshals out everything required for
+// https://www.gnu.org/software/grub/manual/multiboot/multiboot.html#Boot-information-format
+// which is a memory map; a list of module structures, pointed to by mods_addr
+// and mods_count; and the multiboot info structure itself.
 func (h *header) addInfo(m *multiboot) (addr uintptr, err error) {
 	iw, err := h.newMultibootInfo(m)
 	if err != nil {
@@ -349,6 +355,12 @@ func (h *header) addInfo(m *multiboot) (addr uintptr, err error) {
 	return r.Start, nil
 }
 
+// addInfo collects and adds mutiboot (without L!) into the segments.
+//
+// The format is described in the structs in
+// https://github.com/vmware/esx-boot/blob/master/include/mutiboot.h
+//
+// It includes a memory map and a list of modules.
 func (*mutibootHeader) addInfo(m *multiboot) (addr uintptr, err error) {
 	var mi mutibootInfo
 
@@ -404,6 +416,7 @@ func (m multiboot) memoryMap() memoryMaps {
 	return ret
 }
 
+// addMmap adds a multiboot-marshaled memory map in memory.
 func (m *multiboot) addMmap() (addr uintptr, size uint, err error) {
 	mmap := m.memoryMap()
 	d, err := mmap.marshal()

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -424,7 +424,7 @@ func (m memoryMaps) marshal() ([]byte, error) {
 func (m *multiboot) addTrampoline() (entry uintptr, err error) {
 	// Trampoline setups the machine registers to desired state
 	// and executes the loaded kernel.
-	d, err := trampoline.Setup(m.trampoline, m.infoAddr, m.kernelEntry)
+	d, err := trampoline.Setup(m.trampoline, bootMagic, m.infoAddr, m.kernelEntry)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/boot/multiboot/multiboot_test.go
+++ b/pkg/boot/multiboot/multiboot_test.go
@@ -106,8 +106,8 @@ func TestParseHeader(t *testing.T) {
 				return
 			}
 			if test.size-test.offset > mandatorySize {
-				if !reflect.DeepEqual(got, want) {
-					t.Errorf("parseHeader() got %+v, want %+v", got, want)
+				if !reflect.DeepEqual(*got, want) {
+					t.Errorf("parseHeader() got %+v, want %+v", *got, want)
 				}
 			} else {
 				if !reflect.DeepEqual(got.mandatory, want.mandatory) {

--- a/pkg/boot/multiboot/mutiboot_info.go
+++ b/pkg/boot/multiboot/mutiboot_info.go
@@ -1,0 +1,136 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package multiboot
+
+import (
+	"github.com/u-root/u-root/pkg/uio"
+)
+
+type mutibootInfo struct {
+	cmdline uint64
+
+	elems []elem
+}
+
+func (m *mutibootInfo) marshal() []byte {
+	buf := uio.NewNativeEndianBuffer(nil)
+	buf.Write64(m.cmdline)
+	buf.Write64(uint64(len(m.elems)))
+
+	// These elems are encoded as TLV.
+	// Which is nice, because then we don't have to encode offsets and shit.
+	for _, el := range m.elems {
+		b := el.marshal()
+		buf.Write32(uint32(el.typ()))
+		// The element size is the total size including itself - typ +
+		// size + data.
+		buf.Write64(uint64(len(b)) + 8 + 4)
+		buf.WriteData(b)
+	}
+	return buf.Data()
+}
+
+type elem interface {
+	typ() mutibootType
+	marshal() []byte
+}
+
+type mutibootType uint32
+
+const (
+	MUTIBOOT_INVALID_TYPE  mutibootType = 0
+	MUTIBOOT_MEMRANGE_TYPE mutibootType = 1
+	MUTIBOOT_MODULE_TYPE   mutibootType = 2
+	MUTIBOOT_VBE_TYPE      mutibootType = 3
+	MUTIBOOT_EFI_TYPE      mutibootType = 4
+	MUTIBOOT_LOADESX_TYPE  mutibootType = 5
+)
+
+type mutibootMemRange struct {
+	startAddr uint64
+	length    uint64
+	memType   uint32
+}
+
+func (m mutibootMemRange) typ() mutibootType {
+	return MUTIBOOT_MEMRANGE_TYPE
+}
+
+func (m *mutibootMemRange) marshal() []byte {
+	buf := uio.NewNativeEndianBuffer(nil)
+	buf.Write64(m.startAddr)
+	buf.Write64(m.length)
+	buf.Write32(m.memType)
+	return buf.Data()
+}
+
+type mutibootModuleRange struct {
+	startPageNum uint64
+	numPages     uint32
+}
+
+type mutibootModule struct {
+	cmdline    uint64
+	moduleSize uint64
+	ranges     []mutibootModuleRange
+}
+
+func (m mutibootModule) typ() mutibootType {
+	return MUTIBOOT_MODULE_TYPE
+}
+
+func (m *mutibootModule) marshal() []byte {
+	buf := uio.NewNativeEndianBuffer(nil)
+	buf.Write64(m.cmdline)
+	buf.Write64(m.moduleSize)
+	buf.Write32(uint32(len(m.ranges)))
+	for _, r := range m.ranges {
+		buf.Write64(r.startPageNum)
+		buf.Write32(r.numPages)
+		// Padding.
+		buf.Write32(0)
+	}
+	return buf.Data()
+}
+
+type mutibootEfiFlags uint32
+
+const (
+	// 64-bit ARM EFI. (Why would we have to tell the next kernel that it's
+	// an aarch64 EFI? Shouldn't it know?)
+	MUTIBOOT_EFI_ARCH64 mutibootEfiFlags = 1 << 0
+
+	// EFI Secure Boot in progress.
+	MUTIBOOT_EFI_SECURE_BOOT mutibootEfiFlags = 1 << 1
+
+	// UEFI memory map is valid rather than mutiboot memory map.
+	MUTIBOOT_EFI_MMAP mutibootEfiFlags = 1 << 2
+)
+
+type mutibootEfi struct {
+	flags  mutibootEfiFlags
+	systab uint64
+
+	// Only set if flags & MUTIBOOT_EFI_MMAP.
+	memmap         uint64
+	memmapNumDescs uint32
+	memmapDescSize uint32
+	memmapVersion  uint32
+}
+
+func (m mutibootEfi) typ() mutibootType {
+	return MUTIBOOT_EFI_TYPE
+}
+
+func (m *mutibootEfi) marshal() []byte {
+	buf := uio.NewNativeEndianBuffer(nil)
+	buf.Write32(uint32(m.flags))
+	buf.Write64(m.systab)
+	buf.Write64(m.memmap)
+	buf.Write32(m.memmapNumDescs)
+	buf.Write32(m.memmapDescSize)
+	buf.Write32(m.memmapVersion)
+	return buf.Data()
+}

--- a/pkg/boot/multiboot/mutiboot_info_test.go
+++ b/pkg/boot/multiboot/mutiboot_info_test.go
@@ -1,0 +1,146 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package multiboot
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestInfoMarshal(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		mi   *mutibootInfo
+		want []byte
+	}{
+		{
+			name: "no elements",
+			mi: &mutibootInfo{
+				cmdline: 0xdeadbeef,
+				elems:   nil,
+			},
+			want: []byte{
+				// cmdline
+				0xef, 0xbe, 0xad, 0xde, 0, 0, 0, 0,
+				// 0 elements
+				0, 0, 0, 0, 0, 0, 0, 0,
+			},
+		},
+		{
+			name: "one memrange element",
+			mi: &mutibootInfo{
+				cmdline: 0xdeadbeef,
+				elems: []elem{
+					&mutibootMemRange{
+						startAddr: 0xbeefdead,
+						length:    0xdeadbeef,
+						memType:   2,
+					},
+				},
+			},
+			want: []byte{
+				// cmdline
+				0xef, 0xbe, 0xad, 0xde, 0, 0, 0, 0,
+				// 1 element
+				0x1, 0, 0, 0, 0, 0, 0, 0,
+
+				// TLV -- type, length, value
+
+				// type
+				byte(MUTIBOOT_MEMRANGE_TYPE), 0, 0, 0,
+				// length - 20 bytes + 8 for the length + 4 for the type
+				32, 0, 0, 0, 0, 0, 0, 0,
+				// values
+				0xad, 0xde, 0xef, 0xbe, 0, 0, 0, 0,
+				0xef, 0xbe, 0xad, 0xde, 0, 0, 0, 0,
+				2, 0, 0, 0,
+			},
+		},
+		{
+			name: "one module element",
+			mi: &mutibootInfo{
+				cmdline: 0xdeadbeef,
+				elems: []elem{
+					&mutibootModule{
+						cmdline:    0xbeefdead,
+						moduleSize: 0x1000,
+						ranges: []mutibootModuleRange{
+							{
+								startPageNum: 0x100,
+								numPages:     1,
+							},
+						},
+					},
+				},
+			},
+			want: []byte{
+				// cmdline
+				0xef, 0xbe, 0xad, 0xde, 0, 0, 0, 0,
+				// 1 element
+				0x1, 0, 0, 0, 0, 0, 0, 0,
+
+				// TLV -- type, length, value
+
+				// type
+				byte(MUTIBOOT_MODULE_TYPE), 0, 0, 0,
+				// length - 36 bytes + 8 for the length + 4 for the type
+				48, 0, 0, 0, 0, 0, 0, 0,
+				// values
+				// cmdline
+				0xad, 0xde, 0xef, 0xbe, 0, 0, 0, 0,
+				// moduleSize
+				0x00, 0x10, 0, 0, 0, 0, 0, 0,
+				// numRanges
+				1, 0, 0, 0,
+				// range - startPageNum
+				0x00, 0x01, 0, 0, 0, 0, 0, 0,
+				// range - numPages
+				1, 0, 0, 0,
+				// padding
+				0, 0, 0, 0,
+			},
+		},
+		{
+			name: "one zero-length module element",
+			mi: &mutibootInfo{
+				cmdline: 0xdeadbeef,
+				elems: []elem{
+					&mutibootModule{
+						cmdline:    0xbeefdead,
+						moduleSize: 0,
+					},
+				},
+			},
+			want: []byte{
+				// cmdline
+				0xef, 0xbe, 0xad, 0xde, 0, 0, 0, 0,
+				// 1 element
+				0x1, 0, 0, 0, 0, 0, 0, 0,
+
+				// TLV -- type, length, value
+
+				// type
+				byte(MUTIBOOT_MODULE_TYPE), 0, 0, 0,
+				// length - 20 bytes + 8 for the length + 4 for the type
+				32, 0, 0, 0, 0, 0, 0, 0,
+				// values
+				// cmdline
+				0xad, 0xde, 0xef, 0xbe, 0, 0, 0, 0,
+				// moduleSize
+				0, 0, 0, 0, 0, 0, 0, 0,
+				// numRanges
+				0, 0, 0, 0,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.mi.marshal()
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("marshaled bytes not the same. diff (-want, +got):\n%s", cmp.Diff(tt.want, got))
+			}
+		})
+	}
+}

--- a/pkg/boot/multiboot/mutiheader.go
+++ b/pkg/boot/multiboot/mutiheader.go
@@ -1,0 +1,99 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package multiboot
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"log"
+
+	"github.com/u-root/u-root/pkg/ubinary"
+)
+
+const mutibootMagic = 0x1BADB005
+
+type mutibootHeaderFlag uint32
+
+const (
+	// Kernel runs in EL1, not EL2.
+	MUTIBOOT_ARCH_FLAG_ARM64_EL1 mutibootHeaderFlag = 1 << 0
+	// Must pass video info to OS.
+	MUTIBOOT_FLAG_VIDEO mutibootHeaderFlag = 1 << 2
+
+	// rts_vaddr field is valid.
+	MUTIBOOT_FLAG_EFI_RTS_OLD mutibootHeaderFlag = 1 << 17
+	// rts vaddr and size fields valid.
+	MUTIBOOT_FLAG_EFI_RTS_NEW mutibootHeaderFlag = 1 << 18
+	// LoadESX version field valid.
+	MUTIBOOT_FLAG_LOADESX_VERSION mutibootHeaderFlag = 1 << 19
+	// Video min fields valid.
+	MUTIBOOT_FLAG_VIDEO_MIN mutibootHeaderFlag = 1 << 20
+)
+
+type mutibootVideoMode uint32
+
+const (
+	MUTIBOOT_VIDEO_GRAPHIC = 0
+	MUTIBOOT_VIDEO_TEXT    = 1
+)
+
+type mutibootHeader struct {
+	Magic    uint32
+	Flags    mutibootHeaderFlag
+	Checksum uint32
+
+	// unused.
+	_ uint32
+	_ uint32
+
+	// video stuff
+	MinWidth  uint32
+	MinHeight uint32
+	MinDepth  uint32
+	ModeType  mutibootVideoMode
+	Width     uint32
+	Height    uint32
+	Depth     uint32
+
+	RuntimeServicesVAddr uint64
+	RuntimeServicesSize  uint64
+	LoadESXVersion       uint32
+}
+
+// parseMutiHeader parses mutiboot header.
+func parseMutiHeader(r io.Reader) (*mutibootHeader, error) {
+	sizeofHeader := binary.Size(mutibootHeader{})
+
+	var hdr mutibootHeader
+	// The multiboot header must be contained completely within the
+	// first 8192 bytes of the OS image.
+	buf := make([]byte, 8192)
+	n, err := io.ReadAtLeast(r, buf, sizeofHeader)
+	if err != nil {
+		return nil, err
+	}
+	buf = buf[:n]
+
+	br := new(bytes.Reader)
+	for len(buf) >= sizeofHeader {
+		br.Reset(buf)
+		if err := binary.Read(br, ubinary.NativeEndian, &hdr); err != nil {
+			return nil, err
+		}
+		if hdr.Magic == mutibootMagic && (hdr.Magic+uint32(hdr.Flags)+hdr.Checksum) == 0 {
+			/*if hdr.Flags&flagHeaderUnsupported != 0 {
+				return hdr, ErrFlagsNotSupported
+			}*/
+			if hdr.Flags&MUTIBOOT_FLAG_VIDEO != 0 {
+				log.Print("VideoMode flag is not supproted yet, trying to load anyway")
+			}
+			return &hdr, nil
+		}
+		// The Multiboot header must be 64-bit aligned.
+		buf = buf[8:]
+	}
+	return nil, ErrHeaderNotFound
+}

--- a/pkg/boot/multiboot/mutiheader.go
+++ b/pkg/boot/multiboot/mutiheader.go
@@ -13,6 +13,8 @@ import (
 	"github.com/u-root/u-root/pkg/ubinary"
 )
 
+// mutibootMagic is both the magic value found in the mutiboot kernel header as
+// well as the value the loaded OS expects in EAX at boot time.
 const mutibootMagic = 0x1BADB005
 
 type mutibootHeaderFlag uint32

--- a/pkg/boot/multiboot/mutiheader.go
+++ b/pkg/boot/multiboot/mutiheader.go
@@ -63,6 +63,14 @@ type mutibootHeader struct {
 	LoadESXVersion       uint32
 }
 
+func (m *mutibootHeader) name() string {
+	return "mutiboot"
+}
+
+func (m *mutibootHeader) bootMagic() uintptr {
+	return mutibootMagic
+}
+
 // parseMutiHeader parses mutiboot header.
 func parseMutiHeader(r io.Reader) (*mutibootHeader, error) {
 	sizeofHeader := binary.Size(mutibootHeader{})

--- a/pkg/qemu/devices.go
+++ b/pkg/qemu/devices.go
@@ -118,6 +118,30 @@ func (rod ReadOnlyDirectory) Cmdline() []string {
 
 func (ReadOnlyDirectory) KArgs() []string { return nil }
 
+// IDEBlockDevice emulates an AHCI/IDE block device.
+type IDEBlockDevice struct {
+	File string
+}
+
+func (ibd IDEBlockDevice) Cmdline() []string {
+	if len(ibd.File) == 0 {
+		return nil
+	}
+
+	// There's a better way to do this. I don't know what it is. Some day
+	// I'll learn QEMU's crazy command line.
+	//
+	// I wish someone would make a proto representation of the
+	// command-line. Would be so much more understandable how device
+	// backends and frontends relate to each other.
+	return []string{
+		"-device", "ich9-ahci,id=ahci",
+		"-device", "ide-drive,drive=disk,bus=ahci.0",
+		"-drive", fmt.Sprintf("file=%s,if=none,id=disk", ibd.File),
+	}
+}
+func (IDEBlockDevice) KArgs() []string { return nil }
+
 // P9Directory is a Device that exposes a directory as a Plan9 (9p)
 // read-write filesystem in the VM.
 type P9Directory struct {

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -226,3 +226,9 @@ func (v *VM) ExpectRETimeout(pattern *regexp.Regexp, timeout time.Duration) (str
 	str, _, err := v.gExpect.Expect(pattern, scaled)
 	return str, err
 }
+
+// ExpectBatch matches many regular expressions.
+func (v *VM) ExpectBatch(batch []expect.Batcher, timeout time.Duration) ([]expect.BatchRes, error) {
+	scaled := time.Duration(float64(timeout) * TimeoutMultiplier)
+	return v.gExpect.ExpectBatch(batch, scaled)
+}

--- a/pkg/vmtest/integration.go
+++ b/pkg/vmtest/integration.go
@@ -119,8 +119,18 @@ type testLineWriter struct {
 	prefix string
 }
 
+func replaceCtl(str []byte) []byte {
+	for i, c := range str {
+		if c == 9 || c == 10 {
+		} else if c < 32 || c == 127 {
+			str[i] = '~'
+		}
+	}
+	return str
+}
+
 func (tsw *testLineWriter) OneLine(p []byte) {
-	tsw.tb.Logf("%s %s: %s", testutil.NowLog(), tsw.prefix, strings.ReplaceAll(string(p), "\033", "~"))
+	tsw.tb.Logf("%s %s: %s", testutil.NowLog(), tsw.prefix, string(replaceCtl(p)))
 }
 
 // TestArch returns the architecture under test. Pass this as GOARCH when


### PR DESCRIPTION
mutiboot is VMware ESXi's homegrown multiboot mutation to support EFI and arm64. Post-7.0 GA kernels will not support multiboot anymore.

mutiboot is their interface between the bootloader (http://github.com/vmware/esx-boot) and kernel (well, first-stage kernel, b.b00). Despite being relatively stable, they don't consider it stable, and neither should we. Implementing mutiboot is a temporary measure.

Long-term, we need to pick up Ofir's work and bring it to productionization, and boot ESXi by booting the EFI bootloader.

It's a rough first draft, it needs cleanup and nicer commits. And b.b00 is still crashing somewhere shortly after looping through the mutiboot elements, but I think I've almost got that one.

cc @oweisse @n-canter @TimothyPMann (in case you were curious :))