### PR TITLE
pxeboot gets a terminal boot menu

### DIFF
--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -112,11 +112,15 @@ func main() {
 
 	images, err := NetbootImages(ifName)
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("Netboot failed: %v", err)
 	}
 
 	if *noLoad {
-		log.Printf("Got configuration: %s", images[0])
+		if len(images) > 0 {
+			log.Printf("Got configuration: %s", images[0])
+		} else {
+			log.Fatalf("Nothing bootable found.")
+		}
 		return
 	}
 	menuEntries := menu.OSImages(*dryRun, images...)

--- a/integration/generic-tests/pxeboot_test.go
+++ b/integration/generic-tests/pxeboot_test.go
@@ -61,7 +61,7 @@ func TestPxeboot4(t *testing.T) {
 			),
 		},
 		TestCmds: []string{
-			"pxeboot --dry-run --no-load -v",
+			"pxeboot --dry-run -v",
 			// Sleep so serial console output gets flushed. The expect library is racy.
 			"sleep 5",
 			"shutdown -h",
@@ -84,5 +84,16 @@ func TestPxeboot4(t *testing.T) {
 	}
 	if err := dhcpClient.Expect("Boot URI: tftp://192.168.0.1/pxelinux.0"); err != nil {
 		t.Errorf("%s Boot: %v", testutil.NowLog(), err)
+	}
+
+	// Boot menu should show the label from the pxelinux file.
+	if err := dhcpClient.Expect("01. some-random-kernel"); err != nil {
+		t.Errorf("%s Boot Menu: %v", testutil.NowLog(), err)
+	}
+	if err := dhcpClient.Expect("Attempting to boot"); err != nil {
+		t.Errorf("%s Boot Menu: %v", testutil.NowLog(), err)
+	}
+	if err := dhcpClient.Expect("Kernel: tftp://192.168.0.1/kernel"); err != nil {
+		t.Errorf("%s parsed kernel: %v", testutil.NowLog(), err)
 	}
 }

--- a/integration/generic-tests/testdata/pxe/pxelinux.cfg/default
+++ b/integration/generic-tests/testdata/pxe/pxelinux.cfg/default
@@ -1,4 +1,2 @@
-DEFAULT normal
-
-LABEL normal
-LINUX kernel
+LABEL some-random-kernel
+kernel kernel

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -164,6 +164,18 @@ func ShowMenuAndBoot(input *os.File, entries ...Entry) {
 	}
 }
 
