### PR TITLE
Add a 'tricks and tips' section

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,6 +31,7 @@
 <li><a href="https://groups.google.com/forum/#!forum/u-root">Join the mailing list</a></li>
 <li><a href="https://osfw.slack.com/">Join the Open Source Firmware Slack team</a> (Get an invite <a href="https://slack.osfw.dev">here</a>.)</li>
 <li><a href="https://github.com/u-root/u-root/blob/master/roadmap.md">Checkout the roadmap</a></li>
+<li><a href="https://github.com/u-root/u-root/blob/master/tricksandtips.md">Tricks and tips for building u-root images</a></li>
 </ul>
 <h2 id="contributors">Contributors</h2>
 <ul>

--- a/tricksandtips.md
+++ b/tricksandtips.md
@@ -1,0 +1,42 @@
+# u-root Tricks and Tips
+
+Here are some things we do that you might find useful.
+
+## Pipe u-root output to stdout
+
+One thing to keep in mind is that on many systems, now, standard
+out is a named file you can write to. Further, you can 
+create a cpio that has no Linux initramfs content. Finally, you can
+merge cpios to form a more comprehensive cpio.
+
+## inventory the cpio archive without creating it.
+```
+u-root -o /dev/stdout | cpio -ivt
+```
+
+## Make a pure u-root cpio with no other files.
+
+```
+u-root -base /dev/null
+```
+
+## Make an image that is BOTH dynamic and busybox
+
+Well, it *almost* works ... help wanted.
+
+Because busybox binaries go in /bbin
+and source binaries go in /ubin. This is useful because
+you can get a faster boot but still have a Go toolchain
+
+```
+u-root -base /dev/null -o /tmp/busybox.cpio
+u-root -base /tmp/busybox.cpio -build source -o combined.cpio
+```
+
+To see what that looks like:
+```
+cpio -ivt < combined.cpio
+```
+
+You can use testramfs to run it and watch it fork-bomb itself
+on init. So close! Working on it.


### PR DESCRIPTION
Today during a discussion I realized people did not know you
could do this:
u-root -o /dev/stdout | cpio -ivt
to see what went into an image.

This led to the idea of a tricks and tips page where we can
accumulate these techniques.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>