### PR TITLE
cp: don't error if a destination directory exists

### DIFF
--- a/cmds/core/cp/cp_test.go
+++ b/cmds/core/cp/cp_test.go
@@ -229,6 +229,11 @@ func TestCpRecursiveMultiple(t *testing.T) {
 	if err := cpArgs(args); err != nil {
 		t.Fatalf("cp %q exit with error: %v", args, err)
 	}
+	// Make sure we can do it twice.
+	flags.force = true
+	if err := cpArgs(args); err != nil {
+		t.Fatalf("cp %q exit with error: %v", args, err)
+	}
 	for _, src := range srcDirs {
 		_, srcFile := filepath.Split(src)
 

--- a/pkg/cp/cp.go
+++ b/pkg/cp/cp.go
@@ -108,7 +108,7 @@ func copyFile(src, dst string, srcInfo os.FileInfo) error {
 	m := srcInfo.Mode()
 	switch {
 	case m.IsDir():
-		return os.Mkdir(dst, srcInfo.Mode().Perm())
+		return os.MkdirAll(dst, srcInfo.Mode().Perm())
 
 	case m.IsRegular():
 		return copyRegularFile(src, dst, srcInfo)


### PR DESCRIPTION
currently, given:
a/b/c
and
d/b/

cp -R a/ d/ will error when doing a recursive copy since d/b exists

use os.MkdirAll, not os.Mkdir

Fixes #1923

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>