### PR TITLE
kexec: accurate merging of segments

### DIFF
--- a/pkg/boot/kexec/kexec_load_linux.go
+++ b/pkg/boot/kexec/kexec_load_linux.go
@@ -19,15 +19,14 @@ import (
 //
 // Load will align segments to page boundaries and deduplicate overlapping ranges.
 func Load(entry uintptr, segments Segments, flags uint64) error {
-	for i := range segments {
-		segments[i] = AlignPhys(segments[i])
+	segments, err := AlignAndMerge(segments)
+	if err != nil {
+		return fmt.Errorf("could not align segments: %w", err)
 	}
 
-	segments = Dedup(segments)
 	if !segments.PhysContains(entry) {
-		return fmt.Errorf("entry point %#v is not covered by any segment", entry)
+		return fmt.Errorf("entry point %#v is not contained by any segment", entry)
 	}
-
 	return rawLoad(entry, segments, flags)
 }
 

--- a/pkg/boot/kexec/memory_linux.go
+++ b/pkg/boot/kexec/memory_linux.go
@@ -229,7 +229,7 @@ func NewSegment(buf []byte, phys Range) Segment {
 }
 
 func (s Segment) String() string {
-	return fmt.Sprintf("(virt: %s, phys: %s)", s.Buf, s.Phys)
+	return fmt.Sprintf("(userspace: %s, phys: %s)", s.Buf, s.Phys)
 }
 
 func (s *Segment) tryMerge(s2 Segment) (ok bool) {

--- a/pkg/boot/kexec/memory_linux.go
+++ b/pkg/boot/kexec/memory_linux.go
@@ -196,6 +196,11 @@ func (rs Ranges) FindSpaceIn(sz uint, limit Range) (space Range, err error) {
 // Sort sorts ranges by their start point.
 func (rs Ranges) Sort() {
 	sort.Slice(rs, func(i, j int) bool {
+		if rs[i].Start == rs[j].Start {
+			// let rs[i] be the superset of rs[j]
+			return rs[i].Size > rs[j].Size
+		}
+
 		return rs[i].Start < rs[j].Start
 	})
 }
@@ -425,6 +430,9 @@ func (segs Segments) Phys() Ranges {
 func (segs Segments) IsSupersetOf(o Segments) error {
 	for _, seg := range o {
 		size := minuint(seg.Phys.Size, seg.Buf.Size)
+		if size == 0 {
+			continue
+		}
 		r := Range{Start: seg.Phys.Start, Size: size}
 		buf := segs.GetPhys(r)
 		if buf == nil {

--- a/pkg/boot/kexec/memory_linux_test.go
+++ b/pkg/boot/kexec/memory_linux_test.go
@@ -175,6 +175,36 @@ func TestAlignAndMerge(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "two segments in the same page with first-buffer-truncation and second-buffer-padding",
+			in: Segments{
+				NewSegment([]byte("testtest"), Range{Start: 0, Size: 5}),
+				NewSegment([]byte("foo"), Range{Start: 10, Size: 5}),
+			},
+			want: Segments{
+				NewSegment([]byte("testt\x00\x00\x00\x00\x00foo"), Range{Start: 0, Size: 0x1000}),
+			},
+		},
+		{
+			name: "two segments in the same page with first-buffer-perfect and second-buffer-truncation",
+			in: Segments{
+				NewSegment([]byte("testt"), Range{Start: 0, Size: 5}),
+				NewSegment([]byte("foofoofoo"), Range{Start: 10, Size: 5}),
+			},
+			want: Segments{
+				NewSegment([]byte("testt\x00\x00\x00\x00\x00foofo"), Range{Start: 0, Size: 0x1000}),
+			},
+		},
+		{
+			name: "two segments in the same page with first-buffer-padding and second-buffer-perfect",
+			in: Segments{
+				NewSegment([]byte("tes"), Range{Start: 0, Size: 5}),
+				NewSegment([]byte("foofo"), Range{Start: 10, Size: 5}),
+			},
+			want: Segments{
+				NewSegment([]byte("tes\x00\x00\x00\x00\x00\x00\x00foofo"), Range{Start: 0, Size: 0x1000}),
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := AlignAndMerge(tt.in)

--- a/pkg/boot/kexec/memory_linux_test.go
+++ b/pkg/boot/kexec/memory_linux_test.go
@@ -357,6 +357,46 @@ func TestFindSpaceIn(t *testing.T) {
 	}
 }
 
+func TestFindSpace(t *testing.T) {
+	for i, tt := range []struct {
+		name string
+		rs   Ranges
+		size uint
+		want Range
+		err  error
+	}{
+		{
+			name: "just enough space under 0x1000",
+			rs: Ranges{
+				Range{Start: 0xFF, Size: 0xf},
+				Range{Start: 0xFF0, Size: 0x10},
+				Range{Start: 0x1000, Size: 0x10},
+			},
+			size: 0x10,
+			want: Range{Start: 0xFF0, Size: 0x10},
+		},
+		{
+			name: "no ranges",
+			rs:   Ranges{},
+			size: 0x10,
+			err:  ErrNotEnoughSpace{Size: 0x10},
+		},
+		{
+			name: "no ranges, zero size",
+			rs:   Ranges{},
+			size: 0,
+			err:  ErrNotEnoughSpace{Size: 0},
+		},
+	} {
+		t.Run(fmt.Sprintf("test_%d_%s", i, tt.name), func(t *testing.T) {
+			got, err := tt.rs.FindSpace(tt.size)
+			if !reflect.DeepEqual(got, tt.want) || err != tt.err {
+				t.Errorf("%s.FindSpace(%#x) = (%#x, %v), want (%#x, %v)", tt.rs, tt.size, got, err, tt.want, tt.err)
+			}
+		})
+	}
+}
+
 func TestIntersection(t *testing.T) {
 	for i, tt := range []struct {
 		r             Range


### PR DESCRIPTION
Previously, it was assumed that all adjacent segments would have directly adjoining buffers in the virtual space.

Merging only worked on segments that were directly physically adjoining but not aligned to page size:

```
userspace: [0xff1000, 0xff1234] phys: [0x1000, 0x1234]
userspace: [0xff1234, 0xff2000] phys: [0x1234, 0x2000]

or

userspace: [0xff1000, 0xff1234] phys: [0x1000, 0x1234]
userspace: [0xff2000, 0xff2dcc] phys: [0x1234, 0x2000]
```

However, non-aligned addresses with holes and non-linear continuation are also valid, e.g. in the case where an image wants to  avoid padding with zeros:

```
userspace: [0xff1000, 0xff1234] phys: [0x1000, 0x1234]
userspace: [0xff1234, 0xff2234] phys: [0x2000, 0x2234]
```

Also, holes in the image that are not linear with the physical address space are valid:

```
userspace: [0xff1000, 0xff1234] phys: [0x1000, 0x1234]
userspace: [0xff1e00, 0xff2000] phys: [0x1aaa, 0x1caa]
```

Aligning would make all these physical ranges overlap, and it was assumed that `append(section1Buf, section2Buf)` would be an accurate merging of these segments. This only worked in some small set of cases, which ESXi's `b.b00` and our test multibooot kernel happened to fit.

Fixes #1845 and aids in EFI kexec.