### PR TITLE
uroot: recurse ldd directories and stop trying to ldd non-ELF

### DIFF
--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -9,6 +9,7 @@
 package uroot
 
 import (
+	"debug/elf"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -477,23 +478,40 @@ func ParseExtraFiles(logger ulog.Logger, archive *initramfs.Files, extraFiles []
 		}
 
 		if lddDeps {
-			// Pull dependencies in the case of binaries. If `path` is not
-			// a binary, `libs` will just be empty.
-			libs, err := ldd.List([]string{src})
-			if err != nil {
-				logger.Printf("WARNING: couldn't add ldd dependencies for %q: %v", file, err)
-				continue
-			}
-			for _, lib := range libs {
-				// N.B.: we already added information about the src.
-				// Don't add it twice. We have to do this check here in
-				// case we're renaming the src to a different dest.
-				if lib == src {
-					continue
+			// Users are frequently naming directories now, not just files.
+			// Hence we must use walk here, not just check the one file.
+			if err := filepath.Walk(src, func(name string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
 				}
-				if err := archive.AddFileNoFollow(lib, lib[1:]); err != nil {
-					logger.Printf("WARNING: couldn't add ldd dependencies for %q: %v", lib, err)
+				if info.IsDir() {
+					return nil
 				}
+				// Try to open it as an ELF. If that fails, we can skip the ldd
+				// step. The file will still be included from above.
+				if _, err := elf.Open(name); err != nil {
+					return nil
+				}
+				// Pull dependencies in the case of binaries. If `path` is not
+				// a binary, `libs` will just be empty.
+				libs, err := ldd.List([]string{name})
+				if err != nil {
+					return fmt.Errorf("WARNING: couldn't add ldd dependencies for %q: %v", name, err)
+				}
+				for _, lib := range libs {
+					// N.B.: we already added information about the src.
+					// Don't add it twice. We have to do this check here in
+					// case we're renaming the src to a different dest.
+					if lib == name {
+						continue
+					}
+					if err := archive.AddFileNoFollow(lib, lib[1:]); err != nil {
+						logger.Printf("WARNING: couldn't add ldd dependencies for %q: %v", lib, err)
+					}
+				}
+				return nil
+			}); err != nil {
+				logger.Printf("Getting dependencies for %q: %v", src, err)
 			}
 		}
 	}

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -489,8 +489,12 @@ func ParseExtraFiles(logger ulog.Logger, archive *initramfs.Files, extraFiles []
 				}
 				// Try to open it as an ELF. If that fails, we can skip the ldd
 				// step. The file will still be included from above.
-				if _, err := elf.Open(name); err != nil {
+				f, err := elf.Open(name)
+				if err != nil {
 					return nil
+				}
+				if err = f.Close(); err != nil {
+					logger.Printf("WARNING: Closing ELF file %q: %v", name, err)
 				}
 				// Pull dependencies in the case of binaries. If `path` is not
 				// a binary, `libs` will just be empty.


### PR DESCRIPTION
Users frequently wish to include whole directories of executables.
Further, messages about ldd parsing are confusing when the
LDD on a non-regular-file fails.

Change the enumeration of the single file to a filepath.Walk.
Only try to enumerate ldd on files that are ELF files.

This change makes the use of -files a much better experience,
as well as allowing users to include whole directories
containing executables.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>