### PR TITLE
cpio: fix file modes in archives created on Plan 9

### DIFF
--- a/cmds/core/cpio/cpio_plan9_test.go
+++ b/cmds/core/cpio/cpio_plan9_test.go
@@ -1,0 +1,38 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func checkFileInfo(t *testing.T, ent *dirEnt, newFileInfo os.FileInfo) {
+	t.Helper()
+
+	newStatT := newFileInfo.Sys().(*syscall.Dir)
+	statT := ent.FileInfo.Sys().(*syscall.Dir)
+	t.Logf("Entry %v statT %v", ent, newFileInfo)
+	if ent.FileInfo.Name() != newFileInfo.Name() ||
+		ent.FileInfo.Size() != newFileInfo.Size() ||
+		ent.FileInfo.Mode() != newFileInfo.Mode() ||
+		ent.FileInfo.IsDir() != newFileInfo.IsDir() ||
+		statT.Mode != newStatT.Mode ||
+		statT.Uid != newStatT.Uid ||
+		statT.Gid != newStatT.Gid {
+		msg := "File has mismatched attributes:\n"
+		msg += "Property |   Original |  Extracted\n"
+		msg += fmt.Sprintf("Name:    | %10s | %10s\n", ent.FileInfo.Name(), newFileInfo.Name())
+		msg += fmt.Sprintf("Size:    | %10d | %10d\n", ent.FileInfo.Size(), newFileInfo.Size())
+		msg += fmt.Sprintf("Mode:    | %10d | %10d\n", ent.FileInfo.Mode(), newFileInfo.Mode())
+		msg += fmt.Sprintf("IsDir:   | %10t | %10t\n", ent.FileInfo.IsDir(), newFileInfo.IsDir())
+		msg += fmt.Sprintf("FI Mode: | %10d | %10d\n", statT.Mode, newStatT.Mode)
+		msg += fmt.Sprintf("Uid:     | %10s | %10s\n", statT.Uid, newStatT.Uid)
+		msg += fmt.Sprintf("Gid:     | %10s | %10s\n", statT.Gid, newStatT.Gid)
+		t.Error(msg)
+	}
+}

--- a/cmds/core/cpio/cpio_posix_test.go
+++ b/cmds/core/cpio/cpio_posix_test.go
@@ -1,0 +1,42 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !plan9
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func checkFileInfo(t *testing.T, ent *dirEnt, newFileInfo os.FileInfo) {
+	t.Helper()
+
+	newStatT := newFileInfo.Sys().(*syscall.Stat_t)
+	statT := ent.FileInfo.Sys().(*syscall.Stat_t)
+	t.Logf("Entry %v statT %v old ino %d new Ino %d", ent, newFileInfo, statT.Ino, newStatT.Ino)
+	if ent.FileInfo.Name() != newFileInfo.Name() ||
+		ent.FileInfo.Size() != newFileInfo.Size() ||
+		ent.FileInfo.Mode() != newFileInfo.Mode() ||
+		ent.FileInfo.IsDir() != newFileInfo.IsDir() ||
+		statT.Mode != newStatT.Mode ||
+		statT.Uid != newStatT.Uid ||
+		statT.Gid != newStatT.Gid ||
+		statT.Nlink != newStatT.Nlink {
+		msg := "File has mismatched attributes:\n"
+		msg += "Property |   Original |  Extracted\n"
+		msg += fmt.Sprintf("Name:    | %10s | %10s\n", ent.FileInfo.Name(), newFileInfo.Name())
+		msg += fmt.Sprintf("Size:    | %10d | %10d\n", ent.FileInfo.Size(), newFileInfo.Size())
+		msg += fmt.Sprintf("Mode:    | %10d | %10d\n", ent.FileInfo.Mode(), newFileInfo.Mode())
+		msg += fmt.Sprintf("IsDir:   | %10t | %10t\n", ent.FileInfo.IsDir(), newFileInfo.IsDir())
+		msg += fmt.Sprintf("FI Mode: | %10d | %10d\n", statT.Mode, newStatT.Mode)
+		msg += fmt.Sprintf("Uid:     | %10d | %10d\n", statT.Uid, newStatT.Uid)
+		msg += fmt.Sprintf("Gid:     | %10d | %10d\n", statT.Gid, newStatT.Gid)
+		msg += fmt.Sprintf("NLink:   | %10d | %10d\n", statT.Nlink, newStatT.Nlink)
+		t.Error(msg)
+	}
+}

