### PR TITLE
Change tftp window size to 64

### DIFF
--- a/pkg/curl/schemes.go
+++ b/pkg/curl/schemes.go
@@ -62,7 +62,7 @@ var (
 	DefaultHTTPClient = NewHTTPClient(http.DefaultClient)
 
 	// DefaultTFTPClient is the default TFTP FileScheme.
-	DefaultTFTPClient = NewTFTPClient(tftp.ClientMode(tftp.ModeOctet), tftp.ClientBlocksize(1450), tftp.ClientWindowsize(65535))
+	DefaultTFTPClient = NewTFTPClient(tftp.ClientMode(tftp.ModeOctet), tftp.ClientBlocksize(1450), tftp.ClientWindowsize(64))
 
 	// DefaultSchemes are the schemes supported by default.
 	DefaultSchemes = Schemes{


### PR DESCRIPTION
Some tftpd clients fails when he windowsize is greater than 64. For
example tftp-hpa:
https://github.com/ClausKlein/tftp-hpa/blob/develop/tftpd/tftpd.c#L84

Also, according to rfc7440 (https://tools.ietf.org/html/rfc7440), the
performance levels out around 64.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>