### PR TITLE
[pkg/golang] Do not force rebuild of all packages

### DIFF
--- a/pkg/golang/build.go
+++ b/pkg/golang/build.go
@@ -147,7 +147,6 @@ func (c Environ) Build(importPath string, binaryPath string, opts BuildOpts) err
 func (c Environ) BuildDir(dirPath string, binaryPath string, opts BuildOpts) error {
 	args := []string{
 		"build",
-		"-a", // Force rebuilding of packages.
 		"-o", binaryPath,
 		"-installsuffix", "uroot",
 		"-gcflags=all=-l", // Disable "function inlining" to get a smaller binary


### PR DESCRIPTION
Go's caching is mature and can be trusted to detect changes.