### PR TITLE
Use Go crypto/rand as rand implementation for Windows

### DIFF
--- a/pkg/rand/random_std.go
+++ b/pkg/rand/random_std.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build plan9
+// +build plan9 windows
 
 package rand
 


### PR DESCRIPTION
I am working on an userland network stack based on gvisor (https://github.com/containers/gvisor-tap-vsock). 
In order to add a DHCP to the virtual network, I use https://github.com/insomniacslk/dhcp.
It is using the rand pkg as a dependency. It is the only package which doesn't compile on Windows.

This change uses the default Golang implementation.
