### PR TITLE
[tools/checklicenses] Fix multi-pattern rules

### DIFF
--- a/tools/checklicenses/checklicenses.go
+++ b/tools/checklicenses/checklicenses.go
@@ -114,17 +114,26 @@ func main() {
 	}
 	files := strings.Fields(string(out))
 
-	rules := append(config.accept, config.reject...)
-
 	// Iterate over files.
-outer:
 	for _, file := range files {
 		// Test rules.
 		trimmedPath := strings.TrimPrefix(file, pkgPath)
-		for _, r := range rules {
-			if r.MatchString(trimmedPath) == r.invert {
-				continue outer
+		foundAccept, foundReject := false, false
+		// First go through accepted patterns
+		for _, r := range config.accept {
+			if r.MatchString(trimmedPath) {
+				foundAccept = true
 			}
+		}
+		// Then go through rejected patterns. Rejection patterns override
+		// acceptance patterns.
+		for _, r := range config.reject {
+			if r.MatchString(trimmedPath) {
+				foundReject = true
+			}
+		}
+		if foundReject || !foundAccept {
+			continue
 		}
 
 		// Make sure it is not a directory.


### PR DESCRIPTION
Currently if more than one accept/reject pattern is specified,
checklicense will just ignore the check. This patch addresses the issue,
and also enforces that rejection rules have priority over acceptance
rules, in case there are colliding accept/reject matches.

Signed-off-by: Andrea Barberio <insomniac@slackware.it>