### PR TITLE
pci: Fix flaky test

### DIFF
--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -36,6 +36,8 @@ func TestBusReader(t *testing.T) {
 	if len(n.(*bus).Devices) == 0 {
 		t.Fatal("got 0 devices, want at least 1")
 	}
+
+	// A single read should be okay.
 	d, err := n.Read()
 	if err != nil {
 		t.Fatal(err)
@@ -43,6 +45,7 @@ func TestBusReader(t *testing.T) {
 	if len(n.(*bus).Devices) != len(d) {
 		t.Fatalf("Got %d devices, wanted %d", len(d), len(n.(*bus).Devices))
 	}
+
 	// Multiple reads should be ok
 	d, err = n.Read()
 	if err != nil {
@@ -51,20 +54,26 @@ func TestBusReader(t *testing.T) {
 	if len(n.(*bus).Devices) != len(d) {
 		t.Fatalf("Got %d devices, wanted %d", len(d), len(n.(*bus).Devices))
 	}
-	// Filter by vendor and dev id.
+
+	// We are going to partition the set into devices which match and
+	// devices which don't match ven:dev.
 	ven, dev := d[0].Vendor, d[0].Device
-	d, err = n.Read(func(p *PCI) bool {
-		if p.Vendor == ven && p.Device == dev {
-			return false
-		}
-		return true
+
+	matches, err := n.Read(func(p *PCI) bool {
+		return p.Vendor == ven && p.Device == dev
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	// That should filter just one thing.
-	if len(n.(*bus).Devices)-1 != len(d) {
-		t.Fatalf("Got %d devices, wanted %d", len(d), len(n.(*bus).Devices)-1)
+	notMatches, err := n.Read(func(p *PCI) bool {
+		return !(p.Vendor == ven && p.Device == dev)
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 
+	// Check that the partitions add up.
+	if len(matches)+len(notMatches) != len(n.(*bus).Devices) {
+		t.Fatalf("Got %d+%d devices, wanted %d", len(matches), len(notMatches), len(n.(*bus).Devices))
+	}
 }


### PR DESCRIPTION
The test is flaky because it assumed the machine you ran it on had no
two pcie devices which matching vendor and device id.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>