### PR TITLE
boot/multiboot: fix symbols in amd64 trampoline

### DIFF
--- a/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.go
+++ b/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.go
@@ -27,6 +27,10 @@ func end()
 func info()
 func magic()
 func entry()
+func boot()
+func farjump32()
+func farjump64()
+func gdt()
 
 // funcPC gives the program counter of the given function.
 //

--- a/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.s
+++ b/pkg/boot/multiboot/internal/trampoline/trampoline_linux_amd64.s
@@ -57,7 +57,7 @@ TEXT ·start(SB),NOSPLIT,$0
 	JMP	farjump64(SB)
 
 
-TEXT boot(SB),NOSPLIT,$0
+TEXT ·boot(SB),NOSPLIT,$0
 	// We are in 32-bit mode now.
 	//
 	// Be careful editing this code!!! Go compiler
@@ -90,19 +90,19 @@ TEXT boot(SB),NOSPLIT,$0
 	MOVL	SI, AX
 	JMP	farjump32(SB)
 
-TEXT farjump64(SB),NOSPLIT,$0
+TEXT ·farjump64(SB),NOSPLIT,$0
 	BYTE	$0xFF; BYTE $0x2D; LONG $0x0 // ljmp *(ip)
 
 	LONG	$0x0 // farjump64+6(SB)
 	LONG	$0x8 // code segment
 
-TEXT farjump32(SB),NOSPLIT,$0
+TEXT ·farjump32(SB),NOSPLIT,$0
 	// ljmp $0x18, offset
 	BYTE	$0xEA
 	LONG	$0x0 // farjump32+1(SB)
 	WORD	$0x18 // code segment
 
-TEXT gdt(SB),NOSPLIT,$0
+TEXT ·gdt(SB),NOSPLIT,$0
 	QUAD	$0x0		// 0x0 null entry
 	QUAD	$CODE_SEGMENT	// 0x8
 	QUAD	$DATA_SEGMENT	// 0x10


### PR DESCRIPTION
symbols such as boot were getting multiple definition errors
when other commands such as webboot were compiled in, as they also
included the trampoline code as part of their vendoring.

Just adding the unicode . resolves this issue.

Signed-off-by: Ronald Minnich <rminnich@gmail.com>