### PR TITLE
dhcpv6: add IPv6 addresses as /128

### DIFF
--- a/pkg/dhclient/dhcp6.go
+++ b/pkg/dhclient/dhcp6.go
@@ -56,8 +56,17 @@ func (p *Packet6) Configure() error {
 	// Add the address to the iface.
 	dst := &netlink.Addr{
 		IPNet: &net.IPNet{
-			IP:   l.IPv6Addr,
-			Mask: net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff::")),
+			IP: l.IPv6Addr,
+
+			// This mask tells Linux which addresses we know to be
+			// "on-link" (i.e., reachable on this interface without
+			// having to talk to a router).
+			//
+			// Since DHCPv6 does not give us that information, we
+			// have to assume that no addresses are on-link. To do
+			// that, we use /128. (See also RFC 5942 Section 5,
+			// "Observed Incorrect Implementation Behavior".)
+			Mask: net.CIDRMask(128, 128),
 		},
 		PreferedLft: int(l.PreferredLifetime),
 		ValidLft:    int(l.ValidLifetime),


### PR DESCRIPTION
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=684009

"Note that the dhcpv6 protocol doesn't have an option for a netmask. So
it is always /128 and routing is left to icmpv6 router advertisements."

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=684009

RFC5942, p.7 under "Host Rules":

```
 The assignment of an IPv6 address -- whether through IPv6
       stateless address autoconfiguration [RFC4862], DHCPv6 [RFC3315],
       or manual configuration -- MUST NOT implicitly cause a prefix
       derived from that address to be treated as on-link and added to
       the Prefix List.  ...
```

and on p.8 under the heading "Observed Incorrect Implementation Behavior":

```
   ...  An address
   could be acquired through the DHCPv6 identity association for non-
   temporary addresses (IA_NA) option from [RFC3315] (which does not
   include a prefix length), or through manual configuration (if no
   prefix length is specified).  The host incorrectly assumes an
   invented prefix is on-link.  This invented prefix typically is a /64
   that was written by the developer of the operating system network
   module API to any IPv6 application as a "default" prefix length when
   a length isn't specified...
```