### PR TITLE
remove ineffassign as it incorrectly flags non-problems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,6 @@ jobs:
             go get -u golang.org/x/lint/golint
             go get github.com/alecthomas/gometalinter
       - run:
-          name: Install ineffassign
-          command: go get github.com/gordonklaus/ineffassign
-      - run:
           name: Check vendored dependencies
           command: |
             ./dep version
@@ -109,9 +106,6 @@ jobs:
                 --exclude="(function|type|const|method|var|type field|struct field) (\w|_|\.)+ should be (\w|_|\.)+" \
                 --exclude="stutter" \
                 --exclude="which can be annoying to use"
-      - run:
-          name: ineffassign
-          command: ineffassign .
   test:
     <<: *golang-template
     steps:


### PR DESCRIPTION
I've checked out ineffassign on various pieces of code and it's just not
right. It fails on much of the Go runtime.

For example, it marked this code:
	p, err := pty.New()
	if err != nil {
		log.Fatalf("Console exits: can't open pty: %v", err)
	}
	p.Command(a[0], a[1:]...)
	// Make a good faith effort to set up root. This being
	// a kind of init program, we do our best and keep going.
	if *setupRoot {
		libinit.SetEnv()
		libinit.CreateRootfs()
	}
	in, out, err := console(*serial)

/go/src/github.com/u-root/u-root/cmds/exp/console/console.go:50:11: ineffectual assignment to err

But the standard says:

"Unlike regular variable declarations, a short variable declaration may
redeclare variables provided they were originally declared earlier in
the same block (or the parameter lists if the block is the function
body) with the same type, and at least one of the non-blank variables is
new. As a consequence, redeclaration can only appear in a multi-variable
short declaration. Redeclaration does not introduce a new variable; it
just assigns a new value to the original.""