### PR TITLE
Fix u-root command outside of $GOPATH

### DIFF
--- a/uroot_test.go
+++ b/uroot_test.go
@@ -83,9 +83,11 @@ func xTestDCE(t *testing.T) {
 		t,
 		[]string{
 			"-build=bb", "-no-strip",
-			"./cmds/*/*",
-			"-cmds/core/installcommand", "-cmds/exp/builtin", "-cmds/exp/run",
-			"pkg/uroot/test/foo",
+			"world",
+			"-github.com/u-root/u-root/cmds/core/installcommand",
+			"-github.com/u-root/u-root/cmds/exp/builtin",
+			"-github.com/u-root/u-root/cmds/exp/run",
+			"github.com/u-root/u-root/pkg/uroot/test/foo",
 		},
 		nil,
 		nil)
@@ -209,7 +211,7 @@ func TestUrootCmdline(t *testing.T) {
 		},
 		{
 			name: "uinitcmd",
-			args: []string{"-build=bb", "-uinitcmd=echo foobar fuzz", "-defaultsh=", "./cmds/core/init", "./cmds/core/echo"},
+			args: []string{"-build=bb", "-uinitcmd=echo foobar fuzz", "-defaultsh=", "github.com/u-root/u-root/cmds/core/init", "github.com/u-root/u-root/cmds/core/echo"},
 			err:  nil,
 			validators: []itest.ArchiveValidator{
 				itest.HasRecord{cpio.Symlink("bin/uinit", "../bbin/echo")},
@@ -248,11 +250,13 @@ func TestUrootCmdline(t *testing.T) {
 			name: "make sure dead code gets eliminated",
 			args: []string{
 				// Build the world + test symbols, unstripped.
-				"-build=bb", "-no-strip", "world", "pkg/uroot/test/foo",
+				"-build=bb", "-no-strip", "world", "github.com/u-root/u-root/pkg/uroot/test/foo",
 				// These are known to disable DCE and need to be exluded.
 				// The reason is https://github.com/golang/go/issues/36021 and is fixed in Go 1.15,
 				// so these can be removed once we no longer support Go < 1.15.
-				"-cmds/core/installcommand", "-cmds/exp/builtin", "-cmds/exp/run",
+				"-github.com/u-root/u-root/cmds/core/installcommand",
+				"-github.com/u-root/u-root/cmds/exp/builtin",
+				"-github.com/u-root/u-root/cmds/exp/run",
 			},
 			err: nil,
 			validators: []itest.ArchiveValidator{
@@ -366,11 +370,18 @@ func buildIt(t *testing.T, args, env []string, want error) (*os.File, []byte) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// Use the u-root command outside of the $GOPATH tree to make sure it
+	// still works.
+	dir, err := ioutil.TempDir("", "build-")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	arg := append([]string{"-o", f.Name()}, args...)
 	c := testutil.Command(t, arg...)
 	t.Logf("Commandline: %v", arg)
 	c.Env = append(c.Env, env...)
+	c.Dir = dir
 	if out, err := c.CombinedOutput(); err != want {
 		t.Fatalf("Error: %v\nOutput:\n%s", err, out)
 	} else if err != nil {


### PR DESCRIPTION
u-root busybox builds are currently broken when using the u-root command outside of the u-root repo directory.

The `go.mod` change (https://github.com/u-root/u-root/pull/1821) failed to account for this possibility.

As a result, people saw stuff like this:

```console
chrisko@foo:~$ u-root core
2020/09/18 17:02:13 Disabling CGO for u-root...
2020/09/18 17:02:13 Build environment: GOARCH=amd64 GOOS=linux GOROOT=/usr/local/google/home/chrisko/sdk/go1.13 GOPATH=/usr/local/google/home/chrisko/go CGO_ENABLED=0 GO111MODULE=off
2020/09/18 17:02:13 Skipping package "/usr/local/google/home/chrisko/go/src/github.com/u-root/u-root/cmds/core/bind": no buildable Go source files in /usr/local/google/home/chrisko/go/src/github.com/u-root/u-root/cmds/core/bind
2020/09/18 17:02:31 error building: type checking failed: /usr/local/google/home/chrisko/go/src/github.com/u-root/u-root/cmds/core/gzip/gzip.go:14:2: could not import github.com/u-root/u-root/pkg/gzip (type-checking package "github.com/u-root/u-root/pkg/gzip" failed (/usr/local/google/home/chrisko/go/src/github.com/u-root/u-root/pkg/gzip/gunzip.go:10:2: could not import github.com/klauspost/pgzip (type-checking package "github.com/klauspost/pgzip" failed (/usr/local/google/home/chrisko/go/pkg/mod/github.com/klauspost/pgzip@v1.2.5/gunzip.go:26:2: could not import github.com/klauspost/compress/flate (cannot find package "github.com/klauspost/compress/flate" in any of:
        /usr/local/google/home/chrisko/sdk/go1.13/src/github.com/klauspost/compress/flate (from $GOROOT)
        /usr/local/google/home/chrisko/go/src/github.com/klauspost/compress/flate (from $GOPATH))))))
```

This should fix the mistake, and adds a crude test for the condition.

can't wait for https://github.com/u-root/gobusybox to become more mature: please try it out if you have some time.