### PR TITLE
Fix mipsle

### DIFF
--- a/cmds/core/strace/strace.go
+++ b/cmds/core/strace/strace.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !386
+// +build !386,!mipsle
 
 // strace is a simple multi-process tracer.
 // It starts the comand and lets the strace.Run() do all the work.

--- a/pkg/cpio/sysinfo_linux.go
+++ b/pkg/cpio/sysinfo_linux.go
@@ -17,11 +17,11 @@ func sysInfo(n string, sys *syscall.Stat_t) Info {
 		NLink:    uint64(sys.Nlink),
 		MTime:    uint64(sys.Mtim.Sec),
 		FileSize: uint64(sys.Size),
-		Dev:      sys.Dev,
-		Major:    sys.Dev >> 8,
-		Minor:    sys.Dev & 0xff,
-		Rmajor:   sys.Rdev >> 8,
-		Rminor:   sys.Rdev & 0xff,
+		Dev:      uint64(sys.Dev),
+		Major:    uint64(sys.Dev >> 8),
+		Minor:    uint64(sys.Dev & 0xff),
+		Rmajor:   uint64(sys.Rdev >> 8),
+		Rminor:   uint64(sys.Rdev & 0xff),
 		Name:     n,
 	}
 }

--- a/pkg/mount/switch_root_linux.go
+++ b/pkg/mount/switch_root_linux.go
@@ -19,7 +19,7 @@ func getDev(fd int) (dev uint64, err error) {
 	if err := unix.Fstat(fd, &stat); err != nil {
 		return 0, err
 	}
-	return stat.Dev, nil
+	return uint64(stat.Dev), nil
 }
 
 // recursiveDelete deletes a directory identified by `fd` and everything in it.


### PR DESCRIPTION
This is to tackle #1652, though I cannot yet confirm that it really works.

For testing, I am using https://people.debian.org/~aurel32/qemu/mipsel/

QEMU command:
```sh
#!/bin/sh

# https://people.debian.org/~aurel32/qemu/mipsel/
# quick note: 4kc is 32bit, 5kc is 64bit
export RAM_SIZE=32M
export KERNEL=vmlinux-3.2.0-4-4kc-malta
export INITRD=initramfs.linux_mipsle_mini.cpio

qemu-system-mipsel \
  -M malta \
  -m $RAM_SIZE \
  -kernel $KERNEL \
  -initrd $INITRD \
  -append "console=ttyS0" \
  -nographic
```

With the initramfs, the output is stuck early:
```
[    0.000000] Initializing cgroup subsys cpuset
[    0.000000] Initializing cgroup subsys cpu
[    0.000000] Linux version 3.2.0-4-4kc-malta (debian-kernel@lists.debian.org) (gcc version 4.6.3 (Debian 4.6.3-14) ) #1 Debian 3.2.51-1
[    0.000000] bootconsole [early0] enabled
[    0.000000] CPU revision is: 00019300 (MIPS 24Kc)
[    0.000000] FPU revision is: 00739300
[    0.000000] Determined physical RAM map:
[    0.000000]  memory: 00001000 @ 00000000 (reserved)
[    0.000000]  memory: 000ef000 @ 00001000 (ROM data)
[    0.000000]  memory: 00675000 @ 000f0000 (reserved)
[    0.000000]  memory: 0189b000 @ 00765000 (usable)
[    0.000000] Wasting 60576 bytes for tracking 1893 unused pages
[    0.000000] Initial ramdisk at: 0x81310000 (13318340 bytes)
[    0.000000] Zone PFN ranges:
[    0.000000]   DMA      0x00000000 -> 0x00001000
[    0.000000]   Normal   0x00001000 -> 0x00002000
[    0.000000] Movable zone start PFN for each node
[    0.000000] early_node_map[1] active PFN ranges
[    0.000000]     0: 0x00000000 -> 0x00002000
```

