### PR TITLE
trampoline: find info,entry,magic location using funcPC

### DIFF
--- a/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.go
+++ b/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.go
@@ -9,8 +9,6 @@
 package trampoline
 
 import (
-	"bytes"
-	"fmt"
 	"io"
 	"reflect"
 	"unsafe"
@@ -26,33 +24,29 @@ const (
 
 func start()
 func end()
+func info()
+func magic()
+func entry()
 
 // funcPC gives the program counter of the given function.
 //
 //go:linkname funcPC runtime.funcPC
 func funcPC(f interface{}) uintptr
 
-// alignUp aligns x to a 0x10 bytes boundary.
-// go compiler aligns TEXT parts at 0x10 bytes boundary.
-func alignUp(x int) int {
-	const mask = 0x10 - 1
-	return (x + mask) & ^mask
-}
-
 // Setup scans file for trampoline code and sets
 // values for multiboot info address and kernel entry point.
 func Setup(path string, magic, infoAddr, entryPoint uintptr) ([]byte, error) {
-	d, err := extract(path)
+	trampStart, d, err := extract(path)
 	if err != nil {
 		return nil, err
 	}
-	return patch(d, magic, infoAddr, entryPoint)
+	return patch(trampStart, d, magic, infoAddr, entryPoint)
 }
 
 // extract extracts trampoline segment from file.
 // trampoline segment begins after "u-root-trampoline-begin" byte sequence + padding,
 // and ends at "u-root-trampoline-end" byte sequence.
-func extract(path string) ([]byte, error) {
+func extract(path string) (uintptr, []byte, error) {
 	// TODO(https://github.com/golang/go/issues/35055): deal with
 	// potentially non-contiguous trampoline. Rather than locating start
 	// and end, we should locate start,boot,farjump{32,64},gdt,info,entry
@@ -60,14 +54,14 @@ func extract(path string) ([]byte, error) {
 	tbegin := funcPC(start)
 	tend := funcPC(end)
 	if tend <= tbegin {
-		return nil, io.ErrUnexpectedEOF
+		return 0, nil, io.ErrUnexpectedEOF
 	}
 	tramp := ptrToSlice(tbegin, int(tend-tbegin))
 
 	// tramp is read-only executable memory. So we gotta copy it to a
 	// slice. Gotta modify it later.
 	cp := append([]byte(nil), tramp...)
-	return cp, nil
+	return tbegin, cp, nil
 }
 
 func ptrToSlice(ptr uintptr, size int) []byte {
@@ -81,33 +75,31 @@ func ptrToSlice(ptr uintptr, size int) []byte {
 	return data
 }
 
-// patch patches the trampoline code to store value for multiboot info address
-// after "u-root-header-long" byte sequence + padding and value
-// for kernel entry point, after "u-root-entry-long" byte sequence + padding.
-func patch(trampoline []byte, magic, infoAddr, entryPoint uintptr) ([]byte, error) {
-	replace := func(d, label []byte, val uint32) error {
+// patch patches the trampoline code to store value for multiboot info address,
+// entry point, and boot magic value.
+//
+// All 3 are determined by pretending they are functions, and finding their PC
+// within our own address space.
+func patch(trampStart uintptr, trampoline []byte, magicVal, infoAddr, entryPoint uintptr) ([]byte, error) {
+	replace := func(start uintptr, d []byte, f func(), val uint32) error {
 		buf := make([]byte, 4)
 		ubinary.NativeEndian.PutUint32(buf, val)
 
-		ind := bytes.Index(d, label)
-		if ind == -1 {
-			return fmt.Errorf("%q label not found in file", label)
-		}
-		ind = alignUp(ind + len(label))
-		if len(d) < ind+len(buf) {
+		offset := funcPC(f) - start
+		if int(offset+4) > len(d) {
 			return io.ErrUnexpectedEOF
 		}
-		copy(d[ind:], buf)
+		copy(d[int(offset):], buf)
 		return nil
 	}
 
-	if err := replace(trampoline, []byte(trampolineInfo), uint32(infoAddr)); err != nil {
+	if err := replace(trampStart, trampoline, info, uint32(infoAddr)); err != nil {
 		return nil, err
 	}
-	if err := replace(trampoline, []byte(trampolineEntry), uint32(entryPoint)); err != nil {
+	if err := replace(trampStart, trampoline, entry, uint32(entryPoint)); err != nil {
 		return nil, err
 	}
-	if err := replace(trampoline, []byte(trampolineMagic), uint32(magic)); err != nil {
+	if err := replace(trampStart, trampoline, magic, uint32(magicVal)); err != nil {
 		return nil, err
 	}
 	return trampoline, nil

--- a/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.s
+++ b/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.s
@@ -27,11 +27,11 @@ TEXT ·start(SB),NOSPLIT,$0
 
 	// Store value of multiboot info addr in BX.
 	// Don't modify BX.
-	MOVL	info(SB), BX
+	MOVL	·info(SB), BX
 
 	// Store value of mu(l)tiboot magic in SI.
 	// Don't modify SI.
-	MOVL	magic(SB), SI
+	MOVL	·magic(SB), SI
 
 	// Far return doesn't work on QEMU in 64-bit mode,
 	// let's do far jump.
@@ -47,7 +47,7 @@ TEXT ·start(SB),NOSPLIT,$0
 	//
 	// Setup offset to make a far jump from boot(SB)
 	// to a final kernel in a 32-bit mode.
-	MOVL	entry(SB), AX
+	MOVL	·entry(SB), AX
 	MOVL	AX, farjump32+1(SB)
 
 	// Setup offset to make a far jump to boot(SB)
@@ -90,13 +90,6 @@ TEXT boot(SB),NOSPLIT,$0
 	MOVL	SI, AX
 	JMP	farjump32(SB)
 
-	// Unreachable code.
-	// Need reference text labels for compiler to
-	// include them to a binary.
-	JMP	infotext(SB)
-	JMP	entrytext(SB)
-  JMP magictext(SB)
-
 TEXT farjump64(SB),NOSPLIT,$0
 	BYTE	$0xFF; BYTE $0x2D; LONG $0x0 // ljmp *(ip)
 
@@ -115,30 +108,13 @@ TEXT gdt(SB),NOSPLIT,$0
 	QUAD	$DATA_SEGMENT	// 0x10
 	QUAD	$CODE_SEGMENT	// 0x18
 
-TEXT infotext(SB),NOSPLIT,$0
-	// u-root-info-long
-	BYTE $'u'; BYTE $'-'; BYTE $'r'; BYTE $'o'; BYTE $'o';
-	BYTE $'t'; BYTE $'-'; BYTE $'i'; BYTE $'n'; BYTE $'f';
-	BYTE $'o'; BYTE $'-'; BYTE $'l'; BYTE $'o'; BYTE $'n';
-	BYTE $'g';
-TEXT info(SB),NOSPLIT,$0
+TEXT ·info(SB),NOSPLIT,$0
 	LONG	$0x0
 
-TEXT entrytext(SB),NOSPLIT,$0
-	// u-root-entry-long
-	BYTE $'u'; BYTE $'-'; BYTE $'r'; BYTE $'o'; BYTE $'o';
-	BYTE $'t'; BYTE $'-'; BYTE $'e'; BYTE $'n'; BYTE $'t';
-	BYTE $'r'; BYTE $'y'; BYTE $'-'; BYTE $'l'; BYTE $'o';
-	BYTE $'n'; BYTE $'g';
-TEXT entry(SB),NOSPLIT,$0
+TEXT ·entry(SB),NOSPLIT,$0
 	LONG	$0x0
 
-TEXT magictext(SB),NOSPLIT,$0
-	// u-root-mb-magic
-	BYTE $'u'; BYTE $'-'; BYTE $'r'; BYTE $'o'; BYTE $'o';
-	BYTE $'t'; BYTE $'-'; BYTE $'m'; BYTE $'b'; BYTE $'-';
-	BYTE $'m'; BYTE $'a'; BYTE $'g'; BYTE $'i'; BYTE $'c';
-TEXT magic(SB),NOSPLIT,$0
+TEXT ·magic(SB),NOSPLIT,$0
 	LONG	$0x0
 
 TEXT ·end(SB),NOSPLIT,$0


### PR DESCRIPTION
The crux of the problem is that we're trying to find these symbols'
location in order to insert some bytes at each. Until now, we've done
this by putting some strings before the symbol, and finding the string
in the trampoline, and then replacing the bytes in the function _after_
assuming a Go compiler's alignment of 16 bytes.

Go 1.15's https://github.com/golang/go/commit/30f8074e3510da8c39f879cfdbde600eb876a79e changes the default alignment of functions from 16 to 32 bytes.

We could decide to use 16 bytes for <= Go 1.14 and 32 bytes for >= Go
1.15. Instead, each symbol is treated like a function so we can use funcPC
to find their location. This fix works in Go 1.13, 1.14, as well as 1.15
without keying off an internal Go compiler alignment value.

Fixes #1803

Signed-off-by: Chris Koch <chrisko@google.com>