### PR TITLE
mount: Add pool for managing a list of MountPoints

### DIFF
--- a/cmds/boot/boot/boot.go
+++ b/cmds/boot/boot/boot.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Copyright 2012-2020 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -38,6 +38,7 @@ import (
 	"github.com/u-root/u-root/pkg/boot/localboot"
 	"github.com/u-root/u-root/pkg/boot/menu"
 	"github.com/u-root/u-root/pkg/cmdline"
+	"github.com/u-root/u-root/pkg/mount"
 	"github.com/u-root/u-root/pkg/mount/block"
 	"github.com/u-root/u-root/pkg/ulog"
 )
@@ -89,7 +90,8 @@ func main() {
 	if *verbose {
 		l = ulog.Log
 	}
-	images, mps, err := localboot.Localboot(l, blockDevs)
+	mountPool := &mount.Pool{}
+	images, err := localboot.Localboot(l, blockDevs, mountPool)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -105,5 +107,5 @@ func main() {
 	menuEntries = append(menuEntries, menu.StartShell{})
 
 	// Boot does not return.
-	bootcmd.ShowMenuAndBoot(menuEntries, mps, *noLoad, *noExec)
+	bootcmd.ShowMenuAndBoot(menuEntries, mountPool, *noLoad, *noExec)
 }

--- a/pkg/boot/bootcmd/bootcmd.go
+++ b/pkg/boot/bootcmd/bootcmd.go
@@ -17,10 +17,10 @@ import (
 // ShowMenuAndBoot handles common cleanup functions and flags that all boot
 // commands should support.
 //
-// mps are mounts to unmount before kexecing. noLoad prints the list of entries
+// mountPool is unmounted before kexecing. noLoad prints the list of entries
 // and exits. If noLoad is false, a boot menu is shown to the user. The
 // user-chosen boot entry will be kexec'd unless noExec is true.
-func ShowMenuAndBoot(entries []menu.Entry, mps []*mount.MountPoint, noLoad, noExec bool) {
+func ShowMenuAndBoot(entries []menu.Entry, mountPool *mount.Pool, noLoad, noExec bool) {
 	if noLoad {
 		log.Print("Not loading menu or kernel. Options:")
 		for i, entry := range entries {
@@ -33,10 +33,8 @@ func ShowMenuAndBoot(entries []menu.Entry, mps []*mount.MountPoint, noLoad, noEx
 	loadedEntry := menu.ShowMenuAndLoad(os.Stdin, entries...)
 
 	// Clean up.
-	for _, mp := range mps {
-		if err := mp.Unmount(mount.MNT_DETACH); err != nil {
-			log.Printf("Failed to unmount %s: %v", mp, err)
-		}
+	if err := mountPool.UnmountAll(mount.MNT_DETACH); err != nil {
+		log.Printf("Failed to unmount: %v", err)
 	}
 	if loadedEntry == nil {
 		log.Fatalf("Nothing to boot.")

--- a/pkg/mount/block/blockdev.go
+++ b/pkg/mount/block/blockdev.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2019 the u-root Authors. All rights reserved
+// Copyright 2017-2020 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -30,6 +30,7 @@ var (
 	// LinuxMountsPath is the standard mountpoint list path
 	LinuxMountsPath = "/proc/mounts"
 
+	// Debug function to override for verbose logging.
 	Debug = func(string, ...interface{}) {}
 )
 
@@ -68,6 +69,11 @@ func (b *BlockDev) String() string {
 // DevicePath is the path to the actual device.
 func (b BlockDev) DevicePath() string {
 	return filepath.Join("/dev/", b.Name)
+}
+
+// Name implements mount.Mounter.
+func (b *BlockDev) DevName() string {
+	return b.Name
 }
 
 // Mount implements mount.Mounter.

--- a/pkg/mount/loop/loop_linux.go
+++ b/pkg/mount/loop/loop_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2018 the u-root Authors. All rights reserved
+// Copyright 2018-2020 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -48,6 +48,11 @@ func New(source, fstype string, data string) (*Loop, error) {
 		FSType: fstype,
 		Data:   data,
 	}, nil
+}
+
+// DevName implements mount.Mounter.
+func (l *Loop) DevName() string {
+	return l.Dev
 }
 
 // Mount mounts the provided source file, with type fstype, and flags and data options

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Copyright 2012-2020 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,9 @@ package mount
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 )
@@ -36,6 +38,8 @@ const (
 
 // Mounter is a device that can be attached at a file system path.
 type Mounter interface {
+	// DevName returns the name of the device.
+	DevName() string
 	// Mount attaches the device at path.
 	Mount(path string, flags uintptr) (*MountPoint, error)
 }
@@ -143,4 +147,84 @@ func Unmount(path string, force, lazy bool) error {
 		return fmt.Errorf("umount %q flags %x: %v", path, flags, err)
 	}
 	return nil
+}
+
+// Pool keeps track of multiple MountPoint.
+type Pool struct {
+	// List of items mounted by this pool.
+	MountPoints []*MountPoint
+	// Temporary directory which contains sub-directories for mounts.
+	tmpDir string
+}
+
+// Mount mounts a file system using Mounter and returns the MountPoint. If the
+// device has already been mounted, it is not mounted again.
+//
+// Note the pool is keyed on Mounter.DevName() alone meaning DevName is used to
+// determine whether it has already been mounted.
+func (p *Pool) Mount(mounter Mounter, flags uintptr) (*MountPoint, error) {
+	for _, m := range p.MountPoints {
+		if m.Device == mounter.DevName() {
+			return m, nil
+		}
+	}
+
+	// Create temporary directory if one does not already exist.
+	if p.tmpDir == "" {
+		tmpDir, err := ioutil.TempDir("", "u-root-mounts")
+		if err != nil {
+			return nil, fmt.Errorf("cannot create tmpdir: %v", err)
+		}
+		p.tmpDir = tmpDir
+	}
+
+	path := filepath.Join(p.tmpDir, mounter.DevName())
+	os.MkdirAll(path, 0777)
+	m, err := mounter.Mount(path, flags)
+	if err != nil {
+		// unix.Rmdir is used (instead of os.RemoveAll) because it
+		// fails when the directory is non-empty. It would be a bit
+		// dangerous to use os.RemoveAll because it could accidentally
+		// delete everything in a mount.
+		unix.Rmdir(p.tmpDir)
+		return nil, err
+	}
+	p.MountPoints = append(p.MountPoints, m)
+	return m, err
+}
+
+// Add adds MountPoints to the pool.
+func (p *Pool) Add(m ...*MountPoint) {
+	p.MountPoints = append(p.MountPoints, m...)
+}
+
+// UnmountAll umounts all the mountpoints from the pool. This makes a
+// best-effort attempt to unmount everything and cleanup temporary directories.
+// If this function fails, it can be re-tried.
+func (p *Pool) UnmountAll(flags uintptr) error {
+	// Errors get concatenated together here.
+	var returnErr error
+
+	for _, m := range p.MountPoints {
+		if err := m.Unmount(flags); err != nil {
+			if returnErr == nil {
+				returnErr = err
+			} else {
+				returnErr = fmt.Errorf("%w; %s", returnErr, err.Error())
+			}
+		}
+
+		// unix.Rmdir is used (instead of os.RemoveAll) because it
+		// fails when the directory is non-empty. It would be a bit
+		// dangerous to use os.RemoveAll because it could accidentally
+		// delete everything in a mount.
+		unix.Rmdir(m.Path)
+	}
+
+	if returnErr == nil && p.tmpDir != "" {
+		returnErr = unix.Rmdir(p.tmpDir)
+		p.tmpDir = ""
+	}
+
+	return returnErr
 }


### PR DESCRIPTION
The Pool will allow the grub interpreter to keep track of mount points,
inform the caller of new mounts so it can unmount everything, prevent
re-mounting a partition unnecessarily and makes it easy to fake out
mounts points for testing.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>