### PR TITLE
Move to more inclusive language.

### DIFF
--- a/cmds/core/elvish/edit/ui/render_test.go
+++ b/cmds/core/elvish/edit/ui/render_test.go
@@ -2,15 +2,15 @@ package ui
 
 import "testing"
 
-type dummyRenderer struct {
+type testRenderer struct {
 }
 
-func (dummyRenderer) Render(b *Buffer) {
+func (testRenderer) Render(b *Buffer) {
 	b.WriteString("xy", "1")
 }
 
 func TestRender(t *testing.T) {
-	b := Render(dummyRenderer{}, 10)
+	b := Render(testRenderer{}, 10)
 	if b.Width != 10 {
 		t.Errorf("Rendered Buffer has Width %d, want %d", b.Width, 10)
 	}

--- a/cmds/core/scp/scp_test.go
+++ b/cmds/core/scp/scp_test.go
@@ -23,17 +23,17 @@ func TestScpSource(t *testing.T) {
 		t.Fatalf("creating temp file: %v", err)
 	}
 	defer os.Remove(tf.Name())
-	tf.Write([]byte("dummy-file-contents"))
+	tf.Write([]byte("test-file-contents"))
 
 	r.Write([]byte{0})
 	err = scpSource(&w, &r, tf.Name())
 	if err != nil {
 		t.Fatalf("error: %v", err)
 	}
-	expected := []byte(fmt.Sprintf("C0600 19 %s\ndummy-file-contents", path.Base(tf.Name())))
+	expected := []byte(fmt.Sprintf("C0600 18 %s\ntest-file-contents", path.Base(tf.Name())))
 	expected = append(expected, 0)
 	if string(expected) != w.String() {
-		t.Fatalf("Got: %v\nExpected: %v", w.Bytes(), expected)
+		t.Fatalf("Got: %v\nExpected: %v", w.String(), string(expected))
 	}
 }
 
@@ -47,7 +47,7 @@ func TestScpSink(t *testing.T) {
 	}
 	defer os.Remove(tf.Name())
 
-	r.Write([]byte(fmt.Sprintf("C0600 19 dummy\ndummy-file-contents")))
+	r.Write([]byte(fmt.Sprintf("C0600 18 test\ntest-file-contents")))
 	// Post IO-copy success status
 	r.Write([]byte{0})
 
@@ -64,13 +64,13 @@ func TestScpSink(t *testing.T) {
 		t.Fatalf("Got: %v\nExpected: %v", w.Bytes(), expected)
 	}
 
-	m := make([]byte, 19)
+	m := make([]byte, 18)
 	n, err := tf.Read(m)
 	if err != nil {
 		t.Fatalf("IO error: %v", err)
 	}
-	if n != 19 {
-		t.Fatalf("Expected 19 bytes, got %v", n)
+	if n != 18 {
+		t.Fatalf("Expected 18 bytes, got %v", n)
 	}
 
 	// Ensure EOF
@@ -79,7 +79,7 @@ func TestScpSink(t *testing.T) {
 		t.Fatalf("Expected EOF, got %v", err)
 	}
 
-	if string(m) != "dummy-file-contents" {
-		t.Fatalf("Expected 'dummy-file-contents', got '%v'", string(m))
+	if string(m) != "test-file-contents" {
+		t.Fatalf("Expected 'test-file-contents', got '%v'", string(m))
 	}
 }

--- a/cmds/exp/hdparm/hdparm.go
+++ b/cmds/exp/hdparm/hdparm.go
@@ -40,7 +40,7 @@ var (
 	debug           = func(string, ...interface{}) {}
 	unlock          = flag.String("security-unlock", "", "Unlock the drive with a password")
 	identify        = flag.Bool("i", false, "Get drive identifying information")
-	master          = flag.Bool("user-master", false, "Unlock master (true) or user (false)")
+	admin           = flag.Bool("user-master", false, "Unlock admin (true) or user (false)")
 	timeoutDuration = flag.String("timeout", "15s", "Timeout for operations expressed as a Go duration (e.g. 15s)")
 	verbs           = []string{"security-unlock", "i"}
 )
@@ -71,7 +71,7 @@ func checkVerbs() (op, error) {
 }
 
 func unlockop(d scuzz.Disk) (string, error) {
-	return "", d.Unlock(*unlock, *master)
+	return "", d.Unlock(*unlock, *admin)
 }
 
 func identifyop(d scuzz.Disk) (string, error) {

--- a/pkg/boot/menu/menu_test.go
+++ b/pkg/boot/menu/menu_test.go
@@ -22,7 +22,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-type dummyEntry struct {
+type testEntry struct {
 	mu         sync.Mutex
 	label      string
 	isDefault  bool
@@ -30,36 +30,36 @@ type dummyEntry struct {
 	loadCalled bool
 }
 
-func (d *dummyEntry) Label() string {
+func (d *testEntry) Label() string {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.label
 }
 
-func (d *dummyEntry) String() string {
+func (d *testEntry) String() string {
 	return d.Label()
 }
 
-func (d *dummyEntry) Load() error {
+func (d *testEntry) Load() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.loadCalled = true
 	return d.load
 }
 
-func (d *dummyEntry) Exec() error {
+func (d *testEntry) Exec() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return nil
 }
 
-func (d *dummyEntry) LoadCalled() bool {
+func (d *testEntry) LoadCalled() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.loadCalled
 }
 
-func (d *dummyEntry) IsDefault() bool {
+func (d *testEntry) IsDefault() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	return d.isDefault
@@ -70,9 +70,9 @@ func TestChoose(t *testing.T) {
 	// anything root-specific.
 	testutil.SkipIfInVMTest(t)
 
-	entry1 := &dummyEntry{label: "1"}
-	entry2 := &dummyEntry{label: "2"}
-	entry3 := &dummyEntry{label: "3"}
+	entry1 := &testEntry{label: "1"}
+	entry2 := &testEntry{label: "2"}
+	entry3 := &testEntry{label: "3"}
 
 	for _, tt := range []struct {
 		name      string
@@ -174,7 +174,7 @@ func TestShowMenuAndLoad(t *testing.T) {
 
 	tests := []struct {
 		name      string
-		entries   []*dummyEntry
+		entries   []*testEntry
 		userEntry []byte
 
 		// calledLabels are the entries for which Do was called.
@@ -182,7 +182,7 @@ func TestShowMenuAndLoad(t *testing.T) {
 	}{
 		{
 			name: "default_entry",
-			entries: []*dummyEntry{
+			entries: []*testEntry{
 				{label: "1", isDefault: true, load: nil},
 				{label: "2", isDefault: true, load: nil},
 			},
@@ -192,7 +192,7 @@ func TestShowMenuAndLoad(t *testing.T) {
 		},
 		{
 			name: "non_default_entry_default",
-			entries: []*dummyEntry{
+			entries: []*testEntry{
 				{label: "1", isDefault: false, load: nil},
 				{label: "2", isDefault: true, load: nil},
 				{label: "3", isDefault: true, load: nil},
@@ -203,7 +203,7 @@ func TestShowMenuAndLoad(t *testing.T) {
 		},
 		{
 			name: "non_default_entry_chosen_but_broken",
-			entries: []*dummyEntry{
+			entries: []*testEntry{
 				{label: "1", isDefault: false, load: fmt.Errorf("borked")},
 				{label: "2", isDefault: true, load: nil},
 				{label: "3", isDefault: true, load: nil},
@@ -213,7 +213,7 @@ func TestShowMenuAndLoad(t *testing.T) {
 		},
 		{
 			name: "last_entry_works",
-			entries: []*dummyEntry{
+			entries: []*testEntry{
 				{label: "1", isDefault: true, load: fmt.Errorf("foo")},
 				{label: "2", isDefault: true, load: fmt.Errorf("bar")},
 				{label: "3", isDefault: true, load: nil},

--- a/pkg/boot/stboot/signature.go
+++ b/pkg/boot/stboot/signature.go
@@ -29,12 +29,12 @@ type Signer interface {
 	Verify(sig Signature, hash []byte) error
 }
 
-// DummySigner creates signatures that are always valid.
-type DummySigner struct{}
+// AlwaysValidSigner creates signatures that are always valid.
+type AlwaysValidSigner struct{}
 
-// Hash hashes the the provided files. I case of DummySigner
+// Hash hashes the the provided files. I case of AlwaysValidSigner
 // just 8 random bytes are returned.
-func (DummySigner) Hash(files ...string) ([]byte, error) {
+func (AlwaysValidSigner) Hash(files ...string) ([]byte, error) {
 	hash := make([]byte, 8)
 	_, err := rand.Read(hash)
 	if err != nil {
@@ -43,9 +43,9 @@ func (DummySigner) Hash(files ...string) ([]byte, error) {
 	return hash, nil
 }
 
-// Sign signes the provided data with privKey. In case of DummySigner
+// Sign signes the provided data with privKey. In case of AlwaysValidSigner
 // just 8 random bytes are returned
-func (DummySigner) Sign(privKey string, data []byte) ([]byte, error) {
+func (AlwaysValidSigner) Sign(privKey string, data []byte) ([]byte, error) {
 	sig := make([]byte, 8)
 	_, err := rand.Read(sig)
 	if err != nil {
@@ -55,8 +55,8 @@ func (DummySigner) Sign(privKey string, data []byte) ([]byte, error) {
 }
 
 // Verify checks if sig contains a valid signature of hash. In case of
-// DummySigner this is allwazs the case.
-func (DummySigner) Verify(sig Signature, hash []byte) error {
+// AlwaysValidSigner this is allwazs the case.
+func (AlwaysValidSigner) Verify(sig Signature, hash []byte) error {
 	return nil
 }
 

--- a/pkg/boot/systembooter/bootentry_test.go
+++ b/pkg/boot/systembooter/bootentry_test.go
@@ -52,7 +52,7 @@ func TestGetBootEntries(t *testing.T) {
 		bootConfig0000 = []byte(`{"type": "netboot", "method": "dhcpv6", "mac": "aa:bb:cc:dd:ee:ff"}`)
 		bootConfig0001 = []byte(`{"type": "localboot", "uuid": "blah-bleh", "kernel": "/path/to/kernel"}`)
 	)
-	// Override the package-level variable Get so it will use our dummy getter
+	// Override the package-level variable Get so it will use our test getter
 	// instead of VPD
 	Get = func(key string, readOnly bool) ([]byte, error) {
 		switch key {
@@ -73,7 +73,7 @@ func TestGetBootEntries(t *testing.T) {
 }
 
 func TestGetBootEntriesOnlyRO(t *testing.T) {
-	// Override the package-level variable Get so it will use our dummy getter
+	// Override the package-level variable Get so it will use our test getter
 	// instead of VPD
 	Get = func(key string, readOnly bool) ([]byte, error) {
 		if !readOnly || key != "Boot0000" {

--- a/pkg/boot/systembooter/booter.go
+++ b/pkg/boot/systembooter/booter.go
@@ -13,8 +13,8 @@ type Booter interface {
 	TypeName() string
 }
 
-// NullBooter is a dummy booter that does nothing. It is used when no other
-// booter has been found
+// NullBooter is a booter that does nothing. It is used when no other booter
+// has been found.
 type NullBooter struct {
 }
 

--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func dummyProcess(t *testing.T) *os.Process {
+func testProcess(t *testing.T) *os.Process {
 	p := exec.Command("sleep", "1000")
 	if err := p.Start(); err != nil {
 		t.Fatal(err)
@@ -23,9 +23,9 @@ func dummyProcess(t *testing.T) *os.Process {
 }
 
 func TestTryLock(t *testing.T) {
-	p1 := dummyProcess(t)
+	p1 := testProcess(t)
 	defer p1.Kill()
-	p2 := dummyProcess(t)
+	p2 := testProcess(t)
 	defer p2.Kill()
 
 	dir, err := ioutil.TempDir("", "lockfile-")
@@ -64,7 +64,7 @@ func TestTryLock(t *testing.T) {
 }
 
 func TestLockFileRemoval(t *testing.T) {
-	p := dummyProcess(t)
+	p := testProcess(t)
 	defer p.Kill()
 
 	dir, err := ioutil.TempDir("", "lockfile-")
@@ -96,9 +96,9 @@ func TestLockFileRemoval(t *testing.T) {
 }
 
 func TestDeadProcess(t *testing.T) {
-	p1 := dummyProcess(t)
+	p1 := testProcess(t)
 	defer p1.Kill()
-	p2 := dummyProcess(t)
+	p2 := testProcess(t)
 	defer p2.Kill()
 
 	dir, err := ioutil.TempDir("", "lockfile-")

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -69,7 +69,7 @@ func (mp *MountPoint) Unmount(flags uintptr) error {
 // Mount attaches the fsType file system at path.
 //
 // dev is the device to mount (this is often the path of a block device, name
-// of a file, or a dummy string). data usually contains arguments for the
+// of a file, or a placeholder string). data usually contains arguments for the
 // specific file system.
 func Mount(dev, path, fsType, data string, flags uintptr) (*MountPoint, error) {
 	// Create the mount point if it doesn't already exist.

--- a/pkg/mount/mtd/dat.go
+++ b/pkg/mount/mtd/dat.go
@@ -550,7 +550,7 @@ var (
 		/*
 		 * The Sanyo chip found so far uses SPI, first byte is manufacture code,
 		 * second byte is the device code,
-		 * third byte is a dummy byte.
+		 * third byte is a placeholder byte.
 		 */
 		{vendor: "SANYO", devices: []ChipName{"LE25FW203A"}, id: 0x1600},
 		{vendor: "SANYO", devices: []ChipName{"LE25FW403A"}, id: 0x1100},

--- a/pkg/mount/scuzz/control.go
+++ b/pkg/mount/scuzz/control.go
@@ -37,8 +37,8 @@ type Info struct {
 // operate on them.
 type Disk interface {
 	// Unlock unlocks the drive, given a password and an indication of
-	// whether it is the master (true) or user (false) password.
-	Unlock(password string, master bool) error
+	// whether it is the admin (true) or user (false) password.
+	Unlock(password string, admin bool) error
 
 	// Identify returns drive identity information
 	Identify() (*Info, error)

--- a/pkg/mount/scuzz/sg_linux.go
+++ b/pkg/mount/scuzz/sg_linux.go
@@ -226,10 +226,10 @@ func (s *SGDisk) newPacket(cmd Cmd, direction direction, ataType uint8) *packet 
 	return p
 }
 
-func (s *SGDisk) unlockPacket(password string, master bool) *packet {
+func (s *SGDisk) unlockPacket(password string, admin bool) *packet {
 	p := s.newPacket(unix.WIN_SECURITY_UNLOCK, _SG_DXFER_TO_DEV, lba48)
 	p.genCommandDataBlock()
-	if master {
+	if admin {
 		p.block[1] = 1
 	}
 	copy(p.block[2:], []byte(password))
@@ -237,8 +237,8 @@ func (s *SGDisk) unlockPacket(password string, master bool) *packet {
 }
 
 // Unlock performs unlock requests for Linux SCSI Generic Disks
-func (s *SGDisk) Unlock(password string, master bool) error {
-	p := s.unlockPacket(password, master)
+func (s *SGDisk) Unlock(password string, admin bool) error {
+	p := s.unlockPacket(password, admin)
 	if err := s.operate(p); err != nil {
 		return err
 	}

--- a/pkg/tarutil/tar.go
+++ b/pkg/tarutil/tar.go
@@ -202,7 +202,7 @@ func VerboseLogFilter(hdr *tar.Header) bool {
 }
 
 // SafeFilter filters out all files which are not regular and not directories.
-// It also sets sane permissions.
+// It also sets appropriate permissions.
 func SafeFilter(hdr *tar.Header) bool {
 	if hdr.Typeflag == tar.TypeDir {
 		hdr.Mode = 0770


### PR DESCRIPTION
Quoting https://go-review.googlesource.com/c/go/+/236857:

"There's been plenty of discussion on the usage of these terms in tech.
I'm not trying to have yet another debate. It's clear that there are
people who are hurt by them and who are made to feel unwelcome by their
use due not to technical reasons but to their historical and social
context. That's simply enough reason to replace them."

Omitted a few places where we're trying to maintain 1:1 command-line API
compatibility (hdparm, ip). Also did not change PCI product names. Also
did not change a few places yet where I didn't understand the usage or
the code.

Also did not change vendored files.

I followed this guide: https://twitter.com/TwitterEng/status/1278733305190342656/photo/1