### PR TITLE
Clean up some code and enable more distributions in netboot

### DIFF
--- a/cmds/exp/netbootxyz/netbootxyz.go
+++ b/cmds/exp/netbootxyz/netbootxyz.go
@@ -1,3 +1,7 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/exp/netbootxyz/network.go
+++ b/cmds/exp/netbootxyz/network.go
@@ -24,18 +24,44 @@ func downloadFile(filepath string, url string) error {
 	if err != nil {
 		return err
 	}
-	defer resp.Body.Close()
+	defer closeIO(resp.Body, &err)
 
 	// Create the file
 	out, err := os.Create(filepath)
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer closeFile(out, &err)
 
 	// Write the body to file
 	_, err = io.Copy(out, resp.Body)
 	return err
+}
+
+// Allows error handling on deferred file.Close()
+func closeFile(f *os.File, err *error) {
+	e := f.Close()
+	switch *err {
+	case nil:
+		*err = e
+	default:
+		if e != nil {
+			log.Println("Error:", e)
+		}
+	}
+}
+
+// Allows error handling on deferred io.Close()
+func closeIO(c io.Closer, err *error) {
+	e := c.Close()
+	switch *err {
+	case nil:
+		*err = e
+	default:
+		if e != nil {
+			log.Println("Error:", e)
+		}
+	}
 }
 
 func configureDHCPNetwork() error {

--- a/cmds/exp/netbootxyz/network.go
+++ b/cmds/exp/netbootxyz/network.go
@@ -1,3 +1,7 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package main
 
 import (

--- a/cmds/exp/netbootxyz/network.go
+++ b/cmds/exp/netbootxyz/network.go
@@ -89,9 +89,8 @@ func configureDHCPNetwork() error {
 	for result := range r {
 		if result.Err == nil {
 			return result.Lease.Configure()
-		} else {
-			log.Printf("dhcp response error: %v", result.Err)
 		}
+		log.Printf("dhcp response error: %v", result.Err)
 	}
 	return errors.New("no valid DHCP configuration recieved")
 }

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -61,6 +61,11 @@ func parseBootNum(choice string, entries []Entry) (int, error) {
 	return num, nil
 }
 
+// SetInitialTimeout sets the initial timeout of the menu to the provided duration
+func SetInitialTimeout(timeout time.Duration) {
+	initialTimeout = timeout
+}
+
 // Choose presents the user a menu on input to choose an entry from and returns that entry.
 func Choose(input *os.File, entries ...Entry) Entry {
 	fmt.Println("")


### PR DESCRIPTION
Working so far:
- Ubuntu 20.xx
- Debian
- Mint (based on Ubuntu 20.xx)
- Fedora
- Pop!_OS (based on Ubuntu 20.xx)

Ubuntu 18.xx and older use a different cmdline and are not yet handled