### PR TITLE
mb: rename mutiboot into ESXBootInfo

### DIFF
--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -158,15 +158,15 @@ func (m modules) marshal() ([]byte, error) {
 	return buf.Bytes(), err
 }
 
-// elems adds mutiboot info elements describing where to find each module and
+// elems adds esxBootInfo info elements describing where to find each module and
 // its cmdline.
 func (m modules) elems() []elem {
 	var e []elem
 	for _, mm := range m {
-		e = append(e, &mutibootModule{
+		e = append(e, &esxBootInfoModule{
 			cmdline:    uint64(mm.Cmdline),
 			moduleSize: uint64(mm.End - mm.Start),
-			ranges: []mutibootModuleRange{
+			ranges: []esxBootInfoModuleRange{
 				{
 					startPageNum: uint64(mm.Start / uint32(os.Getpagesize())),
 					numPages:     pageAlign(mm.End-mm.Start) / uint32(os.Getpagesize()),

--- a/pkg/boot/multiboot/mutiboot_info.go
+++ b/pkg/boot/multiboot/mutiboot_info.go
@@ -8,13 +8,13 @@ import (
 	"github.com/u-root/u-root/pkg/uio"
 )
 
-type mutibootInfo struct {
+type esxBootInfoInfo struct {
 	cmdline uint64
 
 	elems []elem
 }
 
-func (m *mutibootInfo) marshal() []byte {
+func (m *esxBootInfoInfo) marshal() []byte {
 	buf := uio.NewNativeEndianBuffer(nil)
 	buf.Write64(m.cmdline)
 	buf.Write64(uint64(len(m.elems)))
@@ -33,32 +33,32 @@ func (m *mutibootInfo) marshal() []byte {
 }
 
 type elem interface {
-	typ() mutibootType
+	typ() esxBootInfoType
 	marshal() []byte
 }
 
-type mutibootType uint32
+type esxBootInfoType uint32
 
 const (
-	MUTIBOOT_INVALID_TYPE  mutibootType = 0
-	MUTIBOOT_MEMRANGE_TYPE mutibootType = 1
-	MUTIBOOT_MODULE_TYPE   mutibootType = 2
-	MUTIBOOT_VBE_TYPE      mutibootType = 3
-	MUTIBOOT_EFI_TYPE      mutibootType = 4
-	MUTIBOOT_LOADESX_TYPE  mutibootType = 5
+	ESXBOOTINFO_INVALID_TYPE  esxBootInfoType = 0
+	ESXBOOTINFO_MEMRANGE_TYPE esxBootInfoType = 1
+	ESXBOOTINFO_MODULE_TYPE   esxBootInfoType = 2
+	ESXBOOTINFO_VBE_TYPE      esxBootInfoType = 3
+	ESXBOOTINFO_EFI_TYPE      esxBootInfoType = 4
+	ESXBOOTINFO_LOADESX_TYPE  esxBootInfoType = 5
 )
 
-type mutibootMemRange struct {
+type esxBootInfoMemRange struct {
 	startAddr uint64
 	length    uint64
 	memType   uint32
 }
 
-func (m mutibootMemRange) typ() mutibootType {
-	return MUTIBOOT_MEMRANGE_TYPE
+func (m esxBootInfoMemRange) typ() esxBootInfoType {
+	return ESXBOOTINFO_MEMRANGE_TYPE
 }
 
-func (m *mutibootMemRange) marshal() []byte {
+func (m *esxBootInfoMemRange) marshal() []byte {
 	buf := uio.NewNativeEndianBuffer(nil)
 	buf.Write64(m.startAddr)
 	buf.Write64(m.length)
@@ -66,22 +66,22 @@ func (m *mutibootMemRange) marshal() []byte {
 	return buf.Data()
 }
 
-type mutibootModuleRange struct {
+type esxBootInfoModuleRange struct {
 	startPageNum uint64
 	numPages     uint32
 }
 
-type mutibootModule struct {
+type esxBootInfoModule struct {
 	cmdline    uint64
 	moduleSize uint64
-	ranges     []mutibootModuleRange
+	ranges     []esxBootInfoModuleRange
 }
 
-func (m mutibootModule) typ() mutibootType {
-	return MUTIBOOT_MODULE_TYPE
+func (m esxBootInfoModule) typ() esxBootInfoType {
+	return ESXBOOTINFO_MODULE_TYPE
 }
 
-func (m *mutibootModule) marshal() []byte {
+func (m *esxBootInfoModule) marshal() []byte {
 	buf := uio.NewNativeEndianBuffer(nil)
 	buf.Write64(m.cmdline)
 	buf.Write64(m.moduleSize)
@@ -95,36 +95,36 @@ func (m *mutibootModule) marshal() []byte {
 	return buf.Data()
 }
 
-type mutibootEfiFlags uint32
+type esxBootInfoEfiFlags uint32
 
 const (
 	// 64-bit ARM EFI. (Why would we have to tell the next kernel that it's
 	// an aarch64 EFI? Shouldn't it know?)
-	MUTIBOOT_EFI_ARCH64 mutibootEfiFlags = 1 << 0
+	ESXBOOTINFO_EFI_ARCH64 esxBootInfoEfiFlags = 1 << 0
 
 	// EFI Secure Boot in progress.
-	MUTIBOOT_EFI_SECURE_BOOT mutibootEfiFlags = 1 << 1
+	ESXBOOTINFO_EFI_SECURE_BOOT esxBootInfoEfiFlags = 1 << 1
 
-	// UEFI memory map is valid rather than mutiboot memory map.
-	MUTIBOOT_EFI_MMAP mutibootEfiFlags = 1 << 2
+	// UEFI memory map is valid rather than esxBootInfo memory map.
+	ESXBOOTINFO_EFI_MMAP esxBootInfoEfiFlags = 1 << 2
 )
 
-type mutibootEfi struct {
-	flags  mutibootEfiFlags
+type esxBootInfoEfi struct {
+	flags  esxBootInfoEfiFlags
 	systab uint64
 
-	// Only set if flags & MUTIBOOT_EFI_MMAP.
+	// Only set if flags & ESXBOOTINFO_EFI_MMAP.
 	memmap         uint64
 	memmapNumDescs uint32
 	memmapDescSize uint32
 	memmapVersion  uint32
 }
 
-func (m mutibootEfi) typ() mutibootType {
-	return MUTIBOOT_EFI_TYPE
+func (m esxBootInfoEfi) typ() esxBootInfoType {
+	return ESXBOOTINFO_EFI_TYPE
 }
 
-func (m *mutibootEfi) marshal() []byte {
+func (m *esxBootInfoEfi) marshal() []byte {
 	buf := uio.NewNativeEndianBuffer(nil)
 	buf.Write32(uint32(m.flags))
 	buf.Write64(m.systab)

--- a/pkg/boot/multiboot/mutiboot_info_test.go
+++ b/pkg/boot/multiboot/mutiboot_info_test.go
@@ -13,12 +13,12 @@ import (
 func TestInfoMarshal(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		mi   *mutibootInfo
+		mi   *esxBootInfoInfo
 		want []byte
 	}{
 		{
 			name: "no elements",
-			mi: &mutibootInfo{
+			mi: &esxBootInfoInfo{
 				cmdline: 0xdeadbeef,
 				elems:   nil,
 			},
@@ -31,10 +31,10 @@ func TestInfoMarshal(t *testing.T) {
 		},
 		{
 			name: "one memrange element",
-			mi: &mutibootInfo{
+			mi: &esxBootInfoInfo{
 				cmdline: 0xdeadbeef,
 				elems: []elem{
-					&mutibootMemRange{
+					&esxBootInfoMemRange{
 						startAddr: 0xbeefdead,
 						length:    0xdeadbeef,
 						memType:   2,
@@ -50,7 +50,7 @@ func TestInfoMarshal(t *testing.T) {
 				// TLV -- type, length, value
 
 				// type
-				byte(MUTIBOOT_MEMRANGE_TYPE), 0, 0, 0,
+				byte(ESXBOOTINFO_MEMRANGE_TYPE), 0, 0, 0,
 				// length - 20 bytes + 8 for the length + 4 for the type
 				32, 0, 0, 0, 0, 0, 0, 0,
 				// values
@@ -61,13 +61,13 @@ func TestInfoMarshal(t *testing.T) {
 		},
 		{
 			name: "one module element",
-			mi: &mutibootInfo{
+			mi: &esxBootInfoInfo{
 				cmdline: 0xdeadbeef,
 				elems: []elem{
-					&mutibootModule{
+					&esxBootInfoModule{
 						cmdline:    0xbeefdead,
 						moduleSize: 0x1000,
-						ranges: []mutibootModuleRange{
+						ranges: []esxBootInfoModuleRange{
 							{
 								startPageNum: 0x100,
 								numPages:     1,
@@ -85,7 +85,7 @@ func TestInfoMarshal(t *testing.T) {
 				// TLV -- type, length, value
 
 				// type
-				byte(MUTIBOOT_MODULE_TYPE), 0, 0, 0,
+				byte(ESXBOOTINFO_MODULE_TYPE), 0, 0, 0,
 				// length - 36 bytes + 8 for the length + 4 for the type
 				48, 0, 0, 0, 0, 0, 0, 0,
 				// values
@@ -105,10 +105,10 @@ func TestInfoMarshal(t *testing.T) {
 		},
 		{
 			name: "one zero-length module element",
-			mi: &mutibootInfo{
+			mi: &esxBootInfoInfo{
 				cmdline: 0xdeadbeef,
 				elems: []elem{
-					&mutibootModule{
+					&esxBootInfoModule{
 						cmdline:    0xbeefdead,
 						moduleSize: 0,
 					},
@@ -123,7 +123,7 @@ func TestInfoMarshal(t *testing.T) {
 				// TLV -- type, length, value
 
 				// type
-				byte(MUTIBOOT_MODULE_TYPE), 0, 0, 0,
+				byte(ESXBOOTINFO_MODULE_TYPE), 0, 0, 0,
 				// length - 20 bytes + 8 for the length + 4 for the type
 				32, 0, 0, 0, 0, 0, 0, 0,
 				// values

--- a/pkg/boot/multiboot/mutiheader.go
+++ b/pkg/boot/multiboot/mutiheader.go
@@ -13,38 +13,38 @@ import (
 	"github.com/u-root/u-root/pkg/ubinary"
 )
 
-// mutibootMagic is both the magic value found in the mutiboot kernel header as
+// esxBootInfoMagic is both the magic value found in the esxBootInfo kernel header as
 // well as the value the loaded OS expects in EAX at boot time.
-const mutibootMagic = 0x1BADB005
+const esxBootInfoMagic = 0x1BADB005
 
-type mutibootHeaderFlag uint32
+type esxBootInfoHeaderFlag uint32
 
 const (
 	// Kernel runs in EL1, not EL2.
-	MUTIBOOT_ARCH_FLAG_ARM64_EL1 mutibootHeaderFlag = 1 << 0
+	ESXBOOTINFO_ARCH_FLAG_ARM64_EL1 esxBootInfoHeaderFlag = 1 << 0
 	// Must pass video info to OS.
-	MUTIBOOT_FLAG_VIDEO mutibootHeaderFlag = 1 << 2
+	ESXBOOTINFO_FLAG_VIDEO esxBootInfoHeaderFlag = 1 << 2
 
 	// rts_vaddr field is valid.
-	MUTIBOOT_FLAG_EFI_RTS_OLD mutibootHeaderFlag = 1 << 17
+	ESXBOOTINFO_FLAG_EFI_RTS_OLD esxBootInfoHeaderFlag = 1 << 17
 	// rts vaddr and size fields valid.
-	MUTIBOOT_FLAG_EFI_RTS_NEW mutibootHeaderFlag = 1 << 18
+	ESXBOOTINFO_FLAG_EFI_RTS_NEW esxBootInfoHeaderFlag = 1 << 18
 	// LoadESX version field valid.
-	MUTIBOOT_FLAG_LOADESX_VERSION mutibootHeaderFlag = 1 << 19
+	ESXBOOTINFO_FLAG_LOADESX_VERSION esxBootInfoHeaderFlag = 1 << 19
 	// Video min fields valid.
-	MUTIBOOT_FLAG_VIDEO_MIN mutibootHeaderFlag = 1 << 20
+	ESXBOOTINFO_FLAG_VIDEO_MIN esxBootInfoHeaderFlag = 1 << 20
 )
 
-type mutibootVideoMode uint32
+type esxBootInfoVideoMode uint32
 
 const (
-	MUTIBOOT_VIDEO_GRAPHIC = 0
-	MUTIBOOT_VIDEO_TEXT    = 1
+	ESXBOOTINFO_VIDEO_GRAPHIC = 0
+	ESXBOOTINFO_VIDEO_TEXT    = 1
 )
 
-type mutibootHeader struct {
+type esxBootInfoHeader struct {
 	Magic    uint32
-	Flags    mutibootHeaderFlag
+	Flags    esxBootInfoHeaderFlag
 	Checksum uint32
 
 	// unused.
@@ -55,7 +55,7 @@ type mutibootHeader struct {
 	MinWidth  uint32
 	MinHeight uint32
 	MinDepth  uint32
-	ModeType  mutibootVideoMode
+	ModeType  esxBootInfoVideoMode
 	Width     uint32
 	Height    uint32
 	Depth     uint32
@@ -65,19 +65,19 @@ type mutibootHeader struct {
 	LoadESXVersion       uint32
 }
 
-func (m *mutibootHeader) name() string {
-	return "mutiboot"
+func (m *esxBootInfoHeader) name() string {
+	return "ESXBootInfo"
 }
 
-func (m *mutibootHeader) bootMagic() uintptr {
-	return mutibootMagic
+func (m *esxBootInfoHeader) bootMagic() uintptr {
+	return esxBootInfoMagic
 }
 
-// parseMutiHeader parses mutiboot header.
-func parseMutiHeader(r io.Reader) (*mutibootHeader, error) {
-	sizeofHeader := binary.Size(mutibootHeader{})
+// parseMutiHeader parses esxBootInfo header.
+func parseMutiHeader(r io.Reader) (*esxBootInfoHeader, error) {
+	sizeofHeader := binary.Size(esxBootInfoHeader{})
 
-	var hdr mutibootHeader
+	var hdr esxBootInfoHeader
 	// The multiboot header must be contained completely within the
 	// first 8192 bytes of the OS image.
 	buf := make([]byte, 8192)
@@ -93,11 +93,11 @@ func parseMutiHeader(r io.Reader) (*mutibootHeader, error) {
 		if err := binary.Read(br, ubinary.NativeEndian, &hdr); err != nil {
 			return nil, err
 		}
-		if hdr.Magic == mutibootMagic && (hdr.Magic+uint32(hdr.Flags)+hdr.Checksum) == 0 {
+		if hdr.Magic == esxBootInfoMagic && (hdr.Magic+uint32(hdr.Flags)+hdr.Checksum) == 0 {
 			/*if hdr.Flags&flagHeaderUnsupported != 0 {
 				return hdr, ErrFlagsNotSupported
 			}*/
-			if hdr.Flags&MUTIBOOT_FLAG_VIDEO != 0 {
+			if hdr.Flags&ESXBOOTINFO_FLAG_VIDEO != 0 {
 				log.Print("VideoMode flag is not supproted yet, trying to load anyway")
 			}
 			return &hdr, nil


### PR DESCRIPTION
Renamed as of https://github.com/vmware/esx-boot/commit/868a4f89de7eb8f627ca42a5f3fcec35a6545d04

    The name "Mutiboot" was originally a joke, meaning "VMware's mutated
    boot". The name has proven to be too confusing, as it looks too much
    like a typo for Multiboot.