### PR TITLE
ACPI: Add functions to read *SDT and tables from memory

### DIFF
--- a/cmds/exp/acpicat/main.go
+++ b/cmds/exp/acpicat/main.go
@@ -18,10 +18,14 @@ import (
 
 var (
 	source = flag.String("s", acpi.DefaultMethod, "source of the tables")
+	debug  = flag.Bool("d", false, "Enable debug prints")
 )
 
 func main() {
 	flag.Parse()
+	if *debug {
+		acpi.Debug = log.Printf
+	}
 	t, err := acpi.ReadTables(*source)
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/acpi/acpi_test.go
+++ b/pkg/acpi/acpi_test.go
@@ -8,6 +8,7 @@ package acpi
 
 import (
 	"bytes"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -41,4 +42,31 @@ func TestTabWrite(t *testing.T) {
 		t.Fatalf("Written table does not match")
 	}
 
+}
+
+// TestAddr tests the decoding of those stupid "use this 64-bit if set else 32 things"
+// that permeate ACPI
+func TestAddr(t *testing.T) {
+	var tests = []struct {
+		n   string
+		dat []byte
+		a64 int64
+		a32 int64
+		val int64
+		err error
+	}{
+		{n: "zero length data", dat: []byte{}, a64: 5, a32: 1, val: -1, err: fmt.Errorf("No 64-bit address at 5, no 32-bit address at 1, in 0-byte slice")},
+		{n: "32 bits at 1, no 64-bit", dat: []byte{1, 2, 3, 4, 5}, a64: 5, a32: 1, val: 84148994, err: nil},
+		{n: "64 bits at 5", dat: []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14}, a64: 5, a32: 1, val: 940138559942690566, err: nil},
+	}
+	Debug = t.Logf
+	for _, tt := range tests {
+		v, err := getaddr(tt.dat, tt.a64, tt.a32)
+		if v != tt.val {
+			t.Errorf("Test %s: got %d, want %d", tt.n, v, tt.val)
+		}
+		if !reflect.DeepEqual(err, tt.err) {
+			t.Errorf("Test %s: got %v, want %v", tt.n, err, tt.err)
+		}
+	}
 }

--- a/pkg/acpi/bios.go
+++ b/pkg/acpi/bios.go
@@ -1,0 +1,92 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package acpi
+
+import "fmt"
+
+const (
+	llDSDTAddr = 140
+	lDSDTAddr  = 40
+)
+
+// BiosTable contains the information needed to create table images for
+// firmware such as coreboot or oreboot. It hence includes the RSDP,
+// [XR]SDT, and the raw table data. The *SDT is always Tables[0]
+// as in the real tables.
+type BiosTable struct {
+	RSDP   *RSDP
+	Tables []Table
+}
+
+// ReadBiosTables reads tables that are not interpreted by the OS,
+// i.e. it goes straight to memory and gets them there. We optimistically
+// hope the bios has not stomped around in low memory messing around.
+func ReadBiosTables() (*BiosTable, error) {
+	r, err := GetRSDPEBDA()
+	if err != nil {
+		r, err = GetRSDPMem()
+		if err != nil {
+			return nil, err
+		}
+	}
+	Debug("Found an RSDP at %#x", r.base)
+	x, err := NewSDTAddr(r.SDTAddr())
+	if err != nil {
+		return nil, err
+	}
+	Debug("Found an SDT: %s", String(x))
+	bios := &BiosTable{
+		RSDP:   r,
+		Tables: []Table{x},
+	}
+	for _, a := range x.Addrs {
+		Debug("Check Table at %#x", a)
+		t, err := ReadRawTable(a)
+		if err != nil {
+			return nil, fmt.Errorf("%#x:%v", a, err)
+		}
+		Debug("Add table %s", String(t))
+		bios.Tables = append(bios.Tables, t)
+		// What I love about ACPI is its unchanging
+		// consistency. One table, the FADT, points
+		// to another table, the DSDT. There are
+		// very good reasons for this:
+		// (1) ACPI is a bad design
+		// (2) see (1)
+		// The signature of the FADT is "FACP".
+		// Most appropriate that the names
+		// start with F. So does Failure Of Vision.
+		if t.Sig() != "FACP" {
+			continue
+		}
+		// 64-bit CPUs had been around for 30 years when ACPI
+		// was defined. Nevertheless, they filled it chock full
+		// of 32-bit pointers, and then had to go back and paste
+		// in 64-bit pointers. The mind reels.
+		dsdt, err := getaddr(t.Data(), llDSDTAddr, lDSDTAddr)
+		if err != nil {
+			return nil, err
+		}
+		// This is sometimes a kernel virtual address.
+		// Fix that.
+		t, err = ReadRawTable(int64(uint32(dsdt)))
+		if err != nil {
+			return nil, fmt.Errorf("%#x:%v", uint64(dsdt), err)
+		}
+		Debug("Add table %s", String(t))
+		bios.Tables = append(bios.Tables, t)
+
+	}
+	return bios, nil
+}
+
+// RawTablesFromMem reads all the tables from Mem, using the SDT.
+func RawTablesFromMem() ([]Table, error) {
+	x, err := ReadBiosTables()
+	if err != nil {
+		return nil, err
+	}
+	return x.Tables, err
+}

--- a/pkg/acpi/raw.go
+++ b/pkg/acpi/raw.go
@@ -23,6 +23,7 @@ import (
 // for figuring out how to skip a table you don't care about or, possibly,
 // truncating a table and regenerating a checksum.
 type Raw struct {
+	addr int64
 	data []byte
 }
 
@@ -82,7 +83,12 @@ func ReadRawTable(physAddr int64) (Table, error) {
 	if err := memio.Read(physAddr, &dat); err != nil {
 		return nil, err
 	}
-	return &Raw{data: []byte(dat)}, nil
+	return &Raw{addr: physAddr, data: []byte(dat)}, nil
+}
+
+// Address returns the table's base address
+func (r *Raw) Address() int64 {
+	return r.addr
 }
 
 // Data returns all the data in a Raw table.

--- a/pkg/acpi/rsdp.go
+++ b/pkg/acpi/rsdp.go
@@ -18,7 +18,7 @@ var (
 // RSDP is the v2 version of the ACPI RSDP struct.
 type RSDP struct {
 	// base is the base address of the RSDP struct in physical memory.
-	base uint64
+	base int64
 
 	data [headerLength]byte
 }
@@ -64,7 +64,7 @@ func (r *RSDP) OEMID() string {
 }
 
 // RSDPAddr returns the physical base address of the RSDP.
-func (r *RSDP) RSDPAddr() uint64 {
+func (r *RSDP) RSDPAddr() int64 {
 	return r.base
 }
 
@@ -72,15 +72,15 @@ func (r *RSDP) RSDPAddr() uint64 {
 //
 // It will preferentially return the XSDT, but if that is
 // 0 it will return the RSDT address.
-func (r *RSDP) SDTAddr() uint64 {
+func (r *RSDP) SDTAddr() int64 {
 	b := uint64(binary.LittleEndian.Uint32(r.data[16:20]))
 	if b != 0 {
-		return b
+		return int64(b)
 	}
-	return binary.LittleEndian.Uint64(r.data[24:32])
+	return int64(binary.LittleEndian.Uint64(r.data[24:32]))
 }
 
-func readRSDP(base uint64) (*RSDP, error) {
+func readRSDP(base int64) (*RSDP, error) {
 	r := &RSDP{}
 	r.base = base
 

--- a/pkg/acpi/rsdp_linux.go
+++ b/pkg/acpi/rsdp_linux.go
@@ -40,7 +40,7 @@ func GetRSDPEFI() (*RSDP, error) {
 		if start == "" {
 			continue
 		}
-		base, err := strconv.ParseUint(start, 0, 64)
+		base, err := strconv.ParseInt(start, 0, 63)
 		if err != nil {
 			continue
 		}

--- a/pkg/acpi/rsdp_unix.go
+++ b/pkg/acpi/rsdp_unix.go
@@ -28,10 +28,10 @@ func GetRSDPEBDA() (*RSDP, error) {
 		return nil, err
 	}
 
-	return getRSDPMem(uint64(e.BaseOffset), uint64(e.BaseOffset+e.Length))
+	return getRSDPMem(int64(e.BaseOffset), int64(e.BaseOffset+e.Length))
 }
 
-func getRSDPMem(start, end uint64) (*RSDP, error) {
+func getRSDPMem(start, end int64) (*RSDP, error) {
 	for base := start; base < end; base += 16 {
 		var r memio.Uint64
 		if err := memio.Read(int64(base), &r); err != nil {

--- a/pkg/acpi/sdt.go
+++ b/pkg/acpi/sdt.go
@@ -1,0 +1,76 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package acpi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+)
+
+var (
+	sdtLen = 36
+)
+
+// SDT contains information about tables. It does not differentiate 32- vs 64-bit
+// tables.
+type SDT struct {
+	// Table is the SDT itself.
+	Table
+
+	// Addrs is the array of physical addresses in the SDT.
+	Addrs []int64
+
+	// Base is the SDT base, used to generate a new SDT for, e.g, coreboot.
+	Base int64
+}
+
+var _ = Table(&SDT{})
+
+// NewSDTAddr returns an SDT, given an address.
+func NewSDTAddr(addr int64) (*SDT, error) {
+	t, err := ReadRawTable(addr)
+	if err != nil {
+		return nil, fmt.Errorf("can not read SDT at %#x", addr)
+	}
+	Debug("NewSDTAddr: %s %#x", String(t), t.TableData())
+	return NewSDT(t, addr)
+}
+
+// NewSDT returns an SDT, given a Table
+func NewSDT(t Table, addr int64) (*SDT, error) {
+	s := &SDT{
+		Table: t,
+		Base:  addr,
+	}
+	r := bytes.NewReader(t.TableData())
+	x := true
+	if t.Sig() == "RSDT" {
+		x = false
+	}
+	for r.Len() > 0 {
+		var a int64
+		if x {
+			if err := binary.Read(r, binary.LittleEndian, &a); err != nil {
+				return nil, err
+			}
+		} else {
+			var a32 uint32
+			if err := binary.Read(r, binary.LittleEndian, &a32); err != nil {
+				return nil, err
+			}
+			a = int64(a32)
+		}
+		Debug("Add addr %#x", a)
+		s.Addrs = append(s.Addrs, a)
+	}
+	Debug("NewSDT: %v", s.String())
+	return s, nil
+}
+
+// String implements string for an SDT.
+func (sdt *SDT) String() string {
+	return fmt.Sprintf("%s at %#x with %d tables: %#x", String(sdt), sdt.Base, len(sdt.Addrs), sdt.Addrs)
+}

--- a/pkg/acpi/tables_linux.go
+++ b/pkg/acpi/tables_linux.go
@@ -11,9 +11,12 @@ import (
 )
 
 var (
+	// DefaultMethod is the name of the default method used to get tables.
 	DefaultMethod = "files"
-	Methods       = map[string]TableMethod{
+	// Methods is the map of all methods implemented for Linux.
+	Methods = map[string]TableMethod{
 		"files": RawTablesFromSys,
+		"ebda":  RawTablesFromMem,
 	}
 )
 


### PR DESCRIPTION
What is in FLASH (top 128K) and what kernels show you is not
always the same. Here is an example, the first coming from ebda, the
second from linux files in /sys:

```
rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/exp/acpicat$ sudo ./acpicat  -s ebda | ../acpigrep/acpigrep -d . >/dev/null
2020/05/11 21:57:51 Keeping RSDT@0x0 64 1 0x5b "INTEL " "440BX   " 0x06040000 0x50544c20 0x00000000
2020/05/11 21:57:51 Keeping FACP@0x0 116 1 0xf7 "INTEL " "440BX   " 0x06040000 0x204c5450 0x000f4240
2020/05/11 21:57:51 Keeping DSDT@0x0 138866 1 0xaa "PTLTD " "Custom  " 0x06040000 0x5446534d 0x03000001
2020/05/11 21:57:51 Keeping BOOT@0x0 40 1 0xa5 "PTLTD " "$SBFTBL$" 0x06040000 0x50544c20 0x00000001
2020/05/11 21:57:51 Keeping APIC@0x0 1858 1 0x8f "PTLTD " "\t APIC  " 0x06040000 0x50544c20 0x00000000
2020/05/11 21:57:51 Keeping MCFG@0x0 60 1 0x6e "PTLTD " "$PCITBL$" 0x06040000 0x50544c20 0x00000001
2020/05/11 21:57:51 Keeping SRAT@0x0 2256 2 0xa8 "VMWARE" "MEMPLUG " 0x06040000 0x20574d56 0x00000001
2020/05/11 21:57:51 Keeping HPET@0x0 56 1 0xaa "VMWARE" "VMW HPET" 0x06040000 0x20574d56 0x00000001
2020/05/11 21:57:51 Keeping WAET@0x0 40 1 0x62 "VMWARE" "VMW WAET" 0x06040000 0x20574d56 0x00000001
rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/exp/acpicat$ sudo ./acpicat  | ../acpigrep/acpigrep -d . >/dev/null
2020/05/11 21:57:56 Keeping APIC@0x0 1858 1 0x8f "PTLTD " "\t APIC  " 0x06040000 0x50544c20 0x00000000
2020/05/11 21:57:56 Keeping BOOT@0x0 40 1 0xa5 "PTLTD " "$SBFTBL$" 0x06040000 0x50544c20 0x00000001
2020/05/11 21:57:56 Keeping DSDT@0x0 138866 1 0xaa "PTLTD " "Custom  " 0x06040000 0x5446534d 0x03000001
2020/05/11 21:57:56 Keeping FACP@0x0 244 4 0x51 "INTEL " "440BX   " 0x06040000 0x204c5450 0x000f4240
2020/05/11 21:57:56 Keeping FACS@0x0 64 0 0x00 "\x00\x00\x00\x00\x00\x00" "\x00\x00\x00\x00\x00\x00\x00\x00" 0x00000000 0x00000000 0x00000000
2020/05/11 21:57:56 Keeping HPET@0x0 56 1 0xaa "VMWARE" "VMW HPET" 0x06040000 0x20574d56 0x00000001
2020/05/11 21:57:56 Keeping MCFG@0x0 60 1 0x6e "PTLTD " "$PCITBL$" 0x06040000 0x50544c20 0x00000001
2020/05/11 21:57:56 Keeping SRAT@0x0 2256 2 0xa8 "VMWARE" "MEMPLUG " 0x06040000 0x20574d56 0x00000001
2020/05/11 21:57:56 Keeping WAET@0x0 40 1 0x62 "VMWARE" "VMW WAET" 0x06040000 0x20574d56 0x00000001
```

The FACS is generated, somehow, but looks like garbage.
The standard method, via /sys, does not include the RSDT, and the ebda method does.

Note that the address is not available in the output stream (so you see @0x0) so acpigrep
shows 0.

Also, the use of uint64 for physical addresses was an early mistake,
cleaned up here. int64 is 63 bits. By the time we
need more than 63 bits for a physical address,
we will be using 128-bit machines, so uint64 won't help much anyway;
and int64 is compatible with Pread where uint64 is not.