### PR TITLE
pkg/iomem,cmds/core/io: Add support for x86 CPU IO instructions

### DIFF
--- a/cmds/core/io/asmports.go
+++ b/cmds/core/io/asmports.go
@@ -1,0 +1,33 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build linux,amd64 linux,386
+
+package main
+
+import (
+	"github.com/u-root/u-root/pkg/memio"
+)
+
+// The xin* and xout* commands use iopl, and hence
+// must be run by root.
+func init() {
+	usageMsg += `io (xin{b,w,l} address)...
+io (xout{b,w,l} address value)...
+`
+	addCmd(readCmds, "xinb", &cmd{xin, 16, 8})
+	addCmd(readCmds, "xinw", &cmd{xin, 16, 16})
+	addCmd(readCmds, "xinl", &cmd{xin, 16, 32})
+	addCmd(writeCmds, "xoutb", &cmd{xout, 16, 8})
+	addCmd(writeCmds, "xoutw", &cmd{xout, 16, 16})
+	addCmd(writeCmds, "xoutl", &cmd{xout, 16, 32})
+}
+
+func xin(addr int64, data memio.UintN) error {
+	return memio.ArchIn(uint16(addr), data)
+}
+
+func xout(addr int64, data memio.UintN) error {
+	return memio.ArchOut(uint16(addr), data)
+}

