### PR TITLE
README: Go >= 1.13 is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ u-root embodies four different projects.
 
 # Usage
 
-Make sure your Go version is 1.13. Make sure your `GOPATH` is set up correctly.
+Make sure your Go version is >=1.13. Make sure your `GOPATH` is set up
+correctly.
 While u-root uses Go modules, it still vendors dependencies and builds with
 `GO111MODULE=off`.
 


### PR DESCRIPTION
As reported in
https://github.com/u-root/u-root/issues/1954#issuecomment-790491114,
using 1.13 isn't required, but anything >= 1.13 should do.