### PR TITLE
ACPI functions

### DIFF
--- a/cmds/exp/acpicat/main.go
+++ b/cmds/exp/acpicat/main.go
@@ -1,0 +1,35 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// acpicat cats ACPI tables from the kernel.
+// The default method is "files", commonly provided in Linux via /sys.
+// Other methods are available depending on the platform.
+// Further selection of which tables are used can be done with acpigrep.
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/u-root/u-root/pkg/acpi"
+)
+
+var (
+	source = flag.String("s", acpi.DefaultMethod, "source of the tables")
+)
+
+func main() {
+	flag.Parse()
+	t, err := acpi.ReadTables(*source)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(t) == 0 {
+		log.Fatalf("%s: no tables read", *source)
+	}
+	if err := acpi.WriteTables(os.Stdout, t[0], t[1:]...); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmds/exp/acpigrep/main.go
+++ b/cmds/exp/acpigrep/main.go
@@ -1,0 +1,72 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// grep a stream of ACPI tables by regexp
+//
+// Synopsis:
+//     acpigrep [-v] [-d] regexp
+//
+// Description:
+//	Read tables from stdin and write tables with ACPI signatures
+//	matching a pattern (or not matching, with -v, as in grep)
+//	to stdout.
+//
+//	Read all tables from sysfs and discard MADT
+//	sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -v MADT
+//
+//	Read a large blob and print out its tables
+//	acpigrep -d '.*' >/dev/null < blob
+//
+//      Read all the files in /sys and discard any DSDT. Useful for coreboot work.
+// 	sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -v DSDT > nodsdt.bin
+//
+//	Read all the files, keeping only SRAT and MADT
+// 	sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep 'MADT|SRAT' > madtsrat.bin
+//
+//	Read all the files, keeping only SRAT and MADT, and print what is done
+// 	sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -d 'MADT|SRAT' > madtsrat.bin
+//
+// Options:
+// 	-d print debug information about what is kept and what is discarded.
+//	-v reverse the sense of the match to "discard is matching"
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"regexp"
+
+	"github.com/u-root/u-root/pkg/acpi"
+)
+
+var (
+	v     = flag.Bool("v", false, "Only non-matching signatures will be kept")
+	d     = flag.Bool("d", false, "Print debug messages")
+	debug = func(string, ...interface{}) {}
+)
+
+func main() {
+	flag.Parse()
+	if *d {
+		debug = log.Printf
+	}
+	if len(flag.Args()) != 1 {
+		log.Fatal("Usage: acpigrep [-v] [-d] pattern")
+	}
+	r := regexp.MustCompile(flag.Args()[0])
+	tabs, err := acpi.RawFromFile(os.Stdin)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, t := range tabs {
+		m := r.MatchString(t.Sig())
+		if m == *v {
+			debug("Dropping %s", acpi.String(t))
+			continue
+		}
+		debug("Keeping %s", acpi.String(t))
+		os.Stdout.Write(t.Data())
+	}
+}

