### PR TITLE
cmds/core/backoff: simple backoff command

### DIFF
--- a/cmds/core/backoff/main.go
+++ b/cmds/core/backoff/main.go
@@ -1,0 +1,69 @@
+// Copyright 2012-2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Run a command, repeatedly, until it succeeds or we are out of time
+//
+// Synopsis:
+//	backoff [-t duration-string] command [args...]
+//
+// Description:
+//	backoff will run the command until it succeeds or a timeout has passed.
+//	The default timeout is 30s.
+//	If no args are given, it will just return.
+//
+// Example:
+//	$ backoff echo hi
+//	hi
+//	$
+package main
+
+import (
+	"context"
+	"flag"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+var timeout = flag.String("t", "", "Timeout for command")
+
+func runit(timeout string, c string, a ...string) error {
+	ctx := context.Background()
+	if len(timeout) != 0 {
+		d, err := time.ParseDuration(timeout)
+		if err != nil {
+			return err
+		}
+		cx, cancel := context.WithTimeout(context.Background(), d)
+		defer cancel()
+		ctx = cx
+	}
+	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
+	f := func() error {
+		cmd := exec.Command(c, a...)
+		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+		return cmd.Run()
+	}
+
+	return backoff.Retry(f, b)
+}
+
+func main() {
+	flag.Parse()
+
+	var args []string
+	a := flag.Args()
+	if len(a) == 0 {
+		return
+	}
+	if len(a) > 1 {
+		args = a[1:]
+	}
+	if err := runit(*timeout, a[0], args[:]...); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmds/core/backoff/main_test.go
+++ b/cmds/core/backoff/main_test.go
@@ -1,0 +1,104 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"regexp"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
+)
+
+type test struct {
+	args   []string
+	stdout string
+	stderr string
+	exitok bool
+}
+
+func run(c *exec.Cmd) (string, string, error) {
+	var o, e bytes.Buffer
+	c.Stdout, c.Stderr = &o, &e
+	err := c.Run()
+	return o.String(), e.String(), err
+}
+
+// TestOK for now just runs a simple successful test with 0 args or more than one arg.
+func TestOK(t *testing.T) {
+	var tests = []test{
+		{args: []string{}, stdout: "", exitok: true},
+		{args: []string{"date"}, stdout: ".*", exitok: true},
+		{args: []string{"-t", "wh", "date"}, stdout: ".*", stderr: ".*invalid.*duration.*wh", exitok: false},
+		{args: []string{"echo", "hi"}, stdout: ".*hi", exitok: true},
+	}
+
+	for _, v := range tests {
+		c := testutil.Command(t, v.args...)
+		stdout, stderr, err := run(c)
+		if (err != nil) && v.exitok {
+			t.Errorf("%v: got %v, want nil", v, err)
+		}
+		if (err == nil) && !v.exitok {
+			t.Errorf("%v: got nil, want err", v)
+		}
+		m, err := regexp.MatchString(v.stderr, stderr)
+		if err != nil {
+			t.Errorf("stderr: %v: got %v, want nil", v, err)
+		} else {
+			if !m {
+				t.Errorf("%v: regexp.MatchString(%s, %s) false, wanted match", v, v.stderr, stderr)
+			}
+		}
+
+		m, err = regexp.MatchString(v.stdout, stdout)
+		if err != nil {
+			t.Errorf("stdout: %v: got %v, want nil", v, err)
+			continue
+		}
+		if !m {
+			t.Errorf("%v: regexp.MatchString(%s, %s) false, wanted match", v, v.stdout, stderr)
+		}
+	}
+}
+func TestTO(t *testing.T) {
+	// The integration test dies after 25s, so do shit for 6s
+	var tests = []test{
+		{args: []string{"-t", "6s", "false"}, stdout: ".*", stderr: ".*exit.*status.*1", exitok: false},
+	}
+
+	for _, v := range tests {
+		c := testutil.Command(t, v.args...)
+		stdout, stderr, err := run(c)
+		if (err != nil) && v.exitok {
+			t.Errorf("%v: got %v, want nil", v, err)
+		}
+		if (err == nil) && !v.exitok {
+			t.Errorf("%v: got nil, want err", v)
+		}
+		m, err := regexp.MatchString(v.stderr, stderr)
+		if err != nil {
+			t.Errorf("stderr: %v: got %v, want nil", v, err)
+		} else {
+			if !m {
+				t.Errorf("%v: regexp.MatchString(%s, %s) false, wanted match", v, v.stderr, stderr)
+			}
+		}
+
+		m, err = regexp.MatchString(v.stdout, stdout)
+		if err != nil {
+			t.Errorf("stdout: %v: got %v, want nil", v, err)
+			continue
+		}
+		if !m {
+			t.Errorf("%v: regexp.MatchString(%s, %s) false, wanted match", v, v.stdout, stdout)
+		}
+	}
+}
+
+func TestMain(m *testing.M) {
+	testutil.Run(m, main)
+}


### PR DESCRIPTION
backoff will run a command, repeatedly, with exponential
backoff, until it succeeds or a timeout is passed.
The default timeout is zero, meaning "run until success".

The timeout is specified as a standard string duration,
e.g. 30s, 10m, and so on.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>