### PR TITLE
Refactor SchemesWithRetries

### DIFF
--- a/pkg/curl/mock_schemes.go
+++ b/pkg/curl/mock_schemes.go
@@ -100,30 +100,3 @@ func (m *MockScheme) Fetch(ctx context.Context, u *url.URL) (io.ReaderAt, error)
 	}
 	return strings.NewReader(content), nil
 }
-
-// MockSchemeRetryFilter is a Scheme mock for testing and has a method to
-// implement FileSchemeRetryFilter.
-type MockSchemeRetryFilter struct {
-	*MockScheme
-
-	retryFilter func(*url.URL, error) bool
-}
-
-// NewMockSchemeRetryFilter creates a new MockSchemeRetryFilter with the given
-// scheme name.
-func NewMockSchemeRetryFilter(scheme string) *MockSchemeRetryFilter {
-	return &MockSchemeRetryFilter{NewMockScheme(scheme), nil}
-}
-
-// RetryFilter implements FileSchemeRetryFilter.
-func (m *MockSchemeRetryFilter) RetryFilter(u *url.URL, err error) bool {
-	if m.retryFilter == nil {
-		return true
-	}
-	return m.retryFilter(u, err)
-}
-
-// SetRetryFilter sets the function to be used by the RetryFilter method.
-func (m *MockSchemeRetryFilter) SetRetryFilter(f func(*url.URL, error) bool) {
-	m.retryFilter = f
-}

--- a/pkg/curl/schemes.go
+++ b/pkg/curl/schemes.go
@@ -237,7 +237,8 @@ type SchemeWithRetries struct {
 func (s *SchemeWithRetries) Fetch(ctx context.Context, u *url.URL) (io.ReaderAt, error) {
 	var err error
 	s.BackOff.Reset()
-	for d := time.Duration(0); d != backoff.Stop; d = s.BackOff.NextBackOff() {
+	back := backoff.WithContext(s.BackOff, ctx)
+	for d := time.Duration(0); d != backoff.Stop; d = back.NextBackOff() {
 		if d > 0 {
 			time.Sleep(d)
 		}

--- a/pkg/curl/schemes_test.go
+++ b/pkg/curl/schemes_test.go
@@ -154,18 +154,18 @@ var tests = []struct {
 	{
 		name: "retry filter",
 		scheme: func() (FileScheme, *MockScheme) {
-			s := NewMockSchemeRetryFilter("fooftp")
+			s := NewMockScheme("fooftp")
 			s.Add("192.168.0.1", "/foo/pxelinux.cfg/default", "haha")
 			s.SetErr(errTest, 5)
-			s.SetRetryFilter(func(u *url.URL, err error) bool {
-				return err != errTest
-			})
 			r := &SchemeWithRetries{
+				DoRetry: func(u *url.URL, err error) bool {
+					return err != errTest
+				},
 				Scheme: s,
 				// backoff.ZeroBackOff so unit tests run fast.
 				BackOff: backoff.WithMaxRetries(&backoff.ZeroBackOff{}, 10),
 			}
-			return r, s.MockScheme
+			return r, s
 		},
 		url:            testURL,
 		err:            errTest,


### PR DESCRIPTION
Internally, we use SchemesWithRetries on a bunch of netboot operations, but admittedly, it is not working very well.

Even with recent changes such as https://github.com/u-root/u-root/commit/18b0531231224d08946575b21a69824a5b0377d1 there are some cases where buggy HTTP servers will mess with us:

```
[netboot] 2020/06/19 00:18:31 Skipping configuring eth0 with lease IPv4 DHCP Lease IP 10.177.153.193/26
2020/06/19 00:18:31 Boot URI: http://.../ipxe.script/01-94-eb-2c-1a-2c-46
2020/06/19 00:18:32 Got ipxe config file http://.../ipxe.script/01-94-eb-2c-1a-2c-46:
#!ipxe
kernel http://../94-eb-2c-1a-2c-46.vmlinuz redacted
initrd http://../94-eb-2c-1a-2c-46.rd.gz
boot

[netboot] 2020/06/19 00:18:32 Error: Getting http://.../01-94-eb-2c-1a-2c-46: HTTP server responded with error code 500, want 200: response <nil>
[netboot] 2020/06/19 00:18:32 Retrying http://.../01-94-eb-2c-1a-2c-46
[netboot] 2020/06/19 00:18:32 Error: Getting http://.../01-94-eb-2c-1a-2c-46: HTTP server responded with error code 500, want 200: response <nil>
[netboot] 2020/06/19 00:18:32 Retrying http://.../01-94-eb-2c-1a-2c-46
[netboot] 2020/06/19 00:18:33 Error: Getting http://.../01-94-eb-2c-1a-2c-46: HTTP server responded with error code 500, want 200: response <nil>
[netboot] 2020/06/19 00:18:33 Retrying http://.../01-94-eb-2c-1a-2c-46
[netboot] 2020/06/19 00:18:35 Error: Getting http://.../01-94-eb-2c-1a-2c-46: HTTP server responded with error code 500, want 200: response <nil>
[netboot] 2020/06/19 00:18:35 Retrying http://.../01-94-eb-2c-1a-2c-46

... goes on for several minutes
```

We can't be retrying connections like this for several minutes.

So let me re-examine why we are retrying. Two reasons come to mind:

- TFTP operations are inherently racy. We need actual retries for each file here, because stuff may have gotten dropped.
- Sometimes, we race between IPv6 configuration and downloading netboot files. When you configure a kernel for IPv6, that doesn't mean the network is immediately available: we (user space) supply an IP from a DHCPv6 request, but the kernel still has to reconcile that with routing information (and/or potentially request routing information from the network) which may take several seconds.

Our solution to the latter was to generalize the TFTP retry scheme we had and also retry HTTP connections. It turns out that in a number of cases that kinda sucks, and we retry and drag out netboots that should be quick.

So here's something more specific. TFTP can keep using SchemeWithRetries and retry its heart out. For the IPv6 case, we just do something like `RetryOr(RetryConnectErrors, RetryTemporaryNetworkErrors)`:

```go
// RetryConnectErrors retries only connect(2) errors.
func RetryConnectErrors(u *url.URL, err error) bool {
	var serr *os.SyscallError
	if errors.As(err, &serr) && serr.Syscall == "connect" {
		return true
	}
	return false
}

// RetryTemporaryNetworkErrors only retries network errors.
//                                                                                                                                                                                                                             
// This relies on Go's net.Error.Temporary definition of temporary network                                                                                                                                                       
// errors, which does not include network configuration errors. The latter are                                                                                                                                                   
// relevant for users of DHCP, for example.      
func RetryTemporaryNetworkErrors(u *url.URL, err error) bool {
	var nerr net.Error
	if errors.As(err, &nerr) {
		return nerr.Temporary()
	}
	return false
}
```

(Note that when the network isn't set up, the error return by http is an http-wrapped &net.OpError{&os.SyscallError{"connect"}}, essentially.)