### PR TITLE
dhclient: wait on iface OperUp instead of FlagUp

### DIFF
--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -66,7 +66,7 @@ func NetbootImages(ifaceNames string) ([]boot.OSImage, error) {
 	if *verbose {
 		c.LogLevel = dhclient.LogSummary
 	}
-	r := dhclient.SendRequests(ctx, filteredIfs, true, true, c)
+	r := dhclient.SendRequests(ctx, filteredIfs, true, true, c, 30*time.Second)
 
 	for {
 		select {

--- a/cmds/boot/stboot/network.go
+++ b/cmds/boot/stboot/network.go
@@ -82,7 +82,7 @@ func configureDHCPNetwork() error {
 		LogLevel: level,
 	}
 
-	r := dhclient.SendRequests(context.TODO(), links, true, false, config)
+	r := dhclient.SendRequests(context.TODO(), links, true, false, config, 30*time.Second)
 	for result := range r {
 		if result.Err == nil {
 			return result.Lease.Configure()

--- a/cmds/core/dhclient/dhclient.go
+++ b/cmds/core/dhclient/dhclient.go
@@ -83,7 +83,7 @@ func configureAll(ifs []netlink.Link) {
 	if *vverbose {
 		c.LogLevel = dhclient.LogDebug
 	}
-	r := dhclient.SendRequests(context.Background(), ifs, *ipv4, *ipv6, c)
+	r := dhclient.SendRequests(context.Background(), ifs, *ipv4, *ipv6, c, 30*time.Second)
 
 	for result := range r {
 		if result.Err != nil {


### PR DESCRIPTION
We used to wait on FlagUp, which actually gets set the moment you call
LinkSetUp, and has no bearing on whether the link is actually
operational. Sometimes the nic is still waiting for carrier and we
incorrectly proceed while the nic is still down.

Signed-off-by: Gan Shun Lim <ganshun@gmail.com>