### PR TITLE
pox: Add self-executing pox archive

### DIFF
--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -1,91 +1,91 @@
-// Copyright 2012-2018 the u-root Authors. All rights reserved
+// Copyright 2012-2021 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// pox builds a portable executable as a squashfs image.
-// It is intended to create files compatible with tinycore
-// tcz files. One of more of the files can be programs
-// but that is not required.
-// This could have been a simple program but mksquashfs does not
-// preserve path information.
-// Yeah.
+// pox packages dynamic executable into an archive.
 //
 // Synopsis:
-//     pox [-[-debug]|d] [-[-file]|f tcz-file] -[-create]|c FILE [...FILE]
-//     pox [-[-debug]|d] [-[-file]|f tcz-file] -[-run|r] PROGRAM -- [...ARGS]
-//     pox [-[-debug]|d] [-[-file]|f tcz-file] -[-create]|c -[-run|r] PROGRAM -- [...ARGS]
+//     pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-create]|c FILE [...FILE]
+//     pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-run|r] PROGRAM -- [...ARGS]
+//     pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-create]|c -[-run|r] PROGRAM -- [...ARGS]
 //
 // Description:
-//     pox makes portable executables in squashfs format compatible with
-//     tcz format. We don't build in the execution code, rather, we set it
-//     up so we can use the command itself. You can either create the TCZ image
-//     or run a command within an image that was previously created.
+//     pox packages a dynamic executable into an archive for use on another
+//     machine. By default, it uses the tcz format compatible with tinycore.
+//
+//     pox supports 3 archive formats:
+//     1) squashfs (default): The tcz is a squashfs. This requires mksquashfs.
+//     2) zip
+//     3) elf+zip: Self-extracting.
 //
 // Options:
-//     debug|d: verbose
-//     file|f file: file name (default /tmp/pox.tcz)
+//     create|c: create the TCZ file.
+//     verbose|d: verbose
+//     file|f FILE: file name (default /tmp/pox.tcz)
 //     run|r: Runs the first non-flag argument to pox.  Remaining arguments will
 //            be passed to the program.  Use '--' before any flag-like arguments
 //            to prevent pox from interpretting the flags.
-//     create|c: create the TCZ file.
-//     zip|z: Use zip and unzip instead of a loopback mounted squashfs.  Be sure
+//     self|s: Create a self-extracting elf. This implies -z.
+//     zip|z: Use zip and unzip instead of a loopback mounted squashfs. Be sure
 //            to use -z for both creation and running, or not at all.
 //     For convenience and testing, you can create and run a pox in one command.
 //
 // Example:
-//	$ pox -c /bin/bash /bin/cat /bin/ls /etc/hosts
-//	Will build a squashfs, which will be /tmp/pox.tcz
+//     $ pox -c /bin/bash /bin/cat /bin/ls /etc/hosts
+//     Will build a squashfs, which will be /tmp/pox.tcz
 //
-//	$ sudo pox -r /bin/bash
-//	Will drop you into the /tmp/pox.tcz running bash
-//	You can use ls and cat on /etc/hosts.
+//     $ sudo pox -r /bin/bash
+//     Will drop you into the /tmp/pox.tcz running bash
+//     You can use ls and cat on /etc/hosts.
 //
-//	Simpler example, with arguments:
-//	$ sudo pox -r /bin/ls -- -la
-//	will run `ls -la` and exit.
+//     Simpler example, with arguments:
+//     $ sudo pox -r /bin/ls -- -la
+//     will run `ls -la` and exit.
 //
-//	$ sudo pox -r -- /bin/ls -la
-//	Syntactically easier: the program name can come after '--'
+//     $ sudo pox -r -- /bin/ls -la
+//     Syntactically easier: the program name can come after '--'
 //
-//	$ sudo pox -c -r /bin/bash
-//      Create a pox with a bash and run it.
+//     $ sudo pox -c -r /bin/bash
+//     Create a pox with a bash and run it.
+//
+//     $ pox -cvsf date /bin/date
+//     Creates a self-executing pox called "date".
+//     $ ./date --utc
 //
 // Notes:
-// - When running a pox, you likely need sudo to chroot
+//     - When running a pox, you likely need sudo to chroot
 //
