### PR TITLE
Plan 9 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -183,6 +183,8 @@ jobs:
                   go run u-root.go -build=bb all core
                   go run u-root.go all core
                   go run u-root.go -fourbins minimal
+                  go build .
+                  GOOS=plan9 ./u-root plan9 -defaultsh=/bbin/rush -initcmd=/bbin/rush
   test-integration-amd64:
     <<: *integration-template
     docker:

--- a/cmds/core/dhclient/dhclient.go
+++ b/cmds/core/dhclient/dhclient.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !plan9
+
 // dhclient sets up network config using DHCP.
 //
 // Synopsis:

--- a/cmds/exp/rush/attr.go
+++ b/cmds/exp/rush/attr.go
@@ -1,0 +1,13 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !linux
+
+package main
+
+func builtinAttr(c *Command) {
+}
+
+func forkAttr(c *Command) {
+}

--- a/cmds/exp/rush/attr_linux.go
+++ b/cmds/exp/rush/attr_linux.go
@@ -1,0 +1,25 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux
+
+package main
+
+import (
+	"syscall"
+)
+
+func builtinAttr(c *Command) {
+	c.Cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNS
+}
+
+func forkAttr(c *Command) {
+	c.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+	if c.bg {
+		c.Cmd.SysProcAttr.Setpgid = true
+	} else {
+		c.Cmd.SysProcAttr.Foreground = true
+		c.Cmd.SysProcAttr.Ctty = int(ttyf.Fd())
+	}
+}

--- a/cmds/exp/rush/rush.go
+++ b/cmds/exp/rush/rush.go
@@ -17,7 +17,6 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
-	"syscall"
 )
 
 type builtin func(c *Command) error
@@ -93,13 +92,7 @@ func runit(c *Command) error {
 			return err
 		}
 	} else {
-		c.Cmd.SysProcAttr = &syscall.SysProcAttr{}
-		if c.bg {
-			c.Cmd.SysProcAttr.Setpgid = true
-		} else {
-			c.Cmd.SysProcAttr.Foreground = true
-			c.Cmd.SysProcAttr.Ctty = int(ttyf.Fd())
-		}
+		forkAttr(c)
 		if err := c.Start(); err != nil {
 			return fmt.Errorf("%v: Path %v", err, os.Getenv("PATH"))
 		}
@@ -169,7 +162,7 @@ func commands(cmds []*Command) error {
 		// Not sure of the issue but this hack will have to do until
 		// we understand it. Barf.
 		if c.cmd == "builtin" {
-			c.Cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNS
+			builtinAttr(c)
 		}
 	}
 	return nil

--- a/cmds/exp/rush/tty.go
+++ b/cmds/exp/rush/tty.go
@@ -1,0 +1,13 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !linux
+
+package main
+
+func tty() {
+}
+
+func foreground() {
+}

--- a/templates.go
+++ b/templates.go
@@ -112,4 +112,7 @@ var templates = map[string][]string{
 		"github.com/u-root/u-root/cmds/core/uname",
 		"github.com/u-root/u-root/cmds/core/wget",
 	},
+	"plan9": {
+		"github.com/u-root/u-root/cmds/exp/rush",
+	},
 }


### PR DESCRIPTION
Start to get things to build on plan 9.

Create a plan9 template so nobody has to remember what builds
and what does not. Add a test for building for Plan 9 on amd64.
This should help force us walk the line on OS dependencies.