### PR TITLE
Add boot menu to cmds/boot

### DIFF
--- a/cmds/boot/boot/boot.go
+++ b/cmds/boot/boot/boot.go
@@ -41,6 +41,7 @@ import (
 	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/boot/bls"
 	"github.com/u-root/u-root/pkg/boot/grub"
+	"github.com/u-root/u-root/pkg/boot/menu"
 	"github.com/u-root/u-root/pkg/boot/syslinux"
 	"github.com/u-root/u-root/pkg/cmdline"
 	"github.com/u-root/u-root/pkg/mount"
@@ -79,15 +80,7 @@ func updateBootCmdline(cl string) string {
 	return f.Update(cl)
 }
 
-func mountAndBoot(device *block.BlockDev, mountDir string) {
-	os.MkdirAll(mountDir, 0777)
-
-	mp, err := device.Mount(mountDir, mount.ReadOnly)
-	if err != nil {
-		return
-	}
-	defer mp.Unmount(mount.MNT_DETACH)
-
+func parse(device *block.BlockDev, mountDir string) []boot.OSImage {
 	imgs, err := bls.ScanBLSEntries(ulog.Log, mountDir)
 	if err != nil {
 		log.Printf("Failed to parse systemd-boot BootLoaderSpec configs, trying another format...: %v", err)
@@ -105,44 +98,14 @@ func mountAndBoot(device *block.BlockDev, mountDir string) {
 	}
 	imgs = append(imgs, syslinuxImgs...)
 
-	if len(imgs) == 0 {
-		return
-	}
-
-	// Boot just the first image.
-	img := imgs[0]
-
-	// Make changes to the kernel command line based on our cmdline.
-	if li, ok := img.(*boot.LinuxImage); ok {
-		li.Cmdline = updateBootCmdline(li.Cmdline)
-	}
-
-	log.Printf("BootImage: %s", img)
-	if err := img.Load(*verbose); err != nil {
-		log.Printf("kexec load of %v failed: %v", img, err)
-		return
-	}
-
-	if err := mp.Unmount(mount.MNT_DETACH); err != nil {
-		log.Printf("Can't unmount %v: %v", mp, err)
-	}
-	if *dryRun {
-		return
-	}
-
-	if err := boot.Execute(); err != nil {
-		log.Printf("boot.Execute of %v failed: %v", img, err)
-	}
-
-	// kexec was successful. kexec should have taken over. What happened?
-	log.Fatalf("kexec boot returned success, but new kernel is not running...")
+	return imgs
 }
 
 // Localboot tries to boot from any local filesystem by parsing grub configuration
-func Localboot() error {
+func Localboot() ([]boot.OSImage, []*mount.MountPoint, error) {
 	blockDevs, err := block.GetBlockDevices()
 	if err != nil {
-		return errors.New("no available block devices to boot from")
+		return nil, nil, errors.New("no available block devices to boot from")
 	}
 
 	// Try to only boot from "good" block devices.
@@ -151,15 +114,25 @@ func Localboot() error {
 
 	mountPoints, err := ioutil.TempDir("", "u-root-boot")
 	if err != nil {
-		return fmt.Errorf("Can't create tmpdir: %v", err)
+		return nil, nil, fmt.Errorf("cannot create tmpdir: %v", err)
 	}
-	defer os.RemoveAll(mountPoints)
 
+	var images []boot.OSImage
+	var mps []*mount.MountPoint
 	for _, device := range blockDevs {
 		dir := filepath.Join(mountPoints, device.Name)
-		mountAndBoot(device, dir)
+
+		os.MkdirAll(dir, 0777)
+		mp, err := device.Mount(dir, mount.ReadOnly)
+		if err != nil {
+			continue
+		}
+
+		imgs := parse(device, dir)
+		images = append(images, imgs...)
+		mps = append(mps, mp)
 	}
-	return fmt.Errorf("Sorry no bootable device found")
+	return images, mps, nil
 }
 
 func main() {
@@ -169,7 +142,41 @@ func main() {
 		debug = log.Printf
 	}
 
-	if err := Localboot(); err != nil {
+	images, mps, err := Localboot()
+	if err != nil {
 		log.Fatal(err)
 	}
+	for _, img := range images {
+		// Make changes to the kernel command line based on our cmdline.
+		if li, ok := img.(*boot.LinuxImage); ok {
+			li.Cmdline = updateBootCmdline(li.Cmdline)
+		}
+	}
+
+	menuEntries := menu.OSImages(*dryRun, images...)
+	menuEntries = append(menuEntries, menu.Reboot{})
+	menuEntries = append(menuEntries, menu.StartShell{})
+
+	chosenEntry := menu.ShowMenuAndLoad(os.Stdin, menuEntries...)
+
+	// Clean up.
+	for _, mp := range mps {
+		if err := mp.Unmount(mount.MNT_DETACH); err != nil {
+			debug("Failed to unmount %s: %v", mp, err)
+		}
+	}
+	if chosenEntry == nil {
+		log.Fatalf("Nothing to boot.")
+	}
+	if *dryRun {
+		log.Printf("Chosen menu entry: %s", chosenEntry)
+		os.Exit(0)
+	}
+	// Exec should either return an error or not return at all.
+	if err := chosenEntry.Exec(); err != nil {
+		log.Fatalf("Failed to exec %s: %v", chosenEntry, err)
+	}
+
+	// Kexec should either return an error or not return.
+	panic("unreachable")
 }

--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -105,7 +105,6 @@ func main() {
 	if len(flag.Args()) > 1 {
 		log.Fatalf("Only one regexp-style argument is allowed, e.g.: " + ifName)
 	}
-
 	if len(flag.Args()) > 0 {
 		ifName = flag.Args()[0]
 	}
@@ -123,13 +122,24 @@ func main() {
 		}
 		return
 	}
+
 	menuEntries := menu.OSImages(*dryRun, images...)
 	menuEntries = append(menuEntries, menu.Reboot{})
 	menuEntries = append(menuEntries, menu.StartShell{})
 
-	menu.ShowMenuAndBoot(os.Stdin, menuEntries...)
+	chosenEntry := menu.ShowMenuAndLoad(os.Stdin, menuEntries...)
+	if chosenEntry == nil {
+		log.Fatalf("Nothing to boot.")
+	}
+	if *dryRun {
+		log.Printf("Chosen menu entry: %s", chosenEntry)
+		os.Exit(0)
+	}
+	// Exec should either return an error or not return at all.
+	if err := chosenEntry.Exec(); err != nil {
+		log.Fatalf("Failed to exec %s: %v", chosenEntry, err)
+	}
 
-	// Kexec should either return an error or not return.
+	// Kexec should either return an error or not return at all.
 	panic("unreachable")
-
 }

--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -37,8 +37,8 @@ import (
 
 var (
 	ifName  = "^e.*"
-	noLoad  = flag.Bool("no-load", false, "get DHCP response, but don't load the kernel")
-	dryRun  = flag.Bool("dry-run", false, "download kernel, but don't kexec it")
+	noLoad  = flag.Bool("no-load", false, "get DHCP response, print chosen boot configuration, but do not download + exec it")
+	noExec  = flag.Bool("no-exec", false, "download boot configuration, but do not exec it")
 	verbose = flag.Bool("v", false, "Verbose output")
 )
 
@@ -122,8 +122,7 @@ func main() {
 		}
 		return
 	}
-
-	menuEntries := menu.OSImages(*dryRun, images...)
+	menuEntries := menu.OSImages(*verbose, images...)
 	menuEntries = append(menuEntries, menu.Reboot{})
 	menuEntries = append(menuEntries, menu.StartShell{})
 
@@ -131,7 +130,7 @@ func main() {
 	if chosenEntry == nil {
 		log.Fatalf("Nothing to boot.")
 	}
-	if *dryRun {
+	if *noExec {
 		log.Printf("Chosen menu entry: %s", chosenEntry)
 		os.Exit(0)
 	}

--- a/integration/generic-tests/pxeboot_test.go
+++ b/integration/generic-tests/pxeboot_test.go
@@ -61,7 +61,7 @@ func TestPxeboot4(t *testing.T) {
 			),
 		},
 		TestCmds: []string{
-			"pxeboot --dry-run -v",
+			"pxeboot --no-exec -v",
 			// Sleep so serial console output gets flushed. The expect library is racy.
 			"sleep 5",
 			"shutdown -h",

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -176,12 +176,12 @@ func ShowMenuAndLoad(input *os.File, entries ...Entry) Entry {
 }
 
 // OSImages returns menu entries for the given OSImages.
-func OSImages(dryRun bool, imgs ...boot.OSImage) []Entry {
+func OSImages(verbose bool, imgs ...boot.OSImage) []Entry {
 	var menu []Entry
 	for _, img := range imgs {
 		menu = append(menu, &OSImageAction{
 			OSImage: img,
-			DryRun:  dryRun,
+			Verbose: verbose,
 		})
 	}
 	return menu
@@ -190,12 +190,12 @@ func OSImages(dryRun bool, imgs ...boot.OSImage) []Entry {
 // OSImageAction is a menu.Entry that boots an OSImage.
 type OSImageAction struct {
 	boot.OSImage
-	DryRun bool
+	Verbose bool
 }
 
 // Load implements Entry.Load by loading the OS image into memory.
 func (oia OSImageAction) Load() error {
-	if err := oia.OSImage.Load(oia.DryRun); err != nil {
+	if err := oia.OSImage.Load(oia.Verbose); err != nil {
 		return fmt.Errorf("could not load image %s: %v", oia.OSImage, err)
 	}
 	return nil


### PR DESCRIPTION
This PR adds a terminal UI boot menu to cmds/boot/boot to allow the user to choose which image to boot.

In order to do this cleanly, we should have the ability to unmount all file systems before actually execing the new OS.

Previously, `pkg/boot/menu` took care of both the kexec_load and exec steps. However, having both of those happen in `pkg/boot/menu` doesn't give the caller the ability to clean up the OS (like unmount file systems) before transferring execution to the new OS (or rebooting, or execing a shell).

So, before:

```go
type Entry interface {
  Do() error
}

func (img boot.OSImage) Do() error {
  img.Load()
  boot.Execute()
}

func main() {
  menu.ShowMenuAndBoot(os.Stdin, entries...)

  panic("ShowMenuAndBoot should have kexec'd")
}
```

after:

```go
type Entry interface {
  Load() error
  Exec() error
}

func (img boot.OSImage) Load() error {
  img.Load()
}

func (img boot.OSImage) Exec() error {
  boot.Execute()
}

func main() {
  entry := menu.ShowMenuAndBoot(os.Stdin, entries...)
  
  // unmount stuff here,
  // other cleanup?

  // entry.Load has already been called at this point.
  if err := entry.Exec(); err != nil {
    log.Fatalf("Failed to exec... %v", err)
  }

  panic("Exec should have returned error or not returned at all")
}
```