### PR TITLE
add support for madt creation of coreboot tables

### DIFF
--- a/cmds/exp/acpi2coreboot/main.go
+++ b/cmds/exp/acpi2coreboot/main.go
@@ -1,0 +1,46 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// acpi2coreboot builds coreboot C code from ACPI tables
+//
+// Synopsis:
+//     acpi2coreboot
+//
+// Description:
+//	Read ACPI tables from stdin and write coreboot C code to stdout
+//      for those tables we support.
+//
+//      For MADT, one might to this:
+//      acpicat | acpigrep APIC | acpi2coreboot
+//	or, on Linux:
+//	sudo cat  /sys/firmware/acpi/tables/APIC | ./acpi2coreboot
+//
+// Options:
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/u-root/u-root/pkg/acpi"
+	"github.com/u-root/u-root/pkg/acpi/coreboot"
+)
+
+func main() {
+	flag.Parse()
+	tabs, err := acpi.RawFromFile(os.Stdin)
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, t := range tabs {
+		cb, err := coreboot.NewCorebooter(t)
+		if err != nil {
+			log.Fatal(err)
+		}
+		if err := cb.Coreboot(os.Stdout); err != nil {
+			log.Fatal(err)
+		}
+	}
+}

--- a/cmds/exp/smn/main.go
+++ b/cmds/exp/smn/main.go
@@ -1,0 +1,94 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// smn: read or write registers in the System Management Network on AMD
+//
+// Synopsis:
+//     snm r address
+//     snm w address val
+//
+// Description:
+//     read and write System Management Network registers
+//
+// Options:
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"strconv"
+	"strings"
+
+	"github.com/u-root/u-root/pkg/pci"
+)
+
+// Index/Data register pairs, as, e.g., cf8/cfc for PCI,
+// are known to be a terrible idea, from almost any point of view.
+// It took years to kill them on regular PCI.
+// AMD brought them back for the SMN. Bummer.
+const (
+	regIndex = 0xa0
+	regData  = 0xa4
+)
+
+var (
+	devs  = flag.String("s", "0000:00:00.0", "Glob for northbridge")
+	n     = flag.Uint("n", 1, "Number 32-bit words to dump/set")
+	val   = flag.Uint64("v", 0, "Val to set on write")
+	write = flag.Bool("w", false, "Write a value")
+)
+
+func usage() {
+	log.Fatal("Usage: smn [-w] [-d glob] address [# 32-words to read | 32-bit value to write]")
+}
+
+func main() {
+	flag.Parse()
+	r, err := pci.NewBusReader(strings.Split(*devs, ",")...)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	d, err := r.Read()
+	if err != nil {
+		log.Fatalf("Read: %v", err)
+	}
+
+	a := flag.Args()
+	if uint32(*val>>32) != 0 {
+		log.Fatalf("Value:%#x is not a 32-bit number", *val)
+	}
+	for i := range a {
+		addr, err := strconv.ParseUint(a[i], 16, 32)
+		if err != nil {
+			log.Fatal(err)
+		}
+		switch *write {
+		case true:
+			if err := d.WriteConfigRegister(regIndex, 32, addr); err != nil {
+				log.Fatal(err)
+			}
+			if err := d.WriteConfigRegister(regData, 32, *val); err != nil {
+				log.Fatal(err)
+			}
+		case false:
+			for i := addr; i < addr+uint64(*n); i += 4 {
+				if err := d.WriteConfigRegister(regIndex, 32, i); err != nil {
+					log.Fatal(err)
+				}
+				// SMN data is 32 bits!
+				dat, err := d.ReadConfigRegister(regData, 32)
+				if err != nil {
+					log.Fatal(err)
+				}
+				fmt.Printf("%#x:", i)
+				for i := range dat {
+					fmt.Printf("%s:%#x,", d[i].Addr, dat[i])
+				}
+				fmt.Println()
+			}
+		}
+	}
+}

