### PR TITLE
esxi: use correct partition naming for NVMe

### DIFF
--- a/integration/generic-tests/esxi_boot_test.go
+++ b/integration/generic-tests/esxi_boot_test.go
@@ -7,6 +7,7 @@
 package integration
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -29,6 +30,58 @@ func TestESXi(t *testing.T) {
 		QEMUOpts: qemu.Options{
 			Devices: []qemu.Device{
 				qemu.IDEBlockDevice{File: img},
+				// If at some point we get virtio-net working
+				// again in ESXi, you may need to set num CPUs
+				// to 4.
+				qemu.ArbitraryArgs{"-smp", "2"},
+
+				// QEMU is not good enough to do ESXi without KVM. You'll get kernel panic.
+				qemu.ArbitraryArgs{"-enable-kvm"},
+
+				// IvyBridge is the lowest-common-denominator.
+				// ESXi 7.0 drops support for SandyBridge
+				// afaict.
+				qemu.ArbitraryArgs{"-cpu", "IvyBridge"},
+
+				// Min ESXi requirement is 4G of memory, but in
+				// ESXi 7.0 some plugins fail to load at 4G
+				// under memory pressure, and we never get to
+				// "Boot Successful"
+				qemu.ArbitraryArgs{"-m", "8192"},
+			},
+		},
+	})
+	defer cleanup()
+
+	if out, err := q.ExpectBatch([]expect.Batcher{
+		// Last Linux print.
+		&expect.BExp{R: "kexec_core: Starting new kernel"},
+		// First b.b00 ESXi first-stage kernel print
+		&expect.BExp{R: "Serial port initialized..."},
+		// ~thirdish k.b00 ESXi second-stage kernel print
+		&expect.BExp{R: "Parsing command line boot options"},
+		// When we can be confident it's done.
+		&expect.BExp{R: "Boot Successful"},
+	}, 2*time.Minute); err != nil {
+		t.Fatalf("VM output did not match expectations: %v", out)
+	}
+}
+
+func TestESXiNVMe(t *testing.T) {
+	img := os.Getenv("UROOT_ESXI_IMAGE")
+	if _, err := os.Stat(img); err != nil && os.IsNotExist(err) {
+		t.Skip("ESXi disk image is not present. Please set UROOT_ESXI_IMAGE= to an installed ESXi disk image.")
+	}
+
+	q, cleanup := vmtest.QEMUTest(t, &vmtest.Options{
+		TestCmds: []string{
+			`esxiboot -d="/dev/nvme0n1" --append="vmkBootVerbose=TRUE vmbLog=TRUE debugLogToSerial=1 logPort=com1"`,
+		},
+		QEMUOpts: qemu.Options{
+			Devices: []qemu.Device{
+				qemu.ArbitraryArgs{"-device", "nvme,drive=NVME1,serial=nvme-1"},
+				qemu.ArbitraryArgs{"-drive", fmt.Sprintf("file=%s,if=none,id=NVME1", img)},
+
 				// If at some point we get virtio-net working
 				// again in ESXi, you may need to set num CPUs
 				// to 4.

--- a/pkg/boot/esxi/esxi_test.go
+++ b/pkg/boot/esxi/esxi_test.go
@@ -242,9 +242,9 @@ func TestDev6Valid(t *testing.T) {
 	}
 
 	// No opts5 at all.
-	imgs, _ := getImages(device, nil, opts6)
+	imgs, err := getImages(device, nil, opts6)
 	if !multibootEqual(imgs, want) {
-		t.Fatalf("getImages(%s, %v, %v) = %v, want %v", device, nil, opts6, imgs, want)
+		t.Fatalf("getImages(%s, %v, %v) = %v, want %v (err %v)", device, nil, opts6, imgs, want, err)
 	}
 
 	// Invalid opts5. Higher updated, but invalid state.

--- a/pkg/qemu/devices.go
+++ b/pkg/qemu/devices.go
@@ -140,6 +140,7 @@ func (ibd IDEBlockDevice) Cmdline() []string {
 		"-drive", fmt.Sprintf("file=%s,if=none,id=disk", ibd.File),
 	}
 }
+
 func (IDEBlockDevice) KArgs() []string { return nil }
 
 // P9Directory is a Device that exposes a directory as a Plan9 (9p)


### PR DESCRIPTION
Fixes booting ESXi from NVMe drives.

manual test:

```
    integration.go:133: 2020/11/09 12:06:18 serial: ~2020-11-09T20:06:17.846Z cpu1:135638)Boot Successful
    integration.go:133: 2020/11/09 12:06:18 serial: ~
    integration.go:191: QEMU command line to reproduce TestESXiNVMe:
        qemu-system-x86_64 -enable-kvm -nographic -kernel /tmp/uroot-integration301512720/kernel -append ' console=ttyS0 earlyprintk=ttyS0 uroot.vmtest UROOT_USE_9P=1' -initrd /tmp/uroot-integration301512720/initramfs.cpio -device nvme,drive=NVME1,serial=nvme-1 -drive file=/usr/local/google/home/chrisko/disk.raw,if=none,id=NVME1 -smp 2 -enable-kvm -cpu IvyBridge -m 8192 -device virtio-rng-pci -fsdev local,id=tmpdir,path=/tmp/uroot-integration301512720,security_model=mapped-file -device virtio-9p-pci,fsdev=tmpdir,mount_tag=tmpdir
--- PASS: TestESXiNVMe (98.16s)
PASS
ok      github.com/u-root/u-root/integration/generic-tests      98.210s
```