### PR TITLE
grub: Add missing continues on parser errors

### DIFF
--- a/pkg/boot/grub/grub.go
+++ b/pkg/boot/grub/grub.go
@@ -349,6 +349,7 @@ func (c *parser) append(ctx context.Context, config string) error {
 
 			if err := fs.Parse(kv[1:]); err != nil || fs.NArg() != 1 {
 				log.Printf("Warning: Grub parser could not parse %q", kv)
+				continue
 			}
 			searchName := fs.Arg(0)
 			if *searchUUID && *searchLabel || *searchUUID && *searchFile || *searchLabel && *searchFile {
@@ -402,6 +403,7 @@ func (c *parser) append(ctx context.Context, config string) error {
 				cleanPath, err := filepath.Rel("/", filepath.Clean(filepath.Join("/", searchName)))
 				if err != nil {
 					log.Printf("Error: Could not clean path %q: %v", searchName, err)
+					continue
 				}
 				// Search through all the devices for the file.
 				for _, d := range c.devices {


### PR DESCRIPTION
This gracefully skips unsupported constructions of the `search` command
such as:

        search.fs_uuid be271b43-e570-4af7-9c9a-f9315636679d root hd0,gpt2

As seen on Ubuntu 20.04.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>