--- a/pkg/acpi/coreboot/coreboot.go
+++ b/pkg/acpi/coreboot/coreboot.go
@@ -1,0 +1,41 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package coreboot transforms ACPI tables in various ways, for use in coreboot.
+// The most common transformation is code generation for use in mainboards
+// or chipsets.
+package coreboot
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/u-root/u-root/pkg/acpi"
+)
+
+type newcb func(acpi.Table) (Corebooter, error)
+
+// Corebooter writes C code for coreboot.
+// N.B. proper coreboot spelling is all lower case; we accept
+// Go rules here and call it Corebooter, but not CoreBooter!
+type Corebooter interface {
+	Coreboot(w io.Writer) error
+}
+
+var (
+	// corebooters is the map of names to a corebooter.
+	corebooters = map[string]newcb{}
+
+	// Debug enables various debug prints. External code can set it to, e.g., log.Printf
+	Debug = func(string, ...interface{}) {}
+)
+
+// NewCorebooters returns a Corebooter for a Table or an error
+func NewCorebooter(t acpi.Table) (Corebooter, error) {
+	cb, ok := corebooters[t.Sig()]
+	if !ok {
+		return nil, fmt.Errorf("No corebooter for %q", t.Sig())
+	}
+	return cb(t)
+}

--- a/pkg/acpi/coreboot/coreboot_test.go
+++ b/pkg/acpi/coreboot/coreboot_test.go
@@ -1,0 +1,45 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package coreboot
+
+import (
+	"testing"
+
+	"github.com/u-root/u-root/pkg/acpi"
+)
+
+func TestCB(t *testing.T) {
+	var rawAPIC = []byte{
+		0x00, 0x50, 0x49, 0x43, 0x24, 0x00, 0x00, 0x00, 0x01, 0x8f, 0x50, 0x54, 0x4c, 0x54, 0x44, 0x20,
+		0x09, 0x20, 0x41, 0x50, 0x49, 0x43, 0x20, 0x20, 0x00, 0x00, 0x04, 0x06, 0x20, 0x4c, 0x54, 0x50,
+		0x00, 0x00, 0x00, 0x00,
+	}
+
+	tab, err := acpi.NewRaw(rawAPIC)
+	if err != nil {
+		t.Fatalf("NewRaw: got %v, want nil", err)
+	}
+	// This tab has a bad signature
+	if _, err := NewCorebooter(tab[0]); err == nil {
+		t.Errorf("got nil, want err")
+	}
+	// Test good signature, bad table.
+	rawAPIC[0] = 'A'
+	if tab, err = acpi.NewRaw(rawAPIC); err != nil {
+		t.Fatalf("NewRaw: got %v, want nil", err)
+	}
+	if _, err := NewCorebooter(tab[0]); err == nil {
+		t.Errorf("got nil, want err")
+	}
+	// Create a good table.
+	rawAPIC = append(rawAPIC, make([]byte, minMADT)...)
+	rawAPIC[4] += 8
+	if tab, err = acpi.NewRaw(rawAPIC); err != nil {
+		t.Fatalf("NewRaw: got %v, want nil", err)
+	}
+	if _, err := NewCorebooter(tab[0]); err != nil {
+		t.Fatalf("NewRaw: got %v, want nil", err)
+	}
+}