+// OSImages returns menu entries for the given OSImages.
+func OSImages(dryRun bool, imgs ...boot.OSImage) []Entry {
+	var menu []Entry
+	for _, img := range imgs {
+		menu = append(menu, &OSImageAction{
+			OSImage: img,
+			DryRun:  dryRun,
+		})
+	}
+	return menu
+}
+
 // OSImageAction is a menu.Entry that boots an OSImage.
 type OSImageAction struct {
 	boot.OSImage

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -152,7 +152,7 @@ func ShowMenuAndBoot(input *os.File, entries ...Entry) {
 		// Only perform actions that are default actions. I.e. don't
 		// drop to shell.
 		if e.IsDefault() {
-			fmt.Printf("Attempting to boot %s.\n\n", e.Label())
+			fmt.Printf("Attempting to boot %s.\n\n", e)
 			if err := e.Do(); err == errStopTestOnly {
 				return
 			} else if err != nil {

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -47,9 +47,7 @@ func Choose(input *os.File, entries ...Entry) Entry {
 	for i, e := range entries {
 		fmt.Printf("%02d. %s\n\n", i+1, e.Label())
 	}
-	// For some reason this has to be a non-empty empty line, so that the
-	// terminal prompt doesn't override it. Or something.
-	fmt.Println(" ")
+	fmt.Println("\r")
 
 	oldState, err := terminal.MakeRaw(int(input.Fd()))
 	if err != nil {
@@ -78,7 +76,7 @@ func Choose(input *os.File, entries ...Entry) Entry {
 			choice, err := term.ReadLine()
 			if err != nil {
 				if err != io.EOF {
-					fmt.Printf("BUG: Please report: Terminal read error: %v. ", err)
+					fmt.Printf("BUG: Please report: Terminal read error: %v.\r\n", err)
 				}
 				boot <- nil
 				return
@@ -91,11 +89,11 @@ func Choose(input *os.File, entries ...Entry) Entry {
 			}
 			num, err := strconv.Atoi(choice)
 			if err != nil {
-				fmt.Printf("%s is not a valid entry number: %v. ", choice, err)
+				fmt.Printf("%s is not a valid entry number: %v.\r\n", choice, err)
 				continue
 			}
 			if num-1 < 0 || num > len(entries) {
-				fmt.Printf("%s is not a valid entry number. ", choice)
+				fmt.Printf("%s is not a valid entry number.\r\n", choice)
 				continue
 			}
 			boot <- entries[num-1]
@@ -106,7 +104,7 @@ func Choose(input *os.File, entries ...Entry) Entry {
 	select {
 	case entry := <-boot:
 		if entry != nil {
-			fmt.Printf("Chosen option %s.\n\n", entry.Label())
+			fmt.Printf("Chosen option %s.\r\n\r\n", entry.Label())
 		}
 		return entry
 

--- a/pkg/boot/netboot/netboot.go
+++ b/pkg/boot/netboot/netboot.go
@@ -15,7 +15,6 @@ package netboot
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/url"
 	"path"
@@ -28,18 +27,18 @@ import (
 	"github.com/u-root/u-root/pkg/ulog"
 )
 
-// BootImage figures out the image to boot from the given DHCP lease.
+// BootImages figure out a ranked order of images to boot from the given DHCP lease.
 //
 // Tries, in order:
 //
 // - to detect an iPXE script beginning with #!ipxe,
 //
-// - to detect a pxelinux.0, in which case we will ignore the pxelinux and try
-//   to parse pxelinux.cfg/<files>.
+// - to detect a pxelinux.0, in which case we will ignore the pxelinux.0 and
+//   try to parse pxelinux.cfg/<files>.
 //
 // TODO: detect straight up multiboot and bzImage Linux kernel files rather
 // than just configuration scripts.
-func BootImage(ctx context.Context, l ulog.Logger, s curl.Schemes, lease dhclient.Lease) (*boot.LinuxImage, error) {
+func BootImages(ctx context.Context, l ulog.Logger, s curl.Schemes, lease dhclient.Lease) ([]boot.OSImage, error) {
 	uri, err := lease.Boot()
 	if err != nil {
 		return nil, err
@@ -52,19 +51,23 @@ func BootImage(ctx context.Context, l ulog.Logger, s curl.Schemes, lease dhclien
 	if p4, ok := lease.(*dhclient.Packet4); ok {
 		ip = p4.Lease().IP
 	}
-	return getBootImage(ctx, l, s, uri, lease.Link().Attrs().HardwareAddr, ip)
+	return getBootImages(ctx, l, s, uri, lease.Link().Attrs().HardwareAddr, ip), nil
 }
 
-// getBootImage attempts to parse the file at uri as an ipxe config and returns
+// getBootImages attempts to parse the file at uri as an ipxe config and returns
 // the ipxe boot image. Otherwise falls back to pxe and uses the uri directory,
 // ip, and mac address to search for pxe configs.
-func getBootImage(ctx context.Context, l ulog.Logger, schemes curl.Schemes, uri *url.URL, mac net.HardwareAddr, ip net.IP) (*boot.LinuxImage, error) {
+func getBootImages(ctx context.Context, l ulog.Logger, schemes curl.Schemes, uri *url.URL, mac net.HardwareAddr, ip net.IP) []boot.OSImage {
+	var images []boot.OSImage
+
 	// Attempt to read the given boot path as an ipxe config file.
 	ipc, err := ipxe.ParseConfig(ctx, l, uri, schemes)
-	if err == nil {
-		return ipc, nil
+	if err != nil {
+		l.Printf("Parsing boot files as iPXE failed, trying other formats...: %v", err)
 	}
-	l.Printf("Falling back to pxe boot: %v", err)
+	if ipc != nil {
+		images = append(images, ipc)
+	}
 
 	// Fallback to pxe boot.
 	wd := &url.URL{
@@ -72,14 +75,9 @@ func getBootImage(ctx context.Context, l ulog.Logger, schemes curl.Schemes, uri 
 		Host:   uri.Host,
 		Path:   path.Dir(uri.Path),
 	}
-	pc, err := pxe.ParseConfig(ctx, wd, mac, ip, schemes)
+	pxeImages, err := pxe.ParseConfig(ctx, wd, mac, ip, schemes)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse pxelinux config: %v", err)
+		l.Printf("Failed to try parsing pxelinux config: %v", err)
 	}
-
-	label, ok := pc.Entries[pc.DefaultEntry]
-	if !ok {
-		return nil, fmt.Errorf("Could not find %q from entries %v", pc.DefaultEntry, pc.Entries)
-	}
-	return label, nil
+	return append(images, pxeImages...)
 }

--- a/pkg/boot/netboot/pxe/pxe.go
+++ b/pkg/boot/netboot/pxe/pxe.go
@@ -16,21 +16,22 @@ import (
 	"path"
 	"strings"
 
+	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/boot/syslinux"
 	"github.com/u-root/u-root/pkg/curl"
 )
 
 // ParseConfig probes for config files based on the Mac and IP given
 // and uses s to fetch files.
-func ParseConfig(ctx context.Context, workingDir *url.URL, mac net.HardwareAddr, ip net.IP, s curl.Schemes) (*syslinux.Config, error) {
+func ParseConfig(ctx context.Context, workingDir *url.URL, mac net.HardwareAddr, ip net.IP, s curl.Schemes) ([]boot.OSImage, error) {
 	for _, relname := range probeFiles(mac, ip) {
-		c, err := syslinux.ParseConfigFile(ctx, s, path.Join("pxelinux.cfg", relname), workingDir)
+		imgs, err := syslinux.ParseConfigFile(ctx, s, path.Join("pxelinux.cfg", relname), workingDir)
 		if curl.IsURLError(err) {
 			// We didn't find the file.
 			// TODO(hugelgupf): log this.
 			continue
 		}
-		return c, err
+		return imgs, err
 	}
 	return nil, fmt.Errorf("no valid pxelinux config found")
 }


### PR DESCRIPTION
from:

```go
type Config struct {
	// Entries is a map of label name -> label configuration.	
	Entries map[string]*boot.LinuxImage	


	// DefaultEntry is the default label key to use.
	//			
	// If DefaultEntry is non-empty, the label is guaranteed to exist in
	// `Entries`.
	DefaultEntry string
}

func ParseConfigFile(ctx context.Context, s curl.Schemes, url string, wd *url.URL) (*Config, error)
```

to:

```go
func ParseConfigFile(ctx context.Context, s curl.Schemes, url string, wd *url.URL)
    ([]boot.OSImage, error)
```


- pxeboot now displays a menu with that ordered list, and if no option is chosen within 10 seconds, tries to boot them in the order that they're in the menu