### PR TITLE
Update run.go to allow for background tasks

### DIFF
--- a/pkg/sh/run.go
+++ b/pkg/sh/run.go
@@ -33,6 +33,10 @@ func RunWithIO(in io.Reader, out, err io.Writer, arg0 string, args ...string) er
 	cmd.Stdin = in
 	cmd.Stdout = out
 	cmd.Stderr = err
+	// If it is a background process, don't wait for it to return.
+	if len(args) > 0 && args[len(args)-1] == "&" {
+		return cmd.Start()
+	}
 	return cmd.Run()
 }
 


### PR DESCRIPTION
Allow for non-returning daemon commands to be run in the init script which is run with run.go