### PR TITLE
Get 386 to build again; add a test to make sure.

### DIFF
--- a/cmds/core/strace/strace.go
+++ b/cmds/core/strace/strace.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !386
+
 // strace is a simple multi-process tracer.
 // It starts the comand and lets the strace.Run() do all the work.
 //

--- a/uroot_test.go
+++ b/uroot_test.go
@@ -144,6 +144,18 @@ func TestUrootCmdline(t *testing.T) {
 			},
 		},
 		{
+			name: "386 source build",
+			env:  []string{"GOARCH=386"},
+			args: []string{"-build=source", "all"},
+			validators: []itest.ArchiveValidator{
+				buildSourceValidator{
+					goroot: "/go",
+					gopath: ".",
+					env:    []string{"GOARCH=386"},
+				},
+			},
+		},
+		{
 			name: "ARM7 bb build",
 			env:  []string{"GOARCH=arm", "GOARM=7"},
 			args: []string{"-build=bb", "all"},
@@ -151,6 +163,11 @@ func TestUrootCmdline(t *testing.T) {
 		{
 			name: "ARM64 bb build",
 			env:  []string{"GOARCH=arm64"},
+			args: []string{"-build=bb", "all"},
+		},
+		{
+			name: "386 (32 bit) bb build",
+			env:  []string{"GOARCH=386"},
 			args: []string{"-build=bb", "all"},
 		},
 		{


### PR DESCRIPTION
386 had stopped building and nobody noticed.

strace will need to be fixed but for now -- just exclude it.

Add a test case to make sure it does not break again.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>