### PR TITLE
boottest: Correctly use file:/// schemes

### DIFF
--- a/pkg/boot/grub/config_test.go
+++ b/pkg/boot/grub/config_test.go
@@ -1,4 +1,4 @@
-// Copyright 2017-2018 the u-root Authors. All rights reserved
+// Copyright 2017-2020 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 

--- a/pkg/boot/grub/testdata_new/debian_10_4_installed.json
+++ b/pkg/boot/grub/testdata_new/debian_10_4_installed.json
@@ -3,10 +3,10 @@
     "cmdline": "root=UUID=f117f752-02f1-4df8-89ba-20032dea6905 ro console=ttyS0 quiet",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_10_4_installed/boot/initrd.img-4.19.0-9-amd64"
+      "url": "file:///testdata_new/debian_10_4_installed/boot/initrd.img-4.19.0-9-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_10_4_installed/boot/vmlinuz-4.19.0-9-amd64"
+      "url": "file:///testdata_new/debian_10_4_installed/boot/vmlinuz-4.19.0-9-amd64"
     },
     "name": "Debian GNU/Linux"
   },
@@ -14,10 +14,10 @@
     "cmdline": "root=UUID=f117f752-02f1-4df8-89ba-20032dea6905 ro console=ttyS0 quiet",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_10_4_installed/boot/initrd.img-4.19.0-9-amd64"
+      "url": "file:///testdata_new/debian_10_4_installed/boot/initrd.img-4.19.0-9-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_10_4_installed/boot/vmlinuz-4.19.0-9-amd64"
+      "url": "file:///testdata_new/debian_10_4_installed/boot/vmlinuz-4.19.0-9-amd64"
     },
     "name": "Debian GNU/Linux, with Linux 4.19.0-9-amd64"
   },
@@ -25,10 +25,10 @@
     "cmdline": "root=UUID=f117f752-02f1-4df8-89ba-20032dea6905 ro single console=ttyS0",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_10_4_installed/boot/initrd.img-4.19.0-9-amd64"
+      "url": "file:///testdata_new/debian_10_4_installed/boot/initrd.img-4.19.0-9-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_10_4_installed/boot/vmlinuz-4.19.0-9-amd64"
+      "url": "file:///testdata_new/debian_10_4_installed/boot/vmlinuz-4.19.0-9-amd64"
     },
     "name": "Debian GNU/Linux, with Linux 4.19.0-9-amd64 (recovery mode)"
   }

--- a/pkg/boot/grub/testdata_new/debian_9_install.json
+++ b/pkg/boot/grub/testdata_new/debian_9_install.json
@@ -3,10 +3,10 @@
     "cmdline": "boot=live components ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Debian GNU/Linux Live (kernel 4.9.0-3-amd64)"
   },
@@ -14,10 +14,10 @@
     "cmdline": "boot=live components locales=sq_AL.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Albanian (sq)"
   },
@@ -25,10 +25,10 @@
     "cmdline": "boot=live components locales=am_ET ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Amharic (am)"
   },
@@ -36,10 +36,10 @@
     "cmdline": "boot=live components locales=ar_EG.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Arabic (ar)"
   },
@@ -47,10 +47,10 @@
     "cmdline": "boot=live components locales=ast_ES.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Asturian (ast)"
   },
@@ -58,10 +58,10 @@
     "cmdline": "boot=live components locales=eu_ES.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Basque (eu)"
   },
@@ -69,10 +69,10 @@
     "cmdline": "boot=live components locales=be_BY.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Belarusian (be)"
   },
@@ -80,10 +80,10 @@
     "cmdline": "boot=live components locales=bn_BD ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Bangla (bn)"
   },
@@ -91,10 +91,10 @@
     "cmdline": "boot=live components locales=bs_BA.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Bosnian (bs)"
   },
@@ -102,10 +102,10 @@
     "cmdline": "boot=live components locales=bg_BG.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Bulgarian (bg)"
   },
@@ -113,10 +113,10 @@
     "cmdline": "boot=live components locales=bo_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Tibetan (bo)"
   },
