### PR TITLE
Cover all packages, not just package under test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,15 +118,18 @@ jobs:
           command: ineffassign .
   test:
     <<: *golang-template
+    <<: *beefy-template
     steps:
       - checkout
       - run:
-          name: Test all
-          command: go test -a -timeout 15m -ldflags '-s' ./cmds/... ./pkg/...
+          name: Test Packages
+          command: go test -v -a -timeout 15m -ldflags '-s' -coverprofile=coverage_pkg.txt -covermode=atomic -coverpkg=./pkg/... ./pkg/...
           no_output_timeout: 15m
       - run:
-          name: Test coverage
-          command: go test -coverprofile=coverage.txt -covermode=atomic -cover ./cmds/... ./pkg/...
+          name: Test Commands
+          # Commands cannot be tested with -coverpkg due to https://github.com/golang/go/issues/23910, hence they are tested separately.
+          command: go test -v -a -timeout 15m -ldflags '-s' -coverprofile=coverage_cmd.txt -covermode=atomic ./cmds/...
+          no_output_timeout: 15m
       - run:
           name: Upload coverage
           command: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
The default is for each test to analyze only the package being tested.
This should increase test coverage.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>