### PR TITLE
pkg/rand: add implementation for Plan 9

### DIFF
--- a/pkg/rand/random.go
+++ b/pkg/rand/random.go
@@ -1,0 +1,62 @@
+// Copyright 2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package rand implements cancelable reads from a cryptographically safe
+// random number source.
+package rand
+
+import (
+	"context"
+)
+
+// Reader is a cryptographically safe random number source.
+var Reader = DefaultReaderWithContext(context.Background())
+
+// Read blockingly reads from a random number source.
+func Read(b []byte) (int, error) {
+	return Reader.Read(b)
+}
+
+// ReadContext is a context-aware reader for random numbers.
+func ReadContext(ctx context.Context, b []byte) (int, error) {
+	return Reader.ReadContext(ctx, b)
+}
+
+// ContextReader is a cancelable io.Reader.
+type ContextReader interface {
+	// Read behaves like a blocking io.Reader.Read.
+	//
+	// Read wraps ReadContext with a background context.
+	Read(b []byte) (n int, err error)
+
+	// ReadContext is an io.Reader that blocks until data is available or
+	// until ctx is done.
+	ReadContext(ctx context.Context, b []byte) (n int, err error)
+}
+
+// contextReader is a cancelable io.Reader.
+type contextReader interface {
+	ReadContext(context.Context, []byte) (int, error)
+}
+
+// ctxReader takes a contextReader and turns it into a ContextReader.
+type ctxReader struct {
+	contextReader
+	ctx context.Context
+}
+
+func (cr ctxReader) Read(b []byte) (int, error) {
+	return cr.contextReader.ReadContext(cr.ctx, b)
+}
+
+// DefaultReaderWithContext returns a context-aware io.Reader.
+//
+// Because this stores the context, only use this in situations where an
+// io.Reader is unavoidable.
+func DefaultReaderWithContext(ctx context.Context) ContextReader {
+	return ctxReader{
+		ctx:           ctx,
+		contextReader: defaultContextReader,
+	}
+}

--- a/pkg/rand/random_std.go
+++ b/pkg/rand/random_std.go
@@ -1,0 +1,31 @@
+// Copyright 2020 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build plan9
+
+package rand
+
+import (
+	"context"
+	"crypto/rand"
+)
+
+var defaultContextReader = &cryptoRandReader{}
+
+type cryptoRandReader struct{}
+
+// ReadContext implements a cancelable read.
+func (r *cryptoRandReader) ReadContext(ctx context.Context, b []byte) (n int, err error) {
+	ch := make(chan struct{})
+	go func() {
+		n, err = rand.Reader.Read(b)
+		close(ch)
+	}()
+	select {
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	case <-ch:
+		return n, err
+	}
+}

--- a/pkg/rand/random_unix.go
+++ b/pkg/rand/random_unix.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build aix darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris
+// +build aix darwin dragonfly freebsd nacl netbsd openbsd solaris
 
 package rand
 

--- a/pkg/rand/random_urandom.go
+++ b/pkg/rand/random_urandom.go
@@ -2,10 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build aix darwin dragonfly freebsd nacl netbsd openbsd plan9 solaris linux
+// +build aix darwin dragonfly freebsd nacl netbsd openbsd solaris linux
 
-// Package rand implements cancelable reads from a cryptographically safe
-// random number source.
 package rand
 
 import (
@@ -16,57 +14,6 @@ import (
 
 	"golang.org/x/sys/unix"
 )
-
-// Reader is a cryptographically safe random number source.
-var Reader = DefaultReaderWithContext(context.Background())
-
-// Read blockingly reads from a random number source.
-func Read(b []byte) (int, error) {
-	return Reader.Read(b)
-}
-
-// ReadContext is a context-aware reader for random numbers.
-func ReadContext(ctx context.Context, b []byte) (int, error) {
-	return Reader.ReadContext(ctx, b)
-}
-
-// ContextReader is a cancelable io.Reader.
-type ContextReader interface {
-	// Read behaves like a blocking io.Reader.Read.
-	//
-	// Read wraps ReadContext with a background context.
-	Read(b []byte) (n int, err error)
-
-	// ReadContext is an io.Reader that blocks until data is available or
-	// until ctx is done.
-	ReadContext(ctx context.Context, b []byte) (n int, err error)
-}
-
-// contextReader is a cancelable io.Reader.
-type contextReader interface {
-	ReadContext(context.Context, []byte) (int, error)
-}
-
-// ctxReader takes a contextReader and turns it into a ContextReader.
-type ctxReader struct {
-	contextReader
-	ctx context.Context
-}
-
-func (cr ctxReader) Read(b []byte) (int, error) {
-	return cr.contextReader.ReadContext(cr.ctx, b)
-}
-
-// DefaultReaderWithContext returns a context-aware io.Reader.
-//
-// Because this stores the context, only use this in situations where an
-// io.Reader is unavoidable.
-func DefaultReaderWithContext(ctx context.Context) ContextReader {
-	return ctxReader{
-		ctx:           ctx,
-		contextReader: defaultContextReader,
-	}
-}
 
 // urandomReader is a contextReader.
 type urandomReader struct {


### PR DESCRIPTION
Plan 9 doesn't have /dev/urandom. The crypto/rand package in the
standard library implements its own pseudorandom generator seeded by
/dev/random on Plan 9. We just wrap the crypto/rand implementation,
adding a context.

Signed-off-by: Fazlul Shahriar <fshahriar@gmail.com>