### PR TITLE
pkg/pci: fix bug in printing out vendor, dev, class

### DIFF
--- a/pkg/pci/lookup.go
+++ b/pkg/pci/lookup.go
@@ -15,10 +15,10 @@ func Lookup(ids map[uint16]Vendor, vendor uint16, device uint16) (string, string
 
 	if v, ok := ids[vendor]; ok {
 		if d, ok := v.Devices[device]; ok {
-			return v.Name, fmt.Sprintf(venDevFmt, d)
+			return v.Name, string(d)
 		}
 		// If entry for device doesn't exist return the hex ID
-		return fmt.Sprintf(venDevFmt, v.Name), fmt.Sprintf(venDevFmt, device)
+		return v.Name, fmt.Sprintf(venDevFmt, device)
 	}
 	// If entry for vendor doesn't exist both hex IDs
 	return fmt.Sprintf(venDevFmt, vendor), fmt.Sprintf(venDevFmt, device)

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -52,7 +52,7 @@ type PCI struct {
 // String concatenates PCI address, Vendor, and Device and other information
 // to make a useful display for the user.
 func (p *PCI) String() string {
-	return strings.Join(append([]string{fmt.Sprintf("%s: %v: %v %v", p.Addr, p.Class, p.VendorName, p.DeviceName)}, p.ExtraInfo...), "\n")
+	return strings.Join(append([]string{fmt.Sprintf("%s: %v: %v %v", p.Addr, p.ClassName, p.VendorName, p.DeviceName)}, p.ExtraInfo...), "\n")
 }
 
 // SetVendorDeviceName changes VendorName and DeviceName from a name to a number,

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -67,6 +67,7 @@ func OnePCI(dir string) (*PCI, error) {
 		return nil, err
 	}
 	pci.VendorName, pci.DeviceName = fmt.Sprintf("%04x", pci.Vendor), fmt.Sprintf("%04x", pci.Device)
+	pci.ClassName = "ClassUnknown"
 	if nm, ok := ClassNames[pci.Class]; ok {
 		pci.ClassName = nm
 	}

--- a/pkg/pci/types.go
+++ b/pkg/pci/types.go
@@ -20,7 +20,7 @@ type Vendor struct {
 	Devices map[uint16]DeviceName
 }
 
-// Device is a PCI device human readable label
+// DeviceName is a PCI device human readable label
 type DeviceName string
 
 // Control configures how the device responds to operations. It is the 3rd 16-bit word.


### PR DESCRIPTION
The recent bug fixes created other bugs. The testing is hard as we don't
yet have standard qemu tests for /sys/ and such.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>