### PR TITLE
Make ls more compatible with Plan 9

### DIFF
--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -34,6 +34,7 @@ var (
 	human     = flag.BoolP("human-readable", "h", false, "human readable sizes")
 	directory = flag.BoolP("directory", "d", false, "list directories but not their contents")
 	long      = flag.BoolP("long", "l", false, "long form")
+	final     = flag.BoolP("print-last", "p", false, "Print only the final path element of each file name")
 	quoted    = flag.BoolP("quote-name", "Q", false, "quoted")
 	recurse   = flag.BoolP("recursive", "R", false, "equivalent to findutil's find")
 	classify  = flag.BoolP("classify", "F", false, "append indicator (one of */=>@|) to entries")

--- a/pkg/ls/fileinfo_plan9.go
+++ b/pkg/ls/fileinfo_plan9.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"syscall"
 	"time"
 
 	humanize "github.com/dustin/go-humanize"
@@ -39,15 +40,7 @@ func FromOSFileInfo(path string, fi os.FileInfo) FileInfo {
 		Name: fi.Name(),
 		Mode: fi.Mode(),
 		// Plan 9 UIDs from the file system are strings.
-		// os.FileInfo only allows ints.
-		// The Plan 9 runtime does not attach syscall.Dir to the Sys
-		// on FileInfo or there would be no problem.
-		// This is going to require some fixes to the Go runtime.
-		// os.FileInfo botched a few things.
-		// That said, it is a rare case that you could unpack a cpio
-		// in Plan 9 and set file ownership; that's not how it works.
-		// so ... bootes it is.
-		UID:   "bootes",
+		UID:   fi.Sys().(*syscall.Dir).Uid,
 		Size:  fi.Size(),
 		MTime: fi.ModTime(),
 	}


### PR DESCRIPTION
Now properly fetches & sets the username when listing files on Plan 9.

Also adds the -p flag, for compatibility with the Plan 9 script 'lc'. On
Plan 9, this says to only print the last component of the path, because
by default if you say `ls /tmp` you'll see `/tmp/foo`, `/tmp/bar` etc.;
setting -p will show you `foo`, `bar`. The latter behavior is the default
on u-root ls at this time, so no other changes are needed.

Signed-off-by: John Floren <john@jfloren.net>