### PR TITLE
Simple u-root chainloader support

### DIFF
--- a/pkg/boot/syslinux/syslinux.go
+++ b/pkg/boot/syslinux/syslinux.go
@@ -159,6 +159,7 @@ func (c *parser) appendFile(url string) error {
 
 // Append parses `config` and adds the respective configuration to `c`.
 func (c *parser) append(config string) error {
+	chainloadsupport := ""
 	// Here's a shitty parser.
 	for _, line := range strings.Split(config, "\n") {
 		// This is stupid. There should be a FieldsN(...).
@@ -178,6 +179,9 @@ func (c *parser) append(config string) error {
 		case "default":
 			c.config.DefaultEntry = arg
 
+		case "prefix":
+			chainloadsupport = arg
+
 		case "include":
 			if err := c.appendFile(arg); curl.IsURLError(err) {
 				// Means we didn't find the file. Just ignore
@@ -196,21 +200,21 @@ func (c *parser) append(config string) error {
 			c.config.Entries[c.curEntry].Cmdline = c.globalAppend
 			c.config.Entries[c.curEntry].Name = c.curEntry
 
-		case "kernel":
+		case chainloadsupport + "kernel":
 			k, err := c.getFile(arg)
 			if err != nil {
 				return err
 			}
 			c.config.Entries[c.curEntry].Kernel = k
 
-		case "initrd":
+		case chainloadsupport + "initrd":
 			i, err := c.getFile(arg)
 			if err != nil {
 				return err
 			}
 			c.config.Entries[c.curEntry].Initrd = i
 
-		case "append":
+		case chainloadsupport +  "append":
 			switch c.scope {
 			case scopeGlobal:
 				c.globalAppend = arg


### PR DESCRIPTION
change the pxeboot.cfg/default configuration:

==== old ====
      DEFAULT linux
      LABEL linux
            KERNEL /bzImage
            INITRD /initrd.cpio.gz
            APPEND root=/dev/ram0 ramdisk=8192 console=ttyS0,115200n8

==== new ====
    DEFAULT linux
    LABEL linux
            PREFIX final-                              <<<< NEW
            KERNEL /nerf-bzImage
            INITRD /nerf-initrd.cpio.gz
            final-KERNEL /bzImage                      <<<< NEW entry
            final-INITRD /initrd.cpio.gz               <<<< NEW entry
            final-APPEND root=/dev/ram0 ramdisk=8192 ...  <<<< NEW entry

When BIOS is loading, it does not know anything about 'PREFIX' and will simply
load the u-root kernel and initrd. When u-root is loading, it will parse the same
configuration file again and will load the bzImage, and initrd.cpio.gz with the
"final-" prefix in them.

BIOS is loading: /nerf-bzImage, /nerf-initrd.cpio.gz
u-root is loading: /bzImage, /initrd.cpio.gz

==== log ====
[netboot] 2020/05/19 01:24:18 Got config file tftp://10.246.84.208/pxelinux.cfg/default:
    DEFAULT linux
    LABEL linux
            PREFIX final-
            KERNEL /nerf-bzImage
            INITRD /nerf-initrd.cpio.gz
            final-KERNEL /bzImage
            final-INITRD /initrd.cpio.gz
            final-APPEND root=/dev/ram0 ...

    [netboot] 2020/05/19 01:24:18 Got configuration: LinuxImage(
      Name: linux
      Kernel: tftp://10.246.84.208/bzImage
      Initrd: tftp://10.246.84.208/initrd.cpio.gz
      Cmdline: root=/dev/ram0 ...
    )