-// - Binaries run out of a chroot often need files you are unaware of.  For
-// instance, if bash can't find terminfo files, it won't know to handle
-// backspaces properly.  (They occur, but are not shown).  To fix this, pass pox
-// all of the files you need.  For bash: `find /lib/terminfo -type f`.
+//     - Binaries run out of a chroot often need files you are unaware of. For
+//     instance, if bash can't find terminfo files, it won't know to handle
+//     backspaces properly. (They occur, but are not shown). To fix this, pass
+//     pox all of the files you need.  For bash: `find /lib/terminfo -type f`.
 //
-// Other programs rely on help functions, such as '/bin/man'.  If your program
-// has built-in help commands that trigger man pages, e.g. "git help foo",
-// you'll want to include /bin/man too.  But you'll also need everything that
-// man uses, such as /etc/manpath.config.  My advice: skip it.
+//     - Other programs rely on helper functions, such as '/bin/man'. If your
+//     program has built-in help commands that trigger man pages, e.g. "git
+//     help foo", you'll want to include /bin/man too. But you'll also need
+//     everything that man uses, such as /etc/manpath.config. My advice: skip
+//     it.
 //
-// - When adding all files in a directory, the easiest thing to do is:
-// `find $DIR -type f`  (Note the ticks: this is a bash command execution).
+//     - When adding all files in a directory, the easiest thing to do is:
+//     `find $DIR -type f` (Note the ticks: this is a bash command execution).
 //
-// - When creating a pox with an executable with shared libraries that are not
-// installed on your system, such as for a project installed in your home
-// directory, run pox from the installation prefix directory, such that the
-// lib/ and bin/ are in pox's working directory.  Pox will strip its working
-// directory from the paths of the files it builds.  Having bin/ in the root of
-// the pox file helps with PATH lookups, and not having the full path from your
-// machine in the pox file makes it easier to extract a pox file to /usr/local/.
+//     - When creating a pox with an executable with shared libraries that are
+//     not installed on your system, such as for a project installed in your
+//     home directory, run pox from the installation prefix directory, such
+//     that the lib/ and bin/ are in pox's working directory. Pox will strip
+//     its working directory from the paths of the files it builds. Having bin/
+//     in the root of the pox file helps with PATH lookups, and not having the
+//     full path from your machine in the pox file makes it easier to extract a
+//     pox file to /usr/local/.
 //
-// - Consider adding a --extract | -x option to install to the host.  One issue
-// would be how to handle collisions, e.g. libc.  Your app may not like the libc
-// on the system you run on.
-//
-// - pox is not a security boundary. chroot is well known to have holes. Pox is about
-//   enabling execution. Don't expect it to "wall things off". In fact, we mount
-//   /dev, /proc, and /sys; and you can add more things. Commands run under pox
-//   are just as dangerous as anything else.
-//
+//     - pox is not a security boundary. chroot is well known to have holes.
+//     Pox is about enabling execution. Don't expect it to "wall things off".
+//     In fact, we mount /dev, /proc, and /sys; and you can add more things.
+//     Commands run under pox are just as dangerous as anything else.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -93,17 +93,19 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"syscall"
 
 	flag "github.com/spf13/pflag"
+	"github.com/u-root/u-root/pkg/cp"
 	"github.com/u-root/u-root/pkg/ldd"
 	"github.com/u-root/u-root/pkg/mount"
 	"github.com/u-root/u-root/pkg/mount/loop"
 	"github.com/u-root/u-root/pkg/uzip"
 )
 
