### PR TITLE
Make tests compatible with go1.15

### DIFF
--- a/cmds/core/elvish/eval/exception.go
+++ b/cmds/core/elvish/eval/exception.go
@@ -193,7 +193,7 @@ func (f Flow) Repr(int) string {
 
 func (f Flow) Error() string {
 	if f >= Flow(len(flowNames)) {
-		return fmt.Sprintf("!(BAD FLOW: %v)", f)
+		return fmt.Sprintf("!(BAD FLOW: %d)", f)
 	}
 	return flowNames[f]
 }

--- a/cmds/core/uptime/uptime.go
+++ b/cmds/core/uptime/uptime.go
@@ -1,4 +1,4 @@
-// Copyright 2013-2019 the u-root Authors. All rights reserved
+// Copyright 2013-2021 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -33,7 +33,7 @@ func uptime(contents string) (*time.Time, error) {
 	}
 	uptimeDuration, err := time.ParseDuration(string(uptimeArray[0]) + "s")
 	if err != nil {
-		return nil, fmt.Errorf("error %v", err)
+		return nil, err
 	}
 	uptime := time.Time{}.Add(uptimeDuration)
 

--- a/cmds/core/uptime/uptime_test.go
+++ b/cmds/core/uptime/uptime_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 the u-root Authors. All rights reserved
+// Copyright 2019-2021 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -13,6 +13,11 @@ var (
 	testTime = time.Date(0001, 1, 15, 5, 35, 49, 0, time.UTC)
 )
 
+func invalidDurationError(d string) string {
+	_, err := time.ParseDuration(d)
+	return err.Error()
+}
+
 func TestUptime(t *testing.T) {
 	var tests = []struct {
 		name   string
@@ -20,25 +25,40 @@ func TestUptime(t *testing.T) {
 		uptime *time.Time
 		err    string
 	}{
-		{"goodInput", "1229749 1422244", &testTime, ""},
-		{"badDataInput", "string", nil, "error time: invalid duration strings"},
-		{"emptyDataInput", "", nil, "error:the contents of proc/uptime we are trying to read are empty"},
+		{
+			name:   "goodInput",
+			input:  "1229749 1422244",
+			uptime: &testTime,
+			err:    "",
+		},
+		{
+			name:   "badDataInput",
+			input:  "string",
+			uptime: nil,
+			err:    invalidDurationError("strings"),
+		},
+		{
+			name:   "emptyDataInput",
+			input:  "",
+			uptime: nil,
+			err:    "error:the contents of proc/uptime we are trying to read are empty",
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			gotUptime, err := uptime(test.input)
 			if err == nil && test.err != "" {
-				t.Errorf("Error was not returned:got nil,want %v", test.err)
+				t.Errorf("uptime(%q) err = nil, want %q", test.input, test.err)
 			} else if err != nil && err.Error() != test.err {
-				t.Errorf("Mismatched Error returned :got %v ,want %v", err.Error(), test.err)
+				t.Errorf("uptime(%q) err = %q, want %q", test.input, err.Error(), test.err)
 			}
 			if gotUptime == nil && test.uptime != nil {
-				t.Errorf("Error mismatched uptime :got nil ,want %v", *test.uptime)
+				t.Errorf("uptime(%q) = nil, want %v", test.input, *test.uptime)
 			} else if gotUptime != nil && test.uptime != nil && *gotUptime != *test.uptime {
-				t.Errorf("Error mismatched uptime :got %v , want %v", *gotUptime, *test.uptime)
+				t.Errorf("uptime(%q) = %v, want %v", test.input, *gotUptime, *test.uptime)
 			} else if gotUptime != nil && test.uptime == nil {
-				t.Errorf("Error mismatched uptime :got %v , want nil", *gotUptime)
+				t.Errorf("uptime(%q) = %v, want nil", test.input, *gotUptime)
 			}
 		})
 	}
@@ -59,16 +79,16 @@ func TestLoadAverage(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			loadAverage, err := loadavg(test.input)
 			if err == nil && test.err != "" {
-				t.Errorf("Error was not returned:got nil, want %s", test.err)
+				t.Errorf("loadavg(%q) err = nil, want %q", test.input, test.err)
 			} else if err != nil && err.Error() != test.err {
-				t.Errorf("Mismatched Error returned,got %s ,want %s", err.Error(), test.err)
+				t.Errorf("loadavg(%q) err = %q, want %q", test.input, err.Error(), test.err)
 			}
 			if loadAverage == "" && test.loadAverage != "" {
-				t.Errorf("Error mismatched loadaverage: got '', want %s", test.loadAverage)
+				t.Errorf("loadavg(%q) = \"\", want %v", test.input, test.loadAverage)
 			} else if loadAverage != "" && test.loadAverage != "" && loadAverage != test.loadAverage {
-				t.Errorf("Error mismatched loadaverage :got %s ,want %s", loadAverage, test.loadAverage)
+				t.Errorf("loadavg(%q) = %v, want %v", test.input, loadAverage, test.loadAverage)
 			} else if loadAverage != "" && test.loadAverage == "" {
-				t.Errorf("Error mismatched loadaverage :got %s ,want ''", loadAverage)
+				t.Errorf("loadavg(%q) = %v, want \"\"", test.input, loadAverage)
 			}
 		})
 	}

--- a/pkg/tss/capabilities.go
+++ b/pkg/tss/capabilities.go
@@ -1,4 +1,4 @@
-// Copyright 2020 the u-root Authors. All rights reserved
+// Copyright 2020-2021 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -45,7 +45,12 @@ func readTPM20Information(rwc io.ReadWriter) (TPMInfo, error) {
 			return TPMInfo{}, fmt.Errorf("got capability of type %T, want tpm2.TaggedProperty", caps[0])
 		}
 		// Reconstruct the 4 ASCII octets from the uint32 value.
-		vendorInfo += string(subset.Value&0xFF000000) + string(subset.Value&0xFF0000) + string(subset.Value&0xFF00) + string(subset.Value&0xFF)
+		vendorInfo += string([]byte{
+			byte(subset.Value >> 24),
+			byte(subset.Value >> 16),
+			byte(subset.Value >> 8),
+			byte(subset.Value),
+		})
 	}
 
 	caps, _, err := tpm2.GetCapability(rwc, tpm2.CapabilityTPMProperties, 1, uint32(tpm2.Manufacturer))


### PR DESCRIPTION
This fixes the following errors:

	# github.com/u-root/u-root/pkg/tss
	pkg/tss/capabilities.go:48:17: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
	pkg/tss/capabilities.go:48:51: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
	pkg/tss/capabilities.go:48:83: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
	pkg/tss/capabilities.go:48:113: conversion from uint32 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)

	# github.com/u-root/u-root/cmds/core/elvish/eval
	cmds/core/elvish/eval/exception.go:196:10: Sprintf format %v with arg f causes recursive Error method call

	--- FAIL: TestUptime/badDataInput (0.00s)
        uptime_test.go:34: Mismatched Error returned :got error time: invalid duration "strings" ,want error time: invalid duration strings

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>