### PR TITLE
pkg/pci, cmds/core/pci: add more printing per requests from engineers

### DIFF
--- a/pkg/pci/bits.go
+++ b/pkg/pci/bits.go
@@ -1,0 +1,93 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pci
+
+import (
+	"fmt"
+)
+
+// bit puller-aparters. There's a case to be made for the usual tables
+// with widths and values and stuff but this way ends up being easier
+// to read, surprisingly.
+
+// Control register bits are packed, bit 0 to bit 11. Thank you, PCI people.
+var crBits = []string{
+	"I/O",
+	"Memory",
+	"DMA",
+	"Special",
+	"MemWINV",
+	"VGASnoop",
+	"ParErr",
+	"Stepping",
+	"SERR",
+	"FastB2B",
+	"DisInt",
+}
+
+func (c *PCIControl) String() string {
+	var s string
+	for i, n := range crBits {
+		if len(s) > 0 {
+			s = s + " "
+		}
+		s += n
+		ix := (1<<i)&uint16(*c) != 0
+		if ix {
+			s += "+"
+		} else {
+			s += "-"
+		}
+	}
+	return s
+}
+
+var stBits = []string{
+	"Reserved",
+	"Reserved",
+	"INTx",
+	"Cap",
+	"66MHz",
+	"UDF",
+	"FastB2b",
+	"ParErr",
+	"DEVSEL",
+	">Tabort",
+	"<Tabort",
+	"<MABORT",
+	">SERR",
+	"<PERR",
+}
+
+func (c *PCIStatus) String() string {
+	var s string
+
+	for i, n := range stBits {
+		switch i {
+		case 9: // the only multi-bit field
+			spd := (uint16(*c) & 0x600) >> 9
+			if len(s) > 0 {
+				s = s + " "
+			}
+			s += fmt.Sprintf("DEVSEL=%s", []string{"fast", "medium", "slow", "reserved"}[spd])
+		case 0:
+		case 1:
+		case 10:
+			continue
+		default:
+			ix := (1<<i)&uint16(*c) != 0
+			if len(s) > 0 {
+				s = s + " "
+			}
+			s += n
+			if ix {
+				s += "+"
+			} else {
+				s += "-"
+			}
+		}
+	}
+	return s
+}

--- a/pkg/pci/bits_test.go
+++ b/pkg/pci/bits_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pci
+
+import "testing"
+
+func TestControlBits(t *testing.T) {
+	var tests = []struct {
+		c PCIControl
+		w string
+	}{
+		{c: 0, w: "I/O- Memory- DMA- Special- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisInt-"},
+		{c: 0x001, w: "I/O+ Memory- DMA- Special- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisInt-"},
+		{c: 0x003, w: "I/O+ Memory+ DMA- Special- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisInt-"},
+		{c: 0x555, w: "I/O+ Memory- DMA+ Special- MemWINV+ VGASnoop- ParErr+ Stepping- SERR+ FastB2B- DisInt+"},
+		{c: 0xaaa, w: "I/O- Memory+ DMA- Special+ MemWINV- VGASnoop+ ParErr- Stepping+ SERR- FastB2B+ DisInt-"},
+		{c: 0xfff, w: "I/O+ Memory+ DMA+ Special+ MemWINV+ VGASnoop+ ParErr+ Stepping+ SERR+ FastB2B+ DisInt+"},
+	}
+	for _, tt := range tests {
+		s := tt.c.String()
+		if s != tt.w {
+			t.Errorf("Control bits for %#x: got \n%q\n, want \n%q", tt.c, s, tt.w)
+		}
+	}
+
+}
+
+func TestStatusBits(t *testing.T) {
+	var tests = []struct {
+		c PCIStatus
+		w string
+	}{
+		{c: 0, w: "INTx- Cap- 66MHz- UDF- FastB2b- ParErr- DEVSEL- DEVSEL=fast <MABORT- >SERR- <PERR-"},
+		{c: 0x600, w: "INTx- Cap- 66MHz- UDF- FastB2b- ParErr- DEVSEL- DEVSEL=reserved <MABORT- >SERR- <PERR-"},
+		{c: 0x400, w: "INTx- Cap- 66MHz- UDF- FastB2b- ParErr- DEVSEL- DEVSEL=slow <MABORT- >SERR- <PERR-"},
+		{c: 0x200, w: "INTx- Cap- 66MHz- UDF- FastB2b- ParErr- DEVSEL- DEVSEL=medium <MABORT- >SERR- <PERR-"},
+		{c: 0xffff, w: "INTx+ Cap+ 66MHz+ UDF+ FastB2b+ ParErr+ DEVSEL+ DEVSEL=reserved <MABORT+ >SERR+ <PERR+"},
+	}
+	for _, tt := range tests {
+		s := tt.c.String()
+		if s != tt.w {
+			t.Errorf("Control bits for %#x: got \n%q, want \n%q", tt.c, s, tt.w)
+		}
+	}
+
+}

