### PR TITLE
Add option to disable bootmenu edits

### DIFF
--- a/cmds/exp/netbootxyz/netbootxyz.go
+++ b/cmds/exp/netbootxyz/netbootxyz.go
@@ -128,7 +128,7 @@ func (o OSEndpoint) Load() error {
 				}
 			}
 		}
-		menu.ShowMenuAndLoad(os.Stdin, subMenu...)
+		menu.ShowMenuAndLoad(true, subMenu...)
 
 		return nil
 	}
@@ -346,5 +346,5 @@ func main() {
 	bootMenu = append(bootMenu, menu.Reboot{})
 	bootMenu = append(bootMenu, menu.StartShell{})
 	menu.SetInitialTimeout(90 * time.Second)
-	menu.ShowMenuAndLoad(os.Stdin, bootMenu...)
+	menu.ShowMenuAndLoad(true, bootMenu...)
 }

--- a/pkg/boot/bootcmd/bootcmd.go
+++ b/pkg/boot/bootcmd/bootcmd.go
@@ -30,7 +30,7 @@ func ShowMenuAndBoot(entries []menu.Entry, mountPool *mount.Pool, noLoad, noExec
 		os.Exit(0)
 	}
 
-	loadedEntry := menu.ShowMenuAndLoad(os.Stdin, entries...)
+	loadedEntry := menu.ShowMenuAndLoad(true, entries...)
 
 	// Clean up.
 	if mountPool != nil {

--- a/pkg/boot/menu/menu_term.go
+++ b/pkg/boot/menu/menu_term.go
@@ -1,0 +1,81 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package menu
+
+import (
+	"io"
+	"log"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/term"
+)
+
+type MenuTerminal interface {
+	io.Writer
+	ReadLine() (string, error)
+	SetPrompt(string)
+	SetEntryCallback(func())
+	SetTimeout(time.Duration) error
+	Close() error
+}
+
+var _ = MenuTerminal(&xterm{})
+
+// xterm is a wrapper for term.Terminal following the MenuTerminal interface
+type xterm struct {
+	term.Terminal
+	// Save variables needed to close the xterm
+	fileInput *os.File
+	oldState  *term.State
+}
+
+// NewTerminal opens an xTerminal using the given file input.
+// Note that the xterm is in raw mode. Write \r\n whenever you would
+// write a \n. When testing in qemu, it might look fine because
+// there might be another tty cooking the newlines. In for
+// example minicom, the behavior is different. And you would
+// see something like:
+//
+//     Select a boot option to edit:
+//                                  >
+//
+// Instead of:
+//
+//     Select a boot option to edit:
+//      >
+func NewTerminal(f *os.File) *xterm {
+	oldState, err := term.MakeRaw(int(f.Fd()))
+	if err != nil {
+		log.Printf("BUG: Please report: We cannot actually let you choose from menu (MakeRaw failed): %v", err)
+	}
+
+	if err = syscall.SetNonblock(int(f.Fd()), true); err != nil {
+		log.Printf("BUG: Error setting Fd %d to nonblocking: %v", f.Fd(), err)
+	}
+
+	return &xterm{
+		*term.NewTerminal(f, ""),
+		f,
+		oldState,
+	}
+}
+
+func (t *xterm) Close() error {
+	return term.Restore(int(t.fileInput.Fd()), t.oldState)
+}
+
+func (t *xterm) SetTimeout(dur time.Duration) error {
+	return t.fileInput.SetDeadline(time.Now().Add(dur))
+}
+
+// Sets the timeout for the file and adds a timeout refresh on user entry
+func (t *xterm) SetEntryCallback(f func()) {
+	t.AutoCompleteCallback = func(line string, pos int, key rune) (string, int, bool) {
+		f()
+		return "", 0, false
+	}
+}

--- a/pkg/boot/menu/menu_test.go
+++ b/pkg/boot/menu/menu_test.go
@@ -5,19 +5,24 @@
 package menu
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"sync"
 	"testing"
 	"time"
 
-	"github.com/google/goterm/term"
+	"github.com/creack/pty"
 	"github.com/u-root/u-root/pkg/testutil"
 )
 
+var (
+	inputDelay = 500 * time.Millisecond
+)
+
 func TestMain(m *testing.M) {
-	SetInitialTimeout(2 * time.Second)
-	subsequentTimeout = 6 * time.Second
+	SetInitialTimeout(inputDelay * 2)
+	subsequentTimeout = inputDelay * 2
 
 	os.Exit(m.Run())
 }