@@ -124,10 +124,10 @@
     "cmdline": "boot=live components locales=C ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "C (C)"
   },
@@ -135,10 +135,10 @@
     "cmdline": "boot=live components locales=ca_ES.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Catalan (ca)"
   },
@@ -146,10 +146,10 @@
     "cmdline": "boot=live components locales=zh_CN.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Chinese (Simplified) (zh_CN)"
   },
@@ -157,10 +157,10 @@
     "cmdline": "boot=live components locales=zh_TW.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Chinese (Traditional) (zh_TW)"
   },
@@ -168,10 +168,10 @@
     "cmdline": "boot=live components locales=hr_HR.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Croatian (hr)"
   },
@@ -179,10 +179,10 @@
     "cmdline": "boot=live components locales=cs_CZ.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Czech (cs)"
   },
@@ -190,10 +190,10 @@
     "cmdline": "boot=live components locales=da_DK.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Danish (da)"
   },
@@ -201,10 +201,10 @@
     "cmdline": "boot=live components locales=nl_NL.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Dutch (nl)"
   },
@@ -212,10 +212,10 @@
     "cmdline": "boot=live components locales=dz_BT ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Dzongkha (dz)"
   },
@@ -223,10 +223,10 @@
     "cmdline": "boot=live components locales=en_US.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "English (en)"
   },
@@ -234,10 +234,10 @@
     "cmdline": "boot=live components locales=eo.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Esperanto (eo)"
   },
@@ -245,10 +245,10 @@
     "cmdline": "boot=live components locales=et_EE.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Estonian (et)"
   },
@@ -256,10 +256,10 @@
     "cmdline": "boot=live components locales=fi_FI.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Finnish (fi)"
   },
@@ -267,10 +267,10 @@
     "cmdline": "boot=live components locales=fr_FR.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "French (fr)"
   },
@@ -278,10 +278,10 @@
     "cmdline": "boot=live components locales=gl_ES.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Galician (gl)"
   },
@@ -289,10 +289,10 @@
     "cmdline": "boot=live components locales=ka_GE.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Georgian (ka)"
   },
@@ -300,10 +300,10 @@
     "cmdline": "boot=live components locales=de_DE.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "German (de)"
   },
@@ -311,10 +311,10 @@
     "cmdline": "boot=live components locales=el_GR.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Greek (el)"
   },
@@ -322,10 +322,10 @@
     "cmdline": "boot=live components locales=gu_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Gujarati (gu)"
   },
@@ -333,10 +333,10 @@
     "cmdline": "boot=live components locales=he_IL.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Hebrew (he)"
   },
@@ -344,10 +344,10 @@
     "cmdline": "boot=live components locales=hi_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Hindi (hi)"
   },
@@ -355,10 +355,10 @@
     "cmdline": "boot=live components locales=hu_HU.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Hungarian (hu)"
   },
@@ -366,10 +366,10 @@
     "cmdline": "boot=live components locales=is_IS.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Icelandic (is)"
   },
@@ -377,10 +377,10 @@
     "cmdline": "boot=live components locales=id_ID.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Indonesian (id)"
   },
@@ -388,10 +388,10 @@
     "cmdline": "boot=live components locales=ga_IE.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Irish (ga)"
   },
@@ -399,10 +399,10 @@
     "cmdline": "boot=live components locales=it_IT.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Italian (it)"
   },
@@ -410,10 +410,10 @@
     "cmdline": "boot=live components locales=ja_JP.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Japanese (ja)"
   },
@@ -421,10 +421,10 @@
     "cmdline": "boot=live components locales=kk_KZ.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Kazakh (kk)"
   },
@@ -432,10 +432,10 @@
     "cmdline": "boot=live components locales=km_KH ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Khmer (km)"
   },
@@ -443,10 +443,10 @@
     "cmdline": "boot=live components locales=kn_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Kannada (kn)"
   },
@@ -454,10 +454,10 @@
     "cmdline": "boot=live components locales=ko_KR.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Korean (ko)"
   },
@@ -465,10 +465,10 @@
     "cmdline": "boot=live components locales=ku_TR.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Kurdish (ku)"
   },
