### PR TITLE
syslinux: multiboot support, support 'menu default' and 'menu label' directives

### DIFF
--- a/pkg/boot/netboot/pxe/pxe.go
+++ b/pkg/boot/netboot/pxe/pxe.go
@@ -25,6 +25,11 @@ import (
 // and uses s to fetch files.
 func ParseConfig(ctx context.Context, workingDir *url.URL, mac net.HardwareAddr, ip net.IP, s curl.Schemes) ([]boot.OSImage, error) {
 	for _, relname := range probeFiles(mac, ip) {
+		// "When booting, the initial working directory for PXELINUX
+		// will be the parent directory of pxelinux.0 unless overridden
+		// with DHCP option 210."
+		//
+		// https://wiki.syslinux.org/wiki/index.php?title=Config#Working_directory
 		imgs, err := syslinux.ParseConfigFile(ctx, s, path.Join("pxelinux.cfg", relname), workingDir)
 		if curl.IsURLError(err) {
 			// We didn't find the file.

--- a/pkg/boot/syslinux/syslinux.go
+++ b/pkg/boot/syslinux/syslinux.go
@@ -113,7 +113,7 @@ func ParseConfigFile(ctx context.Context, s curl.Schemes, url string, wd *url.UR
 
 	var images []boot.OSImage
 	for _, label := range p.labelOrder {
-		if img, ok := p.linuxEntries[label]; ok {
+		if img, ok := p.linuxEntries[label]; ok && img.Kernel != nil {
 			images = append(images, img)
 		}
 	}

--- a/pkg/boot/syslinux/syslinux.go
+++ b/pkg/boot/syslinux/syslinux.go
@@ -368,7 +368,7 @@ func (c *parser) append(ctx context.Context, config string) error {
 							return err
 						}
 						e.Kernel = k
-						if len(kernel) > 0 {
+						if len(kernel) > 1 {
 							e.Cmdline = strings.Join(kernel[1:], " ")
 						}
 						modules = modules[1:]
@@ -384,7 +384,7 @@ func (c *parser) append(ctx context.Context, config string) error {
 							return err
 						}
 						e.Modules = append(e.Modules, multiboot.Module{
-							CmdLine: strings.Join(m, " "),
+							CmdLine: strings.TrimSpace(cmdline),
 							Name:    name,
 							Module:  file,
 						})

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -198,13 +198,14 @@ func TestParseGeneral(t *testing.T) {
 				"/foobar/pxelinux.cfg/default": `
 					default foo
 
+					label bar
+					menu label Bla Bla Bla
+					kernel ./pxefiles/kernel2
+					append console=ttyS0
+
 					label foo
 					kernel ./pxefiles/kernel1
-					append earlyprintk=ttyS0 printk=ttyS0
-
-					label bar
-					kernel ./pxefiles/kernel2
-					append console=ttyS0`,
+					append earlyprintk=ttyS0 printk=ttyS0`,
 			},
 			want: []boot.OSImage{
 				&boot.LinuxImage{
@@ -213,7 +214,34 @@ func TestParseGeneral(t *testing.T) {
 					Cmdline: "earlyprintk=ttyS0 printk=ttyS0",
 				},
 				&boot.LinuxImage{
-					Name:    "bar",
+					Name:    "Bla Bla Bla",
+					Kernel:  strings.NewReader(kernel2),
+					Cmdline: "console=ttyS0",
+				},
+			},
+		},
+		{
+			desc: "menu default, linux directives",
+			configFiles: map[string]string{
+				"/foobar/pxelinux.cfg/default": `
+					label bar
+					menu label Bla Bla Bla
+					kernel ./pxefiles/kernel2
+					append console=ttyS0
+
+					label foo
+					menu default
+					linux ./pxefiles/kernel1
+					append earlyprintk=ttyS0 printk=ttyS0`,
+			},
+			want: []boot.OSImage{
+				&boot.LinuxImage{
+					Name:    "foo",
+					Kernel:  strings.NewReader(kernel1),
+					Cmdline: "earlyprintk=ttyS0 printk=ttyS0",
+				},
+				&boot.LinuxImage{
+					Name:    "Bla Bla Bla",
 					Kernel:  strings.NewReader(kernel2),
 					Cmdline: "console=ttyS0",
 				},
@@ -363,8 +391,13 @@ func TestParseGeneral(t *testing.T) {
 				&boot.LinuxImage{
 					Name:   "stringer",
 					Kernel: strings.NewReader(kernel2),
-					// See TODO in pxe.go initrd handling.
-					Initrd:  strings.NewReader(initrd2),
+					Initrd: strings.NewReader(initrd2),
+
+					// TODO: See syslinux initrd handling. This SHOULD be
+					//
+					// initrd=./pxefiles/global_initrd initrd=./pxefiles/initrd2
+					//
+					// https://wiki.syslinux.org/wiki/index.php?title=Directives/append
 					Cmdline: "initrd=./pxefiles/global_initrd",
 				},
 			},

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -527,6 +527,10 @@ func TestParseGeneral(t *testing.T) {
 					kernel mboot.c32
 					append xen.gz console=none --- ./pxefiles/kernel1 foobar hahaha --- ./pxefiles/initrd1
 
+					label mbootnomodules
+					kernel mboot.c32
+					append xen.gz
+
 					label foo
 					linux mboot.c32
 					append earlyprintk=ttyS0 printk=ttyS0`,
@@ -553,6 +557,10 @@ func TestParseGeneral(t *testing.T) {
 							CmdLine: "./pxefiles/initrd1",
 						},
 					},
+				},
+				&boot.MultibootImage{
+					Name:   "mbootnomodules",
+					Kernel: strings.NewReader(xengz),
 				},
 			},
 		},

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -115,6 +115,16 @@ func TestParseGeneral(t *testing.T) {
 			},
 		},
 		{
+			desc: "empty label",
+			configFiles: map[string]string{
+				"/foobar/pxelinux.cfg/default": `
+					default foo
+					label foo`,
+			},
+			want: nil,
+		},
+
+		{
 			desc: "all files exist, simple config with directive initrd",
 			configFiles: map[string]string{
 				"/foobar/pxelinux.cfg/default": `


### PR DESCRIPTION
- multiboot is required for qubes
- 'menu default' and 'menu label' are used by debian installers and fedora installers
- debian installer also uses absolute paths, relative to the disk partition of course