### PR TITLE
pkg/boot: add PadInitrds helper to align multiple initrds to 512b

### DIFF
--- a/pkg/boot/initrd.go
+++ b/pkg/boot/initrd.go
@@ -1,0 +1,30 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package boot
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/u-root/u-root/pkg/uio"
+)
+
+// CatInitrds concatenates initrds from a list of io.Readers, pads them to a
+// 512 byte boundary, and returns a uio.LazyOpenerAt
+func CatInitrds(initrds ...io.Reader) *uio.LazyOpenerAt {
+	return uio.NewLazyOpenerAt("", func() (io.ReaderAt, error) {
+		buf := new(bytes.Buffer)
+		for _, ireader := range initrds {
+			size, err := buf.ReadFrom(ireader)
+			if err != nil {
+				return nil, err
+			}
+			padding := make([]byte, 512-(size%512))
+			buf.Write(padding)
+		}
+		// Buffer doesn't implement ReadAt, so wrap in NewReader
+		return bytes.NewReader(buf.Bytes()), nil
+	})
+}

--- a/pkg/boot/initrd_test.go
+++ b/pkg/boot/initrd_test.go
@@ -1,0 +1,37 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package boot
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/uio"
+)
+
+func TestConcatenationSize(t *testing.T) {
+	a := strings.NewReader("yay")
+	b := bytes.NewReader(make([]byte, 777))
+	reader := CatInitrds(a, b)
+	res, _ := uio.ReadAll(reader)
+	size := len(res)
+	if size != 1536 {
+		t.Errorf("want 1536 bytes, got %v", size)
+	}
+}
+
+func TestConcatenationBytes(t *testing.T) {
+	a := strings.NewReader("foo")
+	b := strings.NewReader("bar")
+	reader := CatInitrds(a, b)
+	res, _ := uio.ReadAll(reader)
+	if res[0] != 'f' {
+		t.Errorf("byte 0 is not f")
+	}
+	if res[513] != 'a' {
+		t.Errorf("byte 513 is not a")
+	}
+}


### PR DESCRIPTION
This enables passing multiple initrds to the kernel.