### PR TITLE
Add standalone kconf cmd, add ver and cfg subcommands to bzimage

### DIFF
--- a/cmds/exp/bzimage/bzimage.go
+++ b/cmds/exp/bzimage/bzimage.go
@@ -13,6 +13,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -53,6 +54,7 @@ bzimage cfg <image>
 flags:`
 
 var debug = flag.BoolP("debug", "d", false, "enable debug printing")
+var jsonOut = flag.BoolP("json", "j", false, "json output ('ver' subcommand only)")
 
 func usage() {
 	fmt.Fprintln(os.Stderr, cmdUsage)
@@ -173,7 +175,19 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		fmt.Println(br.KVer())
+		if *jsonOut {
+			info, err := bzimage.ParseDesc(v)
+			if err != nil {
+				log.Fatal(err)
+			}
+			j, err := json.MarshalIndent(info, "", "    ")
+			if err != nil {
+				log.Fatal(err)
+			}
+			fmt.Println(string(j))
+		} else {
+			fmt.Println(v)
+		}
 	case "cfg":
 		cfg, err := br.ReadConfig()
 		if err != nil {

--- a/cmds/exp/bzimage/bzimage.go
+++ b/cmds/exp/bzimage/bzimage.go
@@ -29,6 +29,8 @@ var argcounts = map[string]int{
 	"dump":      2,
 	"initramfs": 4,
 	"extract":   3,
+	"ver":       2,
+	"cfg":       2,
 }
 
 const cmdUsage = `Performs various operations on kernel images. Usage:
@@ -43,6 +45,10 @@ bzimage dump <file>
     Dumps header.
 bzimage initramfs <input-bzimage> <new-initramfs> <output-bzimage>
 	Replaces initramfs in input-bzimage, creating output-bzimage.
