### PR TITLE
[tools/vpdbootmanager] Added command `get`

### DIFF
--- a/pkg/vpd/vpd_test.go
+++ b/pkg/vpd/vpd_test.go
@@ -8,37 +8,42 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestGetReadOnly(t *testing.T) {
-	VpdDir = "./tests"
-	value, err := Get("key1", true)
+	r := NewReader()
+	r.VpdDir = "./tests"
+	value, err := r.Get("key1", true)
 	require.NoError(t, err)
-	require.Equal(t, value, []byte("value1\n"))
+	assert.Equal(t, value, []byte("value1\n"))
 }
 
 func TestGetReadWrite(t *testing.T) {
-	VpdDir = "./tests"
-	value, err := Get("mysecretpassword", false)
+	r := NewReader()
+	r.VpdDir = "./tests"
+	value, err := r.Get("mysecretpassword", false)
 	require.NoError(t, err)
-	require.Equal(t, value, []byte("passw0rd\n"))
+	assert.Equal(t, value, []byte("passw0rd\n"))
 }
 
 func TestGetReadBinary(t *testing.T) {
-	VpdDir = "./tests"
-	value, err := Get("binary1", true)
+	r := NewReader()
+	r.VpdDir = "./tests"
+	value, err := r.Get("binary1", true)
 	require.NoError(t, err)
-	require.Equal(t, value, []byte("some\x00binary\ndata"))
+	assert.Equal(t, value, []byte("some\x00binary\ndata"))
 }
 
 func TestGetAllReadOnly(t *testing.T) {
-	VpdDir = "./tests"
+	r := NewReader()
+	r.VpdDir = "./tests"
 	expected := map[string][]byte{
 		"binary1": []byte("some\x00binary\ndata"),
 		"key1":    []byte("value1\n"),
 	}
-	vpdMap, err := GetAll(true)
+	vpdMap, err := r.GetAll(true)
 	require.NoError(t, err)
 	if !reflect.DeepEqual(vpdMap, expected) {
 		t.FailNow()

--- a/tools/vpdbootmanager/add.go
+++ b/tools/vpdbootmanager/add.go
@@ -19,27 +19,30 @@ import (
 var dryRun = false
 
 func add(entrytype string, args []string) error {
-	var entry systembooter.Booter
-	var err error
+	var (
+		entry  systembooter.Booter
+		vpdDir string
+		err    error
+	)
 	switch entrytype {
 	case "netboot":
 		if len(args) < 2 {
-			return fmt.Errorf("You need to pass method and MAC address")
+			return fmt.Errorf("you need to pass method and MAC address")
 		}
-		entry, err = parseNetbootFlags(args[0], args[1], args[2:])
+		entry, vpdDir, err = parseNetbootFlags(args[0], args[1], args[2:])
 		if err != nil {
 			return err
 		}
 	case "localboot":
 		if len(args) < 1 {
-			return fmt.Errorf("You need to provide method")
+			return fmt.Errorf("you need to provide method")
 		}
-		entry, err = parseLocalbootFlags(args[0], args[1:])
+		entry, vpdDir, err = parseLocalbootFlags(args[0], args[1:])
 		if err != nil {
 			return err
 		}
 	default:
-		return fmt.Errorf("Unknown entry type")
+		return fmt.Errorf("unknown entry type")
 	}
 	if dryRun {
 		b, err := json.Marshal(entry)
@@ -50,44 +53,49 @@ func add(entrytype string, args []string) error {
 		fmt.Println(string(b))
 		return nil
 	}
-	return addBootEntry(entry)
+	return addBootEntry(entry, vpdDir)
 }
 
-func parseLocalbootFlags(method string, args []string) (*systembooter.LocalBooter, error) {
+func parseLocalbootFlags(method string, args []string) (*systembooter.LocalBooter, string, error) {
 	cfg := &systembooter.LocalBooter{
 		Type:   "localboot",
 		Method: method,
 	}
+	var flagVpdDir string
 	flg := flag.NewFlagSet("localboot", flag.ExitOnError)
 	flg.StringVar(&cfg.KernelArgs, "kernel-args", "", "additional kernel args")
 	flg.StringVar(&cfg.Initramfs, "ramfs", "", "path of ramfs to be used for kexec'ing into the target kernel.")
-	flg.StringVar(&vpd.VpdDir, "vpd-dir", vpd.VpdDir, "VPD dir to use")
+	flg.StringVar(&flagVpdDir, "vpd-dir", vpd.DefaultVpdDir, "VPD dir to use")
 	flg.BoolVar(&dryRun, "dryrun", false, "only print values that would be set")
 
 	switch method {
 	case "grub":
-		flg.Parse(args)
+		if err := flg.Parse(args); err != nil {
+			return nil, flagVpdDir, err
+		}
 	case "path":
 		if len(args) < 2 {
-			return nil, fmt.Errorf("You need to pass DeviceGUID and Kernel path")
+			return nil, "", fmt.Errorf("you need to pass DeviceGUID and Kernel path")
 		}
 		cfg.DeviceGUID = args[0]
 		cfg.Kernel = args[1]
-		flg.Parse(args[2:])
+		if err := flg.Parse(args[2:]); err != nil {
+			return nil, flagVpdDir, err
+		}
 	default:
-		return nil, fmt.Errorf("Method needs to be grub or path")
+		return nil, flagVpdDir, fmt.Errorf("method needs to be grub or path")
 	}
-	return cfg, nil
+	return cfg, flagVpdDir, nil
 }
 
-func parseNetbootFlags(method, mac string, args []string) (*systembooter.NetBooter, error) {
+func parseNetbootFlags(method, mac string, args []string) (*systembooter.NetBooter, string, error) {
 	if method != "dhcpv4" && method != "dhcpv6" {
-		return nil, fmt.Errorf("Method needs to be either dhcpv4 or dhcpv6")
+		return nil, "", fmt.Errorf("method needs to be either dhcpv4 or dhcpv6")
 	}
 
 	_, err := net.ParseMAC(mac)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
 	cfg := &systembooter.NetBooter{
@@ -95,13 +103,16 @@ func parseNetbootFlags(method, mac string, args []string) (*systembooter.NetBoot
 		Method: method,
 		MAC:    mac,
 	}
+	var flagVpdDir string
 
 	flg := flag.NewFlagSet("netboot", flag.ExitOnError)
 	overrideURL := flg.String("override-url", "", "an optional URL used to override the boot file URL used")
 	retries := flg.Int("retries", -1, "the number of times a DHCP request should be retried if failed.")
 	flg.BoolVar(&dryRun, "dryrun", false, "only print values that would be set")
-	flg.StringVar(&vpd.VpdDir, "vpd-dir", vpd.VpdDir, "VPD dir to use")
-	flg.Parse(args)
+	flg.StringVar(&flagVpdDir, "vpd-dir", vpd.DefaultVpdDir, "VPD dir to use")
+	if err := flg.Parse(args); err != nil {
+		return nil, "", err
+	}
 
 	if *overrideURL != "" {
 		cfg.OverrideURL = overrideURL
@@ -111,19 +122,21 @@ func parseNetbootFlags(method, mac string, args []string) (*systembooter.NetBoot
 		cfg.Retries = retries
 	}
 
-	return cfg, nil
+	return cfg, flagVpdDir, nil
 }
 
-func addBootEntry(cfg systembooter.Booter) error {
+func addBootEntry(cfg systembooter.Booter, vpdDir string) error {
 	data, err := json.Marshal(cfg)
 	if err != nil {
 		return err
 	}
+	vpdReader := vpd.NewReader()
+	vpdReader.VpdDir = vpdDir
 	for i := 1; i < vpd.MaxBootEntry; i++ {
 		key := fmt.Sprintf("Boot%04d", i)
-		if _, err := vpd.Get(key, false); err != nil {
+		if _, err := vpdReader.Get(key, false); err != nil {
 			if os.IsNotExist(err) {
-				if err := vpd.Set(key, data, false); err != nil {
+				if err := vpdReader.Set(key, data, false); err != nil {
 					return err
 				}
 				return nil

--- a/tools/vpdbootmanager/get.go
+++ b/tools/vpdbootmanager/get.go
@@ -1,0 +1,77 @@
+// Copyright 2017-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/u-root/u-root/pkg/vpd"
+)
+
+// NewGetter returns a new initialized Getter.
+func NewGetter() *Getter {
+	return &Getter{
+		R:   vpd.NewReader(),
+		Out: os.Stdout,
+	}
+}
+
+// Getter is the object that gets VPD variables.
+type Getter struct {
+	R   *vpd.Reader
+	Out io.Writer
+}
+
+// Print prints VPD variables. If `key` is an empty string, it will print all
+// the variables it finds. A variable can exist as both read-write and
+// read-only. In that case a "RO" or "RW" string will also be printed.
+func (g *Getter) Print(key string) error {
+	allVars := make(map[bool]map[string][]byte)
+	if key == "" {
+		// read-only variables first
+		rovars, err := g.R.GetAll(true)
+		if err != nil {
+			return fmt.Errorf("failed to read RO variables: %w", err)
+		}
+		allVars[true] = rovars
+
+		// then read-write variables
+		rwvars, err := g.R.GetAll(false)
+		if err != nil {
+			return fmt.Errorf("failed to read RW variables: %w", err)
+		}
+		allVars[false] = rwvars
+	} else {
+		// first the read-only var
+		value, errRO := g.R.Get(key, true)
+		if errRO == nil {
+			allVars[true] = map[string][]byte{key: value}
+		}
+		// then the read-write var
+		value, errRW := g.R.Get(key, false)
+		if errRW == nil {
+			allVars[false] = map[string][]byte{key: value}
+		}
+
+		if len(allVars[true])+len(allVars[false]) == 0 {
+			fmt.Fprintf(g.Out, "No variable named '%s' found\n", key)
+			// if the variable is simply not set, return without error,
+			if os.IsNotExist(errRO) && os.IsNotExist(errRW) {
+				return nil
+			}
+			// otherwise print one or both errors.
+			return fmt.Errorf("failed to read variable '%s': RO: %v, RW: %v", key, errRO, errRW)
+		}
+	}
+	for k, v := range allVars[true] {
+		fmt.Fprintf(g.Out, "%s(RO) => %s\n", k, v)
+	}
+	for k, v := range allVars[false] {
+		fmt.Fprintf(g.Out, "%s(RW) => %s\n", k, v)
+	}
+	return nil
+}

--- a/tools/vpdbootmanager/get_test.go
+++ b/tools/vpdbootmanager/get_test.go
@@ -1,0 +1,47 @@
+// Copyright 2017-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/u-root/u-root/pkg/vpd"
+)
+
+var getter *Getter
+
+func TestNewgetter(t *testing.T) {
+	g := NewGetter()
+	require.NotNil(t, g)
+	require.NotNil(t, g.R)
+	require.NotNil(t, g.Out)
+}
+
+func TestGetOne(t *testing.T) {
+	var buf bytes.Buffer
+	getter := NewGetter()
+	getter.Out = &buf
+	getter.R = vpd.NewReader()
+	getter.R.VpdDir = "./tests"
+	err := getter.Print("firmware_version")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Equal(t, "firmware_version(RO) => 1.2.3\n\nfirmware_version(RW) => 3.2.1\n\n", out)
+}
+
+func TestGetAll(t *testing.T) {
+	var buf bytes.Buffer
+	getter := NewGetter()
+	getter.Out = &buf
+	getter.R = vpd.NewReader()
+	getter.R.VpdDir = "./tests"
+	err := getter.Print("")
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Equal(t, "firmware_version(RO) => 1.2.3\n\nsomething(RO) => else\n\nfirmware_version(RW) => 3.2.1\n\n", out)
+}

--- a/tools/vpdbootmanager/main.go
+++ b/tools/vpdbootmanager/main.go
@@ -9,12 +9,16 @@ import (
 	"os"
 )
 
-const usage = `Usage:
+func getUsage(progname string) string {
+	return fmt.Sprintf(`Usage:
 %s add [netboot [dhcpv6|dhcpv4] [MAC] | localboot [grub|path [Device GUID] [Kernel Path]]]
+%s get [variable name]
 
 Ex.
 add localboot grub
 add netboot dhcpv6 AA:BB:CC:DD:EE:FF
+get
+get firmware_version
 
 Flags for netboot:
 
@@ -30,11 +34,12 @@ Global flags:
 
 -vpd-dir - VPD dir to use
 
-`
+`, progname, progname)
+}
 
 func main() {
 	if err := cli(os.Args[1:]); err != nil {
-		fmt.Printf(usage, os.Args[0])
+		fmt.Println(getUsage(os.Args[0]))
 		fmt.Printf("Error: %s\n\n", err)
 		os.Exit(1)
 	}
@@ -42,11 +47,18 @@ func main() {
 
 func cli(args []string) error {
 	if len(args) < 1 {
-		return fmt.Errorf("You need to provide action")
+		return fmt.Errorf("you need to provide action")
 	}
 	switch args[0] {
 	case "add":
 		return add(args[1], args[2:])
+	case "get":
+		varname := ""
+		if len(args) > 1 {
+			varname = args[1]
+		}
+		getter := NewGetter()
+		return getter.Print(varname)
 	}
 	return fmt.Errorf("Unrecognized action")
 }

--- a/tools/vpdbootmanager/main_test.go
+++ b/tools/vpdbootmanager/main_test.go
@@ -23,12 +23,12 @@ func TestInvalidCommand(t *testing.T) {
 
 func TestNoEntryType(t *testing.T) {
 	err := cli([]string{"add", "localboot"})
-	require.Equal(t, "You need to provide method", err.Error())
+	require.Equal(t, "you need to provide method", err.Error())
 }
 
 func TestNoAction(t *testing.T) {
 	err := cli([]string{})
-	require.Equal(t, "You need to provide action", err.Error())
+	require.Equal(t, "you need to provide action", err.Error())
 }
 
 func TestAddNetbootEntryFull(t *testing.T) {


### PR DESCRIPTION
The `get` command in vpdbootmanager allows to read VPD variables.
Example:
```
~/# vpdbootmanager get firmware_version
firmware_version(RO) => 0.0.0
```

If no arguments are passed to `get`, all the variables are read:
```
~/# vpdbootmanager get
firmware_version(RO) => 0.0.0
internal_versions(RO) => {
  "build_id": "6bc0645",
...
    }
  }
}
~/#
```

Signed-off-by: Andrea Barberio <insomniac@slackware.it>