### PR TITLE
testramfs: fix it so ttys work again

### DIFF
--- a/tools/testramfs/testramfs.go
+++ b/tools/testramfs/testramfs.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/u-root/u-root/pkg/cpio"
 	"github.com/u-root/u-root/pkg/pty"
+	"github.com/u-root/u-root/pkg/termios"
 )
 
 const (
@@ -117,6 +118,15 @@ func main() {
 	cmd.C.SysProcAttr.Cloneflags = cloneFlags
 	cmd.C.SysProcAttr.Unshareflags = unshareFlags
 	if *interactive {
+		t, err := termios.GetTermios(0)
+		if err != nil {
+			log.Fatal("Getting Termios")
+		}
+		defer func(t *termios.Termios) {
+			if err := termios.SetTermios(0, t); err != nil {
+				log.Print(err)
+			}
+		}(t)
 		if err := cmd.Run(); err != nil {
 			log.Fatal(err)
 		}


### PR DESCRIPTION
As of ubuntu 20, on exit, the terminal was left
in raw mode, no echo, etc. etc.

This fixes, we hope, for the last time.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>