--- a/pkg/acpi/coreboot/madt.go
+++ b/pkg/acpi/coreboot/madt.go
@@ -1,0 +1,170 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package coreboot
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/u-root/u-root/pkg/acpi"
+)
+
+type madtType uint8
+
+const (
+	minMADT madtType = 8 // 32-bit address and flags
+)
+const (
+	entryLAPIC         madtType = 0
+	entryIOAPIC        madtType = 1
+	entryISOR          madtType = 2 // pronounced: eyesore, for reasons.
+	entryBOGUS         madtType = 3
+	entryNMI           madtType = 4
+	entryLAPICOverRide madtType = 5
+	entryLX2APIC       madtType = 9
+	entryLX2NMI        madtType = 10
+
+	sizeEntryLAPIC         uint8 = 8
+	sizeEntryIOAPIC        uint8 = 12
+	sizeEntryISOR          uint8 = 10 // pronounced: eyesore, for reasons.
+	sizeEntryNMI           uint8 = 6
+	sizeEntryLAPICOverRide uint8 = 12
+	sizeEntryLX2APIC       uint8 = 16
+	sizeEntryLX2NMI        uint8 = 12
+)
+
+var (
+	// The MADT signature is APIC.
+	// Another failure of vision; they never thought there'd
+	// be more than one APIC I guess.
+	sigMADT = "APIC"
+	info    = map[madtType]struct {
+		name string
+		size uint8
+	}{
+		entryLAPIC:         {"LAPIC", sizeEntryLAPIC},
+		entryIOAPIC:        {"IOAPIC", sizeEntryIOAPIC},
+		entryISOR:          {"ISOR", sizeEntryISOR},
+		entryNMI:           {"NMI", sizeEntryNMI},
+		entryLAPICOverRide: {"LAPICOverRide", sizeEntryLAPICOverRide},
+		entryLX2APIC:       {"LX2APIC", sizeEntryLX2APIC},
+		entryLX2NMI:        {"X2NMI", sizeEntryLX2NMI},
+	}
+)
+
+type subtable struct {
+	t madtType
+	b []byte
+}
+
+// MADT defines the madt struct.
+type MADT struct {
+	acpi.Table
+	// base is the base address of the MADT struct in physical memory.
+	base      int64
+	subtables []subtable
+}
+
+var _ Corebooter = &MADT{}
+
+func init() {
+	corebooters["APIC"] = NewMADT
+}
+
+// rv reverses a slice
+func rv(b []byte) []byte {
+	for i := 0; i < len(b)/2; i++ {
+		j := len(b) - i - 1
+		b[i], b[j] = b[j], b[i]
+	}
+	return b
+}
+
+// NewMADT returns a MADT, from a Table, iff the signature is correct.
+func NewMADT(t acpi.Table) (Corebooter, error) {
+	if t.Sig() != sigMADT {
+		return nil, fmt.Errorf("%s is not a MADT", t.Sig())
+	}
+	b := t.TableData()
+	Debug("NEWMADT Subtables: %d bytes", len(b))
+	if len(b) < int(minMADT) {
+		return nil, fmt.Errorf("Table is only %d bytes, need %d", len(t.TableData()), minMADT)
+	}
+	b = b[8:]
+	Debug("NEWMADT Subtables: after removing 8 bytes of fluff, %d bytes", len(b))
+	m := &MADT{Table: t, base: t.Address()}
+	for len(b) > 0 {
+		Debug("NewMADT loop: %d bytes\n", len(b))
+		if len(b) < 2 {
+			return nil, fmt.Errorf("subtable is too short: have %d bytes, need 2", len(b))
+		}
+		l := b[1]
+		typ := madtType(b[0])
+		Debug("subtable: %d bytes, l is %#x, t is %#x", len(b), l, t)
+		i, ok := info[typ]
+		if ! ok {
+			Debug("Bad type: %#x, offset %#x, skipping %d bytes", typ, len(t.TableData())-len(b), l)
+			b = b[l:]
+			continue
+		}
+		if l != i.size {
+			return nil, fmt.Errorf("Type %s has size %d should be %d", i.name, l, i.size)
+		}
+		if len(b) < int(l) {
+			return nil, fmt.Errorf("Type %s has buf length %d should be %d", i.name, len(b), i.size)
+		}
+		m.subtables = append(m.subtables, subtable{t: typ, b: b[:l]})
+		b = b[l:]
+	}
+	Debug("NEWMADT Subtables: %d bytes tab %d bytes", len(b), len(m.TableData()))
+	return m, nil
+}
+
+// CoreBoot generates the coreboot C code for a MADT.
+// MADT consists of TLV entries: 1-byte type, 1-byte length, value.
+func (m *MADT) Coreboot(w io.Writer) error {
+	s := fmt.Sprintf(`unsigned long acpi_fill_madt(unsigned long current)
+{
+	/* create all subtables for processors */
+`)
+	// OK this is a bit nasty. Right now coreboot is trying to fill out
+	// the lapic address and flags. So we ignore those in the table for now.
+	// If it's getting them wrong, we will have to go back and
+	// fill them in.
+	//lapic(%#x, %#x);\n", b[:4], b[4:8])
+	// The coreboot serialization code for ACPI uses the C compiler to drive serialization.
+	// It uses this pattern:
+	// int acpi_create_madt_lapic(acpi_madt_lapic_t *lapic, u8 cpu, u8 apic);
+	// The first arg is a uintptr cast to a struct pointer of the table type.
+	// The function stores the arguments into the packed struct, the idea being that
+	// the compiler generates code to store into the struct that exactly matches
+	// the ACPI standard.
+	for _, tab := range m.subtables {
+		b := tab.b
+		switch tab.t {
+		case entryLAPIC:
+			// TODO: Check b[4] to see if the LAPIC is enabled? When would it not be, if it's in the table?
+			s += fmt.Sprintf("\tcurrent += acpi_create_madt_lapic((acpi_madt_lapic_t *)current, %#x, %#x);\n", b[2], b[3])
+		case entryIOAPIC:
+			s += fmt.Sprintf("\tcurrent += acpi_create_madt_ioapic((acpi_madt_ioapic_t *)current, %#x, %#x, %#x);\n", b[2], rv(b[4:8]), rv(b[8:12]))
+		case entryISOR:
+			s += fmt.Sprintf("\tcurrent += acpi_create_madt_irqoverride((acpi_madt_irqoverride_t *)current, %#x, %#x, %#x, %#x);\n", b[2], b[3], rv(b[4:8]), rv(b[8:10]))
+		case entryNMI:
+			s += fmt.Sprintf("\tcurrent += acpi_create_madt_lapic_nmi((acpi_madt_lapic_nmi_t *)current, %#x, %#x, %#x);\n", b[2], rv(b[3:5]), b[5])
+		case entryLAPICOverRide:
+			// coreboot appears not to support this.
+			Debug("coreboot does not support Local APIC Address Override, skipping")
+			//s += fmt.Sprintf("current += acpi_create_madt_irqoverride((acpi_madt_irqoverride_t *), %#x, %#x);\n", rv(b[2:4]), b[4:12])
+		case entryLX2APIC:
+			// coreboot does not support the flags parameter ...
+			s += fmt.Sprintf("\tcurrent += acpi_create_madt_lx2apic((acpi_madt_lx2apic_t *) current,  %#x, %#x);\n", rv(b[12:16]), rv(b[4:8]))
+		case entryLX2NMI:
+			s += fmt.Sprintf("\tcurrent += acpi_create_madt_lx2apic_nmi((acpi_madt_lx2apic_nmi_t *) current,  %#x, %#x, %#x);\n", rv(b[4:8]), rv(b[2:4]), b[8:9])
+		}
+	}
+	s += "\treturn current;\n}\n"
+	_, err := w.Write([]byte(s))
+	return err
+}

