### PR TITLE
Fix up console so it correctly runs as uinit

### DIFF
--- a/cmds/exp/console/console.go
+++ b/cmds/exp/console/console.go
@@ -7,7 +7,7 @@
 // being just stdin and stdout. It will also set up a root file system
 // using util.Rootfs, although this can be disabled as well.
 // Console uses a Go version of fork_pty to start up a shell, default
-// /ubin/elvish. Console runs until the shell exits and then exits itself.
+// sh. Console runs until the shell exits and then exits itself.
 package main
 
 import (
@@ -23,7 +23,7 @@ import (
 
 var (
 	serial    = flag.String("serial", "0x3f8", "which IO device: stdio, i8042, or serial port starting with 0")
-	setupRoot = flag.Bool("setuproot", true, "Set up a root file system")
+	setupRoot = flag.Bool("setuproot", false, "Set up a root file system")
 )
 
 func main() {
@@ -32,12 +32,12 @@ func main() {
 
 	a := flag.Args()
 	if len(a) == 0 {
-		a = []string{"/ubin/elvish"}
+		a = []string{"/bin/sh"}
 	}
 
 	p, err := pty.New()
 	if err != nil {
-		log.Fatalf("Can't open pty: %v", err)
+		log.Fatalf("Console exits: can't open pty: %v", err)
 	}
 	p.Command(a[0], a[1:]...)
 	// Make a good faith effort to set up root. This being
@@ -55,24 +55,23 @@ func main() {
 	case []byte(*serial)[0] == '0':
 		u, err := openUART(*serial)
 		if err != nil {
-			log.Fatalf("Sorry, can't get a uart: %v", err)
+			log.Fatalf("Console exits: sorry, can't get a uart: %v", err)
 		}
 		in, out = u, u
 	case *serial == "i8042":
 		u, err := openi8042()
 		if err != nil {
-			log.Fatalf("Sorry, can't get an i8042: %v", err)
+			log.Fatalf("Console exits: sorry, can't get an i8042: %v", err)
 		}
 		in, out = u, os.Stdout
 	case *serial == "stdio":
 	default:
-		log.Fatalf("console must be one of stdio, i8042, or an IO port with a leading 0 (e.g. 0x3f8)")
+		log.Fatalf("Console exits: console must be one of stdio, i8042, or an IO port with a leading 0 (e.g. 0x3f8)")
 	}
 
 	err = p.Start()
 	if err != nil {
-		fmt.Printf("Can't start %v: %v", a, err)
-		os.Exit(1)
+		log.Fatalf("Console exits: can't start %v: %v", a, err)
 	}
 	kid := p.C.Process.Pid
 
@@ -101,7 +100,8 @@ func main() {
 	}()
 
 	if err := p.Wait(); err != nil {
-		log.Fatalf("%v", err)
+		log.Fatalf("Console exits: %v", err)
 	}
+	log.Printf("Console all done")
 	os.Exit(0)
 }


### PR DESCRIPTION
console is invaluable for debugging serial console issues.

It was originally designed to run as init, but we can much
more easily run as uinit, and avoid setup issues.

To build:
u-root -o /tmp/console.cpio -uinitcmd=/bbin/console all github.com/u-root/u-root/cmds/exp/console

to use:
/usr/bin/qemu-system-x86_64 -kernel somekernel -initrd /tmp/console.cpio -append console=ttyS0 -serial stdio -monitor /dev/null -m 8192

kernel will need to have
CONFIG_DEVPORT=y
CONFIG_UNIX98_PTY=y