### PR TITLE
Allow pxeboot to skip nics that may have already been bonded.

### DIFF
--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -40,6 +40,7 @@ var (
 	noLoad      = flag.Bool("no-load", false, "get DHCP response, print chosen boot configuration, but do not download + exec it")
 	noExec      = flag.Bool("no-exec", false, "download boot configuration, but do not exec it")
 	noNetConfig = flag.Bool("no-net-config", false, "get DHCP response, but do not apply the network config it to the kernel interface")
+	skipBonded  = flag.Bool("skip-bonded", false, "Skip NICs that have already been added to a bond")
 	verbose     = flag.Bool("v", false, "Verbose output")
 	ipv4        = flag.Bool("ipv4", true, "use IPV4")
 	ipv6        = flag.Bool("ipv6", true, "use IPV6")
@@ -56,6 +57,10 @@ func NetbootImages(ifaceNames string) ([]boot.OSImage, error) {
 	filteredIfs, err := dhclient.Interfaces(ifaceNames)
 	if err != nil {
 		return nil, err
+	}
+
+	if *skipBonded {
+		filteredIfs = dhclient.FilterBondedInterfaces(filteredIfs, *verbose)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), (1<<dhcpTries)*dhcpTimeout)


### PR DESCRIPTION
Signed-off-by: Gan Shun Lim <ganshun@gmail.com>