### PR TITLE
Changes to fitboot to allow overriding the default FIT config.

### DIFF
--- a/cmds/boot/fitboot/main.go
+++ b/cmds/boot/fitboot/main.go
@@ -17,6 +17,7 @@ var (
 	dryRun     = flag.Bool("dryrun", false, "Do not actually kexec into the boot config")
 	debug      = flag.Bool("d", false, "Print debug output")
 	cmdline    = flag.String("c", "earlyprintk=ttyS0,115200,keep console=ttyS0", "command line")
+	config     = flag.String("config", "", "FIT configuration to use")
 	kernel     = flag.String("k", "", "Kernel image node name.")
 	initramfs  = flag.String("i", "", "InitRAMFS node name -- default none")
 	rsdpLookup = flag.Bool("rsdp", false, "Derrive RSDP table pointer from environment")
@@ -39,13 +40,13 @@ func main() {
 		log.Fatal(err)
 	}
 
-	f.Cmdline, f.Kernel, f.InitRAMFS, f.Dryrun = *cmdline, *kernel, *initramfs, *dryRun
+	f.Cmdline, f.Kernel, f.InitRAMFS, f.Dryrun, f.ConfigOverride = *cmdline, *kernel, *initramfs, *dryRun, *config
 
-	kn, in, err := f.LoadBzConfig(*debug)
+	kn, in, err := f.LoadConfig(*debug)
 	if err == nil {
 		f.Kernel, f.InitRAMFS = kn, in
 	} else {
-		v("Default configuration is not available: %v", err)
+		v("Configuration is not available: %v", err)
 	}
 
 	if f.Kernel == "" {

--- a/pkg/boot/fit/fit_test.go
+++ b/pkg/boot/fit/fit_test.go
@@ -32,6 +32,28 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
+func TestLoadConfigMiss(t *testing.T) {
+	i, err := New("testdata/fitimage.itb")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	i.ConfigOverride = "MagicNonExistentConfig"
+	kn, rn, err := i.LoadConfig(true)
+
+	if kn != "" {
+		t.Fatalf("Kernel %s returned on expected config miss", kn)
+	}
+
+	if rn != "" {
+		t.Fatalf("Initramfs %s returned on expected config miss", rn)
+	}
+
+	if err == nil {
+		t.Fatal("Expected error message for miss on FIT config, got nil")
+	}
+}
+
 func TestLoad(t *testing.T) {
 	i, err := New("testdata/fitimage.itb")
 	if err != nil {

--- a/pkg/boot/fit/fit_test.go
+++ b/pkg/boot/fit/fit_test.go
@@ -10,13 +10,13 @@ import (
 	"github.com/u-root/u-root/pkg/boot"
 )
 
-func TestLoadBzConfig(t *testing.T) {
+func TestLoadConfig(t *testing.T) {
 	i, err := New("testdata/fitimage.itb")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	kn, rn, err := i.LoadBzConfig(true)
+	kn, rn, err := i.LoadConfig(true)
 
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/dt/walk.go
+++ b/pkg/dt/walk.go
@@ -18,6 +18,27 @@ type NodeWalk struct {
 	err error
 }
 
+// AsString returns the NodeWalk Name and error as a string.
+func (nq *NodeWalk) AsString() (string, error) {
+	if nq.err != nil {
+		return "", nq.err
+	}
+	return nq.n.Name, nil
+}
+
+// ListChildNodes returns a string array with the Names of each child Node
+func (nq *NodeWalk) ListChildNodes() ([]string, error) {
+	if nq.err != nil {
+		return nil, nq.err
+	}
+
+	cs := make([]string, len(nq.n.Children))
+	for i := range nq.n.Children {
+		cs[i] = nq.n.Children[i].Name
+	}
+	return cs, nil
+}
+
 // Root returns the Root node from an FDT to start the walk.
 func (fdt *FDT) Root() *NodeWalk {
 	return &NodeWalk{n: fdt.RootNode}


### PR DESCRIPTION
bz config options are no longer prioritized by default but instead can be specified using the -config option.
Print list of configs on miss.

Signed-off-by: Colin Mitchell <colinmitchell@google.com>