### PR TITLE
watchdogd: Synchronize on disarm

### DIFF
--- a/pkg/boot/kexec/kexec_linux.go
+++ b/pkg/boot/kexec/kexec_linux.go
@@ -20,7 +20,7 @@ func Reboot() error {
 		d, err := watchdogd.Find()
 		if err != nil {
 			log.Printf("Error finding watchdog daemon: %v", err)
-		} else if err := d.Disarm(); err != nil {
+		} else if err := d.DisarmAndExit(); err != nil {
 			log.Printf("Error disarming watchdog: %v", err)
 		}
 	}


### PR DESCRIPTION
Occasionally, the kexec might occur before the watchdog daemon has
disarmed the watchdog. This change waits until the daemon has completed
its work.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>