### PR TITLE
pkg/ipmi/ocp: Set current speed instead of max speed for OEM set proc…

### DIFF
--- a/pkg/ipmi/ocp/ocp.go
+++ b/pkg/ipmi/ocp/ocp.go
@@ -191,8 +191,8 @@ func GetOemIpmiProcessorInfo(si *smbios.Info) ([]ProcessorInfo, error) {
 		info[index].CoreNumber = uint8(t4[index].GetCoreCount())
 		info[index].ThreadNumberLSB = uint8(t4[index].GetThreadCount() & 0x00ff)
 		info[index].ThreadNumberMSB = uint8(t4[index].GetThreadCount() >> 8)
-		info[index].ProcessorFrequencyLSB = uint8(t4[index].MaxSpeed & 0x00ff)
-		info[index].ProcessorFrequencyMSB = uint8(t4[index].MaxSpeed >> 8)
+		info[index].ProcessorFrequencyLSB = uint8(t4[index].CurrentSpeed & 0x00ff)
+		info[index].ProcessorFrequencyMSB = uint8(t4[index].CurrentSpeed >> 8)
 		info[index].Revision1 = 0
 		info[index].Revision2 = 0
 	}


### PR DESCRIPTION
…essor info command

To align with UEFI BIOS implementation.

Signed-off-by: JingleHsuWiwynn <jingle_hsu@wiwynn.com>