### PR TITLE
Use new tss package for securelaunch

### DIFF
--- a/pkg/boot/stboot/bootball.go
+++ b/pkg/boot/stboot/bootball.go
@@ -121,7 +121,7 @@ func (ball *BootBall) init() error {
 		return fmt.Errorf("BootBall: getting signatures: %v", err)
 	}
 
-	var x int = 0
+	var x int
 	for _, sigPool := range ball.signatures {
 		if x == 0 {
 			x = len(sigPool)

--- a/pkg/complete/prefix.go
+++ b/pkg/complete/prefix.go
@@ -12,7 +12,7 @@ func Prefix(s []string) string {
 	if len(s) == 0 {
 		return ""
 	}
-	var a string = s[0]
+	var a = s[0]
 	for _, h := range s {
 		if len(h) < len(a) {
 			a = h

--- a/pkg/securelaunch/launcher/launcher.go
+++ b/pkg/securelaunch/launcher/launcher.go
@@ -7,7 +7,6 @@ package launcher
 
 import (
 	"fmt"
-	"io"
 	"log"
 
 	"github.com/u-root/u-root/pkg/boot"
@@ -26,17 +25,17 @@ type Launcher struct {
 
 // MeasureKernel calls file collector in measurement pkg that
 // hashes kernel, initrd files and even store these hashes in tpm pcrs.
-func (l *Launcher) MeasureKernel(tpmDev io.ReadWriteCloser) error {
+func (l *Launcher) MeasureKernel() error {
 
 	kernel := l.Params["kernel"]
 	initrd := l.Params["initrd"]
 
-	if e := measurement.HashFile(tpmDev, kernel); e != nil {
+	if e := measurement.HashFile(kernel); e != nil {
 		log.Printf("ERR: measure kernel input=%s, err=%v", kernel, e)
 		return e
 	}
 
-	if e := measurement.HashFile(tpmDev, initrd); e != nil {
+	if e := measurement.HashFile(initrd); e != nil {
 		log.Printf("ERR: measure initrd input=%s, err=%v", initrd, e)
 		return e
 	}
@@ -57,7 +56,7 @@ func (l *Launcher) MeasureKernel(tpmDev io.ReadWriteCloser) error {
  * - if mount fails
  * - if kexec fails
  */
-func (l *Launcher) Boot(tpmDev io.ReadWriteCloser) error {
+func (l *Launcher) Boot() error {
 
 	if l.Type != "kexec" {
 		log.Printf("launcher: Unsupported launcher type. Exiting.")

--- a/pkg/securelaunch/measurement/collectors.go
+++ b/pkg/securelaunch/measurement/collectors.go
@@ -8,7 +8,6 @@ package measurement
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 )
 
 /*
@@ -16,7 +15,7 @@ import (
  * will be stored.
  */
 const (
-	pcr = int(22)
+	pcr = uint32(22)
 )
 
 /*
@@ -25,7 +24,7 @@ const (
  * owned by the tpm device.
  */
 type Collector interface {
-	Collect(tpmHandle io.ReadWriteCloser) error
+	Collect() error
 }
 
 var supportedCollectors = map[string]func([]byte) (Collector, error){

--- a/pkg/securelaunch/measurement/cpuid.go
+++ b/pkg/securelaunch/measurement/cpuid.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"strings"
 
@@ -109,10 +108,10 @@ func getCPUIDInfo() []byte {
 /*
  * measureCPUIDFile stores the CPUIDInfo obtained from cpuid package
  * into the tpm device */
-func measureCPUIDFile(tpmHandle io.ReadWriteCloser) ([]byte, error) {
+func measureCPUIDFile() ([]byte, error) {
 	d := getCPUIDInfo() // return strings builder
 	eventDesc := "CPUID Collector: Measured CPUID Info"
-	if e := tpm.ExtendPCRDebug(tpmHandle, pcr, bytes.NewReader(d), eventDesc); e != nil {
+	if e := tpm.ExtendPCRDebug(pcr, bytes.NewReader(d), eventDesc); e != nil {
 		return nil, e
 	}
 
@@ -125,9 +124,9 @@ func measureCPUIDFile(tpmHandle io.ReadWriteCloser) ([]byte, error) {
  * 2. stores hash of the result in the tpm device.
  * 3. also keeps a copy of the result on disk at location provided in policy file.
  */
-func (s *CPUIDCollector) Collect(tpmHandle io.ReadWriteCloser) error {
+func (s *CPUIDCollector) Collect() error {
 
-	d, err := measureCPUIDFile(tpmHandle)
+	d, err := measureCPUIDFile()
 	if err != nil {
 		log.Printf("CPUID Collector: err = %v", err)
 		return err

--- a/pkg/securelaunch/measurement/dmi.go
+++ b/pkg/securelaunch/measurement/dmi.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"strings"
 
@@ -109,9 +108,9 @@ func parseTypeFilter(typeStrings []string) (map[smbios.TableType]bool, error) {
  * Collect satisfies collector interface. It calls
  * 1. smbios package to get all smbios data,
  * 2. then, filters smbios data based on type provided in policy file, and
- * 3. the filtered data is then measured into the tpmHandle (tpm device).
+ * 3. the filtered data is then measured into the tpm device.
  */
-func (s *DmiCollector) Collect(tpmHandle io.ReadWriteCloser) error {
+func (s *DmiCollector) Collect() error {
 	slaunch.Debug("DMI Collector: Entering ")
 	if s.Type != "dmi" {
 		return errors.New("invalid type passed to a DmiCollector method")
@@ -153,7 +152,7 @@ func (s *DmiCollector) Collect(tpmHandle io.ReadWriteCloser) error {
 		slaunch.Debug(pt.String())
 		b := []byte(pt.String())
 		eventDesc := fmt.Sprintf("DMI Collector: Measured dmi label=[%v]", t.Type)
-		if e := tpm.ExtendPCRDebug(tpmHandle, pcr, bytes.NewReader(b), eventDesc); e != nil {
+		if e := tpm.ExtendPCRDebug(pcr, bytes.NewReader(b), eventDesc); e != nil {
 			log.Printf("DMI Collector: err =%v", e)
 			return e // return error if any single type fails ..
 		}

--- a/pkg/securelaunch/policy/policy.go
+++ b/pkg/securelaunch/policy/policy.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"os"
@@ -202,9 +201,9 @@ func parse(pf []byte) (*Policy, error) {
 	return p, nil
 }
 
-func measure(tpmHandle io.ReadWriteCloser, b []byte) error {
+func measure(b []byte) error {
 	eventDesc := "measured securelaunch policy file"
-	return measurement.HashBytes(tpmHandle, b, eventDesc)
+	return measurement.HashBytes(b, eventDesc)
 }
 
 /*
@@ -215,13 +214,13 @@ func measure(tpmHandle io.ReadWriteCloser, b []byte) error {
  *  (1) kernel cmdline "sl_policy" argument.
  *  (2) a file on any partition on any disk called "securelaunch.policy"
  */
-func Get(tpmHandle io.ReadWriteCloser) (*Policy, error) {
+func Get() (*Policy, error) {
 	b, err := locate()
 	if err != nil {
 		return nil, err
 	}
 
-	err = measure(tpmHandle, b)
+	err = measure(b)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/securelaunch/tpm/tpm.go
+++ b/pkg/securelaunch/tpm/tpm.go
@@ -9,18 +9,18 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"log"
-    "errors"
 
-	"github.com/u-root/u-root/pkg/tss"
 	slaunch "github.com/u-root/u-root/pkg/securelaunch"
 	"github.com/u-root/u-root/pkg/securelaunch/eventlog"
+	"github.com/u-root/u-root/pkg/tss"
 )
 
 var hashAlgo = tss.HashSHA256.GoTPMAlg()
-var tpmHandle *tss.TPM = nil
+var tpmHandle *tss.TPM
 
 // marshalPcrEvent writes structure fields piecemeal to buffer.
 func marshalPcrEvent(pcr uint32, h []byte, eventDesc []byte) ([]byte, error) {
@@ -97,13 +97,13 @@ func hashReader(f io.Reader) []byte {
  * New sets up a tpm device handle
  * that can be used for storing hashes.
  */
-func New() (error) {
+func New() error {
 	tpm, err := tss.NewTPM()
 	if err != nil {
 		return fmt.Errorf("couldn't talk to TPM Device: err=%v", err)
 	}
 
-    tpmHandle = tpm
+	tpmHandle = tpm
 	return nil
 }
 
@@ -111,10 +111,10 @@ func New() (error) {
  * Close ends connection to a tpm device handle
  */
 func Close() {
-    if (tpmHandle != nil) {
-        tpmHandle.Close()
-        tpmHandle = nil
-    }
+	if tpmHandle != nil {
+		tpmHandle.Close()
+		tpmHandle = nil
+	}
 }
 
 /*
@@ -124,9 +124,9 @@ func Close() {
  * err is returned if read fails.
  */
 func readPCR(pcr uint32) ([]byte, error) {
-    if (tpmHandle == nil) {
-        return nil, errors.New("tpmHandle is nil")
-    }
+	if tpmHandle == nil {
+		return nil, errors.New("tpmHandle is nil")
+	}
 
 	val, err := tpmHandle.ReadPCR(pcr)
 	if err != nil {
@@ -143,9 +143,9 @@ func readPCR(pcr uint32) ([]byte, error) {
  * err is returned if write to pcr fails.
  */
 func extendPCR(pcr uint32, hash []byte) error {
-    if (tpmHandle == nil) {
-        return errors.New("tpmHandle is nil")
-    }
+	if tpmHandle == nil {
+		return errors.New("tpmHandle is nil")
+	}
 
 	return tpmHandle.Extend(hash, pcr)
 }

--- a/pkg/tss/constants.go
+++ b/pkg/tss/constants.go
@@ -58,7 +58,7 @@ func (a HashAlg) cryptoHash() crypto.Hash {
 	return 0
 }
 
-func (a HashAlg) goTPMAlg() tpm2.Algorithm {
+func (a HashAlg) GoTPMAlg() tpm2.Algorithm {
 	switch a {
 	case HashSHA1:
 		return tpm2.AlgSHA1

--- a/pkg/tss/pcr.go
+++ b/pkg/tss/pcr.go
@@ -21,7 +21,7 @@ func extendPCR12(rwc io.ReadWriter, pcrIndex uint32, hash [20]byte) error {
 }
 
 func extendPCR20(rwc io.ReadWriter, pcrIndex uint32, hash []byte) error {
-	if err := tpm2.PCRExtend(rwc, tpmutil.Handle(pcrIndex), HashSHA256.goTPMAlg(), hash, ""); err != nil {
+	if err := tpm2.PCRExtend(rwc, tpmutil.Handle(pcrIndex), HashSHA256.GoTPMAlg(), hash, ""); err != nil {
 		return err
 	}
 	return nil
@@ -93,5 +93,5 @@ func readPCR12(rwc io.ReadWriter, pcrIndex uint32) ([]byte, error) {
 }
 
 func readPCR20(rwc io.ReadWriter, pcrIndex uint32) ([]byte, error) {
-	return tpm2.ReadPCR(rwc, int(pcrIndex), HashSHA256.goTPMAlg())
+	return tpm2.ReadPCR(rwc, int(pcrIndex), HashSHA256.GoTPMAlg())
 }

--- a/pkg/tss/tss.go
+++ b/pkg/tss/tss.go
@@ -77,7 +77,7 @@ func (t *TPM) ReadPCRs(alg HashAlg) ([]PCR, error) {
 		}
 
 	case TPMVersion20:
-		PCRs, err = readAllPCRs20(t.RWC, alg.goTPMAlg())
+		PCRs, err = readAllPCRs20(t.RWC, alg.GoTPMAlg())
 		if err != nil {
 			return nil, fmt.Errorf("failed to read PCRs: %v", err)
 		}


### PR DESCRIPTION
sluinit will now be using the new in house tss package. In this process, we made tpm a local variable to the sub-package called "tpm" inside securelaunch package. With this change, tpm variable does not need to be passed around in sluinit and other parts of securelaunch package, making all function calls lightweight.