### PR TITLE
Ability to cancel boot downloads with context

### DIFF
--- a/cmds/boot/boot/boot.go
+++ b/cmds/boot/boot/boot.go
@@ -287,9 +287,9 @@ func probeIsolinuxFiles() []string {
 	return files
 }
 
-func IsolinuxParseConfigWithSchemes(workingDir *url.URL, s curl.Schemes) (*syslinux.Config, error) {
+func IsolinuxParseConfig(workingDir *url.URL, s curl.Schemes) (*syslinux.Config, error) {
 	for _, relname := range probeIsolinuxFiles() {
-		c, err := syslinux.ParseConfigFileWithSchemes(s, relname, workingDir)
+		c, err := syslinux.ParseConfigFile(s, relname, workingDir)
 		if curl.IsURLError(err) {
 			continue
 		}
@@ -300,7 +300,7 @@ func IsolinuxParseConfigWithSchemes(workingDir *url.URL, s curl.Schemes) (*sysli
 
 // call IsolinuxBootImage(curl.DefaultSchemes, dir)
 func IsolinuxBootImage(schemes curl.Schemes, workingDir *url.URL) (*boot.LinuxImage, error) {
-	pc, err := IsolinuxParseConfigWithSchemes(workingDir, schemes)
+	pc, err := IsolinuxParseConfig(workingDir, schemes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse pxelinux config: %v", err)
 	}
@@ -317,9 +317,9 @@ var probeGrubFiles = []string{
 	"grub2/grub.cfg",
 }
 
-func GrubParseConfigWithSchemes(workingDir *url.URL, s curl.Schemes) (*grub.Config, error) {
+func GrubParseConfig(workingDir *url.URL, s curl.Schemes) (*grub.Config, error) {
 	for _, relname := range probeGrubFiles {
-		c, err := grub.ParseConfigFileWithSchemes(s, relname, workingDir)
+		c, err := grub.ParseConfigFile(s, relname, workingDir)
 		if curl.IsURLError(err) {
 			continue
 		}
@@ -330,7 +330,7 @@ func GrubParseConfigWithSchemes(workingDir *url.URL, s curl.Schemes) (*grub.Conf
 
 // GrubBootImage
 func GrubBootImage(schemes curl.Schemes, workingDir *url.URL, entryID string, list bool) (boot.OSImage, error) {
-	pc, err := GrubParseConfigWithSchemes(workingDir, schemes)
+	pc, err := GrubParseConfig(workingDir, schemes)
 	if err != nil && err != grub.ErrDefaultEntryNotFound {
 		return nil, fmt.Errorf("failed to parse grub config: %v", err)
 	}

--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -85,7 +85,8 @@ func Netboot(ifaceNames string) error {
 				// If lease failed, fall back to use locally configured
 				// ip/ipv6 address.
 			}
-			img, err := netboot.BootImage(ulog.Log, curl.DefaultSchemes, result.Lease)
+			// Don't use the other context, as it's for the DHCP timeout.
+			img, err := netboot.BootImage(context.Background(), ulog.Log, curl.DefaultSchemes, result.Lease)
 			if err != nil {
 				log.Printf("Failed to boot lease %v: %v", result.Lease, err)
 				continue

--- a/cmds/core/wget/wget.go
+++ b/cmds/core/wget/wget.go
@@ -20,6 +20,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"io"
 	"log"
@@ -75,7 +76,7 @@ func main() {
 		"file":  &curl.LocalFileClient{},
 	}
 
-	readerAt, err := schemes.Fetch(url)
+	readerAt, err := schemes.Fetch(context.Background(), url)
 	if err != nil {
 		log.Fatalf("Failed to download %v: %v", argURL, err)
 	}

--- a/pkg/boot/grub/echo_test.go
+++ b/pkg/boot/grub/echo_test.go
@@ -6,6 +6,7 @@ package grub
 
 import (
 	"bytes"
+	"context"
 	"flag"
 	"fmt"
 	"io/ioutil"
@@ -115,7 +116,7 @@ func TestGrubTests(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error loading file `%s`, %v", file, err)
 			}
-			err = c.append(string(script))
+			err = c.append(context.Background(), string(script))
 			if err != nil {
 				t.Fatalf("error parsing file `%s`, %v", file, err)
 			}

--- a/pkg/boot/grub/echo_test.go
+++ b/pkg/boot/grub/echo_test.go
@@ -108,7 +108,7 @@ func TestGrubTests(t *testing.T) {
 				Scheme: "file",
 				Path:   "./testdata",
 			}
-			c := newParserWithSchemes(wd, curl.DefaultSchemes)
+			c := newParser(wd, curl.DefaultSchemes)
 			c.W = &b
 
 			script, err := ioutil.ReadFile(file)

--- a/pkg/boot/grub/grub.go
+++ b/pkg/boot/grub/grub.go
@@ -67,14 +67,8 @@ type Config struct {
 // `wd` is the default scheme, host, and path for any files named as a
 // relative path - e.g. kernel, include, and initramfs paths are requested
 // relative to the wd.
-func ParseConfigFile(url string, wd *url.URL) (*Config, error) {
-	return ParseConfigFileWithSchemes(curl.DefaultSchemes, url, wd)
-}
-
-// ParseConfigFileWithSchemes is like ParseConfigFile, but uses the given
-// schemes explicitly.
-func ParseConfigFileWithSchemes(s curl.Schemes, url string, wd *url.URL) (*Config, error) {
-	p := newParserWithSchemes(wd, s)
+func ParseConfigFile(s curl.Schemes, url string, wd *url.URL) (*Config, error) {
+	p := newParser(wd, s)
 	if err := p.appendFile(url); err != nil {
 		return nil, err
 	}
@@ -101,7 +95,7 @@ const (
 	scopeEntry
 )
 
-// newParserWithSchemes returns a new grub parser using working directory `wd`
+// newParser returns a new grub parser using working directory `wd`
 // and schemes `s`.
 //
 // If a path encountered in a configuration file is relative instead of a full
@@ -109,7 +103,7 @@ const (
 // resulting URL is roughly `wd.String()/path`.
 //
 // `s` is used to get files referred to by URLs.
-func newParserWithSchemes(wd *url.URL, s curl.Schemes) *parser {
+func newParser(wd *url.URL, s curl.Schemes) *parser {
 	return &parser{
 		config: &Config{
 			Entries: make(map[string]boot.OSImage),

--- a/pkg/boot/grub/grub.go
+++ b/pkg/boot/grub/grub.go
@@ -15,6 +15,7 @@
 package grub
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -67,9 +68,9 @@ type Config struct {
 // `wd` is the default scheme, host, and path for any files named as a
 // relative path - e.g. kernel, include, and initramfs paths are requested
 // relative to the wd.
-func ParseConfigFile(s curl.Schemes, url string, wd *url.URL) (*Config, error) {
+func ParseConfigFile(ctx context.Context, s curl.Schemes, url string, wd *url.URL) (*Config, error) {
 	p := newParser(wd, s)
-	if err := p.appendFile(url); err != nil {
+	if err := p.appendFile(ctx, url); err != nil {
 		return nil, err
 	}
 	return p.config, nil
@@ -148,11 +149,16 @@ func (c *parser) getFile(url string) (io.ReaderAt, error) {
 }
 
 // appendFile parses the config file downloaded from `url` and adds it to `c`.
-func (c *parser) appendFile(url string) error {
-	r, err := c.getFile(url)
+func (c *parser) appendFile(ctx context.Context, url string) error {
+	u, err := parseURL(url, c.wd)
 	if err != nil {
 		return err
 	}
+	r, err := c.schemes.Fetch(ctx, u)
+	if err != nil {
+		return err
+	}
+
 	config, err := uio.ReadAll(r)
 	if err != nil {
 		return err
@@ -164,7 +170,7 @@ func (c *parser) appendFile(url string) error {
 	} else {
 		log.Printf("Got config file %s:\n%s\n", r, string(config))
 	}
-	return c.append(string(config))
+	return c.append(ctx, string(config))
 }
 
 // CmdlineQuote quotes the command line as grub-core/lib/cmdline.c does
@@ -183,7 +189,7 @@ func cmdlineQuote(args []string) string {
 }
 
 // Append parses `config` and adds the respective configuration to `c`.
-func (c *parser) append(config string) error {
+func (c *parser) append(ctx context.Context, config string) error {
 	// Here's a shitty parser.
 	for _, line := range strings.Split(config, "\n") {
 		kv := shlex.Argv(line)
@@ -214,7 +220,7 @@ func (c *parser) append(config string) error {
 
 		case "configfile":
 			// TODO test that
-			if err := c.appendFile(arg); err != nil {
+			if err := c.appendFile(ctx, arg); err != nil {
 				return err
 			}
 

--- a/pkg/boot/netboot/ipxe/ipxe.go
+++ b/pkg/boot/netboot/ipxe/ipxe.go
@@ -6,6 +6,7 @@
 package ipxe
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -45,20 +46,20 @@ type parser struct {
 // schemes.
 //
 // `s` is used to get files referred to by URLs in the configuration.
-func ParseConfig(l ulog.Logger, configURL *url.URL, s curl.Schemes) (*boot.LinuxImage, error) {
+func ParseConfig(ctx context.Context, l ulog.Logger, configURL *url.URL, s curl.Schemes) (*boot.LinuxImage, error) {
 	c := &parser{
 		schemes: s,
 		log:     l,
 	}
-	if err := c.getAndParseFile(configURL); err != nil {
+	if err := c.getAndParseFile(ctx, configURL); err != nil {
 		return nil, err
 	}
 	return c.bootImage, nil
 }
 
 // getAndParse parses the config file downloaded from `url` and fills in `c`.
-func (c *parser) getAndParseFile(u *url.URL) error {
-	r, err := c.schemes.LazyFetch(u)
+func (c *parser) getAndParseFile(ctx context.Context, u *url.URL) error {
+	r, err := c.schemes.Fetch(ctx, u)
 	if err != nil {
 		return err
 	}

--- a/pkg/boot/netboot/ipxe/ipxe.go
+++ b/pkg/boot/netboot/ipxe/ipxe.go
@@ -41,19 +41,11 @@ type parser struct {
 	schemes curl.Schemes
 }
 
-// ParseConfig returns a new  configuration with the file at URL and default
+// ParseConfig returns a new configuration with the file at URL and default
 // schemes.
 //
-// See ParseConfigWithSchemes for more details.
-func ParseConfig(l ulog.Logger, configURL *url.URL) (*boot.LinuxImage, error) {
-	return ParseConfigWithSchemes(l, configURL, curl.DefaultSchemes)
-}
-
-// ParseConfigWithSchemes returns a new  configuration with the file at URL
-// and schemes `s`.
-//
 // `s` is used to get files referred to by URLs in the configuration.
-func ParseConfigWithSchemes(l ulog.Logger, configURL *url.URL, s curl.Schemes) (*boot.LinuxImage, error) {
+func ParseConfig(l ulog.Logger, configURL *url.URL, s curl.Schemes) (*boot.LinuxImage, error) {
 	c := &parser{
 		schemes: s,
 		log:     l,

--- a/pkg/boot/netboot/ipxe/ipxe_test.go
+++ b/pkg/boot/netboot/ipxe/ipxe_test.go
@@ -326,9 +326,9 @@ func TestIpxeConfig(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("Test [%02d] %s", i, tt.desc), func(t *testing.T) {
-			got, err := ParseConfigWithSchemes(ulogtest.Logger{t}, tt.curl, tt.schemeFunc())
+			got, err := ParseConfig(ulogtest.Logger{t}, tt.curl, tt.schemeFunc())
 			if !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("NewConfigWithSchemes() got %v, want %v", err, tt.err)
+				t.Errorf("ParseConfig() got %v, want %v", err, tt.err)
 				return
 			} else if err != nil {
 				return

--- a/pkg/boot/netboot/ipxe/ipxe_test.go
+++ b/pkg/boot/netboot/ipxe/ipxe_test.go
@@ -5,6 +5,7 @@
 package ipxe
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -326,7 +327,7 @@ func TestIpxeConfig(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("Test [%02d] %s", i, tt.desc), func(t *testing.T) {
-			got, err := ParseConfig(ulogtest.Logger{t}, tt.curl, tt.schemeFunc())
+			got, err := ParseConfig(context.Background(), ulogtest.Logger{t}, tt.curl, tt.schemeFunc())
 			if !reflect.DeepEqual(err, tt.err) {
 				t.Errorf("ParseConfig() got %v, want %v", err, tt.err)
 				return

--- a/pkg/boot/netboot/netboot.go
+++ b/pkg/boot/netboot/netboot.go
@@ -59,7 +59,7 @@ func BootImage(l ulog.Logger, s curl.Schemes, lease dhclient.Lease) (*boot.Linux
 // ip, and mac address to search for pxe configs.
 func getBootImage(l ulog.Logger, schemes curl.Schemes, uri *url.URL, mac net.HardwareAddr, ip net.IP) (*boot.LinuxImage, error) {
 	// Attempt to read the given boot path as an ipxe config file.
-	ipc, err := ipxe.ParseConfigWithSchemes(l, uri, schemes)
+	ipc, err := ipxe.ParseConfig(l, uri, schemes)
 	if err == nil {
 		return ipc, nil
 	}
@@ -71,7 +71,7 @@ func getBootImage(l ulog.Logger, schemes curl.Schemes, uri *url.URL, mac net.Har
 		Host:   uri.Host,
 		Path:   path.Dir(uri.Path),
 	}
-	pc, err := pxe.ParseConfigWithSchemes(wd, mac, ip, schemes)
+	pc, err := pxe.ParseConfig(wd, mac, ip, schemes)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse pxelinux config: %v", err)
 	}

--- a/pkg/boot/netboot/pxe/pxe.go
+++ b/pkg/boot/netboot/pxe/pxe.go
@@ -19,16 +19,11 @@ import (
 	"github.com/u-root/u-root/pkg/curl"
 )
 
-// ParseConfig probes for config files based on the Mac and IP given.
-func ParseConfig(workingDir *url.URL, mac net.HardwareAddr, ip net.IP) (*syslinux.Config, error) {
-	return ParseConfigWithSchemes(workingDir, mac, ip, curl.DefaultSchemes)
-}
-
-// ParseConfigWithSchemes probes for config files based on the Mac and IP given
+// ParseConfig probes for config files based on the Mac and IP given
 // and uses s to fetch files.
-func ParseConfigWithSchemes(workingDir *url.URL, mac net.HardwareAddr, ip net.IP, s curl.Schemes) (*syslinux.Config, error) {
+func ParseConfig(workingDir *url.URL, mac net.HardwareAddr, ip net.IP, s curl.Schemes) (*syslinux.Config, error) {
 	for _, relname := range probeFiles(mac, ip) {
-		c, err := syslinux.ParseConfigFileWithSchemes(s, path.Join("pxelinux.cfg", relname), workingDir)
+		c, err := syslinux.ParseConfigFile(s, path.Join("pxelinux.cfg", relname), workingDir)
 		if curl.IsURLError(err) {
 			// We didn't find the file.
 			// TODO(hugelgupf): log this.

--- a/pkg/boot/netboot/pxe/pxe.go
+++ b/pkg/boot/netboot/pxe/pxe.go
@@ -8,6 +8,7 @@
 package pxe
 
 import (
+	"context"
 	"encoding/hex"
 	"fmt"
 	"net"
@@ -21,9 +22,9 @@ import (
 
 // ParseConfig probes for config files based on the Mac and IP given
 // and uses s to fetch files.
-func ParseConfig(workingDir *url.URL, mac net.HardwareAddr, ip net.IP, s curl.Schemes) (*syslinux.Config, error) {
+func ParseConfig(ctx context.Context, workingDir *url.URL, mac net.HardwareAddr, ip net.IP, s curl.Schemes) (*syslinux.Config, error) {
 	for _, relname := range probeFiles(mac, ip) {
-		c, err := syslinux.ParseConfigFile(s, path.Join("pxelinux.cfg", relname), workingDir)
+		c, err := syslinux.ParseConfigFile(ctx, s, path.Join("pxelinux.cfg", relname), workingDir)
 		if curl.IsURLError(err) {
 			// We didn't find the file.
 			// TODO(hugelgupf): log this.

--- a/pkg/boot/syslinux/syslinux.go
+++ b/pkg/boot/syslinux/syslinux.go
@@ -52,21 +52,14 @@ type Config struct {
 // Currently, only the APPEND, INCLUDE, KERNEL, LABEL, DEFAULT, and INITRD
 // directives are partially supported.
 //
-// curl.DefaultSchemes is used to fetch any files that must be parsed or
-// provided.
+// `s` is used to fetch any files that must be parsed or provided.
 //
 // `wd` is the default scheme, host, and path for any files named as a
 // relative path - e.g. kernel, include, and initramfs paths are requested
 // relative to the wd. The default path for config files is assumed to be
 // `wd.Path`/pxelinux.cfg/.
-func ParseConfigFile(url string, wd *url.URL) (*Config, error) {
-	return ParseConfigFileWithSchemes(curl.DefaultSchemes, url, wd)
-}
-
-// ParseConfigFileWithSchemes is like ParseConfigFile, but uses the given
-// schemes explicitly.
-func ParseConfigFileWithSchemes(s curl.Schemes, url string, wd *url.URL) (*Config, error) {
-	p := newParserWithSchemes(wd, s)
+func ParseConfigFile(s curl.Schemes, url string, wd *url.URL) (*Config, error) {
+	p := newParser(wd, s)
 	if err := p.appendFile(url); err != nil {
 		return nil, err
 	}
@@ -91,7 +84,7 @@ const (
 	scopeEntry
 )
 
-// newParserWithSchemes returns a new PXE parser using working directory `wd`
+// newParser returns a new PXE parser using working directory `wd`
 // and schemes `s`.
 //
 // If a path encountered in a configuration file is relative instead of a full
@@ -99,7 +92,7 @@ const (
 // resulting URL is roughly `wd.String()/path`.
 //
 // `s` is used to get files referred to by URLs.
-func newParserWithSchemes(wd *url.URL, s curl.Schemes) *parser {
+func newParser(wd *url.URL, s curl.Schemes) *parser {
 	return &parser{
 		config: &Config{
 			Entries: make(map[string]*boot.LinuxImage),

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -5,6 +5,7 @@
 package syslinux
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -592,7 +593,7 @@ func TestAppendFile(t *testing.T) {
 			s := tt.schemeFunc()
 			par := newParser(tt.wd, s)
 
-			if err := par.appendFile(tt.configFileURI); !reflect.DeepEqual(err, tt.err) {
+			if err := par.appendFile(context.Background(), tt.configFileURI); !reflect.DeepEqual(err, tt.err) {
 				t.Errorf("AppendFile() got %v, want %v", err, tt.err)
 			} else if err != nil {
 				return

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -590,7 +590,7 @@ func TestAppendFile(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("Test [%02d] %s", i, tt.desc), func(t *testing.T) {
 			s := tt.schemeFunc()
-			par := newParserWithSchemes(tt.wd, s)
+			par := newParser(tt.wd, s)
 
 			if err := par.appendFile(tt.configFileURI); !reflect.DeepEqual(err, tt.err) {
 				t.Errorf("AppendFile() got %v, want %v", err, tt.err)

--- a/pkg/curl/mock_schemes.go
+++ b/pkg/curl/mock_schemes.go
@@ -5,6 +5,7 @@
 package curl
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net/url"
@@ -75,7 +76,7 @@ var (
 )
 
 // Fetch implements FileScheme.Fetch.
-func (m *MockScheme) Fetch(u *url.URL) (io.ReaderAt, error) {
+func (m *MockScheme) Fetch(ctx context.Context, u *url.URL) (io.ReaderAt, error) {
 	url := u.String()
 	m.numCalled[url]++
 

--- a/pkg/curl/schemes.go
+++ b/pkg/curl/schemes.go
@@ -8,6 +8,7 @@
 package curl
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -41,7 +42,7 @@ type FileScheme interface {
 	//
 	// It may do so by fetching `u` and placing it in a buffer, or by
 	// returning an io.ReaderAt that fetchs the file.
-	Fetch(u *url.URL) (io.ReaderAt, error)
+	Fetch(ctx context.Context, u *url.URL) (io.ReaderAt, error)
 }
 
 // FileSchemeRetryFilter contains extra RetryFilter method for a FileScheme
@@ -104,8 +105,8 @@ func (s Schemes) Register(scheme string, fs FileScheme) {
 }
 
 // Fetch fetchs a file via DefaultSchemes.
-func Fetch(u *url.URL) (io.ReaderAt, error) {
-	return DefaultSchemes.Fetch(u)
+func Fetch(ctx context.Context, u *url.URL) (io.ReaderAt, error) {
+	return DefaultSchemes.Fetch(ctx, u)
 }
 
 // file is an io.ReaderAt with a nice Stringer.
@@ -125,12 +126,12 @@ func (f file) String() string {
 //
 // If `s` does not contain a FileScheme for `u.Scheme`, ErrNoSuchScheme is
 // returned.
-func (s Schemes) Fetch(u *url.URL) (io.ReaderAt, error) {
+func (s Schemes) Fetch(ctx context.Context, u *url.URL) (io.ReaderAt, error) {
 	fg, ok := s[u.Scheme]
 	if !ok {
 		return nil, &URLError{URL: u, Err: ErrNoSuchScheme}
 	}
-	r, err := fg.Fetch(u)
+	r, err := fg.Fetch(ctx, u)
 	if err != nil {
 		return nil, &URLError{URL: u, Err: err}
 	}
@@ -166,7 +167,8 @@ func (s Schemes) LazyFetch(u *url.URL) (io.ReaderAt, error) {
 	return &file{
 		url: u,
 		ReaderAt: uio.NewLazyOpenerAt(u.String(), func() (io.ReaderAt, error) {
-			r, err := fg.Fetch(u)
+			// TODO
+			r, err := fg.Fetch(context.TODO(), u)
 			if err != nil {
 				return nil, &URLError{URL: u, Err: err}
 			}
@@ -188,7 +190,7 @@ func NewTFTPClient(opts ...tftp.ClientOpt) FileScheme {
 }
 
 // Fetch implements FileScheme.Fetch.
-func (t *TFTPClient) Fetch(u *url.URL) (io.ReaderAt, error) {
+func (t *TFTPClient) Fetch(_ context.Context, u *url.URL) (io.ReaderAt, error) {
 	// TODO(hugelgupf): These clients are basically stateless, except for
 	// the options. Figure out whether you actually have to re-establish
 	// this connection every time. Audit the TFTP library.
@@ -219,7 +221,7 @@ type SchemeWithRetries struct {
 }
 
 // Fetch implements FileScheme.Fetch.
-func (s *SchemeWithRetries) Fetch(u *url.URL) (io.ReaderAt, error) {
+func (s *SchemeWithRetries) Fetch(ctx context.Context, u *url.URL) (io.ReaderAt, error) {
 	var err error
 	s.BackOff.Reset()
 	for d := time.Duration(0); d != backoff.Stop; d = s.BackOff.NextBackOff() {
@@ -229,7 +231,7 @@ func (s *SchemeWithRetries) Fetch(u *url.URL) (io.ReaderAt, error) {
 
 		var r io.ReaderAt
 		// Note: err uses the scope outside the for loop.
-		r, err = s.Scheme.Fetch(u)
+		r, err = s.Scheme.Fetch(ctx, u)
 		if err == nil {
 			return r, nil
 		}
@@ -270,8 +272,12 @@ func NewHTTPClient(c *http.Client) *HTTPClient {
 }
 
 // Fetch implements FileScheme.Fetch.
-func (h HTTPClient) Fetch(u *url.URL) (io.ReaderAt, error) {
-	resp, err := h.c.Get(u.String())
+func (h HTTPClient) Fetch(ctx context.Context, u *url.URL) (io.ReaderAt, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := h.c.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -294,6 +300,6 @@ func (h HTTPClient) RetryFilter(u *url.URL, err error) bool {
 type LocalFileClient struct{}
 
 // Fetch implements FileScheme.Fetch.
-func (lfs LocalFileClient) Fetch(u *url.URL) (io.ReaderAt, error) {
+func (lfs LocalFileClient) Fetch(_ context.Context, u *url.URL) (io.ReaderAt, error) {
 	return os.Open(filepath.Clean(u.Path))
 }

--- a/pkg/curl/schemes_test.go
+++ b/pkg/curl/schemes_test.go
@@ -5,6 +5,7 @@
 package curl
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -182,7 +183,7 @@ func TestFetch(t *testing.T) {
 			s := make(Schemes)
 			s.Register(ms.Scheme, fs)
 
-			r, err = s.Fetch(tt.url)
+			r, err = s.Fetch(context.TODO(), tt.url)
 			if uErr, ok := err.(*URLError); ok && uErr.Err != tt.err {
 				t.Errorf("Fetch() = %v, want %v", uErr.Err, tt.err)
 			} else if !ok && err != tt.err {


### PR DESCRIPTION
Internally, we use SchemeWithRetries to retry our PXE/iPXE downloads due to spurious network config or network errors. The result is something that can spiral out of control sometimes:

```
[bmboot] 2020/05/07 00:57:32 Error: HTTP client: Get "http://10.244.211.18/ipxe.script": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                                
[bmboot] 2020/05/07 00:57:48 Error: HTTP client: Get "http://10.244.211.18/ipxe.script": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                                
[bmboot] 2020/05/07 00:57:48 Error: Too many retries to download http://10.244.211.18/ipxe.script                                                                                                                                                              
[bmboot] 2020/05/07 00:57:48 Falling back to pxe boot: encountered error too many HTTP retries: Get "http://10.244.211.18/ipxe.script": dial tcp 10.244.211.18:80: connect: connection refused with "http://10.244.211.18/ipxe.script"                         
[bmboot] 2020/05/07 00:57:48 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:57:48 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:57:49 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:57:50 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:57:51 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:57:54 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:58:00 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:58:05 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:58:12 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:58:27 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:58:44 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:59:24 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76": dial tcp 10.244.211.18:80: connect: connection refused                                                                                          
[bmboot] 2020/05/07 00:59:24 Error: Too many retries to download http://10.244.211.18/pxelinux.cfg/01-3c-28-6d-33-fb-76                                                                                                                                        
[bmboot] 2020/05/07 00:59:24 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:24 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:25 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:27 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:29 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:32 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:36 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:45 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:52 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
[bmboot] 2020/05/07 00:59:59 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                      
^C[bmboot] 2020/05/07 01:00:24 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D113": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                    
[bmboot] 2020/05/07 01:00:24 Error: Too many retries to download http://10.244.211.18/pxelinux.cfg/0AF4D113                                                                                                                                                    
[bmboot] 2020/05/07 01:00:24 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:00:25 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:00:25 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:00:27 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:00:27 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:00:29 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:00:34 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:00:42 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:00:52 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:01:06 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:01:27 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D11": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                       
[bmboot] 2020/05/07 01:01:27 Error: Too many retries to download http://10.244.211.18/pxelinux.cfg/0AF4D11                                                                                                                                                     
[bmboot] 2020/05/07 01:01:27 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                        
[bmboot] 2020/05/07 01:01:27 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                        
[bmboot] 2020/05/07 01:01:28 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                        
[bmboot] 2020/05/07 01:01:29 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                        
[bmboot] 2020/05/07 01:01:31 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                        
[bmboot] 2020/05/07 01:01:34 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                        
[bmboot] 2020/05/07 01:01:38 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                        
[bmboot] 2020/05/07 01:01:42 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused                                                                                                        
[bmboot] 2020/05/07 01:01:48 Error: HTTP client: Get "http://10.244.211.18/pxelinux.cfg/0AF4D1": dial tcp 10.244.211.18:80: connect: connection refused     
```

I noticed during this that we cannot cancel these. (We also have SIGINT tied to the context, you cannot kill the program with SIGINT.) This needs 2 things:

1. a way to cancel the downloads and retries, because this is nuts
2. fewer retries overall, the retries + file probing makes it go on for 5 minutes!

Right now, this PR just affects the config files that are downloaded. Kernels + initramfses parsed out of those configs use LazyFetch, which currently does not support the context.

It's not as easy to add context to LazyFetch, because it's not entirely clear how to do it.

`pkg/boot` takes io.ReaderAts for kernels and initramfses. I think there's essentially 2 options:

#### version 1

`BootImage.Load(ctx context.Context, verbose bool)`, and kernel and modules go from being `io.ReaderAt` to something like 

```go
type IO interface {
  Read(ctx context.Context) io.ReaderAt
}

type LinuxImage struct {
  Kernel IO
  Initramfs IO
  Cmdline string
}

func (li *LinuxImage) Load(ctx context.Context, verbose bool) {
  li.Kernel.Read(ctx).ReadAt(b, 0)...
}
```

#### version 2

we leave `pkg/boot` the way it is. Instead, we transform the higher-level way we do things.

right now, the high-level flow goes like this:

a) grub/pxe/ipxe parsers return many []boot.OSImage, storing a Lazy io.ReaderAt in the image.
b) choose one.
c) when you call OSImage.Load, the io.ReaderAt automatically downloads the image to disk and uses it.

instead, what if we did the following:

a) grub/pxe/ipxe parsers return many []boot.LazyOSImage
b) choose one, call `Download` or `Fetch` to get the stuff downloaded to disk
c) make a boot.OSImage with the local files, which cannot fail to download, and use that

```go
type LazyLinuxImage struct {
  Kernel IO
  Initramfs IO
  Cmdline string
}

func (lli *LazyLinuxImage) Fetch(ctx context.Context) boot.OSImage {
  // download stuff to tmpfs
  return &boot.LinuxImage{
    Kernel: os.Open("/local file")
  }
}
```

#### my take

I *think* I lean toward option 2. It keeps the easy usability of boot.OSImages with their io.ReaderAts around, which one can just use with os.Open or whatever.