### PR TITLE
boot: add ESXi booting to boot cmd

### DIFF
--- a/cmds/boot/boot/boot.go
+++ b/cmds/boot/boot/boot.go
@@ -38,10 +38,11 @@ import (
 	"github.com/u-root/u-root/pkg/boot/localboot"
 	"github.com/u-root/u-root/pkg/boot/menu"
 	"github.com/u-root/u-root/pkg/cmdline"
+	"github.com/u-root/u-root/pkg/mount/block"
+	"github.com/u-root/u-root/pkg/ulog"
 )
 
 var (
-	debug   = func(string, ...interface{}) {}
 	verbose = flag.Bool("v", false, "Print debug messages")
 	noLoad  = flag.Bool("no-load", false, "print chosen boot configuration, but do not load + exec it")
 	noExec  = flag.Bool("no-exec", false, "load boot configuration, but do not exec it")
@@ -62,11 +63,20 @@ func updateBootCmdline(cl string) string {
 func main() {
 	flag.Parse()
 
-	if *verbose {
-		debug = log.Printf
+	blockDevs, err := block.GetBlockDevices()
+	if err != nil {
+		log.Fatal("no available block devices to boot from")
 	}
 
-	images, mps, err := localboot.Localboot()
+	// Try to only boot from "good" block devices.
+	blockDevs = blockDevs.FilterZeroSize()
+	log.Printf("Booting from the following block devices: %v", blockDevs)
+
+	var l ulog.Logger = ulog.Null
+	if *verbose {
+		l = ulog.Log
+	}
+	images, mps, err := localboot.Localboot(l, blockDevs)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmds/boot/boot/boot.go
+++ b/cmds/boot/boot/boot.go
@@ -65,7 +65,7 @@ func main() {
 
 	blockDevs, err := block.GetBlockDevices()
 	if err != nil {
-		log.Fatal("no available block devices to boot from")
+		log.Fatal("No available block devices to boot from")
 	}
 
 	// Try to only boot from "good" block devices.

--- a/pkg/boot/esxi/esxi_test.go
+++ b/pkg/boot/esxi/esxi_test.go
@@ -23,6 +23,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/kernel_cmdline_mods.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 zee",
 				modules: []module{
@@ -44,6 +45,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/kernelopt_first.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 zee",
 			},
@@ -51,6 +53,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/empty_mods.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 zee",
 			},
@@ -58,6 +61,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/no_mods.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 zee",
 			},
@@ -65,6 +69,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/no_cmdline.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 ",
 			},
@@ -72,6 +77,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/empty_cmdline.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 ",
 			},
@@ -79,6 +85,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/empty_updated.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 zee",
 				// Explicitly stating this as the wanted value.
@@ -88,6 +95,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/updated_twice.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 zee",
 				// Explicitly stating this as the wanted value.
@@ -97,6 +105,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/updated.cfg",
 			want: options{
+				title:   "VMware ESXi",
 				kernel:  "testdata/b.b00",
 				args:    "b.b00 zee",
 				updated: 4,
@@ -105,6 +114,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/empty_bootstate.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 zee",
 				// Explicitly stating this as the wanted value.
@@ -114,6 +124,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/bootstate_twice.cfg",
 			want: options{
+				title:  "VMware ESXi",
 				kernel: "testdata/b.b00",
 				args:   "b.b00 zee",
 				// Explicitly stating this as the wanted value.
@@ -123,6 +134,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/bootstate.cfg",
 			want: options{
+				title:     "VMware ESXi",
 				kernel:    "testdata/b.b00",
 				args:      "b.b00 zee",
 				bootstate: bootDirty,
@@ -131,6 +143,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/bootstate_invalid.cfg",
 			want: options{
+				title:     "VMware ESXi",
 				kernel:    "testdata/b.b00",
 				args:      "b.b00 zee",
 				bootstate: bootInvalid,
@@ -139,6 +152,7 @@ func TestParse(t *testing.T) {
 		{
 			file: "testdata/no_bootstate.cfg",
 			want: options{
+				title:     "VMware ESXi",
 				kernel:    "testdata/b.b00",
 				args:      "b.b00 zee",
 				bootstate: bootInvalid,
@@ -185,6 +199,7 @@ func TestDev5Valid(t *testing.T) {
 	}
 
 	opts5 := &options{
+		title:     "VMware ESXi",
 		kernel:    "testdata/k",
 		updated:   1,
 		bootstate: bootValid,
@@ -198,6 +213,7 @@ func TestDev5Valid(t *testing.T) {
 
 	// Invalid opts6. Higher updated, but invalid state.
 	invalidOpts6 := &options{
+		title:     "VMware ESXi",
 		kernel:    "foobar",
 		updated:   2,
 		bootstate: bootInvalid,
@@ -219,6 +235,7 @@ func TestDev6Valid(t *testing.T) {
 	}
 
 	opts6 := &options{
+		title:     "VMware ESXi",
 		kernel:    "testdata/k",
 		updated:   1,
 		bootstate: bootValid,
@@ -232,6 +249,7 @@ func TestDev6Valid(t *testing.T) {
 
 	// Invalid opts5. Higher updated, but invalid state.
 	invalidOpts5 := &options{
+		title:     "VMware ESXi",
 		kernel:    "foobar",
 		updated:   2,
 		bootstate: bootInvalid,
@@ -252,6 +270,7 @@ func TestImageOrder(t *testing.T) {
 	}
 
 	opt5 := &options{
+		title:     "VMware ESXi",
 		kernel:    "foobar",
 		updated:   2,
 		bootstate: bootValid,
@@ -264,6 +283,7 @@ func TestImageOrder(t *testing.T) {
 	}
 
 	opt6 := &options{
+		title:     "VMware ESXi",
 		kernel:    "testdata/k",
 		updated:   1,
 		bootstate: bootValid,

--- a/pkg/boot/localboot/localboot.go
+++ b/pkg/boot/localboot/localboot.go
@@ -7,15 +7,14 @@ package localboot
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
 	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/boot/bls"
+	"github.com/u-root/u-root/pkg/boot/esxi"
 	"github.com/u-root/u-root/pkg/boot/grub"
 	"github.com/u-root/u-root/pkg/boot/syslinux"
 	"github.com/u-root/u-root/pkg/mount"
@@ -23,38 +22,55 @@ import (
 	"github.com/u-root/u-root/pkg/ulog"
 )
 
-func parse(device *block.BlockDev, mountDir string) []boot.OSImage {
-	imgs, err := bls.ScanBLSEntries(ulog.Log, mountDir)
+// parse treats device as a block device with a file system.
+func parse(l ulog.Logger, device *block.BlockDev, mountDir string) []boot.OSImage {
+	imgs, err := bls.ScanBLSEntries(l, mountDir)
 	if err != nil {
-		log.Printf("Failed to parse systemd-boot BootLoaderSpec configs, trying another format...: %v", err)
+		l.Printf("No systemd-boot BootLoaderSpec configs found on %s, trying another format...: %v", device, err)
 	}
 
 	grubImgs, err := grub.ParseLocalConfig(context.Background(), mountDir)
 	if err != nil {
-		log.Printf("Failed to parse GRUB configs from %s, trying another format...: %v", device, err)
+		l.Printf("No GRUB configs found on %s, trying another format...: %v", device, err)
 	}
 	imgs = append(imgs, grubImgs...)
 
 	syslinuxImgs, err := syslinux.ParseLocalConfig(context.Background(), mountDir)
 	if err != nil {
-		log.Printf("Failed to parse syslinux configs from %s: %v", device, err)
+		l.Printf("No syslinux configs found on %s: %v", device, err)
 	}
 	imgs = append(imgs, syslinuxImgs...)
 
 	return imgs
 }
 
-// Localboot tries to boot from any local filesystem by parsing grub configuration
-func Localboot() ([]boot.OSImage, []*mount.MountPoint, error) {
-	blockDevs, err := block.GetBlockDevices()
+// parseUnmounted treats device as unmounted, with or without partitions.
+func parseUnmounted(l ulog.Logger, device *block.BlockDev) ([]boot.OSImage, []*mount.MountPoint, error) {
+	// This will try to mount device partition 5 and 6.
+	imgs, mps, err := esxi.LoadDisk(device.DevicePath())
 	if err != nil {
-		return nil, nil, errors.New("no available block devices to boot from")
+		l.Printf("No ESXi disk configs found on %s: %v", device, err)
 	}
 
-	// Try to only boot from "good" block devices.
-	blockDevs = blockDevs.FilterZeroSize()
-	log.Printf("Booting from the following block devices: %v", blockDevs)
+	// This tries to mount the device itself, in case it's an installer CD.
+	img, mp, err := esxi.LoadCDROM(device.DevicePath())
+	if err != nil {
+		l.Printf("No ESXi CDROM configs found on %s: %v", device, err)
+	}
+	if img != nil {
+		imgs = append(imgs, img)
+		mps = append(mps, mp)
+	}
+	// Convert from *MultibootImage to OSImage.
+	var images []boot.OSImage
+	for _, i := range imgs {
+		images = append(images, i)
+	}
+	return images, mps, nil
+}
 
+// Localboot tries to boot from any local filesystem by parsing grub configuration
+func Localboot(l ulog.Logger, blockDevs block.BlockDevices) ([]boot.OSImage, []*mount.MountPoint, error) {
 	mountPoints, err := ioutil.TempDir("", "u-root-boot")
 	if err != nil {
 		return nil, nil, fmt.Errorf("cannot create tmpdir: %v", err)
@@ -63,17 +79,24 @@ func Localboot() ([]boot.OSImage, []*mount.MountPoint, error) {
 	var images []boot.OSImage
 	var mps []*mount.MountPoint
 	for _, device := range blockDevs {
-		dir := filepath.Join(mountPoints, device.Name)
+		imgs, mmps, err := parseUnmounted(l, device)
+		if err == nil {
+			images = append(images, imgs...)
+			mps = append(mps, mmps...)
+		} else {
+			dir := filepath.Join(mountPoints, device.Name)
 
-		os.MkdirAll(dir, 0777)
-		mp, err := device.Mount(dir, mount.ReadOnly)
-		if err != nil {
-			continue
+			os.MkdirAll(dir, 0777)
+			mp, err := device.Mount(dir, mount.ReadOnly)
+			if err != nil {
+				os.RemoveAll(dir)
+				continue
+			}
+
+			imgs = parse(l, device, dir)
+			images = append(images, imgs...)
+			mps = append(mps, mp)
 		}
-
-		imgs := parse(device, dir)
-		images = append(images, imgs...)
-		mps = append(mps, mp)
 	}
 	return images, mps, nil
 }


### PR DESCRIPTION
Adds detecting an ESXi install (or installer CD) to boot and its boot menu. Should deprecate `cmds/exp/esxiboot` eventually, I guess.