### PR TITLE
[cmds/core/ping] Implement ping6

### DIFF
--- a/cmds/core/ping/ping.go
+++ b/cmds/core/ping/ping.go
@@ -42,7 +42,12 @@ const (
 	ICMP_TYPE_ECHO_REQUEST             = 8
 	ICMP_TYPE_ECHO_REPLY               = 0
 	ICMP_ECHO_REPLY_HEADER_IPV4_OFFSET = 20
-	ICMP_ECHO_REPLY_HEADER_IPV6_OFFSET = 40
+)
+
+const (
+	ICMP6_TYPE_ECHO_REQUEST             = 128
+	ICMP6_TYPE_ECHO_REPLY               = 129
+	ICMP6_ECHO_REPLY_HEADER_IPV6_OFFSET = 40
 )
 
 func usage() {
@@ -82,18 +87,33 @@ func cksum(bs []byte) uint16 {
 	return ^uint16(sum)
 }
 
-func ping1(netname string, host string, i uint64) (string, error) {
+func ping1(net6 bool, host string, i uint64, waitFor time.Duration) (string, error) {
+	netname := "ip4:icmp"
+	// todo: just figure out if it's an ip6 address and go from there.
+	if net6 {
+		netname = "ip6:ipv6-icmp"
+	}
 	c, derr := net.Dial(netname, host)
 	if derr != nil {
 		return "", fmt.Errorf("net.Dial(%v %v) failed: %v", netname, host, derr)
 	}
 	defer c.Close()
 
+	if net6 {
+		ipc := c.(*net.IPConn)
+		if err := setupICMPv6Socket(ipc); err != nil {
+			return "", fmt.Errorf("failed to set up the ICMPv6 connection: %w", err)
+		}
+	}
+
 	// Send ICMP Echo Request
-	waitFor := time.Duration(*wtf) * time.Millisecond
 	c.SetDeadline(time.Now().Add(waitFor))
 	msg := make([]byte, *packetSize)
-	msg[0] = ICMP_TYPE_ECHO_REQUEST
+	if net6 {
+		msg[0] = ICMP6_TYPE_ECHO_REQUEST
+	} else {
+		msg[0] = ICMP_TYPE_ECHO_REQUEST
+	}
 	msg[1] = 0
 	binary.BigEndian.PutUint16(msg[6:], uint16(i))
 	binary.BigEndian.PutUint16(msg[4:], uint16(i>>16))
@@ -111,17 +131,23 @@ func ping1(netname string, host string, i uint64) (string, error) {
 		return "", fmt.Errorf("read failed: %v", rerr)
 	}
 	latency := time.Since(before)
-	if (rmsg[0] & 0x0F) == 6 {
-		rmsg = rmsg[ICMP_ECHO_REPLY_HEADER_IPV6_OFFSET:]
-	} else {
+	if !net6 {
 		rmsg = rmsg[ICMP_ECHO_REPLY_HEADER_IPV4_OFFSET:]
 	}
-	if rmsg[0] != ICMP_TYPE_ECHO_REPLY {
-		return "", fmt.Errorf("bad ICMP echo reply type: %v", msg[0])
+	if net6 {
+		if rmsg[0] != ICMP6_TYPE_ECHO_REPLY {
+			return "", fmt.Errorf("bad ICMPv6 echo reply type, got %d, want %d", rmsg[0], ICMP6_TYPE_ECHO_REPLY)
+		}
+	} else {
+		if rmsg[0] != ICMP_TYPE_ECHO_REPLY {
+			return "", fmt.Errorf("bad ICMP echo reply type, got %d, want %d", rmsg[0], ICMP_TYPE_ECHO_REPLY)
+		}
 	}
 	cks := binary.BigEndian.Uint16(rmsg[2:])
 	binary.BigEndian.PutUint16(rmsg[2:], 0)
-	if cks != cksum(rmsg) {
+	// only validate the checksum for IPv4. For IPv6 this *should* be done by the
+	// TCP stack (and do we need to validate the checksum anyway?)
+	if !net6 && cks != cksum(rmsg) {
 		return "", fmt.Errorf("bad ICMP checksum: %v (expected %v)", cks, cksum(rmsg))
 	}
 	id := binary.BigEndian.Uint16(rmsg[4:])
@@ -145,18 +171,14 @@ func main() {
 		log.Fatalf("packet size too small (must be >= 8): %v", *packetSize)
 	}
 
-	netname := "ip4:icmp"
 	interval := time.Duration(*intv)
 	host := flag.Args()[0]
-	// todo: just figure out if it's an ip6 address and go from there.
-	if *net6 {
-		netname = "ip6:ipv6-icmp"
-	}
 
 	// ping needs to run forever, except if '*iter' is not zero
+	waitFor := time.Duration(*wtf) * time.Millisecond
 	var i uint64
 	for i = 1; *iter == 0 || i <= *iter; i++ {
-		msg, err := ping1(netname, host, i)
+		msg, err := ping1(*net6, host, i, waitFor)
 		if err != nil {
 			log.Fatalf("ping failed: %v", err)
 		}

--- a/cmds/core/ping/ping_linux.go
+++ b/cmds/core/ping/ping_linux.go
@@ -1,0 +1,23 @@
+// Copyright 2009 The Go Authors.  All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package main
+
+import (
+	"fmt"
+	"net"
+
+	"golang.org/x/sys/unix"
+)
+
+func setupICMPv6Socket(c *net.IPConn) error {
+	file, err := c.File()
+	if err != nil {
+		return fmt.Errorf("net.IPConn.File failed: %w", err)
+	}
+	// we want the stack to return us the network error if any occurred
+	if err := unix.SetsockoptInt(int(file.Fd()), unix.SOL_IPV6, unix.IPV6_RECVERR, 1); err != nil {
+		return fmt.Errorf("Failed to set sock opt IPV6_RECVERR: %w", err)
+	}
+	return nil
+}

--- a/cmds/core/ping/ping_other.go
+++ b/cmds/core/ping/ping_other.go
@@ -1,0 +1,12 @@
+// +build !linux
+
+package main
+
+import (
+	"errors"
+	"net"
+)
+
+func setupICMPv6Socket(c *net.IPConn) error {
+	return errors.New("setting up ICMPv6 socket only supported on Linux")
+}


### PR DESCRIPTION
Fixes #1009

Tested with:

```
$ go build && sudo ./ping -c 3 8.8.8.8
2020/09/15 22:51:10 84 bytes from 8.8.8.8: icmp_seq=1, time=32.758334ms
2020/09/15 22:51:11 84 bytes from 8.8.8.8: icmp_seq=2, time=33.057741ms
2020/09/15 22:51:12 84 bytes from 8.8.8.8: icmp_seq=3, time=32.89407ms
```

```
$ go build && sudo ./ping -6 -c 3 2001:4860:4860::8888
2020/09/15 22:50:52 64 bytes from 2001:4860:4860::8888: icmp_seq=1, time=34.242377ms
2020/09/15 22:50:53 64 bytes from 2001:4860:4860::8888: icmp_seq=2, time=33.450789ms
2020/09/15 22:50:54 64 bytes from 2001:4860:4860::8888: icmp_seq=3, time=37.98115ms
```

Signed-off-by: Andrea Barberio <insomniac@slackware.it>