### PR TITLE
provide an option to use shellbang, not symlinks, for busybox

### DIFF
--- a/u-root.go
+++ b/u-root.go
@@ -48,6 +48,7 @@ var (
 	noStrip                                 *bool
 	statsOutputPath                         *string
 	statsLabel                              *string
+	shellbang                               *bool
 )
 
 func init() {
@@ -78,6 +79,7 @@ func init() {
 	flag.Var(&extraFiles, "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be speficified multiple times.")
 
 	noStrip = flag.Bool("no-strip", false, "Build unstripped binaries")
+	shellbang = flag.Bool("shellbang", false, "Use #! instead of symlinks for busybox")
 
 	statsOutputPath = flag.String("stats-output-path", "", "Write build stats to this file (JSON)")
 
@@ -263,7 +265,7 @@ func Main() error {
 		var b builder.Builder
 		switch *build {
 		case "bb":
-			b = builder.BBBuilder{}
+			b = builder.BBBuilder{ShellBang: *shellbang}
 		case "binary":
 			b = builder.BinaryBuilder{}
 		case "source":


### PR DESCRIPTION
Not all kernels support symlinks, and not all file systems
on all kernels do. Symlinks are not as portable as we want.
For example, a simple u-root on a VFAT file system can not
be created.

It turns out there is a way to use shellbang files that is as
efficient as symlinks and much more portable.

Add an option to the busybox builder to generate shellbang files,
not symlinks.

TODO: update the tests. But this change is known to work on Plan 9.

Question: should we just move to shellbang files
only, given their more universal nature, or keep it as an option?

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>