### PR TITLE
boot: cancelable kernel loads

### DIFF
--- a/cmds/boot/boot/boot.go
+++ b/cmds/boot/boot/boot.go
@@ -29,6 +29,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"log"
 	"strings"
@@ -92,5 +93,5 @@ func main() {
 	menuEntries = append(menuEntries, menu.StartShell{})
 
 	// Boot does not return.
-	bootcmd.ShowMenuAndBoot(menuEntries, mps, *noLoad, *noExec)
+	bootcmd.ShowMenuAndBoot(context.Background(), menuEntries, mps, *noLoad, *noExec)
 }

--- a/cmds/boot/boot/boot.go
+++ b/cmds/boot/boot/boot.go
@@ -31,8 +31,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"log"
 	"strings"
+	"time"
 
 	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/boot/bootcmd"
@@ -47,6 +49,8 @@ var (
 	verbose = flag.Bool("v", false, "Print debug messages")
 	noLoad  = flag.Bool("no-load", false, "print chosen boot configuration, but do not load + exec it")
 	noExec  = flag.Bool("no-exec", false, "load boot configuration, but do not exec it")
+
+	testEntry = flag.Bool("timed-test-entry", false, "add a timed test entry to the menu")
 
 	removeCmdlineItem = flag.String("remove", "console", "comma separated list of kernel params value to remove from parsed kernel configuration (default to console)")
 	reuseCmdlineItem  = flag.String("reuse", "console", "comma separated list of kernel params value to reuse from current kernel (default to console)")
@@ -91,6 +95,13 @@ func main() {
 	menuEntries := menu.OSImages(*verbose, images...)
 	menuEntries = append(menuEntries, menu.Reboot{})
 	menuEntries = append(menuEntries, menu.StartShell{})
+	if *testEntry {
+		menuEntries = append(menuEntries, menu.TimedTestEntry{
+			LoadDur: 10 * time.Second,
+			LoadErr: fmt.Errorf("finished loading"),
+			ExecErr: fmt.Errorf("exec should not be called"),
+		})
+	}
 
 	// Boot does not return.
 	bootcmd.ShowMenuAndBoot(context.Background(), menuEntries, mps, *noLoad, *noExec)

--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -123,5 +123,5 @@ func main() {
 	menuEntries = append(menuEntries, menu.StartShell{})
 
 	// Boot does not return.
-	bootcmd.ShowMenuAndBoot(menuEntries, nil, *noLoad, *noExec)
+	bootcmd.ShowMenuAndBoot(context.Background(), menuEntries, nil, *noLoad, *noExec)
 }

--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -19,6 +19,7 @@
 package main
 
 import (
+	"context"
 	"io"
 	"log"
 	"os"
@@ -91,7 +92,7 @@ func main() {
 		}
 		defer mbkernel.Close()
 		var image boot.OSImage
-		if err := multiboot.Probe(mbkernel); err == nil {
+		if err := multiboot.Probe(context.Background(), mbkernel); err == nil {
 			image = &boot.MultibootImage{
 				Modules: multiboot.LazyOpenModules(opts.modules),
 				Kernel:  mbkernel,
@@ -108,7 +109,7 @@ func main() {
 				Cmdline: newCmdline,
 			}
 		}
-		if err := image.Load(opts.debug); err != nil {
+		if err := image.Load(context.Background(), opts.debug); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/cmds/exp/esxiboot/esxiboot.go
+++ b/cmds/exp/esxiboot/esxiboot.go
@@ -30,6 +30,7 @@
 package main
 
 import (
+	"context"
 	"log"
 	"os"
 	"strings"
@@ -67,7 +68,7 @@ func main() {
 			if len(*appendCmdline) > 0 {
 				img.Cmdline = img.Cmdline + " " + strings.Join(*appendCmdline, " ")
 			}
-			if err := img.Load(false); err != nil {
+			if err := img.Load(context.Background(), false); err != nil {
 				log.Printf("Failed to load ESXi image (%v) into memory: %v", img, err)
 			} else {
 				log.Printf("Loaded image: %v", img)
@@ -99,7 +100,7 @@ func main() {
 		if len(*appendCmdline) > 0 {
 			img.Cmdline = img.Cmdline + " " + strings.Join(*appendCmdline, " ")
 		}
-		if err := img.Load(false); err != nil {
+		if err := img.Load(context.Background(), false); err != nil {
 			log.Fatalf("Failed to load ESXi image (%v) into memory: %v", img, err)
 		}
 		log.Printf("Loaded image: %v", img)

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -7,6 +7,7 @@
 package boot
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/u-root/u-root/pkg/boot/kexec"
@@ -25,7 +26,7 @@ type OSImage interface {
 	//
 	// After Load is called, call boot.Execute() to stop Linux and boot the
 	// loaded OSImage.
-	Load(verbose bool) error
+	Load(ctx context.Context, verbose bool) error
 }
 
 // Execute executes a previously loaded OSImage.

--- a/pkg/boot/bootcmd/bootcmd.go
+++ b/pkg/boot/bootcmd/bootcmd.go
@@ -7,6 +7,7 @@
 package bootcmd
 
 import (
+	"context"
 	"log"
 	"os"
 
@@ -20,7 +21,7 @@ import (
 // mps are mounts to unmount before kexecing. noLoad prints the list of entries
 // and exits. If noLoad is false, a boot menu is shown to the user. The
 // user-chosen boot entry will be kexec'd unless noExec is true.
-func ShowMenuAndBoot(entries []menu.Entry, mps []*mount.MountPoint, noLoad, noExec bool) {
+func ShowMenuAndBoot(ctx context.Context, entries []menu.Entry, mps []*mount.MountPoint, noLoad, noExec bool) {
 	if noLoad {
 		log.Print("Not loading menu or kernel. Options:")
 		for i, entry := range entries {
@@ -30,7 +31,7 @@ func ShowMenuAndBoot(entries []menu.Entry, mps []*mount.MountPoint, noLoad, noEx
 		os.Exit(0)
 	}
 
-	loadedEntry := menu.ShowMenuAndLoad(os.Stdin, entries...)
+	loadedEntry := menu.ShowMenuAndLoad(ctx, os.Stdin, entries...)
 
 	// Clean up.
 	for _, mp := range mps {

--- a/pkg/boot/jsonboot/bootconfig.go
+++ b/pkg/boot/jsonboot/bootconfig.go
@@ -5,6 +5,7 @@
 package jsonboot
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -180,7 +181,7 @@ func (bc *BootConfig) Boot() error {
 		defer mbkernel.Close()
 
 		// check multiboot header
-		if err := multiboot.Probe(mbkernel); err != nil {
+		if err := multiboot.Probe(context.Background(), mbkernel); err != nil {
 			log.Printf("Error parsing multiboot header: %v", err)
 			return err
 		}
@@ -189,7 +190,7 @@ func (bc *BootConfig) Boot() error {
 			return err
 		}
 		defer modules.Close()
-		if err := multiboot.Load(true, mbkernel, bc.MultibootArgs, modules, nil); err != nil {
+		if err := multiboot.Load(context.Background(), true, mbkernel, bc.MultibootArgs, modules, nil); err != nil {
 			return fmt.Errorf("kexec.Load() error: %v", err)
 		}
 	}

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -229,6 +229,17 @@ func (oia OSImageAction) Load(ctx context.Context) error {
 	if err := oia.OSImage.Load(ctx, oia.Verbose); err != nil {
 		return fmt.Errorf("could not load image %s: %v", oia.OSImage, err)
 	}
+
+	// Non-blockingly check whether context was canceled in the meantime.
+	//
+	// Even if loading succeeded, it means user requested cancelation and
+	// we will go back to the menu.
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+
+	default:
+	}
 	return nil
 }
 

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -255,3 +255,36 @@ func (Reboot) Exec() error {
 
 // IsDefault indicates that this should not be run as a default action.
 func (Reboot) IsDefault() bool { return false }
+
+// TimedTestEntry is an entry that returns a specific error after a specific duration of Loading.
+type TimedTestEntry struct {
+	LoadDur time.Duration
+	LoadErr error
+	ExecErr error
+}
+
+// Label is the label to show the user.
+func (tte TimedTestEntry) Label() string {
+	return fmt.Sprintf("Timed Test Entry (%s)", tte.LoadDur)
+}
+
+// Load times out after LoadDur or when ctx exits.
+func (tte TimedTestEntry) Load(ctx context.Context) error {
+	select {
+	case <-time.After(tte.LoadDur):
+		return tte.LoadErr
+
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Exec returns ExecErr.
+func (tte TimedTestEntry) Exec() error {
+	return tte.ExecErr
+}
+
+// IsDefault returns false.
+func (tte TimedTestEntry) IsDefault() bool {
+	return false
+}

--- a/pkg/boot/menu/menu_test.go
+++ b/pkg/boot/menu/menu_test.go
@@ -5,6 +5,7 @@
 package menu
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -40,7 +41,7 @@ func (d *testEntry) String() string {
 	return d.Label()
 }
 
-func (d *testEntry) Load() error {
+func (d *testEntry) Load(context.Context) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.loadCalled = true
@@ -238,7 +239,7 @@ func TestShowMenuAndLoad(t *testing.T) {
 
 			entry := make(chan Entry)
 			go func() {
-				entry <- ShowMenuAndLoad(pty.Slave, entries...)
+				entry <- ShowMenuAndLoad(context.Background(), pty.Slave, entries...)
 			}()
 
 			// Well this sucks.

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -5,6 +5,7 @@
 package boot
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -35,8 +36,8 @@ func (mi *MultibootImage) Label() string {
 }
 
 // Load implements OSImage.Load.
-func (mi *MultibootImage) Load(verbose bool) error {
-	return multiboot.Load(verbose, mi.Kernel, mi.Cmdline, mi.Modules, mi.IBFT)
+func (mi *MultibootImage) Load(ctx context.Context, verbose bool) error {
+	return multiboot.Load(ctx, verbose, mi.Kernel, mi.Cmdline, mi.Modules, mi.IBFT)
 }
 
 // String implements fmt.Stringer.

--- a/pkg/boot/multiboot/header.go
+++ b/pkg/boot/multiboot/header.go
@@ -6,6 +6,7 @@ package multiboot
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -69,7 +70,7 @@ type header struct {
 }
 
 type imageType interface {
-	addInfo(m *multiboot) (uintptr, error)
+	addInfo(ctx context.Context, m *multiboot) (uintptr, error)
 	name() string
 	bootMagic() uintptr
 }

--- a/pkg/boot/multiboot/reader.go
+++ b/pkg/boot/multiboot/reader.go
@@ -7,10 +7,11 @@ package multiboot
 import (
 	"bytes"
 	"compress/gzip"
+	"context"
 	"io"
 	"io/ioutil"
 
-	"github.com/u-root/u-root/pkg/uio"
+	"github.com/u-root/u-root/pkg/curl"
 )
 
 func readGzip(r io.Reader) ([]byte, error) {
@@ -24,8 +25,8 @@ func readGzip(r io.Reader) ([]byte, error) {
 
 // TODO: could be tryCompressionFilters, grub support gz,xz and lzop
 // TODO: do we want to keep the filter inside multiboot? This could be the responsibility of the caller...
-func tryGzipFilter(r io.ReaderAt) io.ReaderAt {
-	b, err := readGzip(uio.Reader(r))
+func tryGzipFilter(ctx context.Context, r io.ReaderAt) io.ReaderAt {
+	b, err := readGzip(curl.Reader(ctx, r))
 	if err == nil {
 		return bytes.NewReader(b)
 	}

--- a/pkg/securelaunch/launcher/launcher.go
+++ b/pkg/securelaunch/launcher/launcher.go
@@ -6,6 +6,7 @@
 package launcher
 
 import (
+	"context"
 	"fmt"
 	"log"
 
@@ -88,7 +89,7 @@ func (l *Launcher) Boot() error {
 		Initrd:  uio.NewLazyFile(i),
 		Cmdline: cmdline,
 	}
-	err := image.Load(false)
+	err := image.Load(context.Background(), false)
 	if err != nil {
 		log.Printf("kexec -l failed. err: %v", err)
 		return err


### PR DESCRIPTION
This implements Option 1 from #1672.

Despite me liking that option less when I wrote #1672, I had started working on version 2 as well, and it involved basically a second copy of every structure we have in pkg/boot and weird translations between them.

Putting this out as an RFC.