### PR TITLE
iSCSI boot from DHCP -- ESXi only

### DIFF
--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -28,6 +28,7 @@ import (
 	"github.com/u-root/u-root/pkg/boot/bootcmd"
 	"github.com/u-root/u-root/pkg/boot/menu"
 	"github.com/u-root/u-root/pkg/boot/netboot"
+	"github.com/u-root/u-root/pkg/boot/netboot/iscsi"
 	"github.com/u-root/u-root/pkg/curl"
 	"github.com/u-root/u-root/pkg/dhclient"
 	"github.com/u-root/u-root/pkg/ulog"
@@ -72,8 +73,15 @@ func main() {
 	parsers := []netboot.BootImageParser{
 		&netboot.IPXEParser{Log: ulog.Log, Schemes: curl.DefaultSchemes},
 		&netboot.PXEParser{Log: ulog.Log, Schemes: curl.DefaultSchemes},
+		&iscsi.ISCSIBoot{
+			Log:        ulog.Log,
+			CreateIBFT: true,
+			DiskParsers: []iscsi.DiskParser{
+				iscsi.ESXIBoot{},
+			},
+		},
 	}
-	images, err := netboot.DHCPAndParse(context.Background(), ulog.Log, filteredIfs, conf, parsers, *noNetConfig)
+	entries, err := netboot.DHCPAndParse(context.Background(), ulog.Log, filteredIfs, conf, parsers, *noNetConfig)
 	if err != nil {
 		log.Printf("Netboot failed: %v", err)
 	}

--- a/pkg/boot/netboot/iscsi/iscsiboot.go
+++ b/pkg/boot/netboot/iscsi/iscsiboot.go
@@ -1,0 +1,124 @@
+package iscsi
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/u-root/iscsinl"
+	"github.com/u-root/u-root/pkg/boot/esxi"
+	"github.com/u-root/u-root/pkg/boot/ibft"
+	"github.com/u-root/u-root/pkg/boot/menu"
+	"github.com/u-root/u-root/pkg/dhclient"
+	"github.com/u-root/u-root/pkg/ulog"
+)
+
+type ESXIBoot struct{}
+
+func (ESXIBoot) Name() string { return "ESXi boot" }
+
+func (ESXIBoot) Parse(ctx context.Context, ibft *ibft.IBFT, partitionedDevice string) ([]menu.Entry, error) {
+	imgs, err := esxi.LoadDisk(partitionedDevice)
+	if err != nil {
+		return nil, err
+	}
+
+	var es []menu.Entry
+	for _, img := range imgs {
+		if ibft != nil {
+			// Insert iBFT.
+			img.IBFT = ibft
+			img.Name = fmt.Sprintf("%s from iSCSI target %s", img.Name, ibft.Target0.Target)
+		}
+		es = append(es, menu.OSImages(true, img)...)
+	}
+	return es, nil
+}
+
+type DiskParser interface {
+	Name() string
+	Parse(ctx context.Context, ibft *ibft.IBFT, partitionedDevice string) ([]menu.Entry, error)
+}
+
+type ISCSIBoot struct {
+	Log         ulog.Logger
+	CreateIBFT  bool
+	DiskParsers []DiskParser
+}
+
+func (ISCSIBoot) Name() string { return "iSCSI boot" }
+
+// Parse attempts to boot from an iSCSI volume.
+func (ib *ISCSIBoot) Parse(ctx context.Context, lease dhclient.Lease) ([]menu.Entry, error) {
+	target, volume, err := lease.ISCSIBoot()
+	if err != nil {
+		return nil, fmt.Errorf("no usable iSCSI path in lease: %v", err)
+	}
+
+	devices, err := iscsinl.MountIscsi(
+		iscsinl.WithTarget(target.String(), volume),
+		iscsinl.WithScheduler("noop"),
+		iscsinl.WithCmdsMax(128),
+		iscsinl.WithQueueDepth(16),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to mount iSCSI for target %s @ volume %s: %v", target, volume, err)
+	}
+
+	var ibft *ibft.IBFT
+	if ib.CreateIBFT {
+		ibft = CreateIBFT(lease.Link().Attrs().HardwareAddr, target, volume)
+	}
+
+	var es []menu.Entry
+	// There really should only be one device, I think?
+	for _, dev := range devices {
+		device := fmt.Sprintf("/dev/%s", dev)
+
+		for _, parser := range ib.DiskParsers {
+			entries, err := parser.Parse(ctx, ibft, device)
+			if err != nil {
+				ib.Log.Printf("Could not interpret iSCSI disk contents as %s: %v", parser.Name(), err)
+			}
+			es = append(es, entries...)
+		}
+	}
+	return es, nil
+}
+
+// CreateIBFT makes an iBFT. It's only guaranteed to work with IPv4 ESXi right now.
+func CreateIBFT(mac net.HardwareAddr, target *net.TCPAddr, volume string) *ibft.IBFT {
+	return &ibft.IBFT{
+		Initiator: ibft.Initiator{
+			Valid: true,
+			Boot:  true,
+			Name:  "NERF",
+		},
+		NIC0: ibft.NIC{
+			Valid:      true,
+			Boot:       true,
+			Global:     true,
+			MACAddress: mac,
+
+			// ESXi can live without this information. It'll do a
+			// DHCP request to get it.
+			//
+			// This makes us trivially compatible with IPv6 as
+			// well, since we don't have to query the kernel for
+			// the RA information that would fill these fields in
+			// addition to DHCPv6. But, note: IPv6 is untested.
+			//
+			// Plus, routes are gonna be more complicated than just
+			// a "gateway". I'm curious what iPXE here.
+			IPNet:   nil,
+			Gateway: nil,
+		},
+		Target0: ibft.Target{
+			Valid:          true,
+			Boot:           true,
+			NICAssociation: 0,
+			Target:         target,
+			TargetName:     volume,
+		},
+	}
+}

--- a/pkg/boot/netboot/netboot.go
+++ b/pkg/boot/netboot/netboot.go
@@ -15,8 +15,11 @@ package netboot
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"net/url"
+	"os"
+	"os/signal"
 	"path"
 
 	"github.com/u-root/u-root/pkg/boot"
@@ -25,6 +28,7 @@ import (
 	"github.com/u-root/u-root/pkg/curl"
 	"github.com/u-root/u-root/pkg/dhclient"
 	"github.com/u-root/u-root/pkg/ulog"
+	"github.com/vishvananda/netlink"
 )
 
 // BootImages figure out a ranked order of images to boot from the given DHCP lease.
@@ -80,4 +84,129 @@ func getBootImages(ctx context.Context, l ulog.Logger, schemes curl.Schemes, uri
 		l.Printf("Failed to try parsing pxelinux config: %v", err)
 	}
 	return append(images, pxeImages...)
+}
+
+type IPXEParser struct {
+	Log     ulog.Logger
+	Schemes curl.Schemes
+}
+
+func (IPXEParser) Name() string { return "iPXE" }
+
+func (i *IPXEParser) Parse(ctx context.Context, lease dhclient.Lease) ([]boot.OSImage, error) {
+	uri, err := lease.Boot()
+	if err != nil {
+		return nil, err
+	}
+	i.Log.Printf("Boot URI: %s", uri)
+
+	// Attempt to read the given boot path as an ipxe config file.
+	ipc, err := ipxe.ParseConfig(ctx, i.Log, uri, i.Schemes)
+	if err != nil {
+		return nil, err
+	}
+	if ipc != nil {
+		return []boot.OSImage{ipc}, nil
+	}
+	return nil, nil
+}
+
+type PXEParser struct {
+	Log     ulog.Logger
+	Schemes curl.Schemes
+}
+
+func (PXEParser) Name() string { return "pxelinux" }
+
+func (p *PXEParser) Parse(ctx context.Context, lease dhclient.Lease) ([]boot.OSImage, error) {
+	uri, err := lease.Boot()
+	if err != nil {
+		return nil, err
+	}
+	p.Log.Printf("Boot URI: %s", uri)
+
+	// IP only makes sense for v4 anyway, because the PXE probing of files
+	// uses a MAC address and an IPv4 address to look at files.
+	var ip net.IP
+	if p4, ok := lease.(*dhclient.Packet4); ok {
+		ip = p4.Lease().IP
+	}
+
+	mac := lease.Link().Attrs().HardwareAddr
+	wd := &url.URL{
+		Scheme: uri.Scheme,
+		Host:   uri.Host,
+		Path:   path.Dir(uri.Path),
+	}
+	pxeImages, err := pxe.ParseConfig(ctx, wd, mac, ip, p.Schemes)
+	if err != nil {
+		return nil, err
+	}
+	return pxeImages, nil
+}
+
+type BootImageParser interface {
+	Name() string
+	Parse(context.Context, dhclient.Lease) ([]boot.OSImage, error)
+}
+
+// DHCPAndParse requests DHCP (v4 + v6) on every ifs given, and parses netboot
+// images from the DHCP leases. Returns bootable OSes.
+func DHCPAndParse(ctx context.Context, l ulog.Logger, ifs []netlink.Link, c dhclient.Config, parsers []BootImageParser, noNetConfig bool) ([]boot.OSImage, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	interrupt := make(chan os.Signal, 1)
+	signal.Notify(interrupt, os.Interrupt)
+
+	l.Printf("Hit Ctrl-C to interrupt DHCP...")
+
+	r := dhclient.SendRequests(ctx, ifs, true, true, c)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+
+		case <-interrupt:
+			return nil, fmt.Errorf("netboot interrupted by interrupt signal (Ctrl-C)")
+
+		case result, ok := <-r:
+			if !ok {
+				return nil, fmt.Errorf("nothing bootable found, all interfaces are configured or timed out")
+			}
+
+			iname := result.Interface.Attrs().Name
+			// Result is either a Lease, or an Error on a specific interface.
+			if result.Err != nil {
+				l.Printf("Could not configure %s for %s: %v", iname, result.Protocol, result.Err)
+				continue
+			}
+
+			if noNetConfig {
+				l.Printf("Skipping configuring %s with lease %s", iname, result.Lease)
+			} else if err := result.Lease.Configure(); err != nil {
+				l.Printf("Failed to configure lease %s: %v", result.Lease, err)
+
+				// Boot further regardless of lease configuration result.
+				//
+				// If lease failed, fall back to use locally configured
+				// ip/ipv6 address.
+			}
+
+			var images []boot.OSImage
+			for _, parser := range parsers {
+				imgs, err := parser.Parse(ctx, result.Lease)
+				if err != nil {
+					l.Printf("Could not interpret lease %s as %s: %v", result.Lease, parser.Name(), err)
+				}
+				images = append(images, imgs...)
+			}
+			if len(images) > 0 {
+				return images, nil
+			}
+
+			l.Printf("Failed to boot lease %v: no boot images found")
+		}
+	}
 }


### PR DESCRIPTION
We only support iBFTs for multiboot kernel, and ESXi is one of the few multiboot formats we support. We have some janky syslinux multiboot support, and some GRUB multiboot support, but no IBFT (yet).