### PR TITLE
mount: with no args, show mounts

### DIFF
--- a/cmds/core/mount/mount.go
+++ b/cmds/core/mount/mount.go
@@ -15,6 +15,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
@@ -95,13 +96,22 @@ func informIfUnknownFS(originFS string) {
 }
 
 func main() {
+	if len(os.Args) == 1 {
+		n := []string{"/proc/self/mounts", "/proc/mounts", "/etc/mtab"}
+		for _, p := range n {
+			if b, err := ioutil.ReadFile(p); err == nil {
+				fmt.Print(string(b))
+				os.Exit(0)
+			}
+		}
+		log.Fatalf("Could not read %s to get namespace", n)
+	}
 	flag.Parse()
-	a := flag.Args()
-	if len(a) < 2 {
+	if len(flag.Args()) < 2 {
 		flag.Usage()
 		os.Exit(1)
 	}
-
+	a := flag.Args()
 	dev := a[0]
 	path := a[1]
 	var flags uintptr

--- a/cmds/core/mount/mount_plan9.go
+++ b/cmds/core/mount/mount_plan9.go
@@ -25,6 +25,9 @@
 package main
 
 import (
+	"flag"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 
@@ -32,7 +35,16 @@ import (
 )
 
 func main() {
-	mod, err := namespace.ParseArgs(os.Args)
+	if len(os.Args) == 1 {
+		n := fmt.Sprintf("/proc/%d/ns", os.Getpid())
+		if b, err := ioutil.ReadFile(n); err == nil {
+			fmt.Print(string(b))
+			os.Exit(0)
+		}
+		log.Fatalf("Could not read %s to get namespace", n)
+	}
+	flag.Parse()
+	mod, err := namespace.ParseArgs(flag.Args())
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/namespace/parser.go
+++ b/pkg/namespace/parser.go
@@ -109,7 +109,7 @@ func ParseArgs(args []string) (Modifier, error) {
 	case "import":
 		c.syscall = IMPORT
 	default:
-		panic(arg)
+		return nil, fmt.Errorf("%q is an unknown operation", arg)
 	}
 
 	c.flag, c.args = ParseFlags(args)


### PR DESCRIPTION
In the early days of u-root we had hoped to cleave to a more
plan 9-like model, in which the operations of mounting were
two separate commands. But the habit of typing mount by itself
to see mounts is not going to go away.

When mount is invoked with no args, it will try to read the mtab
from a number of standard places (Linux, Unix, OSX) or from
/proc/os.Getpid()/ns (Plan 9).

As an experiment, to try to keep the number of system calls down,
handle the "no args" case in init. We still end up with 300, which
is largish.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>