### PR TITLE
grub: Safely join paths in the grub parser

### DIFF
--- a/pkg/upath/safejoin.go
+++ b/pkg/upath/safejoin.go
@@ -1,0 +1,46 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package upath
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// SafeFilepathJoin safely joins two paths path1+path2. The resulting path will
+// always be contained within path1 even if path2 tries to escape with "../".
+//
+// Note: This only works on Unix-like file systems.
+// Second note: Additional care has to be taken to make sure a symlink does not
+// traverse.
+func SafeFilepathJoin(path1, path2 string) (string, error) {
+	cleanPath, err := filepath.Rel("/", filepath.Clean(filepath.Join("/", path2)))
+	if err != nil {
+		return "", fmt.Errorf("could not clean path %q: %v", path2, err)
+	}
+	return filepath.Join(path1, cleanPath), nil
+}
+
+// SafeResolveSymlink recursively resolves a symlink and makes sure it never
+// references a file outside of mountPointPath. If symlinkPath is not a
+// symlink, it is returned immediately. If at the end of the resolution, the
+// file is not regular file or directory, an error is returned.
+/*
+func SafeResolveSymlink(mountPointPath, symlinkPath string) (string, error) {
+	// Fixed upper limit to prevent an infinite loop.
+	for i := 0; i < 10; i++ {
+		fi, err := os.Lstat(symlinkPath)
+		if err != nil {
+			return err
+		}
+		if fi.Mode&os.ModeSymlink != 0 {
+			continue
+		}
+		if fi.Mode.IsRegular() || fi.Mode.IsDir() {
+			return symlinkPath, nil
+		}
+	}
+}
+*/

--- a/pkg/upath/safejoin.go
+++ b/pkg/upath/safejoin.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !windows
+
 package upath
 
 import (
@@ -9,12 +11,12 @@ import (
 	"path/filepath"
 )
 
+// maxSymlinkDepth prevents infinite recursion. This matches Linux.
+const maxSymlinkDepth = 40
+
 // SafeFilepathJoin safely joins two paths path1+path2. The resulting path will
 // always be contained within path1 even if path2 tries to escape with "../".
-//
-// Note: This only works on Unix-like file systems.
-// Second note: Additional care has to be taken to make sure a symlink does not
-// traverse.
+// If that path is not possible, an error is returned.
 func SafeFilepathJoin(path1, path2 string) (string, error) {
 	cleanPath, err := filepath.Rel("/", filepath.Clean(filepath.Join("/", path2)))
 	if err != nil {
@@ -23,24 +25,83 @@ func SafeFilepathJoin(path1, path2 string) (string, error) {
 	return filepath.Join(path1, cleanPath), nil
 }
 
-// SafeResolveSymlink recursively resolves a symlink and makes sure it never
+// SafeResolveSymlink recursively resolves a symlink and make sure it never
 // references a file outside of mountPointPath. If symlinkPath is not a
 // symlink, it is returned immediately. If at the end of the resolution, the
 // file is not regular file or directory, an error is returned.
-/*
+//
+// Implemented based on `man path_resolution`. Mostly correct.
 func SafeResolveSymlink(mountPointPath, symlinkPath string) (string, error) {
-	// Fixed upper limit to prevent an infinite loop.
-	for i := 0; i < 10; i++ {
-		fi, err := os.Lstat(symlinkPath)
+	path := filepath.Clean(symlinkPath)
+
+	// Resolve any symlinks in intermediate components.
+	for i := range strings.Split(path, "/") {
+		intermediatePath := strings.Join(path[:i], "/")
+
+		// The first component may be a root directory, skip it.
+		if intermediatePath == "" {
+			continue
+		}
+
+		// Check if it's a symlink.
+		fi, err := os.Lstat(SafeFilepathJoin(mountPointPath, intermediatePath))
 		if err != nil {
 			return err
 		}
-		if fi.Mode&os.ModeSymlink != 0 {
-			continue
+		if fi.Mode&os.ModeSymlink == 0 {
+			// Not a symlink, continue with the next component.
+			break
 		}
-		if fi.Mode.IsRegular() || fi.Mode.IsDir() {
-			return symlinkPath, nil
+
+		// It's a symlink, resolve it.
+		link, err := os.Readlink(path)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(link, "/") {
+		} else {
+			newPath, err := SafeResolveSymlink(mountPointPath, link)
+			if err != nil {
+				return err
+			}
+			path = newPath
+		}
+		path, err := SafeResolveSymlink(mountPointPath, link)
+		if err != nil {
+			return err
+		}
+
+		if !fi.IsDir() {
+			// A component must be a directory.
+			return "", fmt.Errorf("cannot resolve path %q containing a non-directory", symlinkPath)
 		}
 	}
+
+	// At this point, only the last component could be a symlink.
+	for i := 0; i < maxSymlinkDepth; i++ {
+		fi, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+		if fi.Mode&os.ModeSymlink == 0 {
+			// Not a symlink, we're done!
+			return path, nil
+		}
+
+		// It's a symlink, resolve it.
+		link, err := os.Readlink(path)
+		if err != nil {
+			return err
+		}
+		if strings.HasPrefix(link, "/") {
+			newPath, err := SafeFilepathJoin(moutPointPath, link)
+			if err != nil {
+				return err
+			}
+			path = newPath
+		} else {
+		}
+	}
+	return "", fmt.Errof("symlink depth of %q more than limit of %d",
+		symlinkPath, maxSymlinkDepth)
 }
-*/

--- a/pkg/upath/safejoin_test.go
+++ b/pkg/upath/safejoin_test.go
@@ -60,3 +60,56 @@ func TestSafeFilepathJoin(t *testing.T) {
 		})
 	}
 }
