### PR TITLE
Differentiate between including files with and without ldd dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ option in for example Grub or the QEMU command line or coreboot config variable.
 
 ## Extra Files
 
-You may also include additional files in the initramfs using the `-files` flag.
-If you add binaries with `-files` are listed, their ldd dependencies will be
+You may also include additional files in the initramfs using one or both of the
+`-files` or `-lddfiles` flags.
+
+If you add binaries with `-lddfiles`, their ldd dependencies will be
 included as well. As example for Debian, you want to add two kernel modules for
 testing, executing your currently booted kernel:
 

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -146,7 +146,7 @@ type Opts struct {
 	// TempDir is a temporary directory for builders to store files in.
 	TempDir string
 
-	// ExtraFilesInstall are files to install to the archive in addition to
+	// ExtraFilesLdd are files to install to the archive in addition to
 	// the Go packages.
 	//
 	// Shared library dependencies will automatically also be added to the
@@ -158,9 +158,9 @@ type Opts struct {
 	//     /home/chrisko/foo on the host at the relative root/bar in the
 	//     archive.
 	//   - "/home/foo" is equivalent to "/home/foo:home/foo".
-	ExtraFilesInstall []string
+	ExtraFilesLdd []string
 
-	// ExtraFilesInclude are files to include in the archive in addition to
+	// ExtraFilesNoLdd are files to include in the archive in addition to
 	// the Go packages.
 	//
 	// Shared library dependencies will NOT be added to the archive.
@@ -171,7 +171,7 @@ type Opts struct {
 	//     /home/chrisko/foo on the host at the relative root/bar in the
 	//     archive.
 	//   - "/home/foo" is equivalent to "/home/foo:home/foo".
-	ExtraFilesInclude []string
+	ExtraFilesNoLdd []string
 
 	// OutputFile is the archive output file.
 	OutputFile initramfs.Writer
@@ -272,11 +272,11 @@ func CreateInitramfs(logger ulog.Logger, opts Opts) error {
 		UseExistingInit: opts.UseExistingInit,
 	}
 	// Install extra binaries with their ldd dependencies
-	if err := ParseExtraFiles(logger, archive.Files, opts.ExtraFilesInstall, true); err != nil {
+	if err := ParseExtraFiles(logger, archive.Files, opts.ExtraFilesLdd, true); err != nil {
 		return err
 	}
 	// Include extra files/directories (don't check for ldd dependencies)
-	if err := ParseExtraFiles(logger, archive.Files, opts.ExtraFilesInclude, false); err != nil {
+	if err := ParseExtraFiles(logger, archive.Files, opts.ExtraFilesNoLdd, false); err != nil {
 		return err
 	}
 

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -146,7 +146,7 @@ type Opts struct {
 	// TempDir is a temporary directory for builders to store files in.
 	TempDir string
 
-	// ExtraFilesLdd are files to install to the archive in addition to
+	// ExtraFilesLdd are files to add to the archive in addition to
 	// the Go packages.
 	//
 	// Shared library dependencies will automatically also be added to the
@@ -160,7 +160,7 @@ type Opts struct {
 	//   - "/home/foo" is equivalent to "/home/foo:home/foo".
 	ExtraFilesLdd []string
 
-	// ExtraFilesNoLdd are files to include in the archive in addition to
+	// ExtraFilesNoLdd are files to add in the archive in addition to
 	// the Go packages.
 	//
 	// Shared library dependencies will NOT be added to the archive.

--- a/u-root.go
+++ b/u-root.go
@@ -44,7 +44,8 @@ var (
 	useExistingInit                         *bool
 	fourbins                                *bool
 	noCommands                              *bool
-	extraFiles                              multiFlag
+	extraFilesInstall                       multiFlag
+	extraFilesInclude                       multiFlag
 	noStrip                                 *bool
 	statsOutputPath                         *string
 	statsLabel                              *string
@@ -76,7 +77,8 @@ func init() {
 
 	noCommands = flag.Bool("nocmd", false, "Build no Go commands; initramfs only")
 
-	flag.Var(&extraFiles, "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be speficified multiple times.")
+	flag.Var(&extraFilesInstall, "install", "Additional binaries (with their ldd dependencies) to add to archive. Can be specified multiple times.")
+	flag.Var(&extraFilesInclude, "include", "Additional files/directories to add to archive (no ldd dependencies). Can be specified multiple times.")
 
 	noStrip = flag.Bool("no-strip", false, "Build unstripped binaries")
 	shellbang = flag.Bool("shellbang", false, "Use #! instead of symlinks for busybox")
@@ -307,16 +309,17 @@ func Main() error {
 	}
 
 	opts := uroot.Opts{
-		Env:             env,
-		Commands:        c,
-		TempDir:         tempDir,
-		ExtraFiles:      extraFiles,
-		OutputFile:      w,
-		BaseArchive:     baseFile,
-		UseExistingInit: *useExistingInit,
-		InitCmd:         initCommand,
-		DefaultShell:    *defaultShell,
-		NoStrip:         *noStrip,
+		Env:               env,
+		Commands:          c,
+		TempDir:           tempDir,
+		ExtraFilesInstall: extraFilesInstall,
+		ExtraFilesInclude: extraFilesInclude,
+		OutputFile:        w,
+		BaseArchive:       baseFile,
+		UseExistingInit:   *useExistingInit,
+		InitCmd:           initCommand,
+		DefaultShell:      *defaultShell,
+		NoStrip:           *noStrip,
 	}
 	uinitArgs := shlex.Argv(*uinitCmd)
 	if len(uinitArgs) > 0 {

--- a/u-root.go
+++ b/u-root.go
@@ -44,8 +44,8 @@ var (
 	useExistingInit                         *bool
 	fourbins                                *bool
 	noCommands                              *bool
-	extraFilesInstall                       multiFlag
-	extraFilesInclude                       multiFlag
+	extraFilesLdd                           multiFlag
+	extraFilesNoLdd                         multiFlag
 	noStrip                                 *bool
 	statsOutputPath                         *string
 	statsLabel                              *string
@@ -77,8 +77,8 @@ func init() {
 
 	noCommands = flag.Bool("nocmd", false, "Build no Go commands; initramfs only")
 
-	flag.Var(&extraFilesInstall, "install", "Additional binaries (with their ldd dependencies) to add to archive. Can be specified multiple times.")
-	flag.Var(&extraFilesInclude, "include", "Additional files/directories to add to archive (no ldd dependencies). Can be specified multiple times.")
+	flag.Var(&extraFilesLdd, "lddfiles", "Additional files, directories, and binaries (WITH their ldd dependencies) to add to archive. Can be speficified multiple times.")
+	flag.Var(&extraFilesNoLdd, "files", "Additional files, directories, and binaries (WITHOUT their ldd dependencies) to add to archive. Can be speficified multiple times.")
 
 	noStrip = flag.Bool("no-strip", false, "Build unstripped binaries")
 	shellbang = flag.Bool("shellbang", false, "Use #! instead of symlinks for busybox")
@@ -309,17 +309,17 @@ func Main() error {
 	}
 
 	opts := uroot.Opts{
-		Env:               env,
-		Commands:          c,
-		TempDir:           tempDir,
-		ExtraFilesInstall: extraFilesInstall,
-		ExtraFilesInclude: extraFilesInclude,
-		OutputFile:        w,
-		BaseArchive:       baseFile,
-		UseExistingInit:   *useExistingInit,
-		InitCmd:           initCommand,
-		DefaultShell:      *defaultShell,
-		NoStrip:           *noStrip,
+		Env:             env,
+		Commands:        c,
+		TempDir:         tempDir,
+		ExtraFilesLdd:   extraFilesLdd,
+		ExtraFilesNoLdd: extraFilesNoLdd,
+		OutputFile:      w,
+		BaseArchive:     baseFile,
+		UseExistingInit: *useExistingInit,
+		InitCmd:         initCommand,
+		DefaultShell:    *defaultShell,
+		NoStrip:         *noStrip,
 	}
 	uinitArgs := shlex.Argv(*uinitCmd)
 	if len(uinitArgs) > 0 {


### PR DESCRIPTION
Fixes #1919.

The `-files` flag will include the link dependencies of ELF binaries it encounters by default, and there is no way to turn this off for use cases such as building BusyBox outside of u-root, e.g., using [gobusybox](https://github.com/u-root/gobusybox).

This PR modifies the behavior of `-files` to _not_ look for ldd dependencies, and adds the `-lddfiles` flag which behaves exactly as the current `-files` flag does, i.e., including files with their ldd dependencies.