--- a/pkg/acpi/coreboot/madt_test.go
+++ b/pkg/acpi/coreboot/madt_test.go
@@ -1,0 +1,116 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package coreboot
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/acpi"
+)
+
+func TestMADT(t *testing.T) {
+	// This is a 36 byte table which is about as small as it can get.
+	var rawAPIC = []byte{
+		0x00, 0x50, 0x49, 0x43, 0x24, 0x00, 0x00, 0x00, 0x01, 0x8f, 0x50, 0x54, 0x4c, 0x54, 0x44, 0x20,
+		0x09, 0x20, 0x41, 0x50, 0x49, 0x43, 0x20, 0x20, 0x00, 0x00, 0x04, 0x06, 0x20, 0x4c, 0x54, 0x50,
+		0x00, 0x00, 0x00, 0x00,
+		// Now we have entries.
+	}
+
+	tab, err := acpi.NewRaw(rawAPIC)
+	if err != nil {
+		t.Fatalf("acpi.NewRaw: got %v, want nil", err)
+	}
+	// Test geting a MADT with a bad signature
+	if _, err = NewMADT(tab[0]); err == nil {
+		t.Errorf("MADT with incorrect signature: got nil, want err")
+	}
+	// Test geting a MADT that is too short.
+	rawAPIC[0] = 'A'
+	if _, err = acpi.NewRaw(rawAPIC); err != nil {
+		t.Fatalf("acpi.NewRaw: got %v, want nil", err)
+	}
+	if _, err = NewMADT(tab[0]); err == nil {
+		t.Errorf("MADT that is too short: got nil, want err")
+	}
+
+	// Test a good minimal APIC table
+	rawAPIC = append(rawAPIC, 0xde, 0xad, 0xbe, 0xef, 1, 0, 0, 0)
+	rawAPIC[4] += 8
+	if tab, err = acpi.NewRaw(rawAPIC); err != nil {
+		t.Fatalf("acpi.NewRaw: got %v, want nil", err)
+	}
+	m, err := NewMADT(tab[0])
+	if err != nil {
+		t.Errorf("New good MADT: got %v, want nil", err)
+	}
+	var b bytes.Buffer
+	if err := m.Coreboot(&b); err != nil {
+		t.Errorf("CoreBoot: got %v, want nil", err)
+	}
+	// Now add too short subtable entry
+	// i.e. we have a good madt with no subentries; let's add a bogus entry
+	// that is too short.
+	Debug = t.Logf
+	tooshort := append(rawAPIC, 1)
+	tooshort[4]++
+	if tab, err = acpi.NewRaw(tooshort); err != nil {
+		t.Fatalf("acpi.NewRaw: got %v, want nil", err)
+	}
+	if _, err = NewMADT(tab[0]); err == nil {
+		t.Fatalf("Too short MADT subtable: got nil, want err")
+	}
+	// now try everything.
+	t.Logf("rawapic len %d", len(rawAPIC))
+	rawAPIC = append(rawAPIC, byte(entryLAPIC), sizeEntryLAPIC, 1, 2, 3, 0, 0, 0)
+	rawAPIC = append(rawAPIC, byte(entryIOAPIC), sizeEntryIOAPIC, 32, 0, 4, 5, 6, 7, 9, 10, 11, 12)
+	rawAPIC = append(rawAPIC, byte(entryISOR), sizeEntryISOR, 22, 23, 1, 2, 3, 4, 0, 1)
+	rawAPIC = append(rawAPIC, byte(entryNMI), sizeEntryNMI, 0xfe, 0xfd, 0xfc, 0xfb)
+
+	t.Logf("rawapic len %d", len(rawAPIC))
+	rawAPIC[4] = uint8(len(rawAPIC))
+	if tab, err = acpi.NewRaw(rawAPIC); err != nil {
+		t.Fatalf("acpi.NewRaw: got %v, want nil", err)
+	}
+	t.Logf("Table %dbytes\n", tab[0].TableData())
+	Debug = t.Logf
+	m, err = NewMADT(tab[0])
+	if err != nil {
+		t.Errorf("New good MADT: got %v, want nil", err)
+	}
+	w := &bytes.Buffer{}
+	if err := m.Coreboot(w); err != nil {
+		t.Error(err)
+	}
+	good := `unsigned long acpi_fill_madt(unsigned long current)
+{
+	/* create all subtables for processors */
+	current += acpi_create_madt_lapic((acpi_madt_lapic_t *)current, 0x1, 0x2);
+	current += acpi_create_madt_ioapic((acpi_madt_ioapic_t *)current, 0x20, 0x07060504, 0x0c0b0a09);
+	current += acpi_create_madt_irqoverride((acpi_madt_irqoverride_t *)current, 0x16, 0x17, 0x04030201, 0x0100);
+	current += acpi_create_madt_lapic_nmi((acpi_madt_lapic_nmi_t *)current, 0xfe, 0xfcfd, 0xfb);
+	return current;
+}
+`
+	out := w.String()
+	if len(out) != len(good) {
+		t.Errorf("coreboot: got %d byte string, want %d bytes", len(out), len(good))
+	}
+	if w.String() != good {
+		t.Errorf("Coreboot: got %v, want %v", w.String(), good)
+		t.Errorf("Coreboot: got %q, want %q", w.String(), good)
+	}
+	// now shorten it by 1 to simulate a truncated table
+	rawAPIC = rawAPIC[:len(rawAPIC)-1]
+	rawAPIC[4] = uint8(len(rawAPIC))
+	if tab, err = acpi.NewRaw(rawAPIC); err != nil {
+		t.Errorf("acpi.NewRaw: got %v, want nil", err)
+	}
+	if _, err = NewMADT(tab[0]); err == nil {
+		t.Errorf("Short MADT subtable: got nil, want err")
+	}
+
+}


### PR DESCRIPTION
This generates code that compiles in coreboot.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>