### PR TITLE
shlex: add more tests from anmitsu/go-shlex

### DIFF
--- a/pkg/shlex/shlex_test.go
+++ b/pkg/shlex/shlex_test.go
@@ -42,14 +42,14 @@ func TestArgv(t *testing.T) {
 			want: []string{"stuff", "var=more stuff"},
 		},
 		{
-			desc: "quote specials",
-			in:   "stuff var='more stuff $ \\ \\$ \" '",
-			want: []string{"stuff", "var=more stuff $ \\ \\$ \" "},
+			desc: "single quote specials",
+			in:   `stuff var='more stuff $ \ \$ " '`,
+			want: []string{"stuff", `var=more stuff $ \ \$ " `},
 		},
 		{
-			desc: "double quote",
-			in:   "stuff var=\"more stuff $ \\ \\$ \\\" \"",
-			want: []string{"stuff", "var=more stuff $ \\ $ \" "},
+			desc: "double quote specials",
+			in:   `stuff var="more stuff $ \ \$ \" \n "`,
+			want: []string{"stuff", `var=more stuff $ \ $ " \n `},
 		},
 		{
 			desc: "quote forgot close",
@@ -59,7 +59,105 @@ func TestArgv(t *testing.T) {
 		{
 			desc: "empty",
 			in:   "",
-			want: nil,
+			want: []string{},
+		},
+		{
+			in: `This string has an embedded apostrophe, doesn't it?`,
+			want: []string{
+				"This",
+				"string",
+				"has",
+				"an",
+				"embedded",
+				"apostrophe,",
+				"doesnt it?",
+			},
+		},
+		{
+			in: "This string has embedded \"double quotes\" and 'single quotes' in it,\nand even \"a 'nested example'\".\n",
+			want: []string{
+				"This",
+				"string",
+				"has",
+				"embedded",
+				`double quotes`,
+				"and",
+				`single quotes`,
+				"in",
+				"it,",
+				"and",
+				"even",
+				`a 'nested example'.`,
+			},
+		},
+		{
+			in: `Hello world!, こんにちは　世界！`,
+			want: []string{
+				"Hello",
+				"world!,",
+				"こんにちは",
+				"世界！",
+			},
+		},
+		{
+			in:   `Do"Not"Separate`,
+			want: []string{`DoNotSeparate`},
+		},
+		{
+			in: `Escaped \e Character not in quotes`,
+			want: []string{
+				"Escaped",
+				"e",
+				"Character",
+				"not",
+				"in",
+				"quotes",
+			},
+		},
+		{
+			in: `Escaped "\e" Character in double quotes`,
+			want: []string{
+				"Escaped",
+				`\e`,
+				"Character",
+				"in",
+				"double",
+				"quotes",
+			},
+		},
+		{
+			in: `Escaped '\e' Character in single quotes`,
+			want: []string{
+				"Escaped",
+				`\e`,
+				"Character",
+				"in",
+				"single",
+				"quotes",
+			},
+		},
+		{
+			in: `Escaped '\'' \"\'\" single quote`,
+			want: []string{
+				"Escaped",
+				`\ \"\"`,
+				"single",
+				"quote",
+			},
+		},
+		{
+			in: `Escaped "\"" \'\"\' double quote`,
+			want: []string{
+				"Escaped",
+				`"`,
+				`'"'`,
+				"double",
+				"quote",
+			},
+		},
+		{
+			in:   `"'Strip extra layer of quotes'"`,
+			want: []string{`'Strip extra layer of quotes'`},
 		},
 	} {
 		t.Run(fmt.Sprintf("Test [%02d] %s", i, tt.desc), func(t *testing.T) {
@@ -67,7 +165,6 @@ func TestArgv(t *testing.T) {
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Argv = %#v, want %#v", got, tt.want)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
Our shlex is nearly identical to go-shlex. The only thing is that go-shlex doesn't handle double-quoted $ signs correctly. Might be easier to open a PR there and fix it, then delete ours.