--- a/pkg/acpi/acpi.go
+++ b/pkg/acpi/acpi.go
@@ -1,0 +1,112 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package acpi is designed to support copying individual tables or
+// a blob containing many tables from one spot to another, supporting
+// filtering. For example, one might read tables from /dev/mem, using
+// the RSDP, so as to create an ACPI table blob for use in coreboot.
+// In this case, we only care about checking the signature.
+package acpi
+
+import (
+	"fmt"
+	"io"
+)
+
+const (
+	// lengthOffset is the offset of the table length
+	lengthOffset = 4
+	// checksum1 offset in RSDP struct.
+	cSUM1Off = 8
+	// cSUMOffset is the offset of the single byte checksum in *most* ACPI tables
+	cSUMOffset = 9
+	// minTableLength is the minimum length: 4 byte tag, 4 byte length, 1 byte revision, 1 byte checksum,
+	minTableLength = 10
+
+	// checksum2 offset in RSDP struct.
+	cSUM2Off    = 32
+	xSDTLenOff  = 20
+	xSDTAddrOff = 24
+
+	// headerLength is a common header length for (almost)
+	// all ACPI tables.
+	headerLength = 36
+)
+
+type (
+	// Table is an individual ACPI table.
+	Table interface {
+		Sig() string
+		Len() uint32
+		Revision() uint8
+		CheckSum() uint8
+		OEMID() string
+		OEMTableID() string
+		OEMRevision() uint32
+		CreatorID() uint32
+		CreatorRevision() uint32
+		Data() []byte
+		TableData() []byte
+	}
+	// TableMethod defines the type of functions used to read a table.
+	TableMethod func() ([]Table, error)
+)
+
+var (
+	// Debug implements fmt.Sprintf and can be used for debug printing
+	Debug = func(string, ...interface{}) {}
+)
+
+// gencsum generates a uint8 checksum of a []uint8
+func gencsum(b []uint8) uint8 {
+	var csum uint8
+	for _, bb := range b {
+		csum += bb
+	}
+	Debug("csum %#x %#x across %d bytes", csum, ^csum, len(b))
+	return ^csum + 1
+}
+
+// Method accepts a method name and returns a TableMethod if one exists, or error othewise.
+func Method(n string) (TableMethod, error) {
+	f, ok := Methods[n]
+	if !ok {
+		return nil, fmt.Errorf("only method[s] %q are available, not %q", MethodNames(), n)
+	}
+	return f, nil
+}
+
+// String pretty-prints a Table
+func String(t Table) string {
+	return fmt.Sprintf("%s %d %d %#02x %s %s %#08x %#08x %#08x",
+		t.Sig(),
+		t.Len(),
+		t.Revision(),
+		t.CheckSum(),
+		t.OEMID(),
+		t.OEMTableID(),
+		t.OEMRevision(),
+		t.CreatorID(),
+		t.CreatorRevision())
+
+}
+
+// WriteTables writes one or more tables to an io.Writer.
+func WriteTables(w io.Writer, tab Table, tabs ...Table) error {
+	for _, tt := range append([]Table{tab}, tabs...) {
+		if _, err := w.Write(tt.Data()); err != nil {
+			return fmt.Errorf("Writing %s: %v", tt.Sig(), err)
+		}
+	}
+	return nil
+}
+
+// ReadTables reads tables, given a method name.
+func ReadTables(n string) ([]Table, error) {
+	f, err := Method(n)
+	if err != nil {
+		return nil, err
+	}
+	return f()
+}

--- a/pkg/acpi/acpi.go
+++ b/pkg/acpi/acpi.go
@@ -53,18 +53,12 @@ type (
 	TableMethod func() ([]Table, error)
 )
 
-var (
-	// Debug implements fmt.Sprintf and can be used for debug printing
-	Debug = func(string, ...interface{}) {}
-)
-
 // gencsum generates a uint8 checksum of a []uint8
 func gencsum(b []uint8) uint8 {
 	var csum uint8
 	for _, bb := range b {
 		csum += bb
 	}
-	Debug("csum %#x %#x across %d bytes", csum, ^csum, len(b))
 	return ^csum + 1
 }
 

--- a/pkg/acpi/acpi_test.go
+++ b/pkg/acpi/acpi_test.go
@@ -1,0 +1,44 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package acpi
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+)
+
+// TestTabWrite verifies that we can write a table and
+// read it back the same. For fun, we use the DSDT, which is
+// the important one. We don't keep tables here as data since we don't know
+// which ones we can copy, so we use what's it in sys or skip the test.
+func TestTabWrite(t *testing.T) {
+	tabs, err := RawTablesFromSys()
+	if err != nil || len(tabs) == 0 {
+		t.Logf("Skipping test, no ACPI tables in /sys")
+		return
+	}
+
+	var ttab Table
+	for _, tab := range tabs {
+		if tab.Sig() == "DSDT" {
+			ttab = tab
+			break
+		}
+	}
+	if ttab == nil {
+		ttab = tabs[0]
+	}
+	var b = &bytes.Buffer{}
+	if err := WriteTables(b, ttab); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(b.Bytes(), ttab.Data()) {
+		t.Fatalf("Written table does not match")
+	}
+
+}

