### PR TITLE
Collect build stats during CircleCI run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,9 @@ workflows:
       - compile_cmds:
           requires:
             - clean-code
+      - check_templates:
+          requires:
+            - clean-code
       - check_licenses:
           requires:
             - clean-code
@@ -170,21 +173,25 @@ jobs:
     steps:
       - checkout
       - run:
-          name: ensure that every template builds for a variety of options.
+          name: Ensure that every template builds for a variety of options.
           command: |
-                  go run u-root.go -build=bb minimal
-                  go run u-root.go minimal
-                  go run u-root.go -build=bb core
-                  go run u-root.go core
-                  go run u-root.go -build=bb coreboot-app
-                  go run u-root.go coreboot-app
-                  go run u-root.go -build=bb all
-                  go run u-root.go all
-                  go run u-root.go -build=bb all core
-                  go run u-root.go all core
-                  go run u-root.go -fourbins minimal
                   go build .
-                  GOOS=plan9 ./u-root plan9 -defaultsh=/bbin/rush
+                  goruncmd="./u-root -stats-output-path=/tmp/stats.json"
+                  $goruncmd -build=bb minimal
+                  $goruncmd -build=bb core
+                  $goruncmd -build=bb coreboot-app
+                  $goruncmd -build=bb all
+                  $goruncmd -build=bb world
+                  # Fails because of dups. Is this supposed to work?
+                  #$goruncmd -build=bb all core
+                  #$goruncmd all core
+                  go run u-root.go templates.go -fourbins minimal
+                  GOOS=plan9 $goruncmd -defaultsh=/bbin/rush plan9
+                  cat /tmp/stats.json
+      - store_artifacts:
+          name: Store build stats
+          path: /tmp/stats.json
+          destination: stats.json
   test-integration-amd64:
     <<: *integration-template
     docker:

