### PR TITLE
kexec: support gzip-ELF files so ARM64 works

### DIFF
--- a/pkg/boot/linux.go
+++ b/pkg/boot/linux.go
@@ -13,6 +13,7 @@ import (
 	"os"
 
 	"github.com/u-root/u-root/pkg/boot/kexec"
+	"github.com/u-root/u-root/pkg/boot/util"
 	"github.com/u-root/u-root/pkg/uio"
 )
 
@@ -81,7 +82,7 @@ func (li *LinuxImage) Load(verbose bool) error {
 		return errors.New("LinuxImage.Kernel must be non-nil")
 	}
 
-	kernel, initrd := uio.Reader(li.Kernel), uio.Reader(li.Initrd)
+	kernel, initrd := uio.Reader(util.TryGzipFilter(li.Kernel)), uio.Reader(li.Initrd)
 	if verbose {
 		// In verbose mode, print a dot every 5MiB. It is not pretty,
 		// but it at least proves the files are still downloading.

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -23,6 +23,7 @@ import (
 	"github.com/u-root/u-root/pkg/boot/ibft"
 	"github.com/u-root/u-root/pkg/boot/kexec"
 	"github.com/u-root/u-root/pkg/boot/multiboot/internal/trampoline"
+	"github.com/u-root/u-root/pkg/boot/util"
 	"github.com/u-root/u-root/pkg/ubinary"
 	"github.com/u-root/u-root/pkg/uio"
 )
@@ -133,7 +134,7 @@ func (m memoryMaps) String() string {
 
 // Probe checks if `kernel` is multiboot v1 or mutiboot kernel.
 func Probe(kernel io.ReaderAt) error {
-	r := tryGzipFilter(kernel)
+	r := util.TryGzipFilter(kernel)
 	_, err := parseHeader(uio.Reader(r))
 	if err == ErrHeaderNotFound {
 		_, err = parseMutiHeader(uio.Reader(r))
@@ -173,9 +174,9 @@ func newMB(kernel io.ReaderAt, cmdLine string, modules []Module) (*multiboot, er
 // After Load is called, kexec.Reboot() is ready to be called any time to stop
 // Linux and execute the loaded kernel.
 func Load(debug bool, kernel io.ReaderAt, cmdline string, modules []Module, ibft *ibft.IBFT) error {
-	kernel = tryGzipFilter(kernel)
+	kernel = util.TryGzipFilter(kernel)
 	for i, mod := range modules {
-		modules[i].Module = tryGzipFilter(mod.Module)
+		modules[i].Module = util.TryGzipFilter(mod.Module)
 	}
 
 	m, err := newMB(kernel, cmdline, modules)

--- a/pkg/boot/util/reader.go
+++ b/pkg/boot/util/reader.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package multiboot
+package util
 
 import (
 	"bytes"
@@ -22,9 +22,11 @@ func readGzip(r io.Reader) ([]byte, error) {
 	return ioutil.ReadAll(z)
 }
 
+// TryGzipFilter tries to read from an io.ReaderAt to see if it is a Gzip. If it is not, the
+// io.ReaderAt is returned.
 // TODO: could be tryCompressionFilters, grub support gz,xz and lzop
 // TODO: do we want to keep the filter inside multiboot? This could be the responsibility of the caller...
-func tryGzipFilter(r io.ReaderAt) io.ReaderAt {
+func TryGzipFilter(r io.ReaderAt) io.ReaderAt {
 	b, err := readGzip(uio.Reader(r))
 	if err == nil {
 		return bytes.NewReader(b)


### PR DESCRIPTION
ARM64 kexec_file_load only processes ELF files.

But on many ARM64 Linux distros, the ELF file is
gzip'ed, with names like vmlinuz-x.y.z-whatever.

Move the tryGzipFilter code to boot/util, and
make it exported as TryGzipFilter, so that it
can be used in kexec as well as multiboot.

Not tested on ARM64. Will need to write a test if
this approach is acceptable.