--- a/pkg/acpi/linux_test.go
+++ b/pkg/acpi/linux_test.go
@@ -1,0 +1,28 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package acpi
+
+import (
+	"os"
+	"testing"
+)
+
+// TestLinux just verifies that tables read OK.
+// It does not verify content as content varies all
+// the time.
+func TestLinux(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("not root")
+	}
+	tab, err := RawTablesFromSys()
+	if err != nil {
+		t.Fatalf("Got %v, want nil", err)
+	}
+	for _, tt := range tab {
+		t.Logf("table %s", String(tt))
+	}
+}

--- a/pkg/acpi/raw.go
+++ b/pkg/acpi/raw.go
@@ -1,0 +1,140 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package acpi
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"github.com/u-root/u-root/pkg/memio"
+)
+
+// Raw ACPI table support. Raw tables are those tables
+// one needs to read in, write out, but not change in any way.
+// This is needed when, e.g., there is need to create files for
+// coreboot cbfs.
+
+// Raw is just a table embedded in a []byte.  Operations on Raw are
+// for figuring out how to skip a table you don't care about or, possibly,
+// truncating a table and regenerating a checksum.
+type Raw struct {
+	data []byte
+}
+
+var _ = Table(&Raw{})
+
+// NewRaw returns a new Raw []Table fron a given byte slice.
+func NewRaw(b []byte) ([]Table, error) {
+	var tab []Table
+	for {
+		if len(b) == 0 {
+			break
+		}
+		if len(b) < headerLength {
+			return nil, fmt.Errorf("NewRaw: byte slice is only %d bytes and must be at least %d bytes", len(b), headerLength)
+		}
+		u := binary.LittleEndian.Uint32(b[lengthOffset : lengthOffset+4])
+		if int(u) > len(b) {
+			return nil, fmt.Errorf("Table length %d is too large for %d byte table (Signature %q", u, len(b), string(b[0:4]))
+		}
+		tab = append(tab, &Raw{data: b[:u]})
+		b = b[u:]
+	}
+	return tab, nil
+}
+
+// RawFromFile reads from an io.Reader and returns a []Table and error if any.
+func RawFromFile(r io.Reader) ([]Table, error) {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+	return NewRaw(b)
+}
+
+// RawFromName reads a raw []Table in from a named file.
+func RawFromName(n string) ([]Table, error) {
+	f, err := os.Open(n)
+	defer f.Close()
+	if err != nil {
+		return nil, err
+	}
+	return RawFromFile(f)
+}
+
+// ReadRaw reads a full table in, given an address.
+// ReadRaw uses the io package. This may not always work
+// if the kernel has restrictions on reading memory above
+// the 1M boundary, and the tables are above boundary.
+func ReadRaw(a int64) (Table, error) {
+	var u memio.Uint32
+	// Read the table size at a+4
+	if err := memio.Read(a+4, &u); err != nil {
+		return nil, err
+	}
+	dat := memio.ByteSlice(make([]byte, u))
+	if err := memio.Read(a, &dat); err != nil {
+		return nil, err
+	}
+	return &Raw{data: []byte(dat)}, nil
+}
+
+// Data returns all the data in a Raw table.
+func (r *Raw) Data() []byte {
+	return r.data
+}
+
+// TableData returns the Raw table, minus the standard ACPI header.
+func (r *Raw) TableData() []byte {
+	return r.data[headerLength:]
+}
+
+// Sig returns the table signature.
+func (r *Raw) Sig() string {
+	return fmt.Sprintf("%s", r.data[:4])
+}
+
+// Len returns the total table length.
+func (r *Raw) Len() uint32 {
+	return uint32(len(r.data))
+}
+
+// Revision returns the table Revision.
+func (r *Raw) Revision() uint8 {
+	return uint8(r.data[8])
+}
+
+// CheckSum returns the table CheckSum.
+func (r *Raw) CheckSum() uint8 {
+	return uint8(r.data[9])
+}
+
+// OEMID returns the table OEMID.
+func (r *Raw) OEMID() string {
+	return fmt.Sprintf("%q", r.data[10:16])
+}
+
+// OEMTableID returns the table OEMTableID.
+func (r *Raw) OEMTableID() string {
+	return fmt.Sprintf("%q", r.data[16:24])
+}
+
+// OEMRevision returns the table OEMRevision.
+func (r *Raw) OEMRevision() uint32 {
+	return binary.LittleEndian.Uint32(r.data[24 : 24+4])
+}
+
+// CreatorID returns the table CreatorID.
+func (r *Raw) CreatorID() uint32 {
+	return binary.LittleEndian.Uint32(r.data[28 : 28+4])
+}
+
+// CreatorRevision returns the table CreatorRevision.
+func (r *Raw) CreatorRevision() uint32 {
+	return binary.LittleEndian.Uint32(r.data[32 : 32+4])
+}

