### PR TITLE
cmd/time: add a time command

### DIFF
--- a/cmds/core/time/time.go
+++ b/cmds/core/time/time.go
@@ -1,0 +1,62 @@
+// Copyright 2012-2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Time process execution.
+//
+// Synopsis:
+//     time CMD [ARG]...
+//
+// Description:
+//     After executing CMD, its real, user and system times are printed to
+//     stderr in the POSIX format.
+//
+// Example:
+//     $ time sleep 1.23s
+//     real 1.230
+//     user 0.001
+//     sys 0.000
+//
+// Note:
+//     This is different from bash's time command which is built into the shell
+//     and can time the entire pipeline.
+//
+// Bugs:
+//     Time is not reported when exiting due to a signal.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+)
+
+func printTime(label string, t time.Duration) {
+	fmt.Fprintf(os.Stderr, "%s %.03f\n", label, t.Seconds())
+}
+
+func main() {
+	flag.Parse()
+	a := flag.Args()
+	start := time.Now()
+	if len(a) == 0 {
+		fmt.Fprintf(os.Stderr, "real 0.000\nuser 0.000\nsys 0.000\n")
+		os.Exit(0)
+	}
+	c := exec.Command(a[0], a[1:]...)
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+	defer func(*exec.Cmd, time.Time) {
+		realTime := time.Since(start)
+		printTime("real", realTime)
+		if c.ProcessState != nil {
+			printTime("user", c.ProcessState.UserTime())
+			printTime("sys", c.ProcessState.SystemTime())
+		}
+	}(c, start)
+	if err := c.Run(); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmds/core/time/time_test.go
+++ b/cmds/core/time/time_test.go
@@ -1,0 +1,58 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"regexp"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
+)
+
+type test struct {
+	args   []string
+	r      string
+	exitok bool
+}
+
+func run(c *exec.Cmd) (string, string, error) {
+	var o, e bytes.Buffer
+	c.Stdout, c.Stderr = &o, &e
+	err := c.Run()
+	return o.String(), e.String(), err
+}
+
+func TestTime(t *testing.T) {
+	var tests = []test{
+		{args: []string{}, r: "real 0.000.*\nuser 0.000.*\nsys 0.000", exitok: true},
+		{args: []string{"date"}, r: "real [0-9][0-9]*.*\nuser [0-9][0-9]*.*\nsys [0-9][0-9]*.*", exitok: true},
+		{args: []string{"deadbeef"}, r: ".*exec.*deadbeef.*executable file not found .*", exitok: false},
+	}
+
+	for _, v := range tests {
+		c := testutil.Command(t, v.args...)
+		_, e, err := run(c)
+		if (err != nil) && v.exitok {
+			t.Errorf("%v: got %v, want nil", v, err)
+		}
+		if (err == nil) && !v.exitok {
+			t.Errorf("%v: got nil, want err", v)
+		}
+		m, err := regexp.MatchString(v.r, e)
+		if err != nil {
+			t.Errorf("%v: got %v, want nil", v, err)
+			continue
+		}
+		if !m {
+			t.Errorf("%v: regexp.MatchString(%s, %s) false, wanted match", v, v.r, e)
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	testutil.Run(m, main)
+}


### PR DESCRIPTION
This command was originally part of rush, as a builtin.
It seems we need it standalone.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>