+bzimage ver <image>
+	Dump version info similar to 'file <image>'.
+bzimage cfg <image>
+	Dump embedded config.
 
 flags:`
 
@@ -73,10 +79,10 @@ func main() {
 	var br = &bzimage.BzImage{}
 	var image []byte
 	switch a[0] {
-	case "diff", "dump":
+	case "diff", "dump", "ver":
 		br.NoDecompress = true
 		fallthrough
-	case "copy", "initramfs", "extract":
+	case "copy", "initramfs", "extract", "cfg":
 		var err error
 		image, err = ioutil.ReadFile(a[1])
 		if err != nil {
@@ -162,5 +168,13 @@ func main() {
 		if err := ioutil.WriteFile(a[3], b, 0644); err != nil {
 			log.Fatal(err)
 		}
+	case "ver":
+		fmt.Println(br.KVer())
+	case "cfg":
+		cfg, err := br.ReadConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Printf("%s\n", cfg)
 	}
 }

--- a/cmds/exp/bzimage/bzimage.go
+++ b/cmds/exp/bzimage/bzimage.go
@@ -169,6 +169,10 @@ func main() {
 			log.Fatal(err)
 		}
 	case "ver":
+		v, err := br.KVer()
+		if err != nil {
+			log.Fatal(err)
+		}
 		fmt.Println(br.KVer())
 	case "cfg":
 		cfg, err := br.ReadConfig()

--- a/cmds/exp/bzimage/bzimage_test.go
+++ b/cmds/exp/bzimage/bzimage_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -91,7 +92,19 @@ var (
 			HandoverOffset:      0x00,
 		},
 	}
-	uskip = len("2018/08/10 21:20:42 ")
+	uskip   = len("2018/08/10 21:20:42 ")
+	jsonVer = `{
+	"Release": "4.12.7",
+	"Version": "#6 Fri Aug 10 14:47:18 PDT 2018",
+	"Builder": "rminnich@uroot",
+	"BuildNum": 6,
+	"BuildTime": "2018-08-10T14:47:18Z",
+	"Maj": 4,
+	"Min": 12,
+	"Patch": 7,
+	"LocalVer": ""
+}
+`
 )
 
 func TestSimple(t *testing.T) {
@@ -169,6 +182,18 @@ func TestSimple(t *testing.T) {
 			status: 1,
 			out:    "open b: no such file or directory\n",
 			skip:   uskip,
+		},
+		{
+			args:   []string{"ver", "bzImage"},
+			name:   "kernel version",
+			status: 0,
+			out:    "4.12.7 (rminnich@uroot) #6 Fri Aug 10 14:47:18 PDT 2018\n",
+		},
+		{
+			args:   []string{"-j", "ver", "bzImage"},
+			name:   "kernel version, json",
+			status: 0,
+			out:    strings.ReplaceAll(jsonVer, "\t", "    "),
 		},
 	}
 

--- a/cmds/exp/kconf/kconf.go
+++ b/cmds/exp/kconf/kconf.go
@@ -1,0 +1,104 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"flag"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/u-root/u-root/pkg/boot/bzimage"
+)
+
+const (
+	cfgfile = "/proc/config.gz"
+	notset  = "is not set"
+)
+
+func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Reads kernel config from /proc/config.gz or bzimage, optionally filtering\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage: %s [-k /path/to/bzimage] [-y|-m|-n] [-f filterstr]\n", os.Args[0])
+		flag.PrintDefaults()
+	}
+	y := flag.Bool("y", false, "show only built-in")
+	m := flag.Bool("m", false, "show only modules")
+	n := flag.Bool("n", false, "show only not configured")
+	f := flag.String("f", "", "filter on config symbol, case insensitive")
+	p := flag.Bool("p", true, "pretty: trim prefix; also suffix if -y/-m/-n")
+	k := flag.String("k", "", "use kernel image rather than /proc/config.gz")
+	flag.Parse()
+
+	var cfgIn io.Reader
+	if len(*k) > 0 {
+		image, err := ioutil.ReadFile(*k)
+		if err != nil {
+			log.Fatal(err)
+		}
+		br := &bzimage.BzImage{}
+		if err = br.UnmarshalBinary(image); err != nil {
+			log.Fatal(err)
+		}
+		cfg, err := br.ReadConfig()
+		if err != nil {
+			log.Fatal(err)
+		}
+		cfgIn = strings.NewReader(cfg)
+	} else {
+		configgz, err := os.Open(cfgfile)
+		if err != nil {
+			log.Fatalf("cannot open %s: %s", cfgfile, err)
+		}
+		defer configgz.Close()
+		gz, err := gzip.NewReader(configgz)
+		if err != nil {
+			log.Fatalf("decompress %s: %s", cfgfile, err)
+		}
+		defer gz.Close()
+		cfgIn = gz
+	}
+	filter := strings.ToUpper(*f)
+	scanner := bufio.NewScanner(cfgIn)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if *y && !strings.HasSuffix(line, "=y") {
+			continue
+		}
+		if *m && !strings.HasSuffix(line, "=m") {
+			continue
+		}
+		if *n && !strings.HasSuffix(line, notset) {
+			continue
+		}
+		if len(filter) > 0 && !strings.Contains(line, filter) {
+			continue
+		}
+		if *p {
+			if *n {
+				line = strings.TrimPrefix(line, "# ")
+			}
+			line = strings.TrimPrefix(line, "CONFIG_")
+			if *y || *m {
+				line = strings.Split(line, "=")[0]
+			}
+			if *n {
+				line = strings.TrimSuffix(line, notset)
+			}
+		}
+		fmt.Println(line)
+	}
+	if err := scanner.Err(); err != nil && err != io.EOF {
+		log.Fatalf("reading %s: %s", cfgfile, err)
+	}
+}

--- a/pkg/boot/bzimage/header.go
+++ b/pkg/boot/bzimage/header.go
@@ -7,6 +7,7 @@ package bzimage
 // These are the semi-documented things that define a bzImage
 // Thanks to coreboot for documenting the basic layout.
 
+// E820 types.
 const (
 	RAM      e820type = 1
 	Reserved e820type = 2
@@ -14,6 +15,7 @@ const (
 	NVS      e820type = 4
 )
 
+// Boot types.
 const (
 	NotSet    boottype = 0
 	LoadLin   boottype = 1
@@ -23,6 +25,7 @@ const (
 	Kernel    boottype = 5
 )
 
+//Offsets and magic values.
 const (
 	RamdiskStartMask = 0x07FF
 	Prompt           = 0x8000
@@ -44,12 +47,14 @@ const (
  * EDD stuff
  */
 
+// EDD consts.
 const (
 	EDDMBRSigMax       = 16
 	EDDMaxNR           = 6 /* number of edd_info structs starting at EDDBUF  */
 	EDDDeviceParamSize = 74
 )
 
+// EDDExt consts.
 const (
 	EDDExtFixedDiskAccess = 1 << iota
 	EDDExtDeviceLockingAndEjecting
@@ -57,6 +62,7 @@ const (
 	EDDExt64BitExtensions
 )
 
+// EDDInfo struct.
 type EDDInfo struct {
 	Device                uint8
 	Version               uint8
@@ -69,13 +75,15 @@ type EDDInfo struct {
 
 type e820type uint32
 type boottype uint8
+
+// E820Entry is one e820 entry.
 type E820Entry struct {
 	Addr    uint64
 	Size    uint64
 	MemType e820type
 }
 
-// The header of Linux/i386 kernel
+// LinuxHeader is the header of Linux/i386 kernel
 type LinuxHeader struct {
 	MBRCode         [0xc0]uint8         `offset:"0x000"`
 	ExtRamdiskImage uint32              `offset:"0xc0"`
@@ -132,7 +140,7 @@ type LinuxHeader struct {
 	HandoverOffset uint32 `offset:"0x264"`
 }
 
-// Parameters passed to 32-bit part of Linux
+// LinuxParams is parameters passed to the 32-bit part of Linux
 type LinuxParams struct {
 	Origx           uint8  `offset:"0x00"`
 	Origy           uint8  `offset:"0x01"`
@@ -207,7 +215,7 @@ type LinuxParams struct {
 	CmdLineSize         uint32               `offset:"0x238"`
 	HardwareSubarch     uint32               `offset:"0x23C"`
 	HardwareSubarchData uint64               `offset:"0x240"`
-	Payload_Ofset       uint32               `offset:"0x248"`
+	PayloadOffset       uint32               `offset:"0x248"`
 	PayloadLength       uint32               `offset:"0x24C"`
 	SetupData           uint64               `offset:"0x250"`
 	PrefAddress         uint64               `offset:"0x258"`
@@ -226,6 +234,7 @@ type LinuxParams struct {
 }
 
 var (
+	// LoaderType contains strings describing boot types.
 	LoaderType = map[boottype]string{
 		NotSet:    "Not set",
 		LoadLin:   "loadlin",
@@ -234,15 +243,18 @@ var (
 		EtherBoot: "etherboot",
 		Kernel:    "kernel (kexec)",
 	}
+	//E820 contains strings describing e820types.
 	E820 = map[e820type]string{
 		RAM:      "RAM",
 		Reserved: "Reserved",
 		ACPI:     "ACPI",
 		NVS:      "NVS",
 	}
+	// HeaderMagic is kernel header magic bytes.
 	HeaderMagic = [4]uint8{'H', 'd', 'r', 'S'}
 )
 
+// BzImage represents sections extracted from a kernel.
 type BzImage struct {
 	Header       LinuxHeader
 	BootCode     []byte

--- a/pkg/boot/bzimage/header.go
+++ b/pkg/boot/bzimage/header.go
@@ -252,4 +252,6 @@ type BzImage struct {
 	KernelBase   uintptr
 	KernelOffset uintptr
 	compressed   []byte
+	// Some operations don't need the decompressed code; this speeds them up significantly.
+	NoDecompress bool
 }

--- a/pkg/boot/bzimage/kver.go
+++ b/pkg/boot/bzimage/kver.go
@@ -72,23 +72,23 @@ func KVer(k io.ReadSeeker) (string, error) {
 	return nullterm(buf), nil
 }
 
-// KVer reads the kernel version string. See also: KVer()
-func (bz *BzImage) KVer() string {
+// KVer reads the kernel version string. See also: KVer() above.
+func (bz *BzImage) KVer() (string, error) {
 	if bz.Header.Kveraddr == 0 {
-		return ("(unknown)")
+		return "", ErrParse
 	}
 	start := uint64(bz.Header.Kveraddr + 0x200)
 	bclen := uint64(len(bz.BootCode))
 	hdrlen := uint64(bz.KernelOffset) - bclen
 	bcoffs := start - hdrlen
 	if bcoffs >= bclen {
-		return ("(unknown)")
+		return "", ErrParse
 	}
 	end := bcoffs + kverMax
 	if end > bclen {
 		end = bclen
 	}
-	return nullterm(bz.BootCode[bcoffs:end])
+	return nullterm(bz.BootCode[bcoffs:end]), nil
 }
 
 //read c string from buffer

--- a/pkg/boot/bzimage/kver.go
+++ b/pkg/boot/bzimage/kver.go
@@ -1,0 +1,193 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package bzimage
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+)
+
+/*
+values from kernel documentation and libmagic src
+
+off val
+510 0xAA55
+514 HdrS
+526	(4 bytes) != 0x0000
+526 (2 bytes, little endian) + 0x200 -> start of null-terminated version string
+*/
+
+const kverMax = 1024 //arbitrary
+
+var (
+	ErrBootSig = errors.New("missing 0x55AA boot sig")
+	ErrBadSig  = errors.New("missing kernel header sig")
+	ErrBadOff  = errors.New("null version string offset")
+	ErrParse   = errors.New("parse error")
+)
+
+//Read kernel version string. See also: (*BZImage)Kver()
+func KVer(k io.ReadSeeker) (string, error) {
+	var buf = make([]byte, kverMax)
+	_, err := k.Seek(0, io.SeekStart)
+	if err != nil {
+		return "", err
+	}
+	_, err = k.Read(buf[:530])
+	if err != nil {
+		return "", err
+	}
+	if !bytes.Equal(buf[510:512], []byte{0x55, 0xaa}) {
+		return "", ErrBootSig
+	}
+	if string(buf[514:518]) != "HdrS" {
+		return "", ErrBadSig
+	}
+	if bytes.Equal(buf[526:530], []byte{0, 0, 0, 0}) {
+		return "", ErrBadOff
+	}
+	off := int64(binary.LittleEndian.Uint16(buf[526:528])) + 0x200
+	_, err = k.Seek(off, io.SeekStart)
+	if err != nil {
+		return "", err
+	}
+	if _, err := k.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return nullterm(buf), nil
+}
+
+//Read kernel version string. See also: KVer()
+func (bz *BzImage) KVer() string {
+	if bz.Header.Kveraddr == 0 {
+		return ("(unknown)")
+	}
+	start := uint64(bz.Header.Kveraddr + 0x200)
+	bclen := uint64(len(bz.BootCode))
+	hdrlen := uint64(bz.KernelOffset) - bclen
+	bcoffs := start - hdrlen
+	if bcoffs >= bclen {
+		return ("(unknown)")
+	}
+	end := bcoffs + kverMax
+	if end > bclen {
+		end = bclen
+	}
+	return nullterm(bz.BootCode[bcoffs:end])
+}
+
+//read c string from buffer
+func nullterm(buf []byte) string {
+	var i int
+	var b byte
+	for i, b = range buf {
+		if b == 0 {
+			break
+		}
+	}
+	return string(buf[:i])
+}
+
+type KInfo struct {
+	//2.6.24.111 (bluebat@linux-vm-os64.site) #606 Mon Apr 14 00:06:11 CEST 2014
+	//4.19.16-norm_boot (user@host) #300 SMP Fri Jan 25 16:32:19 UTC 2019
+	//   release               (builder)                              version
+	//maj.min.patch-localver                                      #buildnum SMP buildtime
+	Release, Version string //uname -r, uname -v respectfully
+	Builder          string //user@hostname in parenthesis, shown by `file` but not `uname`
+
+	//the following are extracted from Release and Version
+
+	BuildNum        uint64    //#nnn in Version, 300 in example above
+	BuildTime       time.Time //from Version
+	Maj, Min, Patch uint64    //from Release
+	LocalVer        string    //from Release
+}
+
+func (l KInfo) Equal(r KInfo) bool {
+	return l.Release == r.Release &&
+		l.Builder == r.Builder &&
+		l.Version == r.Version &&
+		l.BuildNum == r.BuildNum &&
+		l.BuildTime.Equal(r.BuildTime) &&
+		l.Maj == r.Maj &&
+		l.Min == r.Min &&
+		l.Patch == r.Patch &&
+		l.LocalVer == r.LocalVer
+}
+
+const layout = "Mon Jan 2 15:04:05 MST 2006"
+
+//Parse output of GetKDesc
+func ParseDesc(desc string) (KInfo, error) {
+	var ki KInfo
+
+	//first split at #
+	split := strings.Split(desc, "#")
+	if len(split) != 2 {
+		return KInfo{}, fmt.Errorf("%w: %s: wrong number of '#' chars", ErrParse, desc)
+	}
+	ki.Version = "#" + split[1]
+
+	//now split first part into release and builder
+	elements := strings.SplitN(split[0], " ", 2)
+	if len(elements) > 2 {
+		return KInfo{}, fmt.Errorf("%w: %s: wrong number of spaces in release/builder", ErrParse, desc)
+	}
+	ki.Release = elements[0]
+	if len(elements) == 2 {
+		//not sure if this is _always_ present
+		ki.Builder = strings.Trim(elements[1], " ()")
+	}
+	//split build number off version
+	elements = strings.SplitN(split[1], " ", 2)
+	if len(elements) != 2 {
+		return KInfo{}, fmt.Errorf("%w: %s: wrong number of spaces in build/version", ErrParse, desc)
+	}
+	i, err := strconv.ParseUint(elements[0], 10, 64)
+	if err != nil {
+		return KInfo{}, fmt.Errorf("%s: bad uint %s: %w", desc, elements[0], err)
+	}
+	ki.BuildNum = i
+	//remove SMP if present
+	t := strings.TrimSpace(strings.TrimPrefix(elements[1], "SMP"))
+	//parse remainder as time, using reference time
+	ki.BuildTime, err = time.Parse(layout, t)
+	if err != nil {
+		return KInfo{}, fmt.Errorf("%s: bad time %s: %w", desc, t, err)
+	}
+	elements = strings.Split(ki.Release, ".")
+	if len(elements) < 3 {
+		return KInfo{}, fmt.Errorf("%w: %s: wrong number of dots in release %s", ErrParse, desc, ki.Release)
+	}
+	ki.Maj, err = strconv.ParseUint(elements[0], 10, 64)
+	if err != nil {
+		return KInfo{}, fmt.Errorf("%s: bad uint %s: %w", desc, elements[0], err)
+	}
+	ki.Min, err = strconv.ParseUint(elements[1], 10, 64)
+	if err != nil {
+		return KInfo{}, fmt.Errorf("%s: bad uint %s: %w", desc, elements[1], err)
+	}
+	elem := strings.SplitN(elements[2], "-", 2)
+	ki.Patch, err = strconv.ParseUint(elem[0], 10, 64)
+	if err != nil {
+		return KInfo{}, fmt.Errorf("%s: bad uint %s: %w", desc, elem[0], err)
+	}
+
+	elements = strings.SplitN(elements[len(elements)-1], "-", 2)
+	if len(elements) > 1 {
+		ki.LocalVer = elements[1]
+	}
+	return ki, nil
+}

--- a/pkg/boot/bzimage/kver_test.go
+++ b/pkg/boot/bzimage/kver_test.go
@@ -1,0 +1,126 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+//
+
+package bzimage
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+)
+
+const (
+	normboot = "4.19.16-norm_boot (user@host) #300 SMP Fri Jan 25 16:32:19 UTC 2019"
+	ancient  = "2.6.24.111 #606 Mon Apr 14 00:06:11 CEST 2014"
+)
+
+//func KVer(k io.ReadSeeker) (string, error)
+func TestKVer(t *testing.T) {
+	items := []bufItem{
+		{510, []byte{0x55, 0xaa}}, //boot sig
+		{514, []byte("HdrS")},     //kernel header
+		{526, []byte{0x58, 0x30}}, //add 0x200 for offset of null-terminated string
+		{12870, []byte("string starting.. " + normboot + "\000 end of str")},
+	}
+	f, err := sparseBuf(items)
+	if err != nil {
+		t.Fatal(err)
+	}
+	str, err := KVer(f)
+	if err != nil {
+		t.Error(err)
+	}
+	if str != normboot {
+		t.Errorf("want %s\n got %s", normboot, str)
+	}
+}
+
+type bufItem struct {
+	off  int
+	data []byte
+}
+
+//return buffer filled with random data, except for listed items
+func sparseBuf(items []bufItem) (io.ReadSeeker, error) {
+	//figure out where last byte will fall
+	var last int
+	for _, i := range items {
+		if len(i.data)+i.off > last {
+			last = len(i.data) + i.off
+		}
+	}
+	//make buffer a bit oversize
+	buf := make([]byte, last+64)
+	//write random data
+	rand.Read(buf)
+	//then write items
+	for _, i := range items {
+		copy(buf[i.off:], i.data)
+	}
+	return bytes.NewReader(buf), nil
+}
+
+//func ParseDesc(desc string) KInfo
+func TestParseDesc(t *testing.T) {
+	tmust := func(tm time.Time, err error) time.Time {
+		if err != nil {
+			t.Error(err)
+		}
+		return tm
+	}
+	testdata := []struct {
+		name, str string
+		want      KInfo
+	}{
+		{
+			name: "normboot",
+			str:  normboot,
+			want: KInfo{
+				Release:   "4.19.16-norm_boot",
+				Version:   "#300 SMP Fri Jan 25 16:32:19 UTC 2019",
+				Builder:   "user@host",
+				BuildNum:  300,
+				BuildTime: tmust(time.Parse(time.RFC3339, "2019-01-25T16:32:19Z")), //equivalent
+				Maj:       4,
+				Min:       19,
+				Patch:     16,
+				LocalVer:  "norm_boot",
+			},
+		},
+		{
+			name: "ancient",
+			str:  ancient,
+			want: KInfo{
+				Release:   "2.6.24.111",
+				Version:   "#606 Mon Apr 14 00:06:11 CEST 2014",
+				Builder:   "",
+				BuildNum:  606,
+				BuildTime: tmust(time.Parse(time.RFC3339, "2014-04-14T00:06:11Z")), //equivalent
+				Maj:       2,
+				Min:       6,
+				Patch:     24,
+				LocalVer:  "",
+			},
+		},
+	}
+	for _, td := range testdata {
+		t.Run(td.name, func(t *testing.T) {
+			ki, err := ParseDesc(td.str)
+			if err != nil {
+				t.Error(err)
+			}
+			if !ki.Equal(td.want) {
+				t.Error("mismatch")
+			}
+			if t.Failed() {
+				t.Logf("\nwant %#v\ngot  %#v", td.want, ki)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* `kconf`: Reads kernel config from /proc/config.gz or a bzimage, optionally filtering
* `bzimage cfg`: Dumps embedded config in a bzimage to stdout
* `bzimage ver`: Dumps version info to stdout, similar to `file <bzimage>`

I tried to improve `bzimage`'s help output for other commands; someone with more knowledge, please verify that I got them correct.

In addition to the commands above, I added  supporting functionality in `pkg/boot/bzimage`.