### PR TITLE
boot/menu: Add menu to edit kernel command line

### DIFF
--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -21,6 +21,10 @@ type OSImage interface {
 	// Label is intended for boot menus.
 	Label() string
 
+	// Edit the kernel command line if possible. Must be called before
+	// Load.
+	Edit(func(cmdline string) string)
+
 	// Load loads the OS image into kernel memory, ready for execution.
 	//
 	// After Load is called, call boot.Execute() to stop Linux and boot the

--- a/pkg/boot/linux.go
+++ b/pkg/boot/linux.go
@@ -76,6 +76,11 @@ func copyToFile(r io.Reader) (*os.File, error) {
 	return readOnlyF, nil
 }
 
+// Edit the kernel command line.
+func (li *LinuxImage) Edit(f func(cmdline string) string) {
+	li.Cmdline = f(li.Cmdline)
+}
+
 // Load implements OSImage.Load and kexec_load's the kernel with its initramfs.
 func (li *LinuxImage) Load(verbose bool) error {
 	if li.Kernel == nil {

--- a/pkg/boot/menu/menu_test.go
+++ b/pkg/boot/menu/menu_test.go
@@ -40,6 +40,9 @@ func (d *testEntry) String() string {
 	return d.Label()
 }
 
+func (d *testEntry) Edit(func(cmdline string) string) {
+}
+
 func (d *testEntry) Load() error {
 	d.mu.Lock()
 	defer d.mu.Unlock()

--- a/pkg/boot/multiboot.go
+++ b/pkg/boot/multiboot.go
@@ -34,6 +34,11 @@ func (mi *MultibootImage) Label() string {
 	return fmt.Sprintf("Multiboot(kernel=%s cmdline=%s iBFT=%s)", stringer(mi.Kernel), mi.Cmdline, mi.IBFT)
 }
 
+// Edit the kernel command line.
+func (mi *MultibootImage) Edit(f func(cmdline string) string) {
+	mi.Cmdline = f(mi.Cmdline)
+}
+
 // Load implements OSImage.Load.
 func (mi *MultibootImage) Load(verbose bool) error {
 	return multiboot.Load(verbose, mi.Kernel, mi.Cmdline, mi.Modules, mi.IBFT)


### PR DESCRIPTION
Example usage from booting OpenSUSE with boot command:

    Welcome to NERF's Boot Menu

    Enter a number to boot a kernel:

    01. Installation

    02. Upgrade

    03. Rescue System

    04. Boot Linux System

    05. Check Installation Media

    06. Reboot

    07. Enter a LinuxBoot shell

    Enter an option ('01' is the default, 'e' to edit kernel cmdline):
     > e
    Select a boot option to edit:
     > 1
    The current quoted cmdline for option 1 is:
     > "splash=silent console=ttyS0,115200,8n1"
     * Note the cmdline is c-style quoted. Ex: \n => newline, \\ => \
    Enter an option:
     * (a)ppend, (o)verwrite, (r)eturn to main menu
     > a
    Enter unquoted cmdline to append:
     > text
    The new quoted cmdline for option 1 is:
     > "splash=silent console=ttyS0,115200,8n1 text"
    Returning to main menu...
    Enter an option ('01' is the default, 'e' to edit kernel cmdline):
     > 1
    Chosen option Installation.

    2020/09/16 08:48:30 Kernel: /tmp/nerf-netboot091194128
    2020/09/16 08:48:30 Initrd: /tmp/nerf-netboot099205423
    2020/09/16 08:48:30 Command line: splash=silent console=ttyS0,115200,8n1 text

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>