-const usage = "pox [-[-debug]|d] -[-run|r] | -[-create]|c  [-[-file]|f tcz-file] file [...file]"
+const usage = "pox [-[-verbose]|v] -[-run|r] | -[-create]|c  [-[-file]|f tcz-file] file [...file]"
 
 type mp struct {
 	source string
@@ -115,15 +117,17 @@ type mp struct {
 }
 
 var (
-	debug  = flag.BoolP("debug", "d", false, "enable debug prints")
-	run    = flag.BoolP("run", "r", false, "Run the first file argument")
-	create = flag.BoolP("create", "c", false, "create it")
-	zip    = flag.BoolP("zip", "z", false, "use zip instead of squashfs")
-	file   = flag.StringP("output", "f", "/tmp/pox.tcz", "Output file")
-	extra  = flag.StringP("extra", "e", "", `comma-separated list of extra directories to add (on create) and binds to do (on run).
+	verbose = flag.BoolP("verbose", "v", false, "enable verbose prints")
+	run     = flag.BoolP("run", "r", false, "Run the first file argument")
+	create  = flag.BoolP("create", "c", false, "create it")
+	zip     = flag.BoolP("zip", "z", false, "use zip instead of squashfs")
+	self    = flag.BoolP("self", "s", false, "use self-extracting zip")
+	file    = flag.StringP("output", "f", "/tmp/pox.tcz", "Output file")
+	extra   = flag.StringP("extra", "e", "", `comma-separated list of extra directories to add (on create) and binds to do (on run).
 You can specify what directories to add, and when you run, specify what directories are bound over them, e.g.:
 pox -c -e /tmp,/etc commands ....
 pox -r -e /a/b/c/tmp:/tmp,/etc:/etc commands ...
+This can also be passed in with the POX_EXTRA variable.
 `)
 	v = func(string, ...interface{}) {}
 )
@@ -147,23 +151,21 @@ func poxCreate(bin ...string) error {
 		if eerr, ok := err.(*exec.ExitError); ok {
 			stderr = eerr.Stderr
 		}
-		return fmt.Errorf("Running ldd on %v: %v %s", bin, err, stderr)
+		return fmt.Errorf("running ldd on %v: %v %s", bin, err, stderr)
 	}
 
 	var names []string
 	for _, dep := range l {
-		v("%s", dep.FullName)
 		names = append(names, dep.FullName)
 	}
+	sort.Strings(names)
 	// Now we need to make a template file hierarchy and put
 	// the stuff we want in there.
 	dir, err := ioutil.TempDir("", "pox")
 	if err != nil {
 		return err
 	}
-	if !*debug {
-		defer os.RemoveAll(dir)
-	}
+	defer os.RemoveAll(dir)
 	pwd, err := os.Getwd()
 	if err != nil {
 		return err
@@ -171,7 +173,7 @@ func poxCreate(bin ...string) error {
 	// We don't use defer() here to close files as
 	// that can cause open failures with a large enough number.
 	for _, f := range names {
-		v("Process %v", f)
+		v("Adding %q", f)
 		fi, err := os.Stat(f)
 		if err != nil {
 			return err
@@ -199,36 +201,46 @@ func poxCreate(bin ...string) error {
 		if err != nil {
 			return err
 		}
-
 	}
+
 	for _, m := range chrootMounts {
 		d := filepath.Join(dir, m.target)
-		v("Mounts: create %q, perm %s", d, m.perm.String())
+		v("Adding mount %q, perm %s", d, m.perm.String())
 		if err := os.MkdirAll(d, m.perm); err != nil {
 			return err
 		}
 	}
-	err = os.Remove(*file)
-	if err != nil && !os.IsNotExist(err) {
+	if err := os.Remove(*file); err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	if *zip {
-		err = uzip.ToZip(dir, *file)
+	if *self {
+		// Make a copy of the exe and append the zip file.
+		exe, err := os.Executable()
+		if err != nil {
+			return err
+		}
+		if err := cp.Copy(exe, *file); err != nil {
+			return err
+		}
+		if err := uzip.AppendZip(dir, *file, bin[0]); err != nil {
+			return err
+		}
+	} else if *zip {
+		if err := uzip.ToZip(dir, *file, ""); err != nil {
+			return err
+		}
 	} else {
 		c := exec.Command("mksquashfs", dir, *file, "-noappend")
-		o, cerr := c.CombinedOutput()
+		o, err := c.CombinedOutput()
 		v("%v", string(o))
-		if cerr != nil {
-			err = fmt.Errorf("%v: %v: %v", c.Args, string(o), cerr)
+		if err != nil {
+			return fmt.Errorf("%v: %v: %v", c.Args, string(o), err)
 		}
 	}
 
-	if err == nil {
-		v("Done, your pox is in %v", *file)
-	}
-
-	return err
+	v("Done, your pox is %q", *file)
+	return nil
 }
 
 func poxRun(args ...string) error {
@@ -238,9 +250,6 @@ func poxRun(args ...string) error {
 	dir, err := ioutil.TempDir("", "pox")
 	if err != nil {
 		return err
-	}
-	if !*debug {
-		defer os.RemoveAll(dir)
 	}
 
 	if *zip {
@@ -291,13 +300,13 @@ func poxRun(args ...string) error {
 	return nil
 }
 
-func extraMounts() error {
-	if *extra == "" {
+func extraMounts(mountList string) error {
+	if mountList == "" {
 		return nil
 	}
-	v("Extra: %q", *extra)
+	v("Extra mounts: %q", mountList)
 	// We have to specify the extra directories and do the create here b/c it is a squashfs. Sorry.
-	for _, e := range strings.Split(*extra, ",") {
+	for _, e := range strings.Split(mountList, ",") {
 		m := mp{flags: mount.MS_BIND, perm: 0755}
 		mp := strings.Split(e, ":")
 		switch len(mp) {
@@ -306,20 +315,42 @@ func extraMounts() error {
 		case 2:
 			m.source, m.target = mp[0], mp[1]
 		default:
-			return fmt.Errorf("-extra: argument (%v) is not in the form src:target", mp)
+			return fmt.Errorf("%q is not in the form src:target", mp)
 		}
-		v("Extra: append %q to chrootMounts", m)
+		v("Extra mounts: append %q to chrootMounts", m)
 		chrootMounts = append(chrootMounts, m)
 	}
 	return nil
 }
 
 func pox() error {
+	// If the current executable is a zip file, extract and run.
+	// Sneakily re-write os.Args to include a "-rzf" before flag parsing.
+	// The zip comment contains the executable path once extracted.
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	if comment, err := uzip.Comment(exe); err == nil {
+		if comment == "" {
+			return errors.New("expected zip comment on self-extracting pox")
+		}
+		os.Args = append([]string{
+			os.Args[0],
+			"-rzf", exe,
+			"--",
+			comment,
+		}, os.Args[1:]...)
+	}
+
 	flag.Parse()
-	if *debug {
+	if *verbose {
 		v = log.Printf
 	}
-	if err := extraMounts(); err != nil {
+	if err := extraMounts(*extra); err != nil {
+		return err
+	}
+	if err := extraMounts(os.Getenv("POX_EXTRA")); err != nil {
 		return err
 	}
 	if !*create && !*run {

--- a/pkg/boot/stboot/bootball.go
+++ b/pkg/boot/stboot/bootball.go
@@ -151,7 +151,7 @@ func (ball *BootBall) Pack() error {
 	if ball.Archive == "" || ball.dir == "" {
 		return errors.New("BootBall.Pacstandak: booball.archive and bootball.dir must be set")
 	}
-	return uzip.ToZip(ball.dir, ball.Archive)
+	return uzip.ToZip(ball.dir, ball.Archive, "")
 }
 
 // Dir returns the temporary directory associated with BootBall.

--- a/pkg/uzip/uzip_test.go
+++ b/pkg/uzip/uzip_test.go
@@ -20,7 +20,7 @@ func TestFromZip(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	f := filepath.Join(tmpDir, "test.zip")
-	err = ToZip("testdata/testFolder", f)
+	err = ToZip("testdata/testFolder", f, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The generated archive can now execute itself:

    $ pox -cvsf date /bin/date
    Creates a self-executing pox called "date".
    $ ./date --utc

The archive is simultaneously an elf file and zip file:

    $ file date
    date: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked
    $ unzip -z date
    Archive:  date
    /bin/date
      Length      Date    Time    Name
    ---------  ---------- -----   ----
            0  2021-03-02 08:07   /bin/
       113864  2021-03-02 08:07   /bin/date
            0  2021-03-02 08:07   /dev/
            0  2021-03-02 08:07   /lib/
	    ... elided ...
    ---------                     -------
      4149104                     12 files

The trick is zip files place their header at the end of the file, while
elf files place theirs at the beginning. The zip file has a special
piece of metadata called the "comment" we use to store the path to the
binary to execute by default.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>