### PR TITLE
Add a test that makes sure dead code elimination works

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,13 @@ u-root
 u-root core boot
 
 # Generate an archive with only these given commands
-u-root ./cmds/core/{init,ls,ip,dhclient,wget,cat,elvish}
+u-root cmds/core/{init,ls,ip,dhclient,wget,cat,elvish}
+
+# Generate an archive with all of the core tools with some exceptions
+u-root core -cmds/core/{installcommand,losetup}
 
 # Generate an archive with a tool outside of u-root
-u-root ./cmds/core/{init,ls,elvish} github.com/u-root/cpu/cmds/cpud
+u-root cmds/core/{init,ls,elvish} github.com/u-root/cpu/cmds/cpud
 ```
 
 The default set of packages included is all packages in

--- a/pkg/bb/bb.go
+++ b/pkg/bb/bb.go
@@ -84,7 +84,7 @@ func getBBLock(bblock string) (*lockfile.Lockfile, error) {
 //
 // pkgs is a list of Go import paths. If nil is returned, binaryPath will hold
 // the busybox-style binary.
-func BuildBusybox(env golang.Environ, pkgs []string, binaryPath string) error {
+func BuildBusybox(env golang.Environ, pkgs []string, noStrip bool, binaryPath string) error {
 	urootPkg, err := env.Package("github.com/u-root/u-root")
 	if err != nil {
 		return err
@@ -155,7 +155,7 @@ func BuildBusybox(env golang.Environ, pkgs []string, binaryPath string) error {
 	}
 
 	// Compile bb.
-	return env.Build("github.com/u-root/u-root/bb", binaryPath, golang.BuildOpts{})
+	return env.Build("github.com/u-root/u-root/bb", binaryPath, golang.BuildOpts{NoStrip: noStrip})
 }
 
 // CreateBBMainSource creates a bb Go command that imports all given pkgs.

--- a/pkg/bb/bb_test.go
+++ b/pkg/bb/bb_test.go
@@ -22,7 +22,7 @@ func TestPackageRewriteFile(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	bin := filepath.Join(dir, "foo")
-	if err := BuildBusybox(golang.Default(), []string{"github.com/u-root/u-root/pkg/uroot/test/foo"}, bin); err != nil {
+	if err := BuildBusybox(golang.Default(), []string{"github.com/u-root/u-root/pkg/uroot/test/foo"}, false, bin); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/golang/build.go
+++ b/pkg/golang/build.go
@@ -58,7 +58,8 @@ type ListPackage struct {
 	ImportPath string
 }
 
-func (c Environ) goCmd(args ...string) *exec.Cmd {
+// GoCmd runs a go command in the environment.
+func (c Environ) GoCmd(args ...string) *exec.Cmd {
 	cmd := exec.Command(filepath.Join(c.GOROOT, "bin", "go"), args...)
 	cmd.Env = append(os.Environ(), c.Env()...)
 	return cmd
@@ -67,7 +68,7 @@ func (c Environ) goCmd(args ...string) *exec.Cmd {
 // Version returns the Go version string that runtime.Version would return for
 // the Go compiler in this environ.
 func (c Environ) Version() (string, error) {
-	cmd := c.goCmd("version")
+	cmd := c.GoCmd("version")
 	v, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", err
@@ -83,7 +84,7 @@ func (c Environ) Version() (string, error) {
 func (c Environ) Deps(importPath string) (*ListPackage, error) {
 	// The output of this is almost the same as build.Import, except for
 	// the dependencies.
-	cmd := c.goCmd("list", "-json", importPath)
+	cmd := c.GoCmd("list", "-json", importPath)
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return nil, err
@@ -124,6 +125,8 @@ func (c Environ) String() string {
 
 // Optional arguments to Environ.Build.
 type BuildOpts struct {
+	// NoStrip builds an unstripped binary.
+	NoStrip bool
 	// ExtraArgs to `go build`.
 	ExtraArgs []string
 }
@@ -147,8 +150,10 @@ func (c Environ) BuildDir(dirPath string, binaryPath string, opts BuildOpts) err
 		"-a", // Force rebuilding of packages.
 		"-o", binaryPath,
 		"-installsuffix", "uroot",
-		"-gcflags=all=-l",   // Disable "function inlining" to get a smaller binary
-		"-ldflags", "-s -w", // Strip all symbols.
+		"-gcflags=all=-l", // Disable "function inlining" to get a smaller binary
+	}
+	if !opts.NoStrip {
+		args = append(args, `-ldflags=-s -w`) // Strip all symbols.
 	}
 	if len(c.BuildTags) > 0 {
 		args = append(args, []string{"-tags", strings.Join(c.BuildTags, " ")}...)
@@ -159,7 +164,7 @@ func (c Environ) BuildDir(dirPath string, binaryPath string, opts BuildOpts) err
 	// We always set the working directory, so this is always '.'.
 	args = append(args, ".")
 
-	cmd := c.goCmd(args...)
+	cmd := c.GoCmd(args...)
 	cmd.Dir = dirPath
 
 	if o, err := cmd.CombinedOutput(); err != nil {

--- a/pkg/uroot/builder/bb.go
+++ b/pkg/uroot/builder/bb.go
@@ -44,7 +44,7 @@ func (BBBuilder) DefaultBinaryDir() string {
 func (BBBuilder) Build(af *initramfs.Files, opts Opts) error {
 	// Build the busybox binary.
 	bbPath := filepath.Join(opts.TempDir, "bb")
-	if err := bb.BuildBusybox(opts.Env, opts.Packages, bbPath); err != nil {
+	if err := bb.BuildBusybox(opts.Env, opts.Packages, opts.NoStrip, bbPath); err != nil {
 		return err
 	}
 

--- a/pkg/uroot/builder/binary.go
+++ b/pkg/uroot/builder/binary.go
@@ -36,7 +36,7 @@ func (BinaryBuilder) Build(af *initramfs.Files, opts Opts) error {
 			result <- opts.Env.Build(
 				p,
 				filepath.Join(opts.TempDir, opts.BinaryDir, filepath.Base(p)),
-				golang.BuildOpts{})
+				golang.BuildOpts{NoStrip: opts.NoStrip})
 		}(pkg)
 	}
 

--- a/pkg/uroot/builder/builder.go
+++ b/pkg/uroot/builder/builder.go
@@ -37,6 +37,9 @@ type Opts struct {
 	//
 	// BinaryDir must be specified.
 	BinaryDir string
+
+	// NoStrip builds unstripped binaries.
+	NoStrip bool
 }
 
 // Builder builds Go packages and adds the binaries to an initramfs.

--- a/pkg/uroot/test/bar/bar.go
+++ b/pkg/uroot/test/bar/bar.go
@@ -1,0 +1,29 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bar
+
+import "fmt"
+
+type Interface interface {
+	UsedInterfaceMethod()
+	UnusedInterfaceMethod()
+}
+
+type Bar struct{}
+
+func (Bar) UsedInterfaceMethod() {
+	fmt.Println("one")
+}
+
+// This method is unused but cannot be eliminated yet.
+// https://github.com/golang/go/issues/38685
+func (Bar) UnusedInterfaceMethod() {
+	fmt.Println("two")
+}
+
+// This method is unused and should be eliminated.
+func (Bar) UnusedNonInterfaceMethod() {
+	fmt.Println("three")
+}

--- a/pkg/uroot/test/foo/foo.go
+++ b/pkg/uroot/test/foo/foo.go
@@ -7,6 +7,8 @@ package main
 import (
 	"fmt"
 	"log"
+
+	"github.com/u-root/u-root/pkg/uroot/test/bar"
 )
 
 var (
@@ -134,6 +136,11 @@ func verify() error {
 	if nil1 != interface{}(nil) {
 		return fmt.Errorf("nil1 is %v, want nil interface", nil1)
 	}
+
+	// Test unused method elimination.
+	var b bar.Interface
+	b = bar.Bar{}
+	b.UsedInterfaceMethod()
 
 	return nil
 }

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -145,6 +145,15 @@ func TestResolvePackagePaths(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		// Excludes
+		{
+			env: defaultEnv,
+			in:  []string{"test/gopath2/src/*", "-test/gopath2/src/mypkga"},
+			expected: []string{
+				"github.com/u-root/u-root/pkg/uroot/test/gopath2/src/mypkgb",
+			},
+			wantErr: false,
+		},
 	} {
 		t.Run(fmt.Sprintf("%q", tc.in), func(t *testing.T) {
 			out, err := ResolvePackagePaths(l, tc.env, tc.in)

--- a/tools/makebb/makebb.go
+++ b/tools/makebb/makebb.go
@@ -32,7 +32,7 @@ func main() {
 
 	pkgs := flag.Args()
 	if len(pkgs) == 0 {
-		pkgs = []string{"github.com/u-root/u-root/cmds/*"}
+		pkgs = []string{"github.com/u-root/u-root/cmds/*/*"}
 	}
 	pkgs, err := uroot.ResolvePackagePaths(l, env, pkgs)
 	if err != nil {
@@ -44,7 +44,7 @@ func main() {
 		l.Fatal(err)
 	}
 
-	if err := bb.BuildBusybox(env, pkgs, o); err != nil {
+	if err := bb.BuildBusybox(env, pkgs, false /* noStrip */, o); err != nil {
 		l.Fatal(err)
 	}
 }

--- a/u-root.go
+++ b/u-root.go
@@ -41,6 +41,7 @@ var (
 	fourbins                                *bool
 	noCommands                              *bool
 	extraFiles                              multiFlag
+	noStrip                                 *bool
 )
 
 func init() {
@@ -69,6 +70,8 @@ func init() {
 	noCommands = flag.Bool("nocmd", false, "Build no Go commands; initramfs only")
 
 	flag.Var(&extraFiles, "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be speficified multiple times.")
+
+	noStrip = flag.Bool("no-strip", false, "Build unstripped binaries")
 }
 
 func main() {
@@ -221,6 +224,7 @@ func Main() error {
 		UseExistingInit: *useExistingInit,
 		InitCmd:         initCommand,
 		DefaultShell:    *defaultShell,
+		NoStrip:         *noStrip,
 	}
 	uinitArgs := shlex.Argv(*uinitCmd)
 	if len(uinitArgs) > 0 {

--- a/uroot_test.go
+++ b/uroot_test.go
@@ -73,12 +73,23 @@ func (b buildSourceValidator) Validate(a *cpio.Archive) error {
 }
 
 func TestUrootCmdline(t *testing.T) {
-	samplef, err := ioutil.TempFile("", "u-root-sample-")
+	samplef, err := ioutil.TempFile("", "u-root-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
 	samplef.Close()
 	defer os.RemoveAll(samplef.Name())
+	sampledir, err := ioutil.TempDir("", "u-root-test-dir-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = ioutil.WriteFile(filepath.Join(sampledir, "foo"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err = ioutil.WriteFile(filepath.Join(sampledir, "bar"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(sampledir)
 
 	for _, tt := range []struct {
 		name       string
@@ -109,10 +120,11 @@ func TestUrootCmdline(t *testing.T) {
 		},
 		{
 			name: "fix usage of an absolute path",
-			args: []string{"-nocmd", "-files=/bin:/bin"},
+			args: []string{"-nocmd", fmt.Sprintf("-files=%s:/bin", sampledir)},
 			err:  nil,
 			validators: []itest.ArchiveValidator{
-				itest.HasFile{"bin/bash"},
+				itest.HasFile{"/bin/foo"},
+				itest.HasFile{"/bin/bar"},
 			},
 		},
 		{


### PR DESCRIPTION
This required two user-visible changes:

 * Added `-no-strip` to `makebb`
 * Added ability to exclude certain commands from image build.
   This is necessary to exclude commands known to offend against DCE
   policy (but that will be fixed by Go 1.15 adoption).

Fixes https://github.com/u-root/u-root/issues/1808

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>