### PR TITLE
cmd/boot/fbnetboot: Fix https client setup debug output

### DIFF
--- a/cmds/boot/fbnetboot/main.go
+++ b/cmds/boot/fbnetboot/main.go
@@ -324,7 +324,7 @@ func getClientForBootfile(bootfile string) (*http.Client, error) {
 		tr := &http.Transport{TLSClientConfig: config}
 		client = &http.Client{Transport: tr}
 		debug("https client setup (use certs from VPD: %t, skipCertVerify %t)",
-			*skipCertVerify, *caCertFile != "")
+			*caCertFile != "", *skipCertVerify)
 	case "http":
 		client = &http.Client{}
 		debug("http client setup")


### PR DESCRIPTION
Just noticed the two params are swapped.

Signed-off-by: Tobias Fleig <tfleig@fb.com>