@@ -476,10 +476,10 @@
     "cmdline": "boot=live components locales=lo_LA ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Lao (lo)"
   },
@@ -487,10 +487,10 @@
     "cmdline": "boot=live components locales=lv_LV.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Latvian (lv)"
   },
@@ -498,10 +498,10 @@
     "cmdline": "boot=live components locales=lt_LT.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Lithuanian (lt)"
   },
@@ -509,10 +509,10 @@
     "cmdline": "boot=live components locales=ml_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Malayalam (ml)"
   },
@@ -520,10 +520,10 @@
     "cmdline": "boot=live components locales=mr_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Marathi (mr)"
   },
@@ -531,10 +531,10 @@
     "cmdline": "boot=live components locales=mk_MK.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Macedonian (mk)"
   },
@@ -542,10 +542,10 @@
     "cmdline": "boot=live components locales=my_MM ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Burmese (my)"
   },
@@ -553,10 +553,10 @@
     "cmdline": "boot=live components locales=ne_NP ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Nepali (ne)"
   },
@@ -564,10 +564,10 @@
     "cmdline": "boot=live components locales=se_NO ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Northern Sami (se_NO)"
   },
@@ -575,10 +575,10 @@
     "cmdline": "boot=live components locales=nb_NO.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Norwegian Bokmaal (nb_NO)"
   },
@@ -586,10 +586,10 @@
     "cmdline": "boot=live components locales=nn_NO.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Norwegian Nynorsk (nn_NO)"
   },
@@ -597,10 +597,10 @@
     "cmdline": "boot=live components locales=fa_IR ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Persian (fa)"
   },
@@ -608,10 +608,10 @@
     "cmdline": "boot=live components locales=pl_PL.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Polish (pl)"
   },
@@ -619,10 +619,10 @@
     "cmdline": "boot=live components locales=pt_PT.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Portuguese (pt)"
   },
@@ -630,10 +630,10 @@
     "cmdline": "boot=live components locales=pt_BR.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Portuguese (Brazil) (pt_BR)"
   },
@@ -641,10 +641,10 @@
     "cmdline": "boot=live components locales=pa_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Punjabi (Gurmukhi) (pa)"
   },
@@ -652,10 +652,10 @@
     "cmdline": "boot=live components locales=ro_RO.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Romanian (ro)"
   },
@@ -663,10 +663,10 @@
     "cmdline": "boot=live components locales=ru_RU.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Russian (ru)"
   },
@@ -674,10 +674,10 @@
     "cmdline": "boot=live components locales=si_LK ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Sinhala (si)"
   },
@@ -685,10 +685,10 @@
     "cmdline": "boot=live components locales=sr_RS ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Serbian (Cyrillic) (sr)"
   },
@@ -696,10 +696,10 @@
     "cmdline": "boot=live components locales=sk_SK.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Slovak (sk)"
   },
@@ -707,10 +707,10 @@
     "cmdline": "boot=live components locales=sl_SI.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Slovenian (sl)"
   },
@@ -718,10 +718,10 @@
     "cmdline": "boot=live components locales=es_ES.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Spanish (es)"
   },
@@ -729,10 +729,10 @@
     "cmdline": "boot=live components locales=sv_SE.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Swedish (sv)"
   },
@@ -740,10 +740,10 @@
     "cmdline": "boot=live components locales=tl_PH.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Tagalog (tl)"
   },
@@ -751,10 +751,10 @@
     "cmdline": "boot=live components locales=ta_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Tamil (ta)"
   },
@@ -762,10 +762,10 @@
     "cmdline": "boot=live components locales=te_IN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Telugu (te)"
   },
@@ -773,10 +773,10 @@
     "cmdline": "boot=live components locales=tg_TJ.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Tajik (tg)"
   },
@@ -784,10 +784,10 @@
     "cmdline": "boot=live components locales=th_TH.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Thai (th)"
   },
@@ -795,10 +795,10 @@
     "cmdline": "boot=live components locales=tr_TR.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Turkish (tr)"
   },