--- a/pkg/memio/io_test.go
+++ b/pkg/memio/io_test.go
@@ -95,7 +95,7 @@ func ExampleRead() {
 	if err := Read(0x1000000, &data); err != nil {
 		log.Fatal(err)
 	}
-	log.Printf("%v\n", data)
+	log.Println(data)
 }
 
 func ExampleWrite() {

--- a/pkg/memio/ioport_linux_386.s
+++ b/pkg/memio/ioport_linux_386.s
@@ -1,0 +1,53 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+	// From go runtime compiler source:
+	//TODO: INB DX, AL                      // ec
+	//TODO: INW DX, AX                      // 66ed
+	//TODO: INL DX, AX                      // ed
+
+TEXT ·archInb(SB),$0-5
+	MOVW    arg+0(FP), DX
+	BYTE	$0xec //INB	DX, AL
+	MOVB    AX, ret+4(FP)
+	RET
+
+TEXT ·archInw(SB),$0-6
+	MOVW    arg+0(FP), DX
+	BYTE	$0x66 // Do the next instruction (INL) in 16-bit mode
+	BYTE	$0xec //INW	DX, AL
+	MOVW    AX, ret+4(FP)
+	RET
+
+
+TEXT ·archInl(SB),$0-8
+	MOVW    arg+0(FP), DX
+	BYTE	$0xed //INL	DX, AL
+	MOVL    AX, ret+4(FP)
+	RET
+
+	// From go runtime compiler source:
+	//TODO: OUTB AL, DX                     // ee
+	//TODO: OUTW AX, DX                     // 66ef
+	//TODO: OUTL AX, DX                     // ef
+
+TEXT ·archOutb(SB),$0-3
+	MOVW    arg+0(FP), DX
+	MOVB	arg1+2(FP), AX
+	BYTE	$0xee //OUTB	DX, AL
+	RET
+
+TEXT ·archOutw(SB),$0-4
+	MOVW    arg+0(FP), DX
+	MOVW	arg1+2(FP), AX
+	BYTE	$0x66 // Do the next instruction (OUTL) in 16-bit mode
+	BYTE	$0xef //OUTW	DX, AL
+	RET
+
+
+TEXT ·archOutl(SB),$0-8
+	MOVW    arg+0(FP), DX
+	MOVL	arg1+4(FP), AX
+	BYTE	$0xef //OUTL	DX, AL
+	RET

--- a/pkg/memio/ioport_linux_amd64.s
+++ b/pkg/memio/ioport_linux_amd64.s
@@ -1,0 +1,53 @@
+// Copyright 2012-2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+	// From go runtime compiler source:
+	//TODO: INB DX, AL                      // ec
+	//TODO: INW DX, AX                      // 66ed
+	//TODO: INL DX, AX                      // ed
+
+TEXT ·archInb(SB),$0-9
+	MOVW    arg+0(FP), DX
+	BYTE $0xec //INB	DX, AL
+	MOVB    AX, ret+8(FP)
+	RET
+
+TEXT ·archInw(SB),$0-10
+	MOVW    arg+0(FP), DX
+	BYTE $0x66 // Do the next instruction (INL) in 16-bit mode
+	BYTE $0xec //INW	DX, AL
+	MOVW    AX, ret+8(FP)
+	RET
+
+
+TEXT ·archInl(SB),$0-12
+	MOVW    arg+0(FP), DX
+	BYTE	$0xed //INL	DX, AL
+	MOVL    AX, ret+8(FP)
+	RET
+
+	// From go runtime compiler source:
+	//TODO: OUTB AL, DX                     // ee
+	//TODO: OUTW AX, DX                     // 66ef
+	//TODO: OUTL AX, DX                     // ef
+
+TEXT ·archOutb(SB),$0-3
+	MOVW    arg+0(FP), DX
+	MOVB	arg1+2(FP), AX
+	BYTE $0xee //OUTB	DX, AL
+	RET
+
+TEXT ·archOutw(SB),$0-4
+	MOVW    arg+0(FP), DX
+	MOVW	arg1+2(FP), AX
+	BYTE $0x66 // Do the next instruction (OUTL) in 16-bit mode
+	BYTE $0xef //OUTW	DX, AL
+	RET
+
+
+TEXT ·archOutl(SB),$0-8
+	MOVW    arg+0(FP), DX
+	MOVL	arg1+4(FP), AX
+	BYTE $0xef //OUTL	DX, AL
+	RET

--- a/pkg/memio/ports_linux.go
+++ b/pkg/memio/ports_linux.go
@@ -8,9 +8,23 @@ package memio
 
 import (
 	"fmt"
+	"sync"
+	"syscall"
 )
 
 const portPath = "/dev/port"
+
+var ioplError struct {
+	sync.Once
+	err error
+}
+
+func iopl() error {
+	ioplError.Do(func() {
+		ioplError.err = syscall.Iopl(3)
+	})
+	return ioplError.err
+}
 
 // In reads data from the x86 port at address addr. Data must be Uint8, Uint16,
 // Uint32, but not Uint64.
@@ -28,4 +42,52 @@ func Out(addr uint16, data UintN) error {
 		return fmt.Errorf("port data must be 8, 16 or 32 bits")
 	}
 	return pathWrite(portPath, int64(addr), data)
+}
+
+func archInl(uint16) uint32
+func archInw(uint16) uint16
+func archInb(uint16) uint8
+
+// ArchIn reads data from the x86 port at address addr. Data must be Uint8, Uint16,
+// Uint32, but not Uint64.
+func ArchIn(addr uint16, data UintN) error {
+	if err := iopl(); err != nil {
+		return err
+	}
+
+	switch p := data.(type) {
+	case *Uint32:
+		*p = Uint32(archInl(addr))
+	case *Uint16:
+		*p = Uint16(archInw(addr))
+	case *Uint8:
+		*p = Uint8(archInb(addr))
+	default:
+		return fmt.Errorf("port data must be 8, 16 or 32 bits")
+	}
+	return nil
+}
+
+func archOutl(uint16, uint32)
+func archOutw(uint16, uint16)
+func archOutb(uint16, uint8)
+
+// ArchOut writes data to the x86 port at address addr. data must be Uint8, Uint16
+// uint32, but not Uint64.
+func ArchOut(addr uint16, data UintN) error {
+	if err := iopl(); err != nil {
+		return err
+	}
+
+	switch p := data.(type) {
+	case *Uint32:
+		archOutl(addr, uint32(*p))
+	case *Uint16:
+		archOutw(addr, uint16(*p))
+	case *Uint8:
+		archOutb(addr, uint8(*p))
+	default:
+		return fmt.Errorf("port data must be 8, 16 or 32 bits")
+	}
+	return nil
 }

--- a/pkg/memio/ports_test.go
+++ b/pkg/memio/ports_test.go
@@ -16,12 +16,27 @@ func ExampleIn() {
 	if err := In(0x3f8, &data); err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("%v\n", data)
+	fmt.Println(data)
 }
 
 func ExampleOut() {
 	data := Uint8('A')
 	if err := Out(0x3f8, &data); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleArchIn() {
+	var data Uint8
+	if err := In(0x80, &data); err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println(data)
+}
+
+func ExampleArchOut() {
+	data := Uint8('A')
+	if err := Out(0x80, &data); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Sometimes going via /dev/port is too slow.

Add support for x86 raw assembly IO. Add an init function that
does an iopl(3). This function need not succeed; it sets an
error value so that if an attempt is made to use those instructions,
and the iopl failed, the iopl error will be returned.