### PR TITLE
 Simple NERF chainloader support (NERFDEFAULT)

### DIFF
--- a/pkg/boot/syslinux/syslinux.go
+++ b/pkg/boot/syslinux/syslinux.go
@@ -159,6 +159,9 @@ func (c *parser) appendFile(url string) error {
 
 // Append parses `config` and adds the respective configuration to `c`.
 func (c *parser) append(config string) error {
+	var defaultEntry string
+	var nerfDefaultEntry string
+
 	// Here's a shitty parser.
 	for _, line := range strings.Split(config, "\n") {
 		// This is stupid. There should be a FieldsN(...).
@@ -176,10 +179,10 @@ func (c *parser) append(config string) error {
 
 		switch directive {
 		case "default":
-			c.config.DefaultEntry = arg
+			defaultEntry = arg
 
 		case "nerfdefault":
-			c.config.DefaultEntry = arg
+			nerfDefaultEntry = arg
 
 		case "include":
 			if err := c.appendFile(arg); curl.IsURLError(err) {
@@ -226,6 +229,14 @@ func (c *parser) append(config string) error {
 				}
 			}
 		}
+	}
+
+	// Select the default entry. "nerfdefault" takes precedence over
+	// "default"
+	if nerfDefaultEntry == "" {
+		c.config.DefaultEntry = defaultEntry
+	} else {
+		c.config.DefaultEntry = nerfDefaultEntry
 	}
 
 	// Go through all labels and download the initrds.

--- a/pkg/boot/syslinux/syslinux.go
+++ b/pkg/boot/syslinux/syslinux.go
@@ -159,7 +159,6 @@ func (c *parser) appendFile(url string) error {
 
 // Append parses `config` and adds the respective configuration to `c`.
 func (c *parser) append(config string) error {
-	chainloadsupport := ""
 	// Here's a shitty parser.
 	for _, line := range strings.Split(config, "\n") {
 		// This is stupid. There should be a FieldsN(...).
@@ -179,8 +178,8 @@ func (c *parser) append(config string) error {
 		case "default":
 			c.config.DefaultEntry = arg
 
-		case "prefix":
-			chainloadsupport = arg
+		case "nerfdefault":
+			c.config.DefaultEntry = arg
 
 		case "include":
 			if err := c.appendFile(arg); curl.IsURLError(err) {
@@ -200,21 +199,21 @@ func (c *parser) append(config string) error {
 			c.config.Entries[c.curEntry].Cmdline = c.globalAppend
 			c.config.Entries[c.curEntry].Name = c.curEntry
 
-		case chainloadsupport + "kernel":
+		case "kernel":
 			k, err := c.getFile(arg)
 			if err != nil {
 				return err
 			}
 			c.config.Entries[c.curEntry].Kernel = k
 
-		case chainloadsupport + "initrd":
+		case "initrd":
 			i, err := c.getFile(arg)
 			if err != nil {
 				return err
 			}
 			c.config.Entries[c.curEntry].Initrd = i
 
-		case chainloadsupport +  "append":
+		case "append":
 			switch c.scope {
 			case scopeGlobal:
 				c.globalAppend = arg

--- a/pkg/boot/syslinux/syslinux.go
+++ b/pkg/boot/syslinux/syslinux.go
@@ -159,6 +159,7 @@ func (c *parser) appendFile(url string) error {
 
 // Append parses `config` and adds the respective configuration to `c`.
 func (c *parser) append(config string) error {
+	chainloadsupport := ""
 	// Here's a shitty parser.
 	for _, line := range strings.Split(config, "\n") {
 		// This is stupid. There should be a FieldsN(...).
@@ -178,6 +179,9 @@ func (c *parser) append(config string) error {
 		case "default":
 			c.config.DefaultEntry = arg
 
+		case "prefix":
+			chainloadsupport = arg
+
 		case "include":
 			if err := c.appendFile(arg); curl.IsURLError(err) {
 				// Means we didn't find the file. Just ignore
@@ -196,21 +200,21 @@ func (c *parser) append(config string) error {
 			c.config.Entries[c.curEntry].Cmdline = c.globalAppend
 			c.config.Entries[c.curEntry].Name = c.curEntry
 
-		case "kernel":
+		case chainloadsupport + "kernel":
 			k, err := c.getFile(arg)
 			if err != nil {
 				return err
 			}
 			c.config.Entries[c.curEntry].Kernel = k
 
-		case "initrd":
+		case chainloadsupport + "initrd":
 			i, err := c.getFile(arg)
 			if err != nil {
 				return err
 			}
 			c.config.Entries[c.curEntry].Initrd = i
 
-		case "append":
+		case chainloadsupport +  "append":
 			switch c.scope {
 			case scopeGlobal:
 				c.globalAppend = arg

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -269,6 +269,49 @@ func TestAppendFile(t *testing.T) {
 			},
 		},
 		{
+			desc:          "valid config with two Entries, and a nerfdefault override",
+			configFileURI: "pxelinux.cfg/default",
+			schemeFunc: func() curl.Schemes {
+				s := make(curl.Schemes)
+				fs := curl.NewMockScheme("tftp")
+				fs.Add("1.2.3.4", "/foobar/pxelinux.0", "")
+				conf := `default foo
+
+				nerfdefault bar
+
+				label foo
+				kernel ./pxefiles/fookernel
+				append earlyprintk=ttyS0 printk=ttyS0
+
+				label bar
+				kernel ./pxefiles/barkernel
+				append console=ttyS0`
+				fs.Add("1.2.3.4", "/foobar/pxelinux.cfg/default", conf)
+				fs.Add("1.2.3.4", "/foobar/pxefiles/fookernel", content1)
+				fs.Add("1.2.3.4", "/foobar/pxefiles/barkernel", content2)
+				s.Register(fs.Scheme, fs)
+				return s
+			},
+			wd: &url.URL{
+				Scheme: "tftp",
+				Host:   "1.2.3.4",
+				Path:   "/foobar",
+			},
+			want: &Config{
+				DefaultEntry: "bar",
+				Entries: map[string]*boot.LinuxImage{
+					"foo": {
+						Kernel:  strings.NewReader(content1),
+						Cmdline: "earlyprintk=ttyS0 printk=ttyS0",
+					},
+					"bar": {
+						Kernel:  strings.NewReader(content2),
+						Cmdline: "console=ttyS0",
+					},
+				},
+			},
+		},
+		{
 			desc:          "valid config with global APPEND directive",
 			configFileURI: "pxelinux.cfg/default",
 			schemeFunc: func() curl.Schemes {


### PR DESCRIPTION
Simple NERF chainloader support (NERFDEFAULT)
  
change the pxeboot.cfg/default configuration:

==== old ====
  DEFAULT foo
  LABEL foo
        KERNEL /bzImage
        INITRD /initrd.cpio.gz
        APPEND root=/dev/ram0 ramdisk=8192 console=ttyS0,115200n8
  LABEL bar
        KERNEL /bar-bzImage
        INITRD /bar-initrd.cpio.gz
        APPEND root=/dev/ram0 ramdisk=8192 console=ttyS0,115200n8

==== new ====
  DEFAULT foo
  NERFDEFAULT bar
  LABEL foo
        KERNEL /bzImage
        INITRD /initrd.cpio.gz
        APPEND root=/dev/ram0 ramdisk=8192 console=ttyS0,115200n8
  LABEL bar
        KERNEL /bar-bzImage
        INITRD /bar-initrd.cpio.gz
        APPEND root=/dev/ram0 ramdisk=8192 console=ttyS0,115200n8

When BIOS is loading, it does not know anything about 'NERFDEFAULT' and will
simply load the foo kernel and initrd. When NERF is loading, it will parse the
same configuration file again and will load the bar-bzImage, and
bar-initrd.cpio.gz.

BIOS is loading: /bzImage, /initrd.cpio.gz
NERF is loading: /bar-bzImage, /bar-initrd.cpio.gz

==== log ====
[netboot] 2020/05/19 18:06:39 Got config file tftp://10.246.84.208/pxelinux.cfg/default:
DEFAULT nerf
NERFDEFAULT linux

LABEL nerf
        KERNEL /nerf-bzImage

LABEL linux
        KERNEL /bzImage
        INITRD /initrd.cpio.gz
        APPEND root=/dev/ram0 ramdisk=8192 ...

LABEL trash
        KERNEL /trash-bzImage

[netboot] 2020/05/19 18:06:39 Got configuration: LinuxImage(
  Name: linux
  Kernel: tftp://10.246.84.208/bzImage
  Initrd: tftp://10.246.84.208/initrd.cpio.gz
  Cmdline: root=/dev/ram0 ramdisk=8192 ...
)
==== log ends here ====

Signed-off-by: Robi Buranyi <rburanyi@google.com>