@@ -806,10 +806,10 @@
     "cmdline": "boot=live components locales=ug_CN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Uyghur (ug)"
   },
@@ -817,10 +817,10 @@
     "cmdline": "boot=live components locales=uk_UA.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Ukrainian (uk)"
   },
@@ -828,10 +828,10 @@
     "cmdline": "boot=live components locales=vi_VN ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Vietnamese (vi)"
   },
@@ -839,10 +839,10 @@
     "cmdline": "boot=live components locales=cy_GB.UTF-8 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/initrd.img-4.9.0-3-amd64"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
+      "url": "file:///testdata_new/debian_9_install/live/vmlinuz-4.9.0-3-amd64"
     },
     "name": "Welsh (cy)"
   },
@@ -850,10 +850,10 @@
     "cmdline": "append video=vesa:ywrap,mtrr vga=788 ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/d-i/gtk/initrd.gz"
+      "url": "file:///testdata_new/debian_9_install/d-i/gtk/initrd.gz"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/d-i/gtk/vmlinuz"
+      "url": "file:///testdata_new/debian_9_install/d-i/gtk/vmlinuz"
     },
     "name": "Graphical Debian Installer"
   },
@@ -861,10 +861,10 @@
     "cmdline": "${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/d-i/initrd.gz"
+      "url": "file:///testdata_new/debian_9_install/d-i/initrd.gz"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/d-i/vmlinuz"
+      "url": "file:///testdata_new/debian_9_install/d-i/vmlinuz"
     },
     "name": "Debian Installer"
   },
@@ -872,10 +872,10 @@
     "cmdline": "speakup.synth=soft ${loopback}",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/debian_9_install/d-i/gtk/initrd.gz"
+      "url": "file:///testdata_new/debian_9_install/d-i/gtk/initrd.gz"
     },
     "kernel": {
-      "url": "file://testdata_new/debian_9_install/d-i/gtk/vmlinuz"
+      "url": "file:///testdata_new/debian_9_install/d-i/gtk/vmlinuz"
     },
     "name": "Debian Installer with Speech Synthesis"
   }

--- a/pkg/boot/grub/testdata_new/fedora_27_install.json
+++ b/pkg/boot/grub/testdata_new/fedora_27_install.json
@@ -3,10 +3,10 @@
     "cmdline": "root=live:CDLABEL=Fedora-WS-Live-27-1-6 rd.live.image rd.live.check quiet",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/fedora_27_install/images/pxeboot/initrd.img"
+      "url": "file:///testdata_new/fedora_27_install/images/pxeboot/initrd.img"
     },
     "kernel": {
-      "url": "file://testdata_new/fedora_27_install/images/pxeboot/vmlinuz"
+      "url": "file:///testdata_new/fedora_27_install/images/pxeboot/vmlinuz"
     },
     "name": "Test this media \u0026 start Fedora-Workstation-Live 27"
   },
@@ -14,10 +14,10 @@
     "cmdline": "root=live:CDLABEL=Fedora-WS-Live-27-1-6 rd.live.image quiet",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/fedora_27_install/images/pxeboot/initrd.img"
+      "url": "file:///testdata_new/fedora_27_install/images/pxeboot/initrd.img"
     },
     "kernel": {
-      "url": "file://testdata_new/fedora_27_install/images/pxeboot/vmlinuz"
+      "url": "file:///testdata_new/fedora_27_install/images/pxeboot/vmlinuz"
     },
     "name": "Start Fedora-Workstation-Live 27"
   },
@@ -25,10 +25,10 @@
     "cmdline": "root=live:CDLABEL=Fedora-WS-Live-27-1-6 rd.live.image nomodeset quiet",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/fedora_27_install/images/pxeboot/initrd.img"
+      "url": "file:///testdata_new/fedora_27_install/images/pxeboot/initrd.img"
     },
     "kernel": {
-      "url": "file://testdata_new/fedora_27_install/images/pxeboot/vmlinuz"
+      "url": "file:///testdata_new/fedora_27_install/images/pxeboot/vmlinuz"
     },
     "name": "Start Fedora-Workstation-Live 27 in basic graphics mode"
   }

