### PR TITLE
pci: allow bus Read() to take a ...Filter

### DIFF
--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -41,22 +41,6 @@ func onePCI(dir string) (*PCI, error) {
 	return &pci, nil
 }
 
-// Read implements the BusReader interface for type bus. Iterating over each
-// PCI bus device.
-func (bus *bus) Read() (Devices, error) {
-	devices := make(Devices, len(bus.Devices))
-	for i, d := range bus.Devices {
-		p, err := onePCI(d)
-		if err != nil {
-			return nil, err
-		}
-		p.Addr = filepath.Base(d)
-		p.FullPath = d
-		devices[i] = p
-	}
-	return devices, nil
-}
-
 // NewBusReader returns a BusReader, given a ...glob to match PCI devices against.
 // If it can't glob in pciPath/g then it returns an error.
 // For convenience, we use * as the glob if none are supplied.

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -27,3 +27,44 @@ func TestNewBusReaderNoGlob(t *testing.T) {
 		}
 	}
 }
+
+func TestBusReader(t *testing.T) {
+	n, err := NewBusReader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(n.(*bus).Devices) == 0 {
+		t.Fatal("got 0 devices, want at least 1")
+	}
+	d, err := n.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(n.(*bus).Devices) != len(d) {
+		t.Fatalf("Got %d devices, wanted %d", len(d), len(n.(*bus).Devices))
+	}
+	// Multiple reads should be ok
+	d, err = n.Read()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(n.(*bus).Devices) != len(d) {
+		t.Fatalf("Got %d devices, wanted %d", len(d), len(n.(*bus).Devices))
+	}
+	// Filter by vendor and dev id.
+	ven, dev := d[0].Vendor, d[0].Device
+	d, err = n.Read(func(p *PCI) bool {
+		if p.Vendor == ven && p.Device == dev {
+			return false
+		}
+		return true
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// That should filter just one thing.
+	if len(n.(*bus).Devices)-1 != len(d) {
+		t.Fatalf("Got %d devices, wanted %d", len(d), len(n.(*bus).Devices)-1)
+	}
+
+}

--- a/pkg/pci/types.go
+++ b/pkg/pci/types.go
@@ -4,8 +4,11 @@
 
 package pci
 
+// Filter can be used to filter a device
+type Filter func(p *PCI) bool
+
 type busReader interface {
-	Read() (Devices, error)
+	Read(...Filter) (Devices, error)
 }
 
 // Vendor is a PCI vendor human readable label. It contains a map of one or


### PR DESCRIPTION
Sometimes we wish to block, match, reject devices based on some
criteria.

If this meets approval I'll add a few examples as tests. We could for example filter
on vendor id as string, name as string, type, etc.