### PR TITLE
Fix failed to unmount error message

### DIFF
--- a/pkg/boot/bootcmd/bootcmd.go
+++ b/pkg/boot/bootcmd/bootcmd.go
@@ -35,7 +35,7 @@ func ShowMenuAndBoot(entries []menu.Entry, mountPool *mount.Pool, noLoad, noExec
 	// Clean up.
 	if mountPool != nil {
 		if err := mountPool.UnmountAll(mount.MNT_DETACH); err != nil {
-			log.Printf("Failed to unmount: %v", err)
+			log.Printf("Failed in UnmountAll: %v", err)
 		}
 	}
 	if loadedEntry == nil {


### PR DESCRIPTION
Error messages during boot
```
Enter an option ('01' is the default, 'e' to edit kernel cmdline):
 >

[diskboot] 2021/07/30 16:20:32 Failed to unmount: directory not empty
[diskboot] 2021/07/30 16:20:32 Nothing to boot.
```

The root cause was the wrong path of rmdir in (p *Pool) Mount().

Verified that this was caused by rmdir() with new error message format
```
2021/08/06 10:21:05 Failed in UnmountAll: (Rmdir) directory not empty
2021/08/06 10:21:05 executing command "/bin/defaultsh" with args []
u-root-mounts716997181
~/# ls /tmp/u-root-mounts716997181
sda
sdb1
sdb2
```