--- a/pkg/acpi/raw.go
+++ b/pkg/acpi/raw.go
@@ -67,18 +67,19 @@ func RawFromName(n string) ([]Table, error) {
 	return RawFromFile(f)
 }
 
-// ReadRaw reads a full table in, given an address.
-// ReadRaw uses the io package. This may not always work
+// ReadRawTable reads a full table in, given an address.
+//
+// ReadRawTable uses the io package. This may not always work
 // if the kernel has restrictions on reading memory above
 // the 1M boundary, and the tables are above boundary.
-func ReadRaw(a int64) (Table, error) {
+func ReadRawTable(physAddr int64) (Table, error) {
 	var u memio.Uint32
 	// Read the table size at a+4
-	if err := memio.Read(a+4, &u); err != nil {
+	if err := memio.Read(physAddr+4, &u); err != nil {
 		return nil, err
 	}
 	dat := memio.ByteSlice(make([]byte, u))
-	if err := memio.Read(a, &dat); err != nil {
+	if err := memio.Read(physAddr, &dat); err != nil {
 		return nil, err
 	}
 	return &Raw{data: []byte(dat)}, nil

--- a/pkg/acpi/rsdp.go
+++ b/pkg/acpi/rsdp.go
@@ -1,0 +1,109 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package acpi
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/u-root/u-root/pkg/memio"
+)
+
+var (
+	defaultRSDP = []byte("RSDP PTR U-ROOT\x02")
+)
+
+// RSDP is the v2 version of the ACPI RSDP struct.
+type RSDP struct {
+	// base is the base address of the RSDP struct in physical memory.
+	base uint64
+
+	data [headerLength]byte
+}
+
+// NewRSDP returns a new and partially initialized RSDP, setting only
+// the defaultRSDP values, address, length, and signature.
+func NewRSDP(addr uintptr, len uint) []byte {
+	var r [headerLength]byte
+	copy(r[:], defaultRSDP)
+
+	// This is a bit of a cheat. All the fields are 0.  So we get a
+	// checksum, set up the XSDT fields, get the second checksum.
+	r[cSUM1Off] = gencsum(r[:])
+	binary.LittleEndian.PutUint32(r[xSDTLenOff:], uint32(len))
+	binary.LittleEndian.PutUint64(r[xSDTAddrOff:], uint64(addr))
+	r[cSUM2Off] = gencsum(r[:])
+	return r[:]
+}
+
+// Len returns the RSDP length
+func (r *RSDP) Len() uint32 {
+	return uint32(len(r.data))
+}
+
+// AllData returns the RSDP as a []byte
+func (r *RSDP) AllData() []byte {
+	return r.data[:]
+}
+
+// TableData returns the RSDP table data as a []byte
+func (r *RSDP) TableData() []byte {
+	return r.data[36:]
+}
+
+// Sig returns the RSDP signature
+func (r *RSDP) Sig() string {
+	return string(r.data[:8])
+}
+
+// OEMID returns the RSDP OEMID
+func (r *RSDP) OEMID() string {
+	return string(r.data[9:15])
+}
+
+// RSDPAddr returns the physical base address of the RSDP.
+func (r *RSDP) RSDPAddr() uint64 {
+	return r.base
+}
+
+// SDTAddr returns a base address or the [RX]SDT.
+//
+// It will preferentially return the XSDT, but if that is
+// 0 it will return the RSDT address.
+func (r *RSDP) SDTAddr() uint64 {
+	b := uint64(binary.LittleEndian.Uint32(r.data[16:20]))
+	if b != 0 {
+		return b
+	}
+	return binary.LittleEndian.Uint64(r.data[24:32])
+}
+
+func readRSDP(base uint64) (*RSDP, error) {
+	r := &RSDP{}
+	r.base = base
+
+	dat := memio.ByteSlice(make([]byte, len(r.data)))
+	if err := memio.Read(int64(base), &dat); err != nil {
+		return nil, err
+	}
+	copy(r.data[:], dat)
+	return r, nil
+}
+
+// GetRSDP finds the RSDP pointer and struct. The rsdpgetters must be defined
+// in rsdp_$(GOOS).go, since, e.g.,OSX, BSD, and Linux have some intersections
+// but some unique aspects too, and Plan 9 has nothing in common with any of them.
+//
+// It is able to use several methods, because there is no consistency
+// about how it is done.
+func GetRSDP() (*RSDP, error) {
+	for _, f := range rsdpgetters {
+		r, err := f()
+		if err == nil {
+			return r, nil
+		}
+	}
+	return nil, fmt.Errorf("cannot find an RSDP")
+}

--- a/pkg/acpi/rsdp_linux.go
+++ b/pkg/acpi/rsdp_linux.go
@@ -1,0 +1,60 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package acpi can find and parse the RSDP pointer and struct.
+package acpi
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// GetRSDPEFI finds the RSDP in the EFI System Table.
+func GetRSDPEFI() (*RSDP, error) {
+	file, err := os.Open("/sys/firmware/efi/systab")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	const (
+		acpi20 = "ACPI20="
+		acpi   = "ACPI="
+	)
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		start := ""
+		if strings.HasPrefix(line, acpi20) {
+			start = strings.TrimPrefix(line, acpi20)
+		}
+		if strings.HasPrefix(line, acpi) {
+			start = strings.TrimPrefix(line, acpi)
+		}
+		if start == "" {
+			continue
+		}
+		base, err := strconv.ParseUint(start, 0, 64)
+		if err != nil {
+			continue
+		}
+		rsdp, err := readRSDP(base)
+		if err != nil {
+			continue
+		}
+		return rsdp, nil
+	}
+	if err := scanner.Err(); err != nil {
+		log.Printf("error while reading EFI systab: %v", err)
+	}
+	return nil, fmt.Errorf("invalid /sys/firmware/efi/systab file")
+}
+
+// You can change the getters if you wish for testing.
+var rsdpgetters = []func() (*RSDP, error){GetRSDPEFI, GetRSDPEBDA, GetRSDPMem}

--- a/pkg/acpi/rsdp_linux_test.go
+++ b/pkg/acpi/rsdp_linux_test.go
@@ -1,0 +1,21 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package acpi
+
+import (
+	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
+)
+
+// TestRSDP tests whether any method for getting an RSDP works.
+func TestRSDP(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	_, err := GetRSDP()
+	if err != nil {
+		t.Fatalf("GetRSDP: got %v, want nil", err)
+	}
+}

--- a/pkg/acpi/rsdp_unix.go
+++ b/pkg/acpi/rsdp_unix.go
@@ -1,0 +1,57 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package acpi
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/u-root/u-root/pkg/boot/ebda"
+	"github.com/u-root/u-root/pkg/memio"
+)
+
+// " RSD PTR" in hex, 8 bytes.
+const rsdpTag = 0x2052545020445352
+
+// GetRSDPEBDA finds the RSDP in the EBDA.
+func GetRSDPEBDA() (*RSDP, error) {
+	f, err := os.OpenFile("/dev/mem", os.O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	e, err := ebda.ReadEBDA(f)
+	if err != nil {
+		return nil, err
+	}
+
+	return getRSDPMem(uint64(e.BaseOffset), uint64(e.BaseOffset+e.Length))
+}
+
+func getRSDPMem(start, end uint64) (*RSDP, error) {
+	for base := start; base < end; base += 16 {
+		var r memio.Uint64
+		if err := memio.Read(int64(base), &r); err != nil {
+			continue
+		}
+		if r != rsdpTag {
+			continue
+		}
+		rsdp, err := readRSDP(base)
+		if err != nil {
+			return nil, err
+		}
+		return rsdp, nil
+	}
+	return nil, fmt.Errorf("could not find ACPI RSDP via /dev/mem from %#08x to %#08x", start, end)
+}
+
+// GetRSDPMem is the option of last choice, it just grovels through
+// the e0000-ffff0 area, 16 bytes at a time, trying to find an RSDP.
+// These are well-known addresses for 20+ years.
+func GetRSDPMem() (*RSDP, error) {
+	return getRSDPMem(0xe0000, 0xffff0)
+}

--- a/pkg/acpi/tables.go
+++ b/pkg/acpi/tables.go
@@ -1,0 +1,20 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package acpi
+
+import "fmt"
+
+// GetTable uses all the Methods until one works.
+func GetTable() (string, []Table, error) {
+	for m, f := range Methods {
+		t, err := f()
+		if err == nil {
+			return m, t, nil
+		}
+	}
+	return "", nil, fmt.Errorf("Could not get ACPI tables")
+}

--- a/pkg/acpi/tables_linux.go
+++ b/pkg/acpi/tables_linux.go
@@ -1,0 +1,42 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package acpi
+
+import (
+	"path/filepath"
+)
+
+var (
+	DefaultMethod = "files"
+	Methods       = map[string]TableMethod{
+		"files": RawTablesFromSys,
+	}
+)
+
+// MethodNames returns the list of supported MethodNames.
+func MethodNames() string {
+	return "files"
+}
+
+// RawTablesFromSys returns an array of Raw tables, for all ACPI tables
+// available in /sys.
+func RawTablesFromSys() ([]Table, error) {
+	n, err := filepath.Glob("/sys/firmware/acpi/tables/[A-Z]*")
+	if err != nil {
+		return nil, err
+	}
+
+	var tabs []Table
+	for _, t := range n {
+		r, err := RawFromName(t)
+		if err != nil {
+			return nil, err
+		}
+		tabs = append(tabs, r...)
+	}
+	return tabs, nil
+}

--- a/pkg/acpi/tables_linux.go
+++ b/pkg/acpi/tables_linux.go
@@ -18,8 +18,12 @@ var (
 )
 
 // MethodNames returns the list of supported MethodNames.
-func MethodNames() string {
-	return "files"
+func MethodNames() []string {
+	var s []string
+	for name := range Methods {
+		s = append(s, name)
+	}
+	return s
 }
 
 // RawTablesFromSys returns an array of Raw tables, for all ACPI tables

--- a/pkg/acpi/tables_linux_test.go
+++ b/pkg/acpi/tables_linux_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package acpi
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
+)
+
+// TestTable tests whether any method for getting a table works.
+// If it succeeds, it is called again with the method it returns
+// to verify at least that much is the same.
+func TestTable(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	m, tg, err := GetTable()
+	if err != nil {
+		t.Skip("no table to get")
+	}
+
+	f, ok := Methods[m]
+	if !ok {
+		t.Fatalf("method type returned from GetTable: got not found in Methods, expect to find it")
+	}
+	tt, err := f()
+	if err != nil {
+		t.Fatalf("Getting table via %q: got %v, want nil", m, err)
+	}
+	if !reflect.DeepEqual(tg, tt) {
+		t.Fatalf("Getting table via GetTable and %q: got different(%s, %s), want same", m, tg, tt)
+	}
+
+}


### PR DESCRIPTION
This simple package supports reading the RSDP, reading, and writing tables.

Programs can read in tables, pick which ones to write, and write them out.

This package is useful for generating tables for cbfs.

Two programs are included:
acpicat, for cat'ing all acpitables from a named source type -- e.g files in /sys
acpigrep, a filter for keeping (discarding) tables whose signature matches (does not match) an RE.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>