### PR TITLE
boot: some improvements to CatInitrds

### DIFF
--- a/pkg/boot/initrd.go
+++ b/pkg/boot/initrd.go
@@ -7,22 +7,31 @@ package boot
 import (
 	"bytes"
 	"io"
+	"strings"
 
 	"github.com/u-root/u-root/pkg/uio"
 )
 
-// CatInitrds concatenates initrds from a list of io.Readers, pads them to a
-// 512 byte boundary, and returns a uio.LazyOpenerAt
-func CatInitrds(initrds ...io.Reader) *uio.LazyOpenerAt {
-	return uio.NewLazyOpenerAt("", func() (io.ReaderAt, error) {
+// CatInitrds concatenates initrds on first ReadAt call from a list of
+// io.ReaderAts, pads them to a 512 byte boundary.
+func CatInitrds(initrds ...io.ReaderAt) io.ReaderAt {
+	var names []string
+	for _, initrd := range initrds {
+		names = append(names, stringer(initrd))
+	}
+
+	return uio.NewLazyOpenerAt(strings.Join(names, ","), func() (io.ReaderAt, error) {
 		buf := new(bytes.Buffer)
-		for _, ireader := range initrds {
-			size, err := buf.ReadFrom(ireader)
+		for i, ireader := range initrds {
+			size, err := buf.ReadFrom(uio.Reader(ireader))
 			if err != nil {
 				return nil, err
 			}
-			padding := make([]byte, 512-(size%512))
-			buf.Write(padding)
+			// Don't pad the ending.
+			if i != len(initrds)-1 {
+				padding := make([]byte, 512-(size%512))
+				buf.Write(padding)
+			}
 		}
 		// Buffer doesn't implement ReadAt, so wrap in NewReader
 		return bytes.NewReader(buf.Bytes()), nil

--- a/pkg/boot/initrd.go
+++ b/pkg/boot/initrd.go
@@ -27,8 +27,8 @@ func CatInitrds(initrds ...io.ReaderAt) io.ReaderAt {
 			if err != nil {
 				return nil, err
 			}
-			// Don't pad the ending.
-			if i != len(initrds)-1 {
+			// Don't pad the ending or an already aligned file.
+			if i != len(initrds)-1 && size%512 != 0 {
 				padding := make([]byte, 512-(size%512))
 				buf.Write(padding)
 			}

--- a/pkg/boot/initrd_test.go
+++ b/pkg/boot/initrd_test.go
@@ -39,6 +39,15 @@ func TestCatInitrds(t *testing.T) {
 	}{
 		{
 			readers: []io.ReaderAt{
+				bytes.NewReader(make([]byte, 512)),
+				bytes.NewReader(make([]byte, 512)),
+			},
+			wantName:    "*bytes.Reader,*bytes.Reader",
+			wantContent: make([]byte, 1024),
+			wantSize:    1024,
+		},
+		{
+			readers: []io.ReaderAt{
 				strings.NewReader("yay"),
 				bytes.NewReader(make([]byte, 777)),
 			},

--- a/pkg/boot/initrd_test.go
+++ b/pkg/boot/initrd_test.go
@@ -6,32 +6,95 @@ package boot
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"strings"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/uio"
 )
 
-func TestConcatenationSize(t *testing.T) {
-	a := strings.NewReader("yay")
-	b := bytes.NewReader(make([]byte, 777))
-	reader := CatInitrds(a, b)
-	res, _ := uio.ReadAll(reader)
-	size := len(res)
-	if size != 1536 {
-		t.Errorf("want 1536 bytes, got %v", size)
-	}
+type file struct {
+	name    string
+	content []byte
 }
 
-func TestConcatenationBytes(t *testing.T) {
-	a := strings.NewReader("foo")
-	b := strings.NewReader("bar")
-	reader := CatInitrds(a, b)
-	res, _ := uio.ReadAll(reader)
-	if res[0] != 'f' {
-		t.Errorf("byte 0 is not f")
+func (f file) String() string {
+	return f.name
+}
+
+func (f file) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(f.content)) {
+		return 0, io.EOF
 	}
-	if res[513] != 'a' {
-		t.Errorf("byte 513 is not a")
+	return copy(p, f.content[off:]), nil
+}
+
+func TestCatInitrds(t *testing.T) {
+	for _, tt := range []struct {
+		readers     []io.ReaderAt
+		wantName    string
+		wantContent []byte
+		wantSize    int
+	}{
+		{
+			readers: []io.ReaderAt{
+				strings.NewReader("yay"),
+				bytes.NewReader(make([]byte, 777)),
+			},
+			wantName:    "*strings.Reader,*bytes.Reader",
+			wantContent: append([]byte("yay"), make([]byte, 509+777)...),
+			wantSize:    3 + 509 + 777,
+		},
+		{
+			readers: []io.ReaderAt{
+				strings.NewReader("yay"),
+			},
+			wantName:    "*strings.Reader",
+			wantContent: []byte("yay"),
+			wantSize:    3,
+		},
+		{
+			readers: []io.ReaderAt{
+				strings.NewReader("foo"),
+				strings.NewReader("bar"),
+			},
+			wantName:    "*strings.Reader,*strings.Reader",
+			wantContent: append(append([]byte("foo"), make([]byte, 509)...), []byte("bar")...),
+			wantSize:    3 + 509 + 3,
+		},
+		{
+			readers: []io.ReaderAt{
+				file{
+					name:    "/bar/foo",
+					content: []byte("foo"),
+				},
+				file{
+					name:    "/bar/bar",
+					content: []byte("bar"),
+				},
+			},
+			wantName:    "/bar/foo,/bar/bar",
+			wantContent: append(append([]byte("foo"), make([]byte, 509)...), []byte("bar")...),
+			wantSize:    3 + 509 + 3,
+		},
+	} {
+		got := CatInitrds(tt.readers...)
+
+		by, err := uio.ReadAll(got)
+		if err != nil {
+			t.Errorf("CatInitrdReader errored: %v", err)
+		}
+
+		if len(by) != tt.wantSize {
+			t.Errorf("Cat(%v) = len %d, want len %d", tt.readers, len(by), tt.wantSize)
+		}
+		if !bytes.Equal(by, tt.wantContent) {
+			t.Errorf("Cat(%v) = %v, want %v", tt.readers, by, tt.wantContent)
+		}
+		s := fmt.Sprintf("%s", got)
+		if s != tt.wantName {
+			t.Errorf("Cat(%v) = name %s, want %s", tt.readers, s, tt.wantName)
+		}
 	}
 }

--- a/pkg/boot/linux.go
+++ b/pkg/boot/linux.go
@@ -34,7 +34,7 @@ func stringer(mod io.ReaderAt) string {
 	if f, ok := mod.(*os.File); ok {
 		return f.Name()
 	}
-	return fmt.Sprintf("%v", mod)
+	return fmt.Sprintf("%T", mod)
 }
 
 // Label returns either the Name or a short description.
@@ -42,7 +42,7 @@ func (li *LinuxImage) Label() string {
 	if len(li.Name) > 0 {
 		return li.Name
 	}
-	return fmt.Sprintf("Linux(kernel=%s, initrd=%s)", stringer(li.Kernel), stringer(li.Initrd))
+	return fmt.Sprintf("Linux(kernel=%s initrd=%s)", stringer(li.Kernel), stringer(li.Initrd))
 }
 
 // String prints a human-readable version of this linux image.

--- a/pkg/boot/linux_test.go
+++ b/pkg/boot/linux_test.go
@@ -1,0 +1,94 @@
+// Copyright 2017-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package boot
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/curl"
+	"github.com/u-root/u-root/pkg/uio"
+)
+
+func TestLinuxLabel(t *testing.T) {
+	dir, err := ioutil.TempDir("", "foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(dir)
+
+	osKernel, err := os.Create(filepath.Join(dir, "kernel"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	osInitrd, err := os.Create(filepath.Join(dir, "initrd"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	k, _ := url.Parse("http://127.0.0.1/kernel")
+	i1, _ := url.Parse("http://127.0.0.1/initrd1")
+	i2, _ := url.Parse("http://127.0.0.1/initrd2")
+	httpKernel, _ := curl.LazyFetch(k)
+	httpInitrd1, _ := curl.LazyFetch(i1)
+	httpInitrd2, _ := curl.LazyFetch(i2)
+
+	for _, tt := range []struct {
+		desc string
+		img  *LinuxImage
+		want string
+	}{
+		{
+			desc: "os.File",
+			img: &LinuxImage{
+				Kernel: osKernel,
+				Initrd: osInitrd,
+			},
+			want: fmt.Sprintf("Linux(kernel=%s/kernel initrd=%s/initrd)", dir, dir),
+		},
+		{
+			desc: "lazy file",
+			img: &LinuxImage{
+				Kernel: uio.NewLazyFile(filepath.Join(dir, "kernel")),
+				Initrd: uio.NewLazyFile(filepath.Join(dir, "initrd")),
+			},
+			want: fmt.Sprintf("Linux(kernel=%s/kernel initrd=%s/initrd)", dir, dir),
+		},
+		{
+			desc: "concat lazy file",
+			img: &LinuxImage{
+				Kernel: uio.NewLazyFile(filepath.Join(dir, "kernel")),
+				Initrd: CatInitrds(
+					uio.NewLazyFile(filepath.Join(dir, "initrd")),
+					uio.NewLazyFile(filepath.Join(dir, "initrd")),
+				),
+			},
+			want: fmt.Sprintf("Linux(kernel=%s/kernel initrd=%s/initrd,%s/initrd)", dir, dir, dir),
+		},
+		{
+			desc: "curl lazy file",
+			img: &LinuxImage{
+				Kernel: httpKernel,
+				Initrd: CatInitrds(
+					httpInitrd1,
+					httpInitrd2,
+				),
+			},
+			want: "Linux(kernel=http://127.0.0.1/kernel initrd=http://127.0.0.1/initrd1,http://127.0.0.1/initrd2)",
+		},
+	} {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := tt.img.Label()
+			if got != tt.want {
+				t.Errorf("Label() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -31,7 +31,7 @@ func (mi *MultibootImage) Label() string {
 	if len(mi.Name) > 0 {
 		return mi.Name
 	}
-	return fmt.Sprintf("Multiboot(kernel=%s, cmdline=%s, iBFT=%s)", mi.Kernel, mi.Cmdline, mi.IBFT)
+	return fmt.Sprintf("Multiboot(kernel=%s cmdline=%s iBFT=%s)", mi.Kernel, mi.Cmdline, mi.IBFT)
 }
 
 // Load implements OSImage.Load.


### PR DESCRIPTION
I wanted to make sure that when you embed a concatenated Initrd into a LinuxImage, it'd show the right name if you call the Stringer or the Label() function. 