### PR TITLE
switch_root fails on recursiveDelete when it shouldn't

### DIFF
--- a/pkg/mount/switch_root_linux.go
+++ b/pkg/mount/switch_root_linux.go
@@ -26,10 +26,16 @@ func getDev(fd int) (dev uint64, err error) {
 //
 // This function allows deleting directories no longer referenceable by
 // any file name. This function does not descend into mounts.
+//
+// It is not an error for this function to fail to delete a file/directory.  That's normal (e.g. mount points).
+// The objective is to clear as much memory as possible.
+// In general this should be best-effort and should generally warn rather than fail,
+// since failure leaves the system in an undefined state.
 func recursiveDelete(fd int) error {
 	parentDev, err := getDev(fd)
 	if err != nil {
-		return err
+		log.Printf("warn: unable to get underlying dev for dir: %v", err)
+		return nil
 	}
 
 	// The file descriptor is already open, but allocating a os.File
@@ -38,7 +44,8 @@ func recursiveDelete(fd int) error {
 	defer dir.Close()
 	names, err := dir.Readdirnames(-1)
 	if err != nil {
-		return err
+		log.Printf("warn: unable to read dir %s: %v", dir.Name(), err)
+		return nil
 	}
 
 	for _, name := range names {
@@ -61,15 +68,16 @@ func recusiveDeleteInner(parentFd int, parentDev uint64, childName string) error
 	if err != nil {
 		// childName points to either a file or a symlink, delete in any case.
 		if err := unix.Unlinkat(parentFd, childName, 0); err != nil {
-			return err
+			log.Printf("warn: unable to remove file %s: %v", childName, err)
 		}
 	} else {
 		// Open succeeded, which means childName points to a real directory.
 		defer unix.Close(childFd)
 
-		// Don't descent into other file systems.
+		// Don't descend into other file systems.
 		if childFdDev, err := getDev(childFd); err != nil {
-			return err
+			log.Printf("warn: unable to get underlying dev for dir: %s: %v", childName, err)
+			return nil
 		} else if childFdDev != parentDev {
 			// This means continue in recursiveDelete.
 			return nil
@@ -80,7 +88,7 @@ func recusiveDeleteInner(parentFd int, parentDev uint64, childName string) error
 		}
 		// Back from recursion, the directory is now empty, delete.
 		if err := unix.Unlinkat(parentFd, childName, unix.AT_REMOVEDIR); err != nil {
-			return err
+			log.Printf("warn: unable to remove dir %s: %v", childName, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
The way `resursiveDelete` is written in `switch_root_linux.go`, there are many conditions under which the function will fail.  This results in two unexpected things:

1. The process of recursiveDelete is terminated at the first failure, potentially leaving much of the old root un-deleted;
2. The function returns an error, which gets passed to calling functions.  The `switch_root` command, in turn, will fail and never execute the specified `init`, meaning total boot failure.

It is actually common for some files/directories in old root to not be deleted.  For instance, they may reference underlying mount points, and sometimes this is intentional.  An example of this is the upper/lower mounts involved in switch_rooting into an overlayfs mount point (the specific case that lead me to this PR).

The recursiveDelete should be a best-effort delete, and it should not generally return errors (though it might print warnings).  This not only does a better job of making sure we successfully move on to executing the new init, but also matches the logic found in util-linux's `switch_root.c`.

This PR changes recursiveDelete to warn rather than error.