### PR TITLE
pkg/io/ports_linux: only allow outb and inb

### DIFF
--- a/pkg/memio/ports_linux.go
+++ b/pkg/memio/ports_linux.go
@@ -29,8 +29,8 @@ func iopl() error {
 // In reads data from the x86 port at address addr. Data must be Uint8, Uint16,
 // Uint32, but not Uint64.
 func In(addr uint16, data UintN) error {
-	if _, ok := data.(*Uint64); ok {
-		return fmt.Errorf("port data must be 8, 16 or 32 bits")
+	if _, ok := data.(*Uint8); !ok {
+		return fmt.Errorf("/dev/port data must be 8 bits on Linux")
 	}
 	return pathRead(portPath, int64(addr), data)
 }
@@ -38,8 +38,8 @@ func In(addr uint16, data UintN) error {
 // Out writes data to the x86 port at address addr. data must be Uint8, Uint16
 // uint32, but not Uint64.
 func Out(addr uint16, data UintN) error {
-	if _, ok := data.(*Uint64); ok {
-		return fmt.Errorf("port data must be 8, 16 or 32 bits")
+	if _, ok := data.(*Uint8); !ok {
+		return fmt.Errorf("/dev/port data must be 8 bits on Linux")
 	}
 	return pathWrite(portPath, int64(addr), data)
 }


### PR DESCRIPTION
/dev/port on linux only does an outb/inb.
see drivers/char/mem.c::write_port and read_port.

This can cause real trouble for hardware. For example,
on an AMD Rome system, writing to 0xcf8 with a write
system call to /dev/ports hangs the system in a way the
BMC can not recover from. This is because the 4-byte write
is realized as four outb instructions, not one outl.

Hence, on Linux, the memio package should return an error
if anything other than a uint8 is written to /dev/port.

Note that this restriction does not apply to Plan 9,
which has a better design for port IO than Linux.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>