--- a/pkg/cpio/fs_plan9.go
+++ b/pkg/cpio/fs_plan9.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"syscall"
 	"time"
 
 	"github.com/u-root/u-root/pkg/ls"
@@ -125,7 +126,10 @@ func (r *Recorder) GetRecord(path string) (Record, error) {
 	if err != nil {
 		return Record{}, err
 	}
-	info := r.inode(sysInfo(path, fi))
+
+	sys := fi.Sys().(*syscall.Dir)
+	info := r.inode(sysInfo(path, sys))
+
 	switch fi.Mode() & os.ModeType {
 	case 0: // Regular file.
 		return Record{Info: info, ReaderAt: uio.NewLazyFile(path)}, nil

--- a/pkg/cpio/sysinfo_plan9.go
+++ b/pkg/cpio/sysinfo_plan9.go
@@ -4,14 +4,22 @@
 
 package cpio
 
-import "os"
+import "syscall"
 
-func sysInfo(n string, fi os.FileInfo) Info {
+func sysInfo(n string, sys *syscall.Dir) Info {
+	// Similar to how the standard library converts Plan 9 Dir to os.FileInfo:
+	// https://github.com/golang/go/blob/go1.16beta1/src/os/stat_plan9.go#L14
+	mode := sys.Mode & 0777
+	if sys.Mode&syscall.DMDIR != 0 {
+		mode |= modeDir
+	} else {
+		mode |= modeFile
+	}
 	return Info{
-		Mode:     uint64(fi.Mode()),
+		Mode:     uint64(mode),
 		UID:      0,
-		MTime:    uint64(fi.ModTime().Second()),
-		FileSize: uint64(fi.Size()),
+		MTime:    uint64(sys.Mtime),
+		FileSize: uint64(sys.Length),
 		Name:     n,
 	}
 }

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -12,7 +12,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 
@@ -91,11 +90,11 @@ func IsExitCode(err error, exitCode int) error {
 	if !ok {
 		return fmt.Errorf("encountered error other than ExitError: %#v", err)
 	}
-	ws, ok := exitErr.Sys().(syscall.WaitStatus)
-	if !ok {
-		return fmt.Errorf("sys() is not a syscall WaitStatus: %v", err)
+	es, err := exitStatus(exitErr)
+	if err != nil {
+		return err
 	}
-	if es := ws.ExitStatus(); es != exitCode {
+	if es != exitCode {
 		return fmt.Errorf("got exit status %d, want %d", es, exitCode)
 	}
 	return nil

--- a/pkg/testutil/testutil_plan9.go
+++ b/pkg/testutil/testutil_plan9.go
@@ -1,0 +1,19 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package testutil
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+func exitStatus(exitErr *exec.ExitError) (int, error) {
+	ws, ok := exitErr.Sys().(syscall.Waitmsg)
+	if !ok {
+		return 0, fmt.Errorf("sys() is not a syscall Waitmsg: %v", exitErr)
+	}
+	return ws.ExitStatus(), nil
+}

--- a/pkg/testutil/testutil_posix.go
+++ b/pkg/testutil/testutil_posix.go
@@ -1,0 +1,21 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build !plan9
+
+package testutil
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+func exitStatus(exitErr *exec.ExitError) (int, error) {
+	ws, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		return 0, fmt.Errorf("sys() is not a syscall WaitStatus: %v", exitErr)
+	}
+	return ws.ExitStatus(), nil
+}


### PR DESCRIPTION
Plan 9 uses different file type bits compared to unix. It uses
0x80000000 for directories and 0 for regular files. Adjust the mode so
that file modes are correct in the resulting archive.

Also get all cpio tests passing on Plan 9.

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>