When omitting the initramfs, I get much more output:
```
[    0.000000] Initializing cgroup subsys cpuset
[    0.000000] Initializing cgroup subsys cpu
[    0.000000] Linux version 3.2.0-4-4kc-malta (debian-kernel@lists.debian.org) (gcc version 4.6.3 (Debian 4.6.3-14) ) #1 Debian 3.2.51-1
[    0.000000] bootconsole [early0] enabled
[    0.000000] CPU revision is: 00019300 (MIPS 24Kc)
[    0.000000] FPU revision is: 00739300
[    0.000000] Determined physical RAM map:
[    0.000000]  memory: 00001000 @ 00000000 (reserved)
[    0.000000]  memory: 000ef000 @ 00001000 (ROM data)
[    0.000000]  memory: 00675000 @ 000f0000 (reserved)
[    0.000000]  memory: 0189b000 @ 00765000 (usable)
[    0.000000] Wasting 60576 bytes for tracking 1893 unused pages
[    0.000000] Initrd not found or empty - disabling initrd
[    0.000000] Zone PFN ranges:
[    0.000000]   DMA      0x00000000 -> 0x00001000
[    0.000000]   Normal   0x00001000 -> 0x00002000
[    0.000000] Movable zone start PFN for each node
[    0.000000] early_node_map[1] active PFN ranges
[    0.000000]     0: 0x00000000 -> 0x00002000
[    0.000000] Built 1 zonelists in Zone order, mobility grouping on.  Total pages: 8128
[    0.000000] Kernel command line: console=ttyS0
[    0.000000] PID hash table entries: 128 (order: -3, 512 bytes)
[    0.000000] Dentry cache hash table entries: 4096 (order: 2, 16384 bytes)
[    0.000000] Inode-cache hash table entries: 2048 (order: 1, 8192 bytes)
[    0.000000] Primary instruction cache 2kB, VIPT, 2-way, linesize 16 bytes.
[    0.000000] Primary data cache 2kB, 2-way, VIPT, no aliases, linesize 16 bytes
[    0.000000] Writing ErrCtl register=00000000
[    0.000000] Readback ErrCtl register=00000000
[    0.000000] Memory: 24868k/25196k available (4596k kernel code, 328k reserved, 1278k data, 220k init, 0k highmem)
[    0.000000] NR_IRQS:256
[    0.000000] CPU frequency 200.00 MHz
[    0.000000] Console: colour dummy device 80x25
[    0.008000] Calibrating delay loop... 976.89 BogoMIPS (lpj=1953792)
[    0.052000] pid_max: default: 32768 minimum: 301
[    0.052000] Security Framework initialized
[    0.056000] AppArmor: AppArmor disabled by boot time parameter
[    0.056000] Mount-cache hash table entries: 512
[    0.068000] Initializing cgroup subsys cpuacct
[    0.068000] Initializing cgroup subsys memory
[    0.068000] Initializing cgroup subsys devices
[    0.072000] Initializing cgroup subsys freezer
[    0.072000] Initializing cgroup subsys net_cls
[    0.072000] Initializing cgroup subsys blkio
[    0.072000] Initializing cgroup subsys perf_event
[    0.100000] devtmpfs: initialized
[    0.116000] print_constraints: dummy: 
[    0.120000] NET: Registered protocol family 16
[    0.136000] bio: create slab <bio-0> at 0
[    0.144000] vgaarb: loaded
[    0.148000] SCSI subsystem initialized
[    0.156000] pci 0000:00:0a.3: address space collision: [io  0x1100-0x110f] conflicts with GT-64120 PCI I/O [io  0x1000-0x1fffff]
[    0.160000] vgaarb: device added: PCI:0000:00:12.0,decodes=io+mem,owns=none,locks=none
[    0.160000] pci 0000:00:0a.3: BAR 14: [io  0x1100-0x110f] has bogus alignment
[    0.164000] pci 0000:00:12.0: BAR 0: assigned [mem 0x10000000-0x11ffffff pref]
[    0.164000] pci 0000:00:0b.0: BAR 6: assigned [mem 0x12000000-0x1203ffff pref]
[    0.164000] pci 0000:00:12.0: BAR 6: assigned [mem 0x12040000-0x1204ffff pref]
[    0.164000] pci 0000:00:12.0: BAR 1: assigned [mem 0x12050000-0x12050fff]
[    0.164000] pci 0000:00:0a.2: BAR 4: assigned [io  0x1000-0x101f]
[    0.164000] pci 0000:00:0b.0: BAR 0: assigned [io  0x1020-0x103f]
[    0.164000] pci 0000:00:0b.0: BAR 1: assigned [mem 0x12051000-0x1205101f]
[    0.164000] pci 0000:00:0a.1: BAR 4: assigned [io  0x1040-0x104f]
[    0.176000] Switching to clocksource MIPS
[    0.244000] NET: Registered protocol family 2
[    0.252000] IP route cache hash table entries: 1024 (order: 0, 4096 bytes)
[    0.260000] TCP established hash table entries: 1024 (order: 1, 8192 bytes)
[    0.260000] TCP bind hash table entries: 1024 (order: 0, 4096 bytes)
[    0.260000] TCP: Hash tables configured (established 1024 bind 1024)
[    0.260000] TCP reno registered
[    0.260000] UDP hash table entries: 256 (order: 0, 4096 bytes)
[    0.260000] UDP-Lite hash table entries: 256 (order: 0, 4096 bytes)
[    0.264000] NET: Registered protocol family 1
[    0.268000] RPC: Registered named UNIX socket transport module.
[    0.268000] RPC: Registered udp transport module.
[    0.268000] RPC: Registered tcp transport module.
[    0.268000] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    0.268000] PCI: Enabling device 0000:00:0a.2 (0000 -> 0001)
[    0.284000] audit: initializing netlink socket (disabled)
[    0.288000] type=2000 audit(1587596923.284:1): initialized
[    0.292000] VFS: Disk quotas dquot_6.5.2
[    0.292000] Dquot-cache hash table entries: 1024 (order 0, 4096 bytes)
[    0.300000] nfs4filelayout_init: NFSv4 File Layout Driver Registering...
[    0.300000] msgmni has been set to 48
[    0.332000] alg: No test for stdrng (krng)
[    0.360000] Block layer SCSI generic (bsg) driver version 0.4 loaded (major 253)
[    0.360000] io scheduler noop registered
[    0.360000] io scheduler deadline registered
[    0.360000] io scheduler cfq registered (default)
[    0.372000] PCI: Enabling device 0000:00:12.0 (0000 -> 0002)
[    0.372000] cirrusfb 0000:00:12.0: Cirrus Logic chipset on PCI bus, RAM (4096 kB) at 0x10000000
[    0.632000] Console: switching to colour frame buffer device 80x30
[    0.652000] Serial: 8250/16550 driver, 4 ports, IRQ sharing enabled
[    0.688000] serial8250.0: ttyS0 at I/O 0x3f8 (irq = 4) is a 16550A
[    0.692000] console [ttyS0] enabled, bootconsole disabled
[    0.692000] console [ttyS0] enabled, bootconsole disabled
[    0.716000] serial8250.0: ttyS1 at I/O 0x2f8 (irq = 3) is a 16550A
[    0.740000] serial8250.0: ttyS2 at MMIO 0x1f000900 (irq = 18) is a 16550A
[    0.744000] PCI: Enabling device 0000:00:0a.1 (0000 -> 0001)
[    0.760000] scsi0 : ata_piix
[    0.764000] scsi1 : ata_piix
[    0.764000] ata1: PATA max UDMA/33 cmd 0x1f0 ctl 0x3f6 bmdma 0x1040 irq 14
[    0.764000] ata2: PATA max UDMA/33 cmd 0x170 ctl 0x376 bmdma 0x1048 irq 15
[    0.768000] pcnet32: pcnet32.c:v1.35 21.Apr.2008 tsbogend@alpha.franken.de
[    0.768000] PCI: Enabling device 0000:00:0b.0 (0000 -> 0003)
[    0.780000] pcnet32: PCnet/PCI II 79C970A at 0x1020, 52:54:00:12:34:56 assigned IRQ 10
[    0.792000] pcnet32: eth0: registered as PCnet/PCI II 79C970A
[    0.792000] pcnet32: 1 cards_found
[    0.796000] serio: i8042 KBD port at 0x60,0x64 irq 1
[    0.800000] serio: i8042 AUX port at 0x60,0x64 irq 12
[    0.804000] mousedev: PS/2 mouse device common for all mice
[    0.812000] rtc_cmos rtc_cmos: rtc core: registered rtc_cmos as rtc0
[    0.812000] rtc0: alarms up to one day, 242 bytes nvram
[    0.816000] TCP cubic registered
[    0.816000] NET: Registered protocol family 17
[    0.820000] Registering the dns_resolver key type
[    0.824000] registered taskstats version 1
[    0.828000] rtc_cmos rtc_cmos: setting system clock to 2020-04-22 23:08:45 UTC (1587596925)
[    0.828000] Initializing network drop monitor service
[    0.912000] input: AT Raw Set 2 keyboard as /devices/platform/i8042/serio0/input/input0
[    0.944000] ata2.00: ATAPI: QEMU DVD-ROM, 2.5+, max UDMA/100
[    0.948000] ata2.00: configured for UDMA/33
[    0.968000] scsi 1:0:0:0: CD-ROM            QEMU     QEMU DVD-ROM     2.5+ PQ: 0 ANSI: 5
[    0.980000] VFS: Cannot open root device "(null)" or unknown-block(0,0)
[    0.980000] Please append a correct "root=" boot option; here are the available partitions:
[    0.980000] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(0,0)
```

Ideas anyone?