### PR TITLE
Remediate zipslip

### DIFF
--- a/pkg/cpio/fs_plan9.go
+++ b/pkg/cpio/fs_plan9.go
@@ -72,7 +72,7 @@ func CreateFileInRoot(f Record, rootDir string, forcePriv bool) error {
 		return err
 	}
 
-	f.Name = filepath.Clean(filepath.Join(rootDir, f.Name))
+	f.Name = filepath.Clean(filepath.Join(rootDir, filepath.Join("/", f.Name)))
 	dir := filepath.Dir(f.Name)
 	// The problem: many cpio archives do not specify the directories and
 	// hence the permissions. They just specify the whole path.  In order

--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -108,7 +108,7 @@ func CreateFileInRoot(f Record, rootDir string, forcePriv bool) error {
 		return err
 	}
 
-	f.Name = filepath.Clean(filepath.Join(rootDir, f.Name))
+	f.Name = filepath.Clean(filepath.Join(rootDir, filepath.Join("/", f.Name)))
 	dir := filepath.Dir(f.Name)
 	// The problem: many cpio archives do not specify the directories and
 	// hence the permissions. They just specify the whole path.  In order

--- a/pkg/tarutil/tar.go
+++ b/pkg/tarutil/tar.go
@@ -131,7 +131,7 @@ func CreateTarFilter(tarFile io.Writer, files []string, filters []Filter) error 
 
 func createFileInRoot(hdr *tar.Header, r io.Reader, rootDir string) error {
 	fi := hdr.FileInfo()
-	path := filepath.Clean(filepath.Join(rootDir, hdr.Name))
+	path := filepath.Clean(filepath.Join(rootDir, filepath.Join("/", hdr.Name)))
 	if !strings.HasPrefix(path, filepath.Clean(rootDir)) {
 		return fmt.Errorf("file outside root directory: %q", path)
 	}

--- a/pkg/uzip/uzip.go
+++ b/pkg/uzip/uzip.go
@@ -89,7 +89,7 @@ func FromZip(src, dir string) error {
 	}
 
 	for _, file := range z.File {
-		path := filepath.Join(dir, file.Name)
+		path := filepath.Join(dir, filepath.Join("/", file.Name))
 		if file.FileInfo().IsDir() {
 			if err = os.MkdirAll(path, file.Mode()); err != nil {
 				return err


### PR DESCRIPTION
paths in the archives containing .. could creep out of directory
they were being unpacked into.

The fix is simple: given a base path and file path, instead of
filepath.Join(base, file)
do
filepath.Join(base, filepath.Join("/", file))

Joining to / has the property of swallowing up and .. that may appear.

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>