### PR TITLE
cmos: add non-constrained docs file

### DIFF
--- a/pkg/cmos/cmos.go
+++ b/pkg/cmos/cmos.go
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// Package cmos lets you read and write to cmos registers while doing basic checks on valid register selections.
+// +build amd64 386
+
 package cmos
 
 import (

--- a/pkg/cmos/docs.go
+++ b/pkg/cmos/docs.go
@@ -1,0 +1,7 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package cmos lets you read and write to cmos registers while doing basic
+// checks on valid register selections.
+package cmos


### PR DESCRIPTION
cmds/core/io/cmos.go is only built into the io package if it's amd64 or
386. In the Go build system, that means pkg/cmos is never even compiled.

However, in blaze/bazel, all dependencies are always built, used or not,
since it doesn't know any better. That means pkg/cmos has to be
buildable on other architectures than amd64 or 386.

If you just add the build tags "+build amd64 386", pkg/cmos won't be
compilable by blaze/bazel because it's empty.

Hence, we need a neutral file in there that always builds.