### PR TITLE
Fix cmdline

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,33 @@ qemu-system-x86_64 -kernel $KERNEL -initrd /tmp/initramfs.linux_amd64.cpio -nogr
 # Go Gopher
 # ~/>
 ```
+Passing command line arguments like above is equivalent to passing the arguments to uinit via a flags file in `/etc/uinit.flags`, see [Extra Files](#extra-files).
+
+Additionally, you can pass arguments to uinit via the `uroot.uinitargs` kernel parameters, for example:
+
+```bash
+u-root -uinitcmd="echo Gopher" ./cmds/core/{init,echo,elvish}
+
+cpio -ivt < /tmp/initramfs.linux_amd64.cpio
+# ...
+# lrwxrwxrwx   0 root     root           12 Dec 31  1969 bin/uinit -> ../bbin/echo
+# lrwxrwxrwx   0 root     root            9 Dec 31  1969 init -> bbin/init
+
+qemu-system-x86_64 -kernel $KERNEL -initrd /tmp/initramfs.linux_amd64.cpio -nographic -append "console=ttyS0 uroot.uinitargs=Go"
+# ...
+# [    0.848021] Freeing unused kernel memory: 896K
+# 2020/05/01 04:04:39 Welcome to u-root!
+#                              _
+#   _   _      _ __ ___   ___ | |_
+#  | | | |____| '__/ _ \ / _ \| __|
+#  | |_| |____| | | (_) | (_) | |_
+#   \__,_|    |_|  \___/ \___/ \__|
+#
+# Go Gopher
+# ~/>
+```
+Note the order of the passed arguments in the above example.
+
 
 The command you name must be present in the command set. The following will *not
 work*:

--- a/cmds/core/init/init_linux.go
+++ b/cmds/core/init/init_linux.go
@@ -28,6 +28,13 @@ func quiet() {
 }
 
 func osInitGo() *initCmds {
+	// Backwards compatibility for the transition from uroot.nohwrng to
+	// UROOT_NOHWRNG=1 on kernel commandline.
+	if cmdline.ContainsFlag("uroot.nohwrng") {
+		os.Setenv("UROOT_NOHWRNG", "1")
+		log.Printf("Deprecation warning: use UROOT_NOHWRNG=1 on kernel cmdline instead of uroot.nohwrng")
+	}
+
 	// Turn off job control when test mode is on.
 	ctty := libinit.WithTTYControl(!*test)
 

--- a/pkg/libinit/root_linux.go
+++ b/pkg/libinit/root_linux.go
@@ -196,13 +196,6 @@ func SetEnv() {
 	for k, v := range env {
 		os.Setenv(k, v)
 	}
-
-	// Backwards compatibility for the transition from uroot.nohwrng to
-	// UROOT_NOHWRNG=1 on kernel commandline.
-	if cmdline.ContainsFlag("uroot.nohwrng") {
-		os.Setenv("UROOT_NOHWRNG", "1")
-		log.Printf("Deprecation warning: use UROOT_NOHWRNG=1 on kernel cmdline instead of uroot.nohwrng")
-	}
 }
 
 // CreateRootfs creates the default u-root file system.


### PR DESCRIPTION
Commit b6836a4 introduced a call to the `cmdline` package trying to open `proc/cmdline` before `libinit.CreateRootfs()` which result in an error and an empty `procCmdLine` inside the `cmdline` package. Since this variable is initialized only once, any further calls to the `cmdline` package will have no effect (operate on an empty `procCmdLine`).

The new part of commit b6836a4
```
// Backwards compatibility for the transition from uroot.nohwrng to
// UROOT_NOHWRNG=1 on kernel commandline.
if cmdline.ContainsFlag("uroot.nohwrng") {
	os.Setenv("UROOT_NOHWRNG", "1")
	log.Printf("Deprecation warning: use UROOT_NOHWRNG=1 on kernel cmdline instead of uroot.nohwrng")
}
```
just needs to go anywhere after the rootfs was created. This approach here is just a proposal, feel free to suggest alternatives. 
