### PR TITLE
ESXi: tweak cmdline handling

### DIFF
--- a/pkg/boot/esxi/esxi.go
+++ b/pkg/boot/esxi/esxi.go
@@ -295,8 +295,21 @@ func parse(configFile string) (options, error) {
 		switch key {
 		case "kernel":
 			opt.kernel = filepath.Join(dir, val)
+
+			// The kernel cmdline is expected to have the filename
+			// first, as in cmdlines[0] here:
+			// https://github.com/vmware/esx-boot/blob/1380fc86cffdfb83448e2913ae11f6b7f248cf23/mboot/mutiboot.c#L870
+			//
+			// Note that the kernel is module 0 in the esx-boot
+			// code base, but it doesn't get loaded like that into
+			// the info structure; see -- so don't panic like I did
+			// when you read that!
+			// https://github.com/vmware/esx-boot/blob/1380fc86cffdfb83448e2913ae11f6b7f248cf23/mboot/mutiboot.c#L578
+			opt.args = val + " " + opt.args
+
 		case "kernelopt":
-			opt.args = val
+			opt.args += val
+
 		case "updated":
 			if len(val) == 0 {
 				// Explicitly setting to 0, as in

--- a/pkg/boot/esxi/esxi_test.go
+++ b/pkg/boot/esxi/esxi_test.go
@@ -25,10 +25,19 @@ func TestParse(t *testing.T) {
 			want: options{
 				kernel: "testdata/b.b00",
 				args:   "zee",
-				modules: []string{
-					"testdata/b.b00 blabla",
-					"testdata/k.b00",
-					"testdata/m.m00 marg marg2",
+				modules: []module{
+					{
+						path:    "testdata/b.b00",
+						cmdline: "b.b00 blabla",
+					},
+					{
+						path:    "testdata/k.b00",
+						cmdline: "k.b00",
+					},
+					{
+						path:    "testdata/m.m00",
+						cmdline: "m.m00 marg marg2",
+					},
 				},
 			},
 		},

--- a/pkg/boot/esxi/esxi_test.go
+++ b/pkg/boot/esxi/esxi_test.go
@@ -24,7 +24,7 @@ func TestParse(t *testing.T) {
 			file: "testdata/kernel_cmdline_mods.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
-				args:   "zee",
+				args:   "b.b00 zee",
 				modules: []module{
 					{
 						path:    "testdata/b.b00",
@@ -42,36 +42,45 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			file: "testdata/kernelopt_first.cfg",
+			want: options{
+				kernel: "testdata/b.b00",
+				args:   "b.b00 zee",
+			},
+		},
+		{
 			file: "testdata/empty_mods.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
-				args:   "zee",
+				args:   "b.b00 zee",
 			},
 		},
 		{
 			file: "testdata/no_mods.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
-				args:   "zee",
+				args:   "b.b00 zee",
 			},
 		},
 		{
 			file: "testdata/no_cmdline.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
+				args:   "b.b00 ",
 			},
 		},
 		{
 			file: "testdata/empty_cmdline.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
+				args:   "b.b00 ",
 			},
 		},
 		{
 			file: "testdata/empty_updated.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
-				args:   "zee",
+				args:   "b.b00 zee",
 				// Explicitly stating this as the wanted value.
 				updated: 0,
 			},
@@ -80,7 +89,7 @@ func TestParse(t *testing.T) {
 			file: "testdata/updated_twice.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
-				args:   "zee",
+				args:   "b.b00 zee",
 				// Explicitly stating this as the wanted value.
 				updated: 0,
 			},
@@ -89,7 +98,7 @@ func TestParse(t *testing.T) {
 			file: "testdata/updated.cfg",
 			want: options{
 				kernel:  "testdata/b.b00",
-				args:    "zee",
+				args:    "b.b00 zee",
 				updated: 4,
 			},
 		},
@@ -97,7 +106,7 @@ func TestParse(t *testing.T) {
 			file: "testdata/empty_bootstate.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
-				args:   "zee",
+				args:   "b.b00 zee",
 				// Explicitly stating this as the wanted value.
 				bootstate: bootValid,
 			},
@@ -106,7 +115,7 @@ func TestParse(t *testing.T) {
 			file: "testdata/bootstate_twice.cfg",
 			want: options{
 				kernel: "testdata/b.b00",
-				args:   "zee",
+				args:   "b.b00 zee",
 				// Explicitly stating this as the wanted value.
 				bootstate: bootValid,
 			},
@@ -115,7 +124,7 @@ func TestParse(t *testing.T) {
 			file: "testdata/bootstate.cfg",
 			want: options{
 				kernel:    "testdata/b.b00",
-				args:      "zee",
+				args:      "b.b00 zee",
 				bootstate: bootDirty,
 			},
 		},
@@ -123,7 +132,7 @@ func TestParse(t *testing.T) {
 			file: "testdata/bootstate_invalid.cfg",
 			want: options{
 				kernel:    "testdata/b.b00",
-				args:      "zee",
+				args:      "b.b00 zee",
 				bootstate: bootInvalid,
 			},
 		},
@@ -131,7 +140,7 @@ func TestParse(t *testing.T) {
 			file: "testdata/no_bootstate.cfg",
 			want: options{
 				kernel:    "testdata/b.b00",
-				args:      "zee",
+				args:      "b.b00 zee",
 				bootstate: bootInvalid,
 			},
 		},
@@ -142,7 +151,7 @@ func TestParse(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("LoadConfig(%s) = %v want %v", tt.file, got, tt.want)
+			t.Errorf("LoadConfig(%s) = %#v want %#v", tt.file, got, tt.want)
 		}
 	}
 }

--- a/pkg/boot/esxi/testdata/kernelopt_first.cfg
+++ b/pkg/boot/esxi/testdata/kernelopt_first.cfg
@@ -1,0 +1,4 @@
+kernel=b.b00
+kernelopt=zee
+modules=
+bootstate=0


### PR DESCRIPTION
The kernel cmdline is expected to have a filename as arg[0], and I doubt /tmp/sda5-blablabla/b.b00 is a useful arg[0] for any of the ESXi cmdlines.

before:

```bash
[root@localhost:~] vsish -e get /system/bootCmdLine
vmkernel bootloader command line {
   command line:no-auto-partition logPort=com1 gdbPort=none tty2Port=none bootUUID=7a2bbd9707adf29999b9eabd783cde33 vmkBootVerbose=TRUE vmbLog=TRUE debugLogToSerial=1
}
```

after:

```bash
[root@localhost:~] vsish -e get /system/bootCmdLine
vmkernel bootloader command line {
   command line:b.b00 no-auto-partition logPort=com1 gdbPort=none tty2Port=none bootUUID=7a2bbd9707adf29999b9eabd783cde33 vmkBootVerbose=TRUE vmbLog=TRUE debugLogToSerial=1
}
```