+
+func TestSafeResolveSymlink(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		path1, path2, want string
+	}{
+		{
+			path1: "a",
+			path2: "b",
+			want:  "a/b",
+		},
+		{
+			path1: "/a",
+			path2: "b",
+			want:  "/a/b",
+		},
+		{
+			path1: "/a",
+			path2: "/b",
+			want:  "/a/b",
+		},
+		{
+			path1: "/a",
+			path2: "../b",
+			want:  "/a/b",
+		},
+		{
+			path1: "/a",
+			path2: "c/../b",
+			want:  "/a/b",
+		},
+		{
+			path1: "/a",
+			path2: "c/d/../b",
+			want:  "/a/c/b",
+		},
+		{
+			path1: "/a",
+			path2: "c/d/../../../b",
+			want:  "/a/b",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeFilepathJoin(tt.path1, tt.path2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("safePathJoin(%q, %q) = %q; want %q", tt.path1, tt.path2, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/upath/safejoin_test.go
+++ b/pkg/upath/safejoin_test.go
@@ -1,0 +1,62 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package upath
+
+import (
+	"testing"
+)
+
+func TestSafeFilepathJoin(t *testing.T) {
+	for _, tt := range []struct {
+		name               string
+		path1, path2, want string
+	}{
+		{
+			path1: "a",
+			path2: "b",
+			want:  "a/b",
+		},
+		{
+			path1: "/a",
+			path2: "b",
+			want:  "/a/b",
+		},
+		{
+			path1: "/a",
+			path2: "/b",
+			want:  "/a/b",
+		},
+		{
+			path1: "/a",
+			path2: "../b",
+			want:  "/a/b",
+		},
+		{
+			path1: "/a",
+			path2: "c/../b",
+			want:  "/a/b",
+		},
+		{
+			path1: "/a",
+			path2: "c/d/../b",
+			want:  "/a/c/b",
+		},
+		{
+			path1: "/a",
+			path2: "c/d/../../../b",
+			want:  "/a/b",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := SafeFilepathJoin(tt.path1, tt.path2)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Errorf("safePathJoin(%q, %q) = %q; want %q", tt.path1, tt.path2, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This prevents paths from escaping the mount point such as
`filepath.Join("/tmp/mount-sda1/", "../../etc/passwd")`.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>