@@ -25,6 +30,7 @@ func TestMain(m *testing.M) {
 type testEntry struct {
 	mu         sync.Mutex
 	label      string
+	cmdline    string
 	isDefault  bool
 	load       error
 	loadCalled bool
@@ -36,7 +42,14 @@ func (d *testEntry) Label() string {
 	return d.label
 }
 
-func (d *testEntry) Edit(func(cmdline string) string) {
+func (d *testEntry) String() string {
+	return d.Label()
+}
+
+func (d *testEntry) Edit(f func(string) string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.cmdline = f(d.cmdline)
 }
 
 func (d *testEntry) Load() error {
@@ -98,97 +111,168 @@ func TestExtendedLabel(t *testing.T) {
 	}
 }
 
+var _ = MenuTerminal(&mockTerm{})
+
+type mockTerm struct {
+	inputSequence []ReadLine
+	readLineCnt   int
+}
+
+func (m *mockTerm) Write(p []byte) (n int, err error) {
+	return len(p), nil
+}
+
+func (m *mockTerm) Close() error                   { return nil }
+func (m *mockTerm) SetPrompt(s string)             {}
+func (m *mockTerm) SetEntryCallback(func())        {}
+func (m *mockTerm) SetTimeout(time.Duration) error { return nil }
+func (m *mockTerm) ReadLine() (string, error) {
+	defer func() { m.readLineCnt++ }()
+	if m.inputSequence == nil || m.readLineCnt >= len(m.inputSequence) {
+		// mimic timeout
+		return "", os.ErrDeadlineExceeded
+	}
+	return m.inputSequence[m.readLineCnt].string, m.inputSequence[m.readLineCnt].error
+}
+
+type ReadLine struct {
+	string
+	error
+}
+
 func TestChoose(t *testing.T) {
 	// This test takes too long to run for the VM test and doesn't use
 	// anything root-specific.
 	testutil.SkipIfInVMTest(t)
 
-	entry1 := &testEntry{label: "1"}
-	entry2 := &testEntry{label: "2"}
-	entry3 := &testEntry{label: "3"}
-
 	for _, tt := range []struct {
-		name      string
-		entries   []Entry
-		userEntry []byte
-		want      Entry
+		name           string
+		userEntry      []ReadLine
+		wantedEntry    int
+		editingAllowed bool
+		expectedCmds   []string
 	}{
 		{
-			name:    "just_hit_enter",
-			entries: []Entry{entry1, entry2, entry3},
+			name: "just_hit_enter",
 			// user just hits enter.
-			userEntry: []byte("\r\n"),
-			want:      nil,
+			userEntry:   []ReadLine{{"", nil}},
+			wantedEntry: -1, //expect nil
 		},
 		{
-			name:      "hit_nothing",
-			entries:   []Entry{entry1, entry2, entry3},
-			userEntry: nil,
-			want:      nil,
+			name:        "hit_nothing",
+			userEntry:   []ReadLine{},
+			wantedEntry: -1, //expect nil
 		},
 		{
-			name:      "hit_1",
-			entries:   []Entry{entry1, entry2, entry3},
-			userEntry: []byte("1\r\n"),
-			want:      entry1,
+			name:        "hit_1",
+			userEntry:   []ReadLine{{"1", nil}},
+			wantedEntry: 1,
 		},
 		{
-			name:      "hit_3",
-			entries:   []Entry{entry1, entry2, entry3},
-			userEntry: []byte("3\r\n"),
-			want:      entry3,
+			name:        "hit_3",
+			userEntry:   []ReadLine{{"3", nil}},
+			wantedEntry: 3,
 		},
 		{
-			name:    "tentative_hit_1",
-			entries: []Entry{entry1, entry2, entry3},
-			// \x08 is the backspace character.
-			userEntry: []byte("2\x081\r\n"),
-			want:      entry1,
+			name:        "out_of_bounds",
+			userEntry:   []ReadLine{{"4", nil}},
+			wantedEntry: -1, //expect nil
 		},
 		{
-			name:      "out_of_bounds",
-			entries:   []Entry{entry1, entry2, entry3},
-			userEntry: []byte("4\r\n"),
-			want:      nil,
+			name:        "not_a_number",
+			userEntry:   []ReadLine{{"abc", nil}},
+			wantedEntry: -1, //expect nil
 		},
 		{
-			name:      "not_a_number",
-			entries:   []Entry{entry1, entry2, entry3},
-			userEntry: []byte("abc\r\n"),
-			want:      nil,
+			name:           "editing_allowed_override",
+			userEntry:      getEditSequence(false, "1", "after"),
+			editingAllowed: true,
+			expectedCmds:   []string{"after", "before", "before"},
+			wantedEntry:    -1, //expect nil
+		},
+		{
+			name:           "editing_allowed_append",
+			userEntry:      getEditSequence(true, "2", "after"),
+			editingAllowed: true,
+			expectedCmds:   []string{"before", "before after", "before"},
+			wantedEntry:    -1, //expect nil
+		},
+		{
+			name: "select_after_override",
+			userEntry: append(getEditSequence(false, "1", "after"),
+				ReadLine{"1", nil}),
+			editingAllowed: true,
+			expectedCmds:   []string{"after", "before", "before"},
+			wantedEntry:    1,
+		},
+		{
+			name:           "editing_not_allowed",
+			userEntry:      getEditSequence(true, "1", "after"),
+			editingAllowed: false,
+			expectedCmds:   []string{"before", "before", "before"},
+			wantedEntry:    1, // Edit attempt is parsed as a boot choice
+		},
+		{
+			name:           "edit_fail_reading_1",
+			userEntry:      errorOn(1, getEditSequence(false, "1", "after")),
+			editingAllowed: true,
+			expectedCmds:   []string{"before", "before", "before"},
+			wantedEntry:    -1, //expect nil
+		},
+		{
+			name:           "edit_fail_reading_2",
+			userEntry:      errorOn(2, getEditSequence(false, "1", "after")),
+			editingAllowed: true,
+			expectedCmds:   []string{"before", "before", "before"},
+			wantedEntry:    -1, //expect nil
+		},
+		{
+			name:           "edit_fail_reading_3",
+			userEntry:      errorOn(3, getEditSequence(false, "1", "after")),
+			editingAllowed: true,
+			expectedCmds:   []string{"before", "before", "before"},
+			wantedEntry:    -1, //expect nil
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			pty, err := term.OpenPTY()
-			if err != nil {
-				t.Fatalf("%v", err)
+			entries := []*testEntry{
+				{label: "1", cmdline: "before"},
+				{label: "2", cmdline: "before"},
+				{label: "3", cmdline: "before"},
 			}
-			defer pty.Close()
+			var menu []Entry
+			for _, e := range entries {
+				menu = append(menu, e)
+			}
 
 			chosen := make(chan Entry)
 			go func() {
-				chosen <- Choose(pty.Slave, tt.entries...)
+				m := &mockTerm{
+					inputSequence: tt.userEntry,
+				}
+				chosen <- Choose(m, tt.editingAllowed, menu...)
 			}()
 
-			// Well this sucks.
-			//
-			// We have to wait until Choose has actually started trying to read, as
-			// ttys are asynchronous.
-			//
-			// Know a better way? Halp.
-			time.Sleep(1 * time.Second)
-
-			if tt.userEntry != nil {
-				if _, err := pty.Master.Write(tt.userEntry); err != nil {
-					t.Fatalf("failed to write new-line: %v", err)
-				}
+			chosenWant := Entry(nil)
+			if tt.wantedEntry > 0 {
+				chosenWant = menu[tt.wantedEntry-1] // 1 based index
 			}
-
-			if got := <-chosen; got != tt.want {
-				t.Errorf("Choose(%#v, %#v) = %#v, want %#v", tt.userEntry, tt.entries, got, tt.want)
+			if got := <-chosen; got != chosenWant {
+				t.Errorf("Choose(%#v, %#v) = %#v, wantedEntry %#v", tt.userEntry, entries, got, tt.wantedEntry)
+			}
+			// Check for editing
+			for i, entry := range entries {
+				if i < len(tt.expectedCmds) && entry.cmdline != tt.expectedCmds[i] {
+					t.Errorf("Entry %s got cmdline %s, wanted %s", entry.Label(), entry.cmdline, tt.expectedCmds[i])
+				}
 			}
 		})
 	}
+}
+
+func errorOn(index int, arr []ReadLine) []ReadLine {
+	arr[index].error = errors.New("Expected test error")
+	return arr
 }
 
 func contains(s []string, t string) bool {
@@ -200,7 +284,7 @@ func contains(s []string, t string) bool {
 	return false
 }
 
-func TestShowMenuAndLoad(t *testing.T) {
+func TestShowMenuAndLoadFromFile(t *testing.T) {
 	// This test takes too long to run for the VM test and doesn't use
 	// anything root-specific.
 	testutil.SkipIfInVMTest(t)
@@ -255,50 +339,91 @@ func TestShowMenuAndLoad(t *testing.T) {
 			userEntry:    []byte("\r\n"),
 			calledLabels: []string{"1", "2", "3"},
 		},
+		{
+			name: "indecisive_entry",
+			entries: []*testEntry{
+				{label: "1", isDefault: true, load: nil},
+				{label: "2", isDefault: true, load: nil},
+				{label: "3", isDefault: true, load: nil},
+			},
+			// \x08 is the backspace character
+			userEntry:    []byte("1\x082\r\n"),
+			calledLabels: []string{"2"},
+		},
+		{
+			name: "timeout_gets_first_default",
+			entries: []*testEntry{
+				{label: "1", isDefault: true, load: nil},
+				{label: "2", isDefault: true, load: nil},
+				{label: "3", isDefault: true, load: nil},
+			},
+			// No input
+			userEntry:    []byte{},
+			calledLabels: []string{"1"},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pty, err := term.OpenPTY()
+			master, slave, err := pty.Open()
 			if err != nil {
 				t.Fatalf("%v", err)
 			}
-			defer pty.Close()
+			defer master.Close()
+			defer slave.Close()
 
 			var entries []Entry
 			for _, e := range tt.entries {
 				entries = append(entries, e)
 			}
 
+			timer := time.NewTimer(initialTimeout * 4)
 			entry := make(chan Entry)
 			go func() {
-				entry <- ShowMenuAndLoad(pty.Slave, entries...)
+				entry <- showMenuAndLoadFromFile(slave, true, entries...)
 			}()
 
-			// Well this sucks.
-			//
-			// We have to wait until Choose has actually started trying to read, as
-			// ttys are asynchronous.
-			//
-			// Know a better way? Halp.
-			time.Sleep(1 * time.Second)
-
-			if tt.userEntry != nil {
-				if _, err := pty.Master.Write(tt.userEntry); err != nil {
+			if tt.userEntry != nil && len(tt.userEntry) > 0 {
+				// We have to wait until Choose has actually started trying to read, as
+				// ttys are asynchronous.
+				//
+				// Know a better way? Halp.
+				time.Sleep(inputDelay)
+				if _, err := master.Write(tt.userEntry); err != nil {
 					t.Fatalf("failed to write new-line: %v", err)
 				}
 			}
 
-			got := <-entry
-			if want := tt.calledLabels[len(tt.calledLabels)-1]; got.Label() != want {
-				t.Errorf("got label %s want label %s", got.Label(), want)
-			}
+			select {
+			case <-timer.C:
+				t.Errorf("Test %s timed out after %v", tt.name, initialTimeout)
+			case got := <-entry:
+				if want := tt.calledLabels[len(tt.calledLabels)-1]; got.Label() != want {
+					t.Errorf("got label %s wantedEntry label %s", got.Label(), want)
+				}
 
-			for _, entry := range tt.entries {
-				wantCalled := contains(tt.calledLabels, entry.label)
-				if wantCalled != entry.LoadCalled() {
-					t.Errorf("Entry %s gotCalled %t, wantCalled %t", entry.Label(), entry.LoadCalled(), wantCalled)
+				for _, entry := range tt.entries {
+					wantCalled := contains(tt.calledLabels, entry.label)
+					if wantCalled != entry.LoadCalled() {
+						t.Errorf("Entry %s gotCalled %t, wantCalled %t", entry.Label(), entry.LoadCalled(), wantCalled)
+					}
 				}
 			}
 		})
+	}
+}
+
+func getEditSequence(append bool, bootnum string, cmdline string) []ReadLine {
+	var editOpt string
+	if append {
+		editOpt = "a"
+	} else {
+		editOpt = "o"
+	}
+
+	return []ReadLine{
+		{"e", nil},
+		{bootnum, nil},
+		{editOpt, nil},
+		{cmdline, nil},
 	}
 }


### PR DESCRIPTION
Add option to disable bootmenu edits and updated menu logic
Removed the spawned function in ShowMenuAndLoad in favor of
file.SetDeadline(). Switched from Stdin to TTY to support this.

Previous tests for menu.Choose spawned a xterm shell and had to use manual sleeps prevent races.
The menu class used methods and member variables of xterm so a wrapper interface/class were made to support mocking+injection
This shaved ~20s off the test time

Signed-off-by: Colin Mitchell <colinmitchell@google.com>