--- a/pkg/uroot/initramfs/archive.go
+++ b/pkg/uroot/initramfs/archive.go
@@ -33,10 +33,7 @@ var (
 // files.
 type Archiver interface {
 	// OpenWriter opens an archive writer at `path`.
-	//
-	// If `path` is unspecified, implementations may choose an arbitrary
-	// default location, potentially based on `goos` and `goarch`.
-	OpenWriter(l ulog.Logger, path, goos, goarch string) (Writer, error)
+	OpenWriter(l ulog.Logger, path string) (Writer, error)
 
 	// Reader returns a Reader that allows reading files from a file.
 	Reader(file io.ReaderAt) Reader

--- a/pkg/uroot/initramfs/cpio.go
+++ b/pkg/uroot/initramfs/cpio.go
@@ -20,21 +20,14 @@ type CPIOArchiver struct {
 
 // OpenWriter opens `path` as the correct file type and returns an
 // Writer pointing to `path`.
-//
-// If `path` is empty, a default path of /tmp/initramfs.GOOS_GOARCH.cpio is
-// used.
-func (ca CPIOArchiver) OpenWriter(l ulog.Logger, path, goos, goarch string) (Writer, error) {
-	if len(path) == 0 && len(goos) == 0 && len(goarch) == 0 {
-		return nil, fmt.Errorf("passed no path, GOOS, and GOARCH to CPIOArchiver.OpenWriter")
-	}
+func (ca CPIOArchiver) OpenWriter(l ulog.Logger, path string) (Writer, error) {
 	if len(path) == 0 {
-		path = fmt.Sprintf("/tmp/initramfs.%s_%s.cpio", goos, goarch)
+		return nil, fmt.Errorf("path is required")
 	}
 	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 	if err != nil {
 		return nil, err
 	}
-	l.Printf("Filename is %s", path)
 	return osWriter{ca.RecordFormat.Writer(f), f}, nil
 }
 

--- a/pkg/uroot/initramfs/dir.go
+++ b/pkg/uroot/initramfs/dir.go
@@ -25,7 +25,7 @@ func (da DirArchiver) Reader(io.ReaderAt) Reader {
 }
 
 // OpenWriter implements Archiver.OpenWriter.
-func (da DirArchiver) OpenWriter(l ulog.Logger, path, goos, goarch string) (Writer, error) {
+func (da DirArchiver) OpenWriter(l ulog.Logger, path string) (Writer, error) {
 	if len(path) == 0 {
 		var err error
 		path, err = ioutil.TempDir("", "u-root")

--- a/pkg/vmtest/integration.go
+++ b/pkg/vmtest/integration.go
@@ -338,7 +338,7 @@ func CreateTestInitramfs(dontSetEnv bool, o uroot.Opts, uinit, outputFile string
 		}
 		outputFile = f.Name()
 	}
-	w, err := initramfs.CPIO.OpenWriter(logger, outputFile, "", "")
+	w, err := initramfs.CPIO.OpenWriter(logger, outputFile)
 	if err != nil {
 		return "", fmt.Errorf("Failed to create initramfs writer: %v", err)
 	}

--- a/templates.go
+++ b/templates.go
@@ -17,6 +17,10 @@ var templates = map[string][]string{
 	"boot": {
 		"github.com/u-root/u-root/cmds/boot/*boot*",
 	},
+	// Absolutely everything, including experimental commands.
+	"world": {
+		"github.com/u-root/u-root/cmds/*/*",
+	},
 	// Core should be things you don't want to live without.
 	"core": {
 		"github.com/u-root/u-root/cmds/core/*",

--- a/tools/mkinitramfs/main.go
+++ b/tools/mkinitramfs/main.go
@@ -28,7 +28,7 @@ func main() {
 	logger := log.New(os.Stderr, "", log.LstdFlags)
 
 	// Open the target initramfs file.
-	w, err := initramfs.CPIO.OpenWriter(logger, *outputFile, "", "")
+	w, err := initramfs.CPIO.OpenWriter(logger, *outputFile)
 	if err != nil {
 		log.Fatalf("failed to open cpio archive %q: %v", *outputFile, err)
 	}

--- a/u-root.go
+++ b/u-root.go
@@ -5,13 +5,17 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"runtime"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/shlex"
@@ -42,6 +46,8 @@ var (
 	noCommands                              *bool
 	extraFiles                              multiFlag
 	noStrip                                 *bool
+	statsOutputPath                         *string
+	statsLabel                              *string
 )
 
 func init() {
@@ -72,16 +78,93 @@ func init() {
 	flag.Var(&extraFiles, "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be speficified multiple times.")
 
 	noStrip = flag.Bool("no-strip", false, "Build unstripped binaries")
+
+	statsOutputPath = flag.String("stats-output-path", "", "Write build stats to this file (JSON)")
+
+	statsLabel = flag.String("stats-label", "", "Use this statsLabel when writing stats")
+}
+
+type buildStats struct {
+	Label      string  `json:"label,omitempty"`
+	Time       int64   `json:"time"`
+	Duration   float64 `json:"duration"`
+	OutputSize int64   `json:"output_size"`
+}
+
+func writeBuildStats(stats buildStats, path string) error {
+	var allStats []buildStats
+	if data, err := ioutil.ReadFile(*statsOutputPath); err == nil {
+		json.Unmarshal(data, &allStats)
+	}
+	found := false
+	for i, s := range allStats {
+		if s.Label == stats.Label {
+			allStats[i] = stats
+			found = true
+			break
+		}
+	}
+	if !found {
+		allStats = append(allStats, stats)
+		sort.Slice(allStats, func(i, j int) bool {
+			return strings.Compare(allStats[i].Label, allStats[j].Label) == -1
+		})
+	}
+	data, err := json.MarshalIndent(allStats, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := ioutil.WriteFile(*statsOutputPath, data, 0644); err != nil {
+		return err
+	}
+	return nil
+}
+
+func generateLabel() string {
+	var baseCmds []string
+	env := golang.Default()
+	if len(flag.Args()) > 0 {
+		// Use the last component of the name to keep the label short
+		for _, e := range flag.Args() {
+			baseCmds = append(baseCmds, path.Base(e))
+		}
+	} else {
+		baseCmds = []string{"core"}
+	}
+	return fmt.Sprintf("%s-%s-%s-%s", *build, env.GOOS, env.GOARCH, strings.Join(baseCmds, "_"))
 }
 
 func main() {
 	flag.Parse()
 
+	start := time.Now()
+
 	// Main is in a separate functions so defers run on return.
 	if err := Main(); err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("Successfully wrote initramfs.")
+
+	elapsed := time.Now().Sub(start)
+
+	stats := buildStats{
+		Label:    *statsLabel,
+		Time:     start.Unix(),
+		Duration: float64(elapsed.Milliseconds()) / 1000,
+	}
+	if stats.Label == "" {
+		stats.Label = generateLabel()
+	}
+	if stat, err := os.Stat(*outputPath); err == nil && stat.ModTime().After(start) {
+		log.Printf("Successfully built %q (size %d).", *outputPath, stat.Size())
+		stats.OutputSize = stat.Size()
+		if *statsOutputPath != "" {
+			if err := writeBuildStats(stats, *statsOutputPath); err == nil {
+				log.Printf("Wrote stats to %q (label %q)", *statsOutputPath, stats.Label)
+			} else {
+				log.Printf("Failed to write stats to %s: %v", *statsOutputPath, err)
+			}
+		}
+	}
 }
 
 var recommendedVersions = []string{
@@ -134,7 +217,13 @@ func Main() error {
 
 	logger := log.New(os.Stderr, "", log.LstdFlags)
 	// Open the target initramfs file.
-	w, err := archiver.OpenWriter(logger, *outputPath, env.GOOS, env.GOARCH)
+	if *outputPath == "" {
+		if len(env.GOOS) == 0 && len(env.GOARCH) == 0 {
+			return fmt.Errorf("passed no path, GOOS, and GOARCH to CPIOArchiver.OpenWriter")
+		}
+		*outputPath = fmt.Sprintf("/tmp/initramfs.%s_%s.cpio", env.GOOS, env.GOARCH)
+	}
+	w, err := archiver.OpenWriter(logger, *outputPath)
 	if err != nil {
 		return err
 	}

--- a/uroot_test.go
+++ b/uroot_test.go
@@ -247,7 +247,7 @@ func TestUrootCmdline(t *testing.T) {
 			name: "make sure dead code gets eliminated",
 			args: []string{
 				// Build the world + test symbols, unstripped.
-				"-build=bb", "-no-strip", "cmds/*/*", "pkg/uroot/test/foo",
+				"-build=bb", "-no-strip", "world", "pkg/uroot/test/foo",
 				// These are known to disable DCE and need to be exluded.
 				// The reason is https://github.com/golang/go/issues/36021 and is fixed in Go 1.15,
 				// so these can be removed once we no longer support Go < 1.15.


### PR DESCRIPTION
This is the first step to https://github.com/u-root/u-root/issues/1809

We collect size and build time stats, store as JSON file and expose them as a build artifact.

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>