### PR TITLE
kexec_linux: enable reading gzip'ed kernels

### DIFF
--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -19,7 +19,10 @@
 package main
 
 import (
+	"bytes"
+	"compress/gzip"
 	"io"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -92,11 +95,33 @@ func main() {
 			log.Fatal(err)
 		}
 		defer mbkernel.Close()
+		var r io.ReaderAt
+		// kernel files are sometimes gzip'ed, and there's no good
+		// pattern to the naming. Just try to read it as a gzip,
+		// and if it fails, proceed with the original.
+		if f, err := gzip.NewReader(mbkernel); err == nil {
+			defer f.Close()
+			// We need a ReaderAt, and it's best to find out
+			// right away if the gunzip will not work out.
+			b, err := ioutil.ReadAll(f)
+			if err != nil {
+				log.Fatalf("Reading gzip'ed kernel: %v", err)
+			}
+			r = bytes.NewReader(b)
+		} else {
+			// gzip can set the file offset, make sure we're back
+			// at the start. There's no reason for this seek
+			// to ever fail, but ...
+			if _, err := mbkernel.Seek(io.SeekStart, 0); err != nil {
+				log.Fatalf("Seeking to 0 on %q: %v", kernelpath, err)
+			}
+			r = mbkernel
+		}
 		var image boot.OSImage
 		if err := multiboot.Probe(mbkernel); err == nil {
 			image = &boot.MultibootImage{
 				Modules: multiboot.LazyOpenModules(opts.modules),
-				Kernel:  mbkernel,
+				Kernel:  r,
 				Cmdline: newCmdline,
 			}
 		} else {


### PR DESCRIPTION
Sometimes kernels are gzip'ed, and the naming does not always make sense.

Try to gunzip the kernel; if that succeeds, use that as for the multiboot
path. If not, proceed as before.