### PR TITLE
teststate: give human-readable test results

### DIFF
--- a/pkg/vmtest/internal/json2test/testcollector.go
+++ b/pkg/vmtest/internal/json2test/testcollector.go
@@ -10,14 +10,14 @@ import (
 	"sync"
 )
 
-type TestState int
+type TestState string
 
 const (
-	StateSkip TestState = iota
-	StateFail
-	StatePass
-	StatePaused
-	StateRunning
+	StateSkip    TestState = "skip"
+	StateFail    TestState = "fail"
+	StatePass    TestState = "pass"
+	StatePaused  TestState = "paused"
+	StateRunning TestState = "running"
 )
 
 var actionToState = map[Action]TestState{


### PR DESCRIPTION
otherwise, our VM tests print non-sense like this:

    gotest.go:126: Test github.com/u-root/u-root/pkg/menu.TestChoose/hit_3 left in state 3:

after this commit, it'll be:

    gotest.go:126: Test github.com/u-root/u-root/pkg/menu.TestChoose/hit_3 left in state paused:

As seen in #1684.

Signed-off-by: Chris Koch <chrisko@google.com>