### PR TITLE
Add a single test to each empty file

### DIFF
--- a/pkg/bb/bbmain/pkg_test.go
+++ b/pkg/bb/bbmain/pkg_test.go
@@ -4,4 +4,8 @@
 
 package bbmain
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/boot/bootcmd/pkg_test.go
+++ b/pkg/boot/bootcmd/pkg_test.go
@@ -4,4 +4,8 @@
 
 package bootcmd
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/boot/boottest/pkg_test.go
+++ b/pkg/boot/boottest/pkg_test.go
@@ -4,4 +4,8 @@
 
 package boottest
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/boot/localboot/pkg_test.go
+++ b/pkg/boot/localboot/pkg_test.go
@@ -4,4 +4,8 @@
 
 package localboot
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/boot/netboot/pkg_test.go
+++ b/pkg/boot/netboot/pkg_test.go
@@ -4,4 +4,8 @@
 
 package netboot
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/boot/netboot/simple/pkg_test.go
+++ b/pkg/boot/netboot/simple/pkg_test.go
@@ -4,4 +4,8 @@
 
 package simple
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/boot/util/pkg_test.go
+++ b/pkg/boot/util/pkg_test.go
@@ -4,4 +4,8 @@
 
 package util
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/checker/pkg_test.go
+++ b/pkg/checker/pkg_test.go
@@ -4,4 +4,8 @@
 
 package checker
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/cmos/pkg_test.go
+++ b/pkg/cmos/pkg_test.go
@@ -4,4 +4,8 @@
 
 package cmos
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/cp/cmp/pkg_test.go
+++ b/pkg/cp/cmp/pkg_test.go
@@ -4,4 +4,8 @@
 
 package cmp
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/fb/pkg_test.go
+++ b/pkg/fb/pkg_test.go
@@ -4,4 +4,8 @@
 
 package fb
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/golang/pkg_test.go
+++ b/pkg/golang/pkg_test.go
@@ -4,4 +4,8 @@
 
 package golang
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/ipmi/blobs/pkg_test.go
+++ b/pkg/ipmi/blobs/pkg_test.go
@@ -4,4 +4,8 @@
 
 package blobs
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/ipmi/ocp/pkg_test.go
+++ b/pkg/ipmi/ocp/pkg_test.go
@@ -4,4 +4,8 @@
 
 package ocp
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/ipmi/pkg_test.go
+++ b/pkg/ipmi/pkg_test.go
@@ -4,4 +4,8 @@
 
 package ipmi
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/kexecbin/pkg_test.go
+++ b/pkg/kexecbin/pkg_test.go
@@ -4,4 +4,8 @@
 
 package kexecbin
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/libinit/pkg_test.go
+++ b/pkg/libinit/pkg_test.go
@@ -4,4 +4,8 @@
 
 package libinit
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/ls/pkg_test.go
+++ b/pkg/ls/pkg_test.go
@@ -4,4 +4,8 @@
 
 package ls
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/mei/pkg_test.go
+++ b/pkg/mei/pkg_test.go
@@ -4,4 +4,8 @@
 
 package mei
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/qemu/pkg_test.go
+++ b/pkg/qemu/pkg_test.go
@@ -4,4 +4,8 @@
 
 package qemu
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/recovery/pkg_test.go
+++ b/pkg/recovery/pkg_test.go
@@ -4,4 +4,8 @@
 
 package recovery
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/rng/pkg_test.go
+++ b/pkg/rng/pkg_test.go
@@ -4,4 +4,8 @@
 
 package rng
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/rtc/pkg_test.go
+++ b/pkg/rtc/pkg_test.go
@@ -4,4 +4,8 @@
 
 package rtc
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/securelaunch/eventlog/pkg_test.go
+++ b/pkg/securelaunch/eventlog/pkg_test.go
@@ -4,4 +4,8 @@
 
 package eventlog
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/securelaunch/launcher/pkg_test.go
+++ b/pkg/securelaunch/launcher/pkg_test.go
@@ -4,4 +4,8 @@
 
 package launcher
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/securelaunch/measurement/pkg_test.go
+++ b/pkg/securelaunch/measurement/pkg_test.go
@@ -4,4 +4,8 @@
 
 package measurement
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/securelaunch/pkg_test.go
+++ b/pkg/securelaunch/pkg_test.go
@@ -4,4 +4,8 @@
 
 package securelaunch
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/securelaunch/policy/pkg_test.go
+++ b/pkg/securelaunch/policy/pkg_test.go
@@ -4,4 +4,8 @@
 
 package policy
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/securelaunch/tpm/pkg_test.go
+++ b/pkg/securelaunch/tpm/pkg_test.go
@@ -4,4 +4,8 @@
 
 package tpm
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/sh/pkg_test.go
+++ b/pkg/sh/pkg_test.go
@@ -4,4 +4,8 @@
 
 package sh
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/strace/internal/binary/pkg_test.go
+++ b/pkg/strace/internal/binary/pkg_test.go
@@ -4,4 +4,8 @@
 
 package binary
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/testutil/pkg_test.go
+++ b/pkg/testutil/pkg_test.go
@@ -4,4 +4,8 @@
 
 package testutil
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/tss/pkg_test.go
+++ b/pkg/tss/pkg_test.go
@@ -4,4 +4,8 @@
 
 package tss
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/txtlog/pkg_test.go
+++ b/pkg/txtlog/pkg_test.go
@@ -4,4 +4,8 @@
 
 package txtlog
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/ubinary/pkg_test.go
+++ b/pkg/ubinary/pkg_test.go
@@ -4,4 +4,8 @@
 
 package ubinary
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/uefivars/vartest/pkg_test.go
+++ b/pkg/uefivars/vartest/pkg_test.go
@@ -4,4 +4,8 @@
 
 package vartest
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/uio/uiotest/pkg_test.go
+++ b/pkg/uio/uiotest/pkg_test.go
@@ -4,4 +4,8 @@
 
 package uiotest
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/ulog/ulogtest/pkg_test.go
+++ b/pkg/ulog/ulogtest/pkg_test.go
@@ -4,4 +4,8 @@
 
 package ulogtest
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/uroot/initramfs/test/pkg_test.go
+++ b/pkg/uroot/initramfs/test/pkg_test.go
@@ -4,4 +4,8 @@
 
 package test
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/uroot/test/bar/pkg_test.go
+++ b/pkg/uroot/test/bar/pkg_test.go
@@ -4,4 +4,8 @@
 
 package bar
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/uroot/util/pkg_test.go
+++ b/pkg/uroot/util/pkg_test.go
@@ -4,4 +4,8 @@
 
 package util
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/vmtest/internal/json2test/pkg_test.go
+++ b/pkg/vmtest/internal/json2test/pkg_test.go
@@ -4,4 +4,8 @@
 
 package json2test
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/vmtest/pkg_test.go
+++ b/pkg/vmtest/pkg_test.go
@@ -4,4 +4,8 @@
 
 package vmtest
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/watchdog/pkg_test.go
+++ b/pkg/watchdog/pkg_test.go
@@ -4,4 +4,8 @@
 
 package watchdog
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}

--- a/pkg/watchdogd/pkg_test.go
+++ b/pkg/watchdogd/pkg_test.go
@@ -4,4 +4,8 @@
 
 package watchdogd
 
-// TODO: Write a unit test.
+import "testing"
+
+func TestTODO(t *testing.T) {
+	// TODO: Write a unit test.
+}


### PR DESCRIPTION
* These empty files are necessary for `go test` to instrument the
  package for code coverage.
* Separately, our internal infra fails when a _test.go file contains no
  tests.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>