### PR TITLE
ls: when provided with directory names, respect quote flag

### DIFF
--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -55,7 +55,11 @@ func listName(stringer ls.Stringer, d string, w io.Writer, prefix bool) error {
 			if osfi.IsDir() {
 				fi.Name = "."
 				if prefix {
-					fmt.Printf("%q\n", d)
+					if *quoted {
+						fmt.Fprintf(w, "%q:\n", d)
+					} else {
+						fmt.Fprintf(w, "%v:\n", d)
+					}
 				}
 			}
 		}

--- a/cmds/core/ls/ls_test.go
+++ b/cmds/core/ls/ls_test.go
@@ -58,6 +58,13 @@ f1
 f2
 f3?line 2
 `,
+	}, {
+		flags: []string{"f1", "d1", "f2"},
+		out: `f1
+d1:
+f4
+f2
+`,
 	},
 }
 


### PR DESCRIPTION
If ls is given a directory as an argument, it always puts the directory name in quotes.  It should instead respect the Q flag.

Signed-off-by: Graham MacDonald <grahamamacdonald@gmail.com>