### PR TITLE
WIP: booter for fit images.

### DIFF
--- a/cmds/boot/fitboot/main.go
+++ b/cmds/boot/fitboot/main.go
@@ -1,0 +1,50 @@
+// Copyright 2017-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	"github.com/u-root/u-root/pkg/boot"
+	"github.com/u-root/u-root/pkg/boot/fit"
+)
+
+var (
+	dryRun    = flag.Bool("dryrun", true, "Do not actually kexec into the boot config")
+	debug     = flag.Bool("d", true, "Print debug output")
+	rootfs    = flag.String("r", "", "Root file system name")
+	initramfs = flag.String("i", "", "initramfs name")
+	cmdline = flag.String("c", "earlyprintk=ttyS0,115200,keep console=ttyS0", "command line")
+)
+
+var v = func(string, ...interface{}) {}
+
+func main() {
+	flag.Parse()
+	if *debug {
+		v = log.Printf
+	}
+	if len(flag.Args()) != 2 {
+		log.Fatal("Usage: fitboot uimage kernel")
+	}
+	f, err := fit.New(flag.Args()[0])
+	if err != nil {
+		log.Fatal(err)
+	}
+	v("Loaded uimage: %s", f)
+	f.Cmdline, f.KernelName, f.RootFS, f.InitRAMFS = *cmdline, flag.Args()[1], *rootfs, *initramfs
+	if err := f.Load(*debug); err != nil {
+		log.Fatal(err)
+	}
+	if *dryRun {
+		v("Not trying to boot since this is a dry run")
+		os.Exit(0)
+	}
+	if err := boot.Execute(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/boot/fit/fit.go
+++ b/pkg/boot/fit/fit.go
@@ -1,0 +1,102 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fit
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/u-root/u-root/pkg/boot"
+	"github.com/u-root/u-root/pkg/boot/kexec"
+	"github.com/u-root/u-root/pkg/dt"
+)
+
+// FIT is a Flattened Image Tree implementation for OSImage.
+type Image struct {
+	name       string
+	mem        kexec.Memory
+	Cmdline    string
+	Root       *dt.FDT
+	KernelName string
+	RootFS     string
+	InitRAMFS  string
+	entryPoint uintptr
+}
+
+var _ = boot.OSImage(&Image{})
+
+// New returns a new image initialized with a file containing an FDT.
+func New(n string) (*Image, error) {
+	f, err := os.Open(n)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	fdt, err := dt.ReadFDT(f)
+	if err != nil {
+		return nil, err
+	}
+	return &Image{name: n, Root: fdt, mem: kexec.Memory{}}, nil
+}
+
+// String is a Stringer for Image.
+func (i *Image) String() string {
+	return fmt.Sprintf("FDT %s from %s, kernel %s, RootFS %s, InitRamfs %s", i.Root, i.name, i.KernelName, i.RootFS, i.InitRAMFS)
+}
+
+// Label returns an Image Label.
+func (i *Image) Label() string {
+	return i.name
+}
+
+// Edit edits the Image cmdline using a func.
+func (i *Image) Edit(f func(s string) string) {
+	i.Cmdline = f(i.Cmdline)
+}
+
+// Load loads an Image.
+func (i *Image) Load(verbose bool) error {
+	if err := i.mem.ParseMemoryMap(); err != nil {
+		return err
+	}
+	// Find the kernel name and its needed data area.
+	if verbose {
+		log.Printf("Find kernel %s", i.KernelName)
+	}
+	kb, err := i.Root.Bytes(i.KernelName, "data")
+	if err != nil {
+		return err
+	}
+	i.mem.Segments.Insert(kexec.NewSegment(kb, kexec.Range{Start: 0x100000, Size: uint(len(kb))}))
+	// Technically, we can have both an initramfs and a rootfs.
+	// The current question: how do we provided the rootfs from a file
+	// to the kernel? We do not know.
+	if len(i.RootFS) > 0 {
+		return fmt.Errorf("No way to provide a rootfs yet")
+	}
+
+	if len(i.InitRAMFS) > 0 {
+		if verbose {
+			log.Printf("Find initramfs %s", i.InitRAMFS)
+		}
+		ib, err := i.Root.Bytes(i.InitRAMFS, "data")
+		if err != nil {
+			return err
+		}
+		i.mem.Segments.Insert(kexec.NewSegment(kb, kexec.Range{Start: 32 * 0x100000, Size: uint(len(ib))}))
+	}
+	i.entryPoint = 0x100000
+
+	if verbose {
+		log.Printf("segments cmdline %v %q", i.mem.Segments, i.Cmdline)
+	}
+
+	if err := kexec.Load(i.entryPoint, i.mem.Segments, 0); err != nil {
+		return fmt.Errorf("kexec.Load() error: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This is just a first pass. Comments welcome. In particular, I think it makes
more sense to copy the kernel/initramfs to files in /tmp and use the file load
instead of trying to use kexec classic? comments?

Signed-off-by: Ronald G Minnich <rminnich@gmail.com>