### PR TITLE
pkg/cpio, cmds/core/cpio: Allow reading from pipes

### DIFF
--- a/cmds/core/cpio/cpio.go
+++ b/cmds/core/cpio/cpio.go
@@ -69,7 +69,10 @@ func main() {
 		var inums map[uint64]string
 		inums = make(map[uint64]string)
 
-		rr := archiver.Reader(os.Stdin)
+		rr, err := archiver.NewFileReader(os.Stdin)
+		if err != nil {
+			log.Fatal(err)
+		}
 		for {
 			rec, err := rr.ReadRecord()
 			if err == io.EOF {
@@ -148,7 +151,10 @@ func main() {
 		}
 
 	case "t":
-		rr := archiver.Reader(os.Stdin)
+		rr, err := archiver.NewFileReader(os.Stdin)
+		if err != nil {
+			log.Fatal(err)
+		}
 		for {
 			rec, err := rr.ReadRecord()
 			if err == io.EOF {

--- a/pkg/cpio/cpio.go
+++ b/pkg/cpio/cpio.go
@@ -123,6 +123,7 @@ type RecordWriter interface {
 // today.
 type RecordFormat interface {
 	Reader(r io.ReaderAt) RecordReader
+	NewFileReader(*os.File) (RecordReader, error)
 	Writer(w io.Writer) RecordWriter
 }
 

--- a/pkg/cpio/newc.go
+++ b/pkg/cpio/newc.go
@@ -10,6 +10,8 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"os"
 
 	"github.com/u-root/u-root/pkg/uio"
 )
@@ -183,19 +185,84 @@ type reader struct {
 	pos int64
 }
 
+// discarder is used to implement ReadAt from a Reader
+// by reading, and discarding, data until the offset
+// is reached. It can only go forward. It is designed
+// for pipe-like files.
+type discarder struct {
+	r   io.Reader
+	pos int64
+}
+
+// ReadAt implements ReadAt for a discarder.
+// It is an error for the offset to be negative.
+func (r *discarder) ReadAt(p []byte, off int64) (int, error) {
+	if off-r.pos < 0 {
+		return 0, fmt.Errorf("negative seek on discarder not allowed")
+	}
+	if off != r.pos {
+		i, err := io.Copy(ioutil.Discard, io.LimitReader(r.r, off-r.pos))
+		if err != nil || i != off-r.pos {
+			return 0, err
+		}
+		r.pos += i
+	}
+	n, err := io.ReadFull(r.r, p)
+	if err != nil {
+		return n, err
+	}
+	r.pos += int64(n)
+	return n, err
+}
+
+var _ io.ReaderAt = &discarder{}
+
 // Reader implements RecordFormat.Reader.
 func (n newc) Reader(r io.ReaderAt) RecordReader {
 	return EOFReader{&reader{n: n, r: r}}
 }
 
+// NewFileReader implements RecordFormat.Reader. If the file
+// implements ReadAt, then it is used for greater efficiency.
+// If it only implements Read, then a discarder will be used
+// instead.
+// Note a complication:
+// 	r, _, _ := os.Pipe()
+//	var b [2]byte
+//	_, err := r.ReadAt(b[:], 0)
+//	fmt.Printf("%v", err)
+// Pipes claim to implement ReadAt; most Unix kernels
+// do not agree. Even a seek to the current position fails.
+// This means that
+// if rat, ok := r.(io.ReaderAt); ok {
+// would seem to work, but would fail when the
+// actual ReadAt on the pipe occurs, even for offset 0,
+// which does not require a seek! The kernel checks for
+// whether the fd is seekable and returns an error,
+// even for values of offset which won't require a seek.
+// So, the code makes a simple test: can we seek to
+// current offset? If not, then the file is wrapped with a
+// discardreader. The discard reader is far less efficient
+// but allows cpio to read from a pipe.
+func (n newc) NewFileReader(f *os.File) (RecordReader, error) {
+	_, err := f.Seek(0, 0)
+	if err == nil {
+		return EOFReader{&reader{n: n, r: f}}, nil
+	}
+	return EOFReader{&reader{n: n, r: &discarder{r: f}}}, nil
+}
+
 func (r *reader) read(p []byte) error {
 	n, err := r.r.ReadAt(p, r.pos)
+
 	if err == io.EOF {
 		return io.EOF
 	}
+
 	if err != nil || n != len(p) {
 		return fmt.Errorf("ReadAt(pos = %d): got %d, want %d bytes; error %v", r.pos, n, len(p), err)
 	}
+
 	r.pos += int64(n)
 	return nil
 }
@@ -211,8 +278,6 @@ func (r *reader) ReadRecord() (Record, error) {
 	hdr := header{}
 	recPos := r.pos
 
-	Debug("Next record: pos is %d\n", r.pos)
-
 	buf := make([]byte, hex.EncodedLen(binary.Size(hdr))+magicLen)
 	if err := r.read(buf); err != nil {
 		return Record{}, err
@@ -222,7 +287,6 @@ func (r *reader) ReadRecord() (Record, error) {
 	if magic := string(buf[:magicLen]); magic != r.n.magic {
 		return Record{}, fmt.Errorf("reader: magic got %q, want %q", magic, r.n.magic)
 	}
-	Debug("Header is %v\n", buf)
 
 	// Decode hex header fields.
 	dst := make([]byte, binary.Size(hdr))
@@ -237,6 +301,7 @@ func (r *reader) ReadRecord() (Record, error) {
 	// Get the name.
 	nameBuf := make([]byte, hdr.NameLength)
 	if err := r.readAligned(nameBuf); err != nil {
+		Debug("name read failed")
 		return Record{}, err
 	}
 
@@ -245,6 +310,7 @@ func (r *reader) ReadRecord() (Record, error) {
 
 	recLen := uint64(r.pos - recPos)
 	filePos := r.pos
+
 	content := io.NewSectionReader(r.r, r.pos, int64(hdr.FileSize))
 	r.pos = round4(r.pos + int64(hdr.FileSize))
 	return Record{


### PR DESCRIPTION
Currently, the cpio package can not read from pipes. This violates
a fundamental property of both cpio and Unix in general.

The fix might seem to be allowing creation of Readers from an os.File.
We could then see if the File in question implements Reader or
ReaderAt: if ok, rat := f.(ReaderAt) ...
and handle each case, transparent to the caller.

The problem is that some Go os.File types, such as Pipes,
advertise themselves as implementing ReaderAt but in fact do not
do so.

e.g.
	r, _, _ := os.Pipe()
	var b [2]byte
	var _ io.ReaderAt = r
	_, err := r.ReadAt(b[:], 0)
	fmt.Printf("%v", err)

will fail, since whatever Go may think, Linux pipes do not allow a
seek, even when the offset is not changing. So the test
above will not work.

The Go runtime needs to be fixed, so that it does not claim
pipes implement io.ReaderAt, but it's going to be a long
time before such a change propagates everywhere. The cpio package
must accomodate this error. Further, there will almost
certainly be other future types which make this mistake.

Provide a NewFileReader function, which accepts *os.File
and returns a Reader. The function performs a simple test,
io.Seek(0,0), and, if that works, just creates a Reader
using the File's ReadAt.

If that seek fails, the function wraps the file in a
discardreader.

It is best to use a ReadAt when possible to avoid having
to read and discard data to implement seek.

cpio can now use stdin from a pipe.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>