### PR TITLE
Updates to disk_unlock command

### DIFF
--- a/cmds/exp/disk_unlock/disk_unlock.go
+++ b/cmds/exp/disk_unlock/disk_unlock.go
@@ -193,27 +193,25 @@ func main() {
 
 	switch {
 	case !info.SecurityStatus.SecurityEnabled():
-		log.Printf("disk security is not enabled on %v", *disk)
+		log.Printf("Disk security is not enabled on %v.", *disk)
 		return
 	case info.SecurityStatus.SecurityFrozen():
 		// If the disk is frozen, its security state cannot be changed until the next
 		// power on or hardware reset. Disk unlock will fail anyways, so return.
 		// This is unlikely to occur, since someone would need to freeze the drive's
 		// security state between the last AC cycle and this code being run.
-		log.Print("disk security is frozen. Power cycle the machine to unfreeze the disk")
+		log.Print("Disk security is frozen. Power cycle the machine to unfreeze the disk.")
 		return
 	case !info.SecurityStatus.SecurityLocked():
-		log.Print("disk is already unlocked")
+		log.Print("Disk is already unlocked.")
 		return
 	case info.SecurityStatus.SecurityCountExpired():
 		// If the security count is expired, this means too many attempts have been
 		// made to unlock the disk. Reset this with an AC cycle or hardware reset
 		// on the disk.
-		log.Print("security count expired on disk. Reset the password counter by power cycling the disk.")
-		return
+		log.Fatalf("Security count expired on disk. Reset the password counter by power cycling the disk.")
 	case info.MasterPasswordRev != skmMPI:
-		log.Printf("disk is locked with unknown master password ID: %X", info.MasterPasswordRev)
-		return
+		log.Fatalf("Disk is locked with unknown master password ID: %X", info.MasterPasswordRev)
 	}
 
 	// Try using each HSS to unlock the disk - only 1 should work.

--- a/pkg/mount/scuzz/ata.go
+++ b/pkg/mount/scuzz/ata.go
@@ -148,8 +148,9 @@ func unpackIdentify(s statusBlock, d dataBlock, w wordBlock) *Info {
 	info.FirmwareRevision = ataString(d[46:54])
 	info.Model = ataString(d[54:94])
 
-	info.MasterPasswordRev = w[92]
-	info.SecurityStatus = w[128]
+	info.MasterPasswordRev = binary.LittleEndian.Uint16(d[184:186])
+	info.SecurityStatus = DiskSecurityStatus(binary.LittleEndian.Uint16(d[256:258]))
+
 	info.TrustedComputingSupport = w[48]
 	return &info
 }

--- a/pkg/mount/scuzz/control.go
+++ b/pkg/mount/scuzz/control.go
@@ -13,12 +13,21 @@ import (
 // DefaultTimeout is the default timeout for disk operations.
 const DefaultTimeout time.Duration = 15 * time.Second
 
+const (
+	_SECURITY_SUPPORTED     = 0x1
+	_SECURITY_ENABLED       = 0x2
+	_SECURITY_LOCKED        = 0x4
+	_SECURITY_FROZEN        = 0x8
+	_SECURITY_COUNT_EXPIRED = 0x10
+	_SECURITY_LEVEL_MAX     = 0x100
+)
+
 // Info is information about a SCSI disk device.
 type Info struct {
 	NumberSectors           uint64
 	ECCBytes                uint
 	MasterPasswordRev       uint16
-	SecurityStatus          uint16
+	SecurityStatus          DiskSecurityStatus
 	TrustedComputingSupport uint16
 
 	Serial           string
@@ -31,6 +40,49 @@ type Info struct {
 	OrigSerial           string
 	OrigModel            string
 	OrigFirmwareRevision string
+}
+
+// DiskSecurityStatus is information about how the disk is secured.
+type DiskSecurityStatus uint16
+
+// SecuritySupported returns true if the disk has security.
+func (d DiskSecurityStatus) SecuritySupported() bool {
+	return (d & _SECURITY_SUPPORTED) != 0
+}
+
+// SecurityEnabled returns true if security is enabled on the disk.
+func (d DiskSecurityStatus) SecurityEnabled() bool {
+	return (d & _SECURITY_ENABLED) != 0
+}
+
+// SecurityLocked returns true if the disk is locked.
+func (d DiskSecurityStatus) SecurityLocked() bool {
+	return (d & _SECURITY_LOCKED) != 0
+}
+
+// SecurityFrozen returns true if the disk is frozen and its security state
+// cannot be changed.
+func (d DiskSecurityStatus) SecurityFrozen() bool {
+	return (d & _SECURITY_FROZEN) != 0
+}
+
+// SecurityCountExpired returns true if all attempts to unlock the disk have
+// been used up.
+func (d DiskSecurityStatus) SecurityCountExpired() bool {
+	return (d & _SECURITY_COUNT_EXPIRED) != 0
+}
+
+func (d DiskSecurityStatus) String() string {
+	return fmt.Sprintf(`
+	Security Status:
+		Supported: %d,
+		Enabled: %d,
+		Locked: %d,
+		Frozen: %d,
+		Count Expired: %d,
+		Level Max: %d
+	`, d&_SECURITY_SUPPORTED, d&_SECURITY_ENABLED, d&_SECURITY_LOCKED,
+		d&_SECURITY_FROZEN, d&_SECURITY_COUNT_EXPIRED, d&_SECURITY_LEVEL_MAX)
 }
 
 // Disk is the interface to a disk, with operations to create packets and

--- a/pkg/mount/scuzz/control.go
+++ b/pkg/mount/scuzz/control.go
@@ -14,13 +14,22 @@ import (
 const DefaultTimeout time.Duration = 15 * time.Second
 
 const (
-	_SECURITY_SUPPORTED     = 0x1
-	_SECURITY_ENABLED       = 0x2
-	_SECURITY_LOCKED        = 0x4
-	_SECURITY_FROZEN        = 0x8
-	_SECURITY_COUNT_EXPIRED = 0x10
-	_SECURITY_LEVEL_MAX     = 0x100
+	securitySupported    DiskSecurityStatus = 0x1
+	securityEnabled      DiskSecurityStatus = 0x2
+	securityLocked       DiskSecurityStatus = 0x4
+	securityFrozen       DiskSecurityStatus = 0x8
+	securityCountExpired DiskSecurityStatus = 0x10
+	securityLevelMax     DiskSecurityStatus = 0x100
 )
+
+var securityStatusStrings = map[DiskSecurityStatus]string{
+	securitySupported:    "SUPPORTED",
+	securityEnabled:      "ENABLED",
+	securityLocked:       "LOCKED",
+	securityFrozen:       "FROZEN",
+	securityCountExpired: "COUNT EXPIRED",
+	securityLevelMax:     "LEVEL MAX",
+}
 
 // Info is information about a SCSI disk device.
 type Info struct {
@@ -42,49 +51,6 @@ type Info struct {
 	OrigFirmwareRevision string
 }
 
-// DiskSecurityStatus is information about how the disk is secured.
-type DiskSecurityStatus uint16
-
-// SecuritySupported returns true if the disk has security.
-func (d DiskSecurityStatus) SecuritySupported() bool {
-	return (d & _SECURITY_SUPPORTED) != 0
-}
-
-// SecurityEnabled returns true if security is enabled on the disk.
-func (d DiskSecurityStatus) SecurityEnabled() bool {
-	return (d & _SECURITY_ENABLED) != 0
-}
-
-// SecurityLocked returns true if the disk is locked.
-func (d DiskSecurityStatus) SecurityLocked() bool {
-	return (d & _SECURITY_LOCKED) != 0
-}
-
-// SecurityFrozen returns true if the disk is frozen and its security state
-// cannot be changed.
-func (d DiskSecurityStatus) SecurityFrozen() bool {
-	return (d & _SECURITY_FROZEN) != 0
-}
-
-// SecurityCountExpired returns true if all attempts to unlock the disk have
-// been used up.
-func (d DiskSecurityStatus) SecurityCountExpired() bool {
-	return (d & _SECURITY_COUNT_EXPIRED) != 0
-}
-
-func (d DiskSecurityStatus) String() string {
-	return fmt.Sprintf(`
-	Security Status:
-		Supported: %d,
-		Enabled: %d,
-		Locked: %d,
-		Frozen: %d,
-		Count Expired: %d,
-		Level Max: %d
-	`, d&_SECURITY_SUPPORTED, d&_SECURITY_ENABLED, d&_SECURITY_LOCKED,
-		d&_SECURITY_FROZEN, d&_SECURITY_COUNT_EXPIRED, d&_SECURITY_LEVEL_MAX)
-}
-
 // Disk is the interface to a disk, with operations to create packets and
 // operate on them.
 type Disk interface {
@@ -94,6 +60,46 @@ type Disk interface {
 
 	// Identify returns drive identity information
 	Identify() (*Info, error)
+}
+
+// DiskSecurityStatus is information about how the disk is secured.
+type DiskSecurityStatus uint16
+
+// SecuritySupported returns true if the disk has security.
+func (d DiskSecurityStatus) SecuritySupported() bool {
+	return (d & securitySupported) != 0
+}
+
+// SecurityEnabled returns true if security is enabled on the disk.
+func (d DiskSecurityStatus) SecurityEnabled() bool {
+	return (d & securityEnabled) != 0
+}
+
+// SecurityLocked returns true if the disk is locked.
+func (d DiskSecurityStatus) SecurityLocked() bool {
+	return (d & securityLocked) != 0
+}
+
+// SecurityFrozen returns true if the disk is frozen and its security state
+// cannot be changed.
+func (d DiskSecurityStatus) SecurityFrozen() bool {
+	return (d & securityFrozen) != 0
+}
+
+// SecurityCountExpired returns true if all attempts to unlock the disk have
+// been used up.
+func (d DiskSecurityStatus) SecurityCountExpired() bool {
+	return (d & securityCountExpired) != 0
+}
+
+func (d DiskSecurityStatus) String() string {
+	s := fmt.Sprint("Security Status: ")
+	for v, name := range securityStatusStrings {
+		if d&v != 0 {
+			s += name + ", "
+		}
+	}
+	return s
 }
 
 // String prints a nice JSON-formatted info.


### PR DESCRIPTION
This PR adds a few changes:

* Try unique HSS values to avoid consuming password retry attempts.
* Have the option to have multiple retries for an HSS in case
there's failure for any reason other than an incorrect password.
* Check disk state more extensively before trying to unlock.
* Rescan SCSI host after unlock.

Signed-off-by: pallaud <plaud@google.com>