--- a/pkg/pci/devices.go
+++ b/pkg/pci/devices.go
@@ -5,20 +5,30 @@
 package pci
 
 import (
-	"bytes"
+	"fmt"
+	"io"
 )
 
 //Devices contains a slice of one or more PCI devices
 type Devices []*PCI
 
-// String stringifies the PCI devices. Currently it just calls the device String().
-func (d Devices) String() string {
-	var buffer bytes.Buffer
+// Print prints information to an io.Writer
+func (d Devices) Print(o io.Writer, verbose int) error {
 	for _, pci := range d {
-		buffer.WriteString(pci.String())
-		buffer.WriteString("\n")
+		if _, err := fmt.Fprintf(o, "%s\n", pci.String()); err != nil {
+			return err
+		}
+		if verbose >= 1 {
+			if _, err := fmt.Fprintf(o, "\tControl: %s\n\tStatus: %s\n", pci.Control.String(), pci.Status.String()); err != nil {
+				return err
+			}
+		}
+
+		if verbose > 0 {
+			fmt.Fprintf(o, "\n")
+		}
 	}
-	return buffer.String()
+	return nil
 }
 
 // SetVendorDeviceName sets all numeric IDs of all the devices

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -24,7 +24,17 @@ type PCI struct {
 	DeviceName string
 	FullPath   string
 	ExtraInfo  []string
+	config     []byte
+	// The rest only gets filled in config space is read.
+	Control PCIControl
+	Status  PCIStatus
 }
+
+// PCIControl configures how the device responds to operations. It is the 3rd 16-bit word.
+type PCIControl uint16
+
+// PCIStatus contains status bits for the PCI device. It is the 4th 16-bit word.
+type PCIStatus uint16
 
 // String concatenates PCI address, Vendor, and Device and other information
 // to make a useful display for the user.
@@ -45,7 +55,10 @@ func (p *PCI) ReadConfig() error {
 	if err != nil {
 		return err
 	}
+	p.config = c
 	p.ExtraInfo = append(p.ExtraInfo, hex.Dump(c))
+	p.Control = PCIControl(binary.LittleEndian.Uint16(c[4:6]))
+	p.Status = PCIStatus(binary.LittleEndian.Uint16(c[6:8]))
 	return nil
 }
 

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -5,6 +5,7 @@
 package pci
 
 import (
+	"log"
 	"testing"
 )
 
@@ -75,5 +76,21 @@ func TestBusReader(t *testing.T) {
 	// Check that the partitions add up.
 	if len(matches)+len(notMatches) != len(n.(*bus).Devices) {
 		t.Fatalf("Got %d+%d devices, wanted %d", len(matches), len(notMatches), len(n.(*bus).Devices))
+	}
+}
+
+func TestBusReadConfig(t *testing.T) {
+	r, err := NewBusReader()
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	d, err := r.Read()
+	if err != nil {
+		log.Fatalf("Read: %v", err)
+	}
+	d.SetVendorDeviceName()
+	if err := d.ReadConfig(); err != nil {
+		log.Fatalf("ReadConfig: got %v, want nil", err)
 	}
 }


### PR DESCRIPTION
The original pci command was modeled after the Plan 9 version.
Hence the original u-root pci command was very simple. On Plan 9,
extra capabilities are added by extra commands. Kind of like Unix.

Simple is not the habit on Linux; the style of "one command that does everything
possible" is more the mode.

And it turns out users like that; they want more printing like lspci.

This is the first of series of changes to give users what they want.

For now, the command will show Control and Status registers for selected
devices when -v=1. The information presented is basically the same as lspci.
Note that for Status, INTx is presented in bit numbered order on pci, and lspci
for some reason puts it last. Your guess is as good as mine.

There is also, now, the ability to dump to JSON
for forensics later.

rminnich@t510:~/go/src/github.com/u-root/u-root/cmds/core/pci$ ./pci -v=1
0000:00:00.0: Intel Corporation Core Processor DRAM Controller
00000000  86 80 44 00 06 00 90 20  02 00 00 06 00 00 00 00  |..D.... ........|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  00 00 00 00 aa 17 93 21  |...............!|
00000030  00 00 00 00 e0 00 00 00  00 00 00 00 00 00 00 00  |................|

	Control: I/O- Memory+ DMA+ Special- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisInt-
	Status: INTx- Cap- 66MHz+ UDF- FastB2b- ParErr+ DEVSEL- DEVSEL=fast <MABORT- >SERR- <PERR+

etc. etc.

Note that this is the output presented for lspci -v -v; there are no plans to present the even simpler
output for lspci -v, absent demand. It is not really that useful as compared to -v -v.

The config space dumping will go back to only being enabled by -c in the next PR.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>