### PR TITLE
Add more info when init is missing

### DIFF
--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -280,7 +280,7 @@ func CreateInitramfs(logger ulog.Logger, opts Opts) error {
 		}
 	}
 	if err := opts.addSymlinkTo(logger, archive, opts.InitCmd, "init"); err != nil {
-		return fmt.Errorf("%v: specify -initcmd=\"\" to ignore this error and build without an init", err)
+		return fmt.Errorf("%v: specify -initcmd=\"\" to ignore this error and build without an init (or, did you specify a list, and are you missing github.com/u-root/u-root/cmds/core/init?)", err)
 	}
 	if err := opts.addSymlinkTo(logger, archive, opts.DefaultShell, "bin/sh"); err != nil {
 		return fmt.Errorf("%v: specify -defaultsh=\"\" to ignore this error and build without a shell", err)

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -258,7 +258,7 @@ func TestCreateInitramfs(t *testing.T) {
 				DefaultShell: "zoocar",
 				InitCmd:      "foobar",
 			},
-			want: "could not create symlink from \"init\" to \"foobar\": command or path \"foobar\" not included in u-root build: specify -initcmd=\"\" to ignore this error and build without an init",
+			want: "could not create symlink from \"init\" to \"foobar\": command or path \"foobar\" not included in u-root build: specify -initcmd=\"\" to ignore this error and build without an init (or, did you specify a list, and are you missing github.com/u-root/u-root/cmds/core/init?)",
 			validators: []itest.ArchiveValidator{
 				itest.IsEmpty{},
 			},


### PR DESCRIPTION
It's important to have an init. The suggested fix, when there is no init,
will lead people down the primrose path, onto the on ramp of the
Information Highway To Hell: they might build an image with no init,
when what really happened is they misconfigured something.

This has happened.

Add a bit more info to this error, in the hopes of making people take
a second look.

It's a lot more wordy now but maybe that is worth it?
% ./u-root github.com/u-root/u-root/cmds/core/date
.
.
.
2021/03/17 16:15:12 could not create symlink from "init" to "init": command \
or path "init" not included in u-root build: specify -initcmd="" to \
ignore this error and build without an init (or, did you specify a list, \
and are you missing github.com/u-root/u-root/cmds/core/init?)

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>