### PR TITLE
Update references to Slack team

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,8 @@ Conduct](https://github.com/u-root/u-root/wiki/Code-of-Conduct).
 
 ## Communication
 
-- [Slack](https://u-root.slack.com), sign up
-[here](http://slack.u-root.com/)
+- [Open Source Firmware Slack team](https://osfw.slack.com),
+  channel `#u-root`, sign up [here](https://slack.osfw.dev/)
 - [Join the mailing list](https://groups.google.com/forum/#!forum/u-root)
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://circleci.com/gh/u-root/u-root/tree/master.png?style=shield&circle-token=8d9396e32f76f82bf4257b60b414743e57734244)](https://circleci.com/gh/u-root/u-root/tree/master)
 [![Go Report Card](https://goreportcard.com/badge/github.com/u-root/u-root)](https://goreportcard.com/report/github.com/u-root/u-root)
 [![GoDoc](https://godoc.org/github.com/u-root/u-root?status.svg)](https://godoc.org/github.com/u-root/u-root)
-[![Slack](http://slack.u-root.com/badge.svg)](http://slack.u-root.com)
+[![Slack](https://slack.osfw.dev/badge.svg)](https://slack.osfw.dev)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/u-root/u-root/blob/master/LICENSE)
 
 # Description

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
 <h2 id="community">Community</h2>
 <ul>
 <li><a href="https://groups.google.com/forum/#!forum/u-root">Join the mailing list</a></li>
-<li><a href="https://u-root.slack.com/">Join slack</a> (Get an invite <a href="http://slack.u-root.com">here</a>.)</li>
+<li><a href="https://osfw.slack.com/">Join the Open Source Firmware Slack team</a> (Get an invite <a href="https://slack.osfw.dev">here</a>.)</li>
 <li><a href="https://github.com/u-root/u-root/blob/master/roadmap.md">Checkout the roadmap</a></li>
 </ul>
 <h2 id="contributors">Contributors</h2>

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,7 +66,7 @@ local and get a userland portable (it's a goal).
 ## Community
 
 - [Join the mailing list](https://groups.google.com/forum/#!forum/u-root)
-- [Join slack](https://u-root.slack.com/) (Get an invite [here](http://slack.u-root.com).)
+- [Join the Open Source Firmware Slack team](https://osfw.slack.com/) (Get an invite [here](https://slack.osfw.dev).)
 - [Checkout the roadmap](https://github.com/u-root/u-root/blob/master/roadmap.md)
 
 


### PR DESCRIPTION
We moved to https://osfw.slack.com 🚚.

Signed-off-by: Daniel Maslowski <info@orangecms.org>