### PR TITLE
fdt: add Bytes, AsString, AsU64 Node funcs, extend printing

### DIFF
--- a/pkg/dt/fdt.go
+++ b/pkg/dt/fdt.go
@@ -418,27 +418,3 @@ func (fdt *FDT) NodeByName(name string) (*Node, bool) {
 		return n.Name == name
 	})
 }
-
-// Bytes returns a []byte for a property of a node,
-// or an error if the node has no data property.
-func (fdt *FDT) Bytes(name, pname string) ([]byte, error) {
-	n, ok := fdt.NodeByName(name)
-	if !ok {
-		return nil, fmt.Errorf("could not find node %q", name)
-	}
-	p, ok := n.LookProperty(pname)
-	if !ok {
-		return nil, fmt.Errorf("%s does not have a data property", n)
-	}
-	return p.Value, nil
-}
-
-// Reader returns a *bytes.Reader for a property of a Node,
-// or an error if the node is not found or the node has no data property.
-func (fdt *FDT) Reader(name, pname string) (*bytes.Reader, error) {
-	b, err := fdt.Bytes(name, pname)
-	if err != nil {
-		return nil, err
-	}
-	return bytes.NewReader(b), nil
-}

--- a/pkg/dt/fdt_test.go
+++ b/pkg/dt/fdt_test.go
@@ -141,7 +141,7 @@ func TestFindProperty(t *testing.T) {
 	}
 }
 
-func TestReader(t *testing.T) {
+func TestWalk(t *testing.T) {
 	f, err := os.Open("testdata/fdt.dtb")
 	if err != nil {
 		t.Fatal(err)
@@ -152,14 +152,9 @@ func TestReader(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r, err := fdt.Reader("psci", "migrate")
+	b, err := fdt.Root().Walk("psci").Property("migrate").AsBytes()
 	if err != nil {
-		t.Fatalf("Getting reader (psci, migrate) in %s: got %v, want nil", fdt, err)
-	}
-	t.Logf("Got the Reader: %v", r)
-	b, err := ioutil.ReadAll(r)
-	if err != nil {
-		t.Fatalf("Reading psci/migrate: got %v, want nil", err)
+		t.Fatalf("Walk to psci/migrate: got %v, want nil", err)
 	}
 	v := []byte{0x84, 0, 0, 0x5}
 	if !bytes.Equal(b, v) {

--- a/pkg/dt/print.go
+++ b/pkg/dt/print.go
@@ -24,11 +24,11 @@ func (fdt *FDT) String() string {
 func (p *Property) String() string {
 	var more string
 	l := len(p.Value)
-	if l > 8 {
+	if l > 64 {
 		more = "..."
-		l = 8
+		l = 64
 	}
-	return fmt.Sprintf("%s[%#02x]%#x%s", p.Name, len(p.Value), p.Value[:l], more)
+	return fmt.Sprintf("%s[%#02x]%q{%#x}%s", p.Name, len(p.Value), p.Value[:l], p.Value[:l], more)
 }
 
 func (n *Node) String() string {

--- a/pkg/dt/walk.go
+++ b/pkg/dt/walk.go
@@ -1,0 +1,81 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dt
+
+import "fmt"
+
+// NodeWalk is used to contain state for walking
+// the FDT, such as an error. A Walk with a non-nil
+// error value can not proceed. Many walks will start
+// with a root, but it is possible to Walk to a node,
+// make a copy of the Walk, and in that way do multiple
+// Walks from that one node. This is very similar to how
+// 9p clients walk 9p servers.
+type NodeWalk struct {
+	n   *Node
+	err error
+}
+
+// Root returns the Root node from an FDT to start the walk.
+func (fdt *FDT) Root() *NodeWalk {
+	return &NodeWalk{n: fdt.RootNode}
+}
+
+// Walk walks from a node to a named Node, returning a NodeWalk.
+func (nq *NodeWalk) Walk(name string) *NodeWalk {
+	if nq.err != nil {
+		return nq
+	}
+	for _, n := range nq.n.Children {
+		if n.Name == name {
+			return &NodeWalk{n: n}
+		}
+	}
+	return &NodeWalk{err: fmt.Errorf("cannot find node name %q", name)}
+}
+
+// Property walks from a Node to a Property of that Node, returning a PropertyWalk.
+func (nq *NodeWalk) Property(name string) *PropertyWalk {
+	if nq.err != nil {
+		return &PropertyWalk{err: nq.err}
+	}
+	for _, p := range nq.n.Properties {
+		if p.Name == name {
+			return &PropertyWalk{p: &p}
+		}
+	}
+	return &PropertyWalk{err: fmt.Errorf("cannot find property name %q", name)}
+}
+
+// PropertyWalk contains the state from a Walk
+// to a Property.
+type PropertyWalk struct {
+	p   *Property
+	err error
+}
+
+// AsU64 returns the PropertyWalk value as a uint64.
+func (pq *PropertyWalk) AsU64() (uint64, error) {
+	if pq.err != nil {
+		return 0, pq.err
+	}
+	return pq.p.AsU64()
+}
+
+// AsString returns the PropertyWalk value as a string.
+func (pq *PropertyWalk) AsString() (string, error) {
+	if pq.err != nil {
+		return "", pq.err
+	}
+	return pq.p.String(), nil
+}
+
+// AsBytes returns the PropertyWalk value as a []byte.
+func (pq *PropertyWalk) AsBytes() ([]byte, error) {
+	if pq.err != nil {
+		return nil, pq.err
+	}
+	return pq.p.Value, nil
+}


### PR DESCRIPTION
One can now get the value of the named property on a node as a
[]byte, string, and uint64.

These conversion operations are needed to support FIT booting.

The printing changes have proven invaluable for debugging.