--- a/pkg/boot/grub/testdata_new/qubes_3_2_boot.json
+++ b/pkg/boot/grub/testdata_new/qubes_3_2_boot.json
@@ -3,18 +3,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen hypervisor"
@@ -23,18 +23,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5 and Linux 4.4.67-13.pvops.qubes.x86_64"
@@ -43,18 +43,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro single rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5 and Linux 4.4.67-13.pvops.qubes.x86_64 (recovery mode)"
@@ -63,18 +63,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-12.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-12.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-12.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-12.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-12.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-12.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-12.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-12.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5 and Linux 4.4.67-12.pvops.qubes.x86_64"
@@ -83,18 +83,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-12.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro single rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-12.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-12.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-12.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-12.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-12.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-12.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-12.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5 and Linux 4.4.67-12.pvops.qubes.x86_64 (recovery mode)"
@@ -103,18 +103,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.62-12.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.62-12.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.62-12.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.62-12.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.62-12.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.62-12.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.62-12.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.62-12.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5 and Linux 4.4.62-12.pvops.qubes.x86_64"
@@ -123,18 +123,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.62-12.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro single rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.62-12.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.62-12.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.62-12.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.62-12.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.62-12.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.62-12.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.62-12.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5 and Linux 4.4.62-12.pvops.qubes.x86_64 (recovery mode)"
@@ -143,18 +143,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5-heads and Linux 4.4.67-13.pvops.qubes.x86_64"
@@ -163,18 +163,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro single rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-13.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-13.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-13.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-13.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5-heads and Linux 4.4.67-13.pvops.qubes.x86_64 (recovery mode)"
@@ -183,18 +183,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-12.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-12.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-12.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-12.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-12.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-12.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-12.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-12.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5-heads and Linux 4.4.67-12.pvops.qubes.x86_64"
@@ -203,18 +203,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.67-12.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro single rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.67-12.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-12.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.67-12.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.67-12.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.67-12.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.67-12.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.67-12.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5-heads and Linux 4.4.67-12.pvops.qubes.x86_64 (recovery mode)"
@@ -223,18 +223,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.62-12.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.62-12.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.62-12.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.62-12.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.62-12.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.62-12.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.62-12.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.62-12.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5-heads and Linux 4.4.62-12.pvops.qubes.x86_64"
@@ -243,18 +243,18 @@
     "cmdline": "placeholder ${xen_rm_opts}",
     "image_type": "multiboot",
     "kernel": {
-      "url": "file://testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
+      "url": "file:///testdata_new/qubes_3_2_boot/xen-4.6.5-heads.gz"
     },
     "modules": [
       {
         "cmdline": "/vmlinuz-4.4.62-12.pvops.qubes.x86_64 placeholder root=/dev/mapper/luks-UUID2 ro single rd.qubes.hide_all_usb",
         "name": "/vmlinuz-4.4.62-12.pvops.qubes.x86_64",
-        "url": "file://testdata_new/qubes_3_2_boot/vmlinuz-4.4.62-12.pvops.qubes.x86_64"
+        "url": "file:///testdata_new/qubes_3_2_boot/vmlinuz-4.4.62-12.pvops.qubes.x86_64"
       },
       {
         "cmdline": "/initramfs-4.4.62-12.pvops.qubes.x86_64.img",
         "name": "/initramfs-4.4.62-12.pvops.qubes.x86_64.img",
-        "url": "file://testdata_new/qubes_3_2_boot/initramfs-4.4.62-12.pvops.qubes.x86_64.img"
+        "url": "file:///testdata_new/qubes_3_2_boot/initramfs-4.4.62-12.pvops.qubes.x86_64.img"
       }
     ],
     "name": "Qubes, with Xen 4.6.5-heads and Linux 4.4.62-12.pvops.qubes.x86_64 (recovery mode)"

