### PR TITLE
cmds/mount: try all block file systems in order if no fstype specified

### DIFF
--- a/cmds/core/mount/mount.go
+++ b/cmds/core/mount/mount.go
@@ -124,12 +124,14 @@ func main() {
 		flags |= unix.MS_RDONLY
 	}
 	if *fsType == "" {
-		// mandatory parameter for the moment
-		log.Fatalf("No file system type provided!\nUsage: mount [-r] [-o mount options] -t fstype dev path")
-	}
-	if _, err := mount.Mount(dev, path, *fsType, strings.Join(data, ","), flags); err != nil {
-		log.Printf("%v", err)
-		informIfUnknownFS(*fsType)
-		os.Exit(1)
+		if _, err := mount.TryMount(dev, path, strings.Join(data, ","), flags); err != nil {
+			log.Fatalf("%v", err)
+		}
+	} else {
+		if _, err := mount.Mount(dev, path, *fsType, strings.Join(data, ","), flags); err != nil {
+			log.Printf("%v", err)
+			informIfUnknownFS(*fsType)
+			os.Exit(1)
+		}
 	}
 }

--- a/pkg/boot/diskboot/device.go
+++ b/pkg/boot/diskboot/device.go
@@ -69,7 +69,7 @@ func FindDevice(devPath string, flags uintptr) (*Device, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create tmp mount directory: %v", err)
 	}
-	mp, err := mount.TryMount(devPath, mountPath, flags)
+	mp, err := mount.TryMount(devPath, mountPath, "", flags)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find a valid boot device: %v", err)
 	}

--- a/pkg/mount/block/blockdev.go
+++ b/pkg/mount/block/blockdev.go
@@ -71,7 +71,7 @@ func (b *BlockDev) Mount(path string, flags uintptr) (*mount.MountPoint, error) 
 		return mount.Mount(devpath, path, b.FSType, "", flags)
 	}
 
-	return mount.TryMount(devpath, path, flags)
+	return mount.TryMount(devpath, path, "", flags)
 }
 
 // GPTTable tries to read a GPT table from the block device described by the

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -95,7 +95,7 @@ func Mount(dev, path, fsType, data string, flags uintptr) (*MountPoint, error) {
 
 // TryMount tries to mount a device on the given mountpoint, trying in order
 // the supported block device file systems on the system.
-func TryMount(device, path string, flags uintptr) (*MountPoint, error) {
+func TryMount(device, path, data string, flags uintptr) (*MountPoint, error) {
 	// TryMount only works on existing block devices. No weirdo devices
 	// like 9P.
 	if _, err := os.Stat(device); err != nil {
@@ -107,7 +107,7 @@ func TryMount(device, path string, flags uintptr) (*MountPoint, error) {
 		return nil, fmt.Errorf("failed to mount %s on %s: %v", device, path, err)
 	}
 	for _, fstype := range fs {
-		mp, err := Mount(device, path, fstype, "", flags)
+		mp, err := Mount(device, path, fstype, data, flags)
 		if err != nil {
 			continue
 		}

--- a/pkg/mount/mount_linux_test.go
+++ b/pkg/mount/mount_linux_test.go
@@ -182,7 +182,7 @@ func TestTryMount(t *testing.T) {
 	defer os.RemoveAll(d)
 
 	sda1 := filepath.Join(d, "sda1")
-	if mp, err := mount.TryMount("/dev/sda1", sda1, mount.ReadOnly); err != nil {
+	if mp, err := mount.TryMount("/dev/sda1", sda1, "", mount.ReadOnly); err != nil {
 		t.Errorf("TryMount(/dev/sda1) = %v, want nil", err)
 	} else {
 		want := &mount.MountPoint{
@@ -201,7 +201,7 @@ func TestTryMount(t *testing.T) {
 	}
 
 	sda2 := filepath.Join(d, "sda2")
-	if mp, err := mount.TryMount("/dev/sda2", sda2, mount.ReadOnly); err != nil {
+	if mp, err := mount.TryMount("/dev/sda2", sda2, "", mount.ReadOnly); err != nil {
 		t.Errorf("TryMount(/dev/sda2) = %v, want nil", err)
 	} else {
 		want := &mount.MountPoint{
@@ -220,12 +220,12 @@ func TestTryMount(t *testing.T) {
 	}
 
 	sdb1 := filepath.Join(d, "sdb1")
-	if _, err := mount.TryMount("/dev/sdb1", sdb1, mount.ReadOnly); !strings.Contains(err.Error(), "no suitable filesystem") {
+	if _, err := mount.TryMount("/dev/sdb1", sdb1, "", mount.ReadOnly); !strings.Contains(err.Error(), "no suitable filesystem") {
 		t.Errorf("TryMount(/dev/sdb1) = %v, want an error containing 'no suitable filesystem'", err)
 	}
 
 	sdz1 := filepath.Join(d, "sdz1")
-	if _, err := mount.TryMount("/dev/sdz1", sdz1, mount.ReadOnly); !os.IsNotExist(err) {
+	if _, err := mount.TryMount("/dev/sdz1", sdz1, "", mount.ReadOnly); !os.IsNotExist(err) {
 		t.Errorf("TryMount(/dev/sdz1) = %v, want an error equivalent to Does Not Exist", err)
 	}
 }


### PR DESCRIPTION
Before this PR, you have to specify `-t ext4` or some file system for mount to work.

After this PR, mount will read file systems from `/proc/filesystems` and automatically try all block file systems if `-t` is not specified.