### PR TITLE
Fix issue where testramfs failed to create mount namespace

### DIFF
--- a/tools/testramfs/testramfs.go
+++ b/tools/testramfs/testramfs.go
@@ -115,7 +115,7 @@ func main() {
 	cmd.Command("/init")
 	cmd.C.SysProcAttr.Chroot = tempDir
 	cmd.C.SysProcAttr.Cloneflags = cloneFlags
-	cmd.C.SysProcAttr.Unshareflags = cloneFlags
+	cmd.C.SysProcAttr.Unshareflags = unshareFlags
 	if *interactive {
 		if err := cmd.Run(); err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
This one-liner fixes an issue where `testramfs` wouldn't actually create a mount namespace because the wrong flags got passed to `SysProcAttr.Unshareflags`.

Signed-off-by: J. Lowell Wofford <lowell@lanl.gov>