--- a/pkg/boot/grub/testdata_new/rhel_7_8_another.json
+++ b/pkg/boot/grub/testdata_new/rhel_7_8_another.json
@@ -3,10 +3,10 @@
     "cmdline": "root=UUID=6e6a0373-fbdf-4e5b-9ea5-07117e10bea5 ro console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto LANG=en_US.UTF-8",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/rhel_7_8_another/boot/initramfs-3.10.0-1127.el7.x86_64.img"
+      "url": "file:///testdata_new/rhel_7_8_another/boot/initramfs-3.10.0-1127.el7.x86_64.img"
     },
     "kernel": {
-      "url": "file://testdata_new/rhel_7_8_another/boot/vmlinuz-3.10.0-1127.el7.x86_64"
+      "url": "file:///testdata_new/rhel_7_8_another/boot/vmlinuz-3.10.0-1127.el7.x86_64"
     },
     "name": "Red Hat Enterprise Linux Server (3.10.0-1127.el7.x86_64) 7.8 (Maipo)"
   },
@@ -14,10 +14,10 @@
     "cmdline": "root=UUID=6e6a0373-fbdf-4e5b-9ea5-07117e10bea5 ro console=tty0 console=ttyS0,115200n8 no_timer_check net.ifnames=0 crashkernel=auto",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/rhel_7_8_another/boot/initramfs-0-rescue-8ae51ce6a0a74f8d85fe6f1281d8477f.img"
+      "url": "file:///testdata_new/rhel_7_8_another/boot/initramfs-0-rescue-8ae51ce6a0a74f8d85fe6f1281d8477f.img"
     },
     "kernel": {
-      "url": "file://testdata_new/rhel_7_8_another/boot/vmlinuz-0-rescue-8ae51ce6a0a74f8d85fe6f1281d8477f"
+      "url": "file:///testdata_new/rhel_7_8_another/boot/vmlinuz-0-rescue-8ae51ce6a0a74f8d85fe6f1281d8477f"
     },
     "name": "Red Hat Enterprise Linux Server (0-rescue-8ae51ce6a0a74f8d85fe6f1281d8477f) 7.8 (Maipo)"
   }

--- a/pkg/boot/grub/testdata_new/rhel_7_8_installed.json
+++ b/pkg/boot/grub/testdata_new/rhel_7_8_installed.json
@@ -3,10 +3,10 @@
     "cmdline": "root=/dev/mapper/rhel-root ro crashkernel=auto spectre_v2=retpoline rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap LANG=en_US.UTF-8 console=ttyS0,9600",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/rhel_7_8_installed/initramfs-3.10.0-1127.el7.x86_64.img"
+      "url": "file:///testdata_new/rhel_7_8_installed/initramfs-3.10.0-1127.el7.x86_64.img"
     },
     "kernel": {
-      "url": "file://testdata_new/rhel_7_8_installed/vmlinuz-3.10.0-1127.el7.x86_64"
+      "url": "file:///testdata_new/rhel_7_8_installed/vmlinuz-3.10.0-1127.el7.x86_64"
     },
     "name": "Red Hat Enterprise Linux Server (3.10.0-1127.el7.x86_64) 7.8 (Maipo)"
   },
@@ -14,10 +14,10 @@
     "cmdline": "root=/dev/mapper/rhel-root ro crashkernel=auto spectre_v2=retpoline rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap LANG=en_US.UTF-8 console=ttyS0,9600",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/rhel_7_8_installed/initramfs-3.10.0-1090.el7.x86_64.img"
+      "url": "file:///testdata_new/rhel_7_8_installed/initramfs-3.10.0-1090.el7.x86_64.img"
     },
     "kernel": {
-      "url": "file://testdata_new/rhel_7_8_installed/vmlinuz-3.10.0-1090.el7.x86_64"
+      "url": "file:///testdata_new/rhel_7_8_installed/vmlinuz-3.10.0-1090.el7.x86_64"
     },
     "name": "Red Hat Enterprise Linux Server (3.10.0-1090.el7.x86_64) 7.8 (Maipo)"
   },
@@ -25,10 +25,10 @@
     "cmdline": "root=/dev/mapper/rhel-root ro crashkernel=auto spectre_v2=retpoline rd.lvm.lv=rhel/root rd.lvm.lv=rhel/swap rhgb quiet",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/rhel_7_8_installed/initramfs-0-rescue-c1f242ee03e54908bf80c667e1d9ef90.img"
