### PR TITLE
OSX support

### DIFF
--- a/pkg/ldd/ldd_darwin.go
+++ b/pkg/ldd/ldd_darwin.go
@@ -1,0 +1,94 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin
+
+// ldd returns none of the library dependencies of an executable.
+//
+// On many Unix kernels, the kernel ABI is stable. On OSX, the stability
+// is held in the library interface; the kernel ABI is explicitly not
+// stable. The ldd package on OSX will only return the files passed to it.
+// It will continue to resolve symbolic links.
+package ldd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Follow starts at a pathname and adds it
+// to a map if it is not there.
+// If the pathname is a symlink, indicated by the Readlink
+// succeeding, links repeats and continues
+// for as long as the name is not found in the map.
+func follow(l string, names map[string]*FileInfo) error {
+	for {
+		if names[l] != nil {
+			return nil
+		}
+		i, err := os.Lstat(l)
+		if err != nil {
+			return fmt.Errorf("%v", err)
+		}
+
+		names[l] = &FileInfo{FullName: l, FileInfo: i}
+		if i.Mode().IsRegular() {
+			return nil
+		}
+		// If it's a symlink, the read works; if not, it fails.
+		// we can skip testing the type, since we still have to
+		// handle any error if it's a link.
+		next, err := os.Readlink(l)
+		if err != nil {
+			return err
+		}
+		// It may be a relative link, so we need to
+		// make it abs.
+		if filepath.IsAbs(next) {
+			l = next
+			continue
+		}
+		l = filepath.Join(filepath.Dir(l), next)
+	}
+}
+
+// Ldd returns the list of files passed to it, and resolves all symbolic
+// links, returning them as well.
+//
+// It's not an error for a file to not be an ELF.
+func Ldd(names []string) ([]*FileInfo, error) {
+	var (
+		list = make(map[string]*FileInfo)
+		libs []*FileInfo
+	)
+	for _, n := range names {
+		if err := follow(n, list); err != nil {
+			return nil, err
+		}
+	}
+	for i := range list {
+		libs = append(libs, list[i])
+	}
+
+	return libs, nil
+}
+
+type FileInfo struct {
+	FullName string
+	os.FileInfo
+}
+
+// List returns the dependency file paths of files in names.
+func List(names []string) ([]string, error) {
+	var list []string
+	l, err := Ldd(names)
+	if err != nil {
+		return nil, err
+	}
+	for i := range l {
+		list = append(list, l[i].FullName)
+	}
+	return list, nil
+}

--- a/pkg/ldd/ldd_darwin_test.go
+++ b/pkg/ldd/ldd_darwin_test.go
@@ -1,0 +1,57 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package ldd
+
+import (
+	"fmt"
+	"testing"
+)
+
+// lddOne is a helper that runs Ldd on one file. It returns
+// the list so we can use elements from the list on another
+// test. We do it this way because, unlike /bin/date, there's
+// almost nothing else we can assume exists, e.g. /lib/libc.so
+// is a different name on almost every *ix* system.
+func lddOne(name string) ([]string, error) {
+	var libMap = make(map[string]bool)
+	n, err := Ldd([]string{name})
+	if err != nil {
+		return nil, fmt.Errorf("Ldd on %v: want nil, got %v", name, err)
+	}
+	l, err := List([]string{name})
+	if err != nil {
+		return nil, fmt.Errorf("LddList on %v: want nil, got %v", name, err)
+	}
+	if len(n) != len(l) {
+		return nil, fmt.Errorf("%v: Len of Ldd(%v) and LddList(%v): want same, got different", name, len(n), len(l))
+	}
+	for i := range n {
+		libMap[n[i].FullName] = true
+	}
+	for i := range n {
+		if !libMap[l[i]] {
+			return nil, fmt.Errorf("%v: %v was in LddList but not in Ldd", name, l[i])
+		}
+	}
+	return l, nil
+}
+
+// TestLddList tests that the LddList is the
+// same as the info returned by Ldd
+func TestLddList(t *testing.T) {
+	n, err := lddOne("/etc/resolv.conf")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, f := range n {
+		t.Logf("Test %v", f)
+		n, err := lddOne(f)
+		if err != nil {
+			t.Error(err)
+		}
+		t.Logf("%v has deps of %v", f, n)
+	}
+}


### PR DESCRIPTION
Making u-root on OSX requires making ldd a no op. The ldd
package on OSX will now continue to bring in symbolic links
but will not try to figure out libraries. OSX does not have
a stable kernel interface guarantee, unlike Linux, so the
ldd step has little value anyway.

With this change, these two commands work:
For OSX:
./u-root -defaultsh="" -initcmd="" github.com/u-root/u-root/cmds/core/date
For Linux
GOOS=linux ./u-root  -defaultsh=rush  github.com/u-root/u-root/cmds/core/init github.com/u-root/u-root/cmds/exp/rush

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>