### PR TITLE
Do not print every ping of the watchdog

### DIFF
--- a/pkg/watchdogd/watchdogd.go
+++ b/pkg/watchdogd/watchdogd.go
@@ -208,7 +208,6 @@ func (d *Daemon) DoPetting() error {
 	if err := d.CurrentWd.KeepAlive(); err != nil {
 		return err
 	}
-	log.Println("Just pet Watchdog.")
 	return nil
 }
 


### PR DESCRIPTION
This was way too verbose.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>