+      "url": "file:///testdata_new/rhel_7_8_installed/initramfs-0-rescue-c1f242ee03e54908bf80c667e1d9ef90.img"
     },
     "kernel": {
-      "url": "file://testdata_new/rhel_7_8_installed/vmlinuz-0-rescue-c1f242ee03e54908bf80c667e1d9ef90"
+      "url": "file:///testdata_new/rhel_7_8_installed/vmlinuz-0-rescue-c1f242ee03e54908bf80c667e1d9ef90"
     },
     "name": "Red Hat Enterprise Linux Server (0-rescue-c1f242ee03e54908bf80c667e1d9ef90) 7.8 (Maipo)"
   }

--- a/pkg/boot/grub/testdata_new/ubuntu_16_04_boot.json
+++ b/pkg/boot/grub/testdata_new/ubuntu_16_04_boot.json
@@ -3,10 +3,10 @@
     "cmdline": "root=/dev/mapper/ubuntu--vg-root ro quiet splash $vt_handoff",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-42-generic"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-42-generic"
     },
     "kernel": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
     },
     "name": "Ubuntu"
   },
@@ -14,10 +14,10 @@
     "cmdline": "root=/dev/mapper/ubuntu--vg-root ro quiet splash $vt_handoff",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-42-generic"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-42-generic"
     },
     "kernel": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
     },
     "name": "Ubuntu, with Linux 4.10.0-42-generic"
   },
@@ -25,10 +25,10 @@
     "cmdline": "root=/dev/mapper/ubuntu--vg-root ro quiet splash $vt_handoff init=/sbin/upstart",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-42-generic"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-42-generic"
     },
     "kernel": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
     },
     "name": "Ubuntu, with Linux 4.10.0-42-generic (upstart)"
   },
@@ -36,10 +36,10 @@
     "cmdline": "root=/dev/mapper/ubuntu--vg-root ro recovery nomodeset",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-42-generic"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-42-generic"
     },
     "kernel": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
     },
     "name": "Ubuntu, with Linux 4.10.0-42-generic (recovery mode)"
   },
@@ -47,10 +47,10 @@
     "cmdline": "root=/dev/mapper/ubuntu--vg-root ro quiet splash $vt_handoff",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-40-generic"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-40-generic"
     },
     "kernel": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-40-generic.efi.signed"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-40-generic.efi.signed"
     },
     "name": "Ubuntu, with Linux 4.10.0-40-generic"
   },
@@ -58,10 +58,10 @@
     "cmdline": "root=/dev/mapper/ubuntu--vg-root ro quiet splash $vt_handoff init=/sbin/upstart",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-40-generic"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-40-generic"
     },
     "kernel": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-40-generic.efi.signed"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-40-generic.efi.signed"
     },
     "name": "Ubuntu, with Linux 4.10.0-40-generic (upstart)"
   },
@@ -69,10 +69,10 @@
     "cmdline": "root=/dev/mapper/ubuntu--vg-root ro recovery nomodeset",
     "image_type": "linux",
     "initrd": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-40-generic"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/initrd.img-4.10.0-40-generic"
     },
     "kernel": {
-      "url": "file://testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-40-generic.efi.signed"
+      "url": "file:///testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-40-generic.efi.signed"
     },
     "name": "Ubuntu, with Linux 4.10.0-40-generic (recovery mode)"
   }


### PR DESCRIPTION
Wikipedia says it best: "while "file:///foo.txt" is valid,
"file://foo.txt" is not, although some interpreters manage to handle the
latter".

File schemes must be absolute and expressed with three slashes '/'. It
seems url.Parse() and url.String() make this assumption at times, which
makes it difficult to modify the grub parser to continue emitting
incorrect URLs with two slashes.

This change permits the grub interpreter to emit file schemes with
absolute paths. The boottest package takes these paths and strips out
the non-hermetic portion in before comparing against the value in the
json.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>