### PR TITLE
Remove "+build ignore" from test command

### DIFF
--- a/cmds/core/cpio/testdata/dir-hard-link.go
+++ b/cmds/core/cpio/testdata/dir-hard-link.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build ignore
-
 // This program was used to generate dir-hard-link.cpio, which is
 // an archive containing two directories with the same inode (0).
 // Depending on how the cpio package generates inodes in the future,


### PR DESCRIPTION
We want to make sure the command still builds in the CI.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>