### PR TITLE
pkg/mount: system-independent FindFileSystem test

### DIFF
--- a/pkg/mount/fs_linux.go
+++ b/pkg/mount/fs_linux.go
@@ -14,18 +14,22 @@ import (
 //
 // It rereads /proc/filesystems each time as the supported file systems can change
 // as modules are added and removed.
-func FindFileSystem(fs string) error {
+func FindFileSystem(fstype string) error {
 	b, err := ioutil.ReadFile("/proc/filesystems")
 	if err != nil {
 		return err
 	}
-	for _, l := range strings.Split(string(b), "\n") {
+	return internalFindFileSystem(string(b), fstype)
+}
+
+func internalFindFileSystem(content string, fstype string) error {
+	for _, l := range strings.Split(content, "\n") {
 		f := strings.Fields(l)
-		if (len(f) > 1 && f[0] == "nodev" && f[1] == fs) || (len(f) > 0 && f[0] != "nodev" && f[0] == fs) {
+		if (len(f) > 1 && f[0] == "nodev" && f[1] == fstype) || (len(f) > 0 && f[0] != "nodev" && f[0] == fstype) {
 			return nil
 		}
 	}
-	return fmt.Errorf("%s not found", fs)
+	return fmt.Errorf("file system type %q not found", fstype)
 }
 
 // GetBlockFilesystems returns the supported file systems for block devices.

--- a/pkg/mount/fs_linux_test.go
+++ b/pkg/mount/fs_linux_test.go
@@ -32,15 +32,26 @@ func TestEmptyFileSystems(t *testing.T) {
 }
 
 func TestFindFileSystem(t *testing.T) {
+	procfilesystems := `nodev   sysfs
+nodev   rootfs
+nodev   ramfs
+        vfat
+        btrfs
+        ext3
+        ext2
+        ext4
+`
+
 	for _, tt := range []struct {
 		name string
 		err  string
 	}{
 		{"rootfs", "<nil>"},
-		{"bogusfs", "bogusfs not found"},
+		{"ext3", "<nil>"},
+		{"bogusfs", "file system type \"bogusfs\" not found"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := FindFileSystem(tt.name)
+			err := internalFindFileSystem(procfilesystems, tt.name)
 			// There has to be a better way to do this.
 			if fmt.Sprintf("%v", err) != tt.err {
 				t.Errorf("%s: got %v, want %v", tt.name, err, tt.err)


### PR DESCRIPTION
circleci has cut pack /proc/filesystems output, and the test is failing
at HEAD right now.

Signed-off-by: Chris Koch <chrisko@google.com>