### PR TITLE
cmds/exp/rush: add changes for tamago

### DIFF
--- a/cmds/exp/rush/info.go
+++ b/cmds/exp/rush/info.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"runtime"
 )
 
@@ -29,6 +30,6 @@ func init() {
 }
 
 func infocmd(c *Command) error {
-	_, err := fmt.Printf("%s %s %s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	_, err := fmt.Printf("%s %s %s %q\n", runtime.Version(), runtime.GOOS, runtime.GOARCH, os.Args)
 	return err
 }

--- a/cmds/exp/rush/info.go
+++ b/cmds/exp/rush/info.go
@@ -1,0 +1,34 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// info command
+//
+// Synopsis:
+//     info
+//
+// Description:
+//     Print out info about our environment.
+//
+// Example:
+//     $ info
+//     Version, goos, etc.
+//
+// Note:
+//
+// Bugs:
+package main
+
+import (
+	"fmt"
+	"runtime"
+)
+
+func init() {
+	addBuiltIn("info", infocmd)
+}
+
+func infocmd(c *Command) error {
+	_, err := fmt.Printf("%s %s %s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	return err
+}

--- a/cmds/exp/rush/info.go
+++ b/cmds/exp/rush/info.go
@@ -26,10 +26,10 @@ import (
 )
 
 func init() {
-	addBuiltIn("info", infocmd)
+	addBuiltIn("rushinfo", infocmd)
 }
 
 func infocmd(c *Command) error {
-	_, err := fmt.Printf("%s %s %s %q\n", runtime.Version(), runtime.GOOS, runtime.GOARCH, os.Args)
+	_, err := fmt.Printf("%s %s %s %q: builtins %v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH, os.Args, builtins)
 	return err
 }

--- a/cmds/exp/rush/parse.go
+++ b/cmds/exp/rush/parse.go
@@ -84,7 +84,7 @@ func tok(b *bufio.Reader) (string, string) {
 
 	//fmt.Printf("TOK %v", c)
 	switch c {
-	case 0:
+	case 0, 4:
 		return "EOF", ""
 	case '>':
 		return "FD", "1"

--- a/cmds/exp/rush/parse.go
+++ b/cmds/exp/rush/parse.go
@@ -116,7 +116,7 @@ func tok(b *bufio.Reader) (string, string) {
 		}
 	case ' ', '\t':
 		return "white", string(c)
-	case '\n':
+	case '\n', '\r':
 		//fmt.Printf("NEWLINE\n")
 		return "EOL", ""
 	case '|', '&':

--- a/cmds/exp/rush/rush.go
+++ b/cmds/exp/rush/rush.go
@@ -23,15 +23,18 @@ type builtin func(c *Command) error
 
 // TODO: probably have one builtin map and use it for both types?
 var (
-	urpath   = "/go/bin:/ubin:/buildbin:/bbin:/bin:/usr/local/bin:"
-	builtins = make(map[string]builtin)
+	urpath = "/go/bin:/ubin:/buildbin:/bbin:/bin:/usr/local/bin:"
 
+	builtins map[string]builtin
 	// the environment dir is INTENDED to be per-user and bound in
 	// a private name space at /env.
 	envDir = "/env"
 )
 
 func addBuiltIn(name string, f builtin) error {
+	if builtins == nil {
+		builtins = make(map[string]builtin)
+	}
 	if _, ok := builtins[name]; ok {
 		return fmt.Errorf("%v already a builtin", name)
 	}

--- a/cmds/exp/rush/rush.go
+++ b/cmds/exp/rush/rush.go
@@ -13,10 +13,14 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
+
+	"github.com/u-root/u-root/pkg/bb/bbmain"
 )
 
 type builtin func(c *Command) error
@@ -91,7 +95,12 @@ func runit(c *Command) error {
 		if err := b(c); err != nil {
 			return err
 		}
+	} else if runtime.GOOS == "tamago" {
+		os.Args = c.Args
+		log.Printf("TAMAGO! %v, run %s", c, filepath.Base(os.Args[0]))
+		return bbmain.Run(filepath.Base(os.Args[0]))
 	} else {
+
 		forkAttr(c)
 		if err := c.Start(); err != nil {
 			return fmt.Errorf("%v: Path %v", err, os.Getenv("PATH"))

--- a/cmds/exp/rush/rush.go
+++ b/cmds/exp/rush/rush.go
@@ -13,14 +13,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
 	"path"
 	"path/filepath"
-	"runtime"
-
-	"github.com/u-root/u-root/pkg/bb/bbmain"
 )
 
 type builtin func(c *Command) error
@@ -95,10 +91,6 @@ func runit(c *Command) error {
 		if err := b(c); err != nil {
 			return err
 		}
-	} else if runtime.GOOS == "tamago" {
-		os.Args = c.Args
-		log.Printf("TAMAGO! %v, run %s", c, filepath.Base(os.Args[0]))
-		return bbmain.Run(filepath.Base(os.Args[0]))
 	} else {
 
 		forkAttr(c)

--- a/cmds/exp/rush/time.go
+++ b/cmds/exp/rush/time.go
@@ -35,14 +35,14 @@ import (
 )
 
 func init() {
-	addBuiltIn("time", runtime)
+	addBuiltIn("time", runtimecmd)
 }
 
 func printTime(label string, t time.Duration) {
 	fmt.Fprintf(os.Stderr, "%s %.03f\n", label, t.Seconds())
 }
 
-func runtime(c *Command) error {
+func runtimecmd(c *Command) error {
 	var err error
 	start := time.Now()
 	if len(c.argv) > 0 {


### PR DESCRIPTION
Add builtin info command so we can better see what it thinks is going on

use \r to break lines too

rename runtime function to runtimecmd, since runtime is a package :-)

It is a builtin because in bare metal environments like tamago debugging
is very hard otherwise.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>