### PR TITLE
Fix wrong device name of esxi image.

### DIFF
--- a/pkg/boot/esxi/esxi.go
+++ b/pkg/boot/esxi/esxi.go
@@ -99,10 +99,12 @@ func getImages(device string, opts5, opts6 *options) ([]*boot.MultibootImage, er
 		err5, err6 error
 	)
 	if opts5 != nil {
-		img5, err5 = getBootImage(*opts5, device, 5, fmt.Sprintf("%s%d", device, 5))
+		name, _ := partNo(device, 5)
+		img5, err5 = getBootImage(*opts5, device, 5, name)
 	}
 	if opts6 != nil {
-		img6, err6 = getBootImage(*opts6, device, 6, fmt.Sprintf("%s%d", device, 6))
+		name, _ := partNo(device, 6)
+		img6, err6 = getBootImage(*opts6, device, 6, name)
 	}
 	if img5 == nil && img6 == nil {
 		return nil, fmt.Errorf("could not read boot configs on partition 5 (%v) or partition 6 (%v)", err5, err6)


### PR DESCRIPTION
Use partNo to get the correct name.

Signed-off-by: Terry Tang <terrytang@google.com>