### PR TITLE
[fbnetboot] Add NTP support

### DIFF
--- a/cmds/core/ntpdate/ntpdate.go
+++ b/cmds/core/ntpdate/ntpdate.go
@@ -28,7 +28,7 @@ import (
 )
 
 var (
-	config  = flag.String("config", "/etc/ntp.conf", "NTP config file.")
+	config  = flag.String("config", ntpdate.DefaultNTPConfig, "NTP config file.")
 	setRTC  = flag.Bool("rtc", false, "Set RTC time as well")
 	verbose = flag.Bool("verbose", false, "Verbose output")
 )

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
 	github.com/beevik/ntp v0.3.0
 	github.com/cenkalti/backoff/v4 v4.0.2
-	github.com/creack/pty v1.1.11 // indirect
+	github.com/creack/pty v1.1.11
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/gliderlabs/ssh v0.1.2-0.20181113160402-cbabf5414432
@@ -14,8 +14,8 @@ require (
 	github.com/google/go-cmp v0.5.2
 	github.com/google/go-tpm v0.2.1-0.20200615092505-5d8a91de9ae3
 	github.com/google/goexpect v0.0.0-20191001010744-5b6988669ffa
-	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f
-	github.com/insomniacslk/dhcp v0.0.0-20210528123148-fb4eaaa00ad2
+	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f // indirect
+	github.com/insomniacslk/dhcp v0.0.0-20210817203519-d82598001386
 	github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2
 	github.com/kaey/framebuffer v0.0.0-20140402104929-7b385489a1ff // indirect
 	github.com/klauspost/compress v1.10.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,8 @@ github.com/hexdigest/gowrap v1.1.8/go.mod h1:H/JiFmQMp//tedlV8qt2xBdGzmne6bpbaSu
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 h1:/jC7qQFrv8CrSJVmaolDVOxTfS9kc36uB6H40kdbQq8=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714/go.mod h1:2Goc3h8EklBH5mspfHFxBnEoURQCGzQQH1ga9Myjvis=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/insomniacslk/dhcp v0.0.0-20210528123148-fb4eaaa00ad2 h1:WDOgJoE6rb7G6A7i1/Yyh5FJeydXeUrXHMRYJo7iFak=
-github.com/insomniacslk/dhcp v0.0.0-20210528123148-fb4eaaa00ad2/go.mod h1:h+MxyHxRg9NH3terB1nfRIUaQEcI0XOVkdR9LNBlp8E=
+github.com/insomniacslk/dhcp v0.0.0-20210817203519-d82598001386 h1:tVT6eeQjYk8cStFUlU7vfFpwUrzRHhC48VUhb2gbF9M=
+github.com/insomniacslk/dhcp v0.0.0-20210817203519-d82598001386/go.mod h1:h+MxyHxRg9NH3terB1nfRIUaQEcI0XOVkdR9LNBlp8E=
 github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2 h1:h+RKaNPjka7LRJGoeub/IQBdXSoEaJjfADkBq02hvjw=
 github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2/go.mod h1:RmeVYf9XrPRbRc3XIx0gLYA8qOFvNoPOfaEZduRlEp4=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=

--- a/pkg/ntpdate/ntpdate.go
+++ b/pkg/ntpdate/ntpdate.go
@@ -17,6 +17,8 @@ import (
 	"github.com/u-root/u-root/pkg/rtc"
 )
 
+const DefaultNTPConfig = "/etc/ntp.conf"
+
 var Debug = func(string, ...interface{}) {}
 
 func parseServers(r *bufio.Reader) []string {
@@ -118,7 +120,7 @@ func setTime(servers []string, config string, fallback string, setRTC bool, gs t
 		return "", 0, fmt.Errorf("unable to get time: %w", err)
 	}
 
-	offset := time.Since(t).Seconds()
+	offset := time.Until(t).Seconds()
 
 	if err = gs.SetSystemTime(t); err != nil {
 		return "", 0, fmt.Errorf("unable to set system time: %w", err)

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv4/server4/conn_unix.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv4/server4/conn_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package server4
 
 import (

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv4/server4/conn_windows.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv4/server4/conn_windows.go
@@ -1,0 +1,11 @@
+package server4
+
+import (
+	"errors"
+	"net"
+)
+
+// NewIPv4UDPConn fails on Windows. Use WithConn() to pass the connection.
+func NewIPv4UDPConn(iface string, addr *net.UDPAddr) (*net.UDPConn, error) {
+	return nil, errors.New("not implemented on Windows")
+}

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv6/dhcpv6message.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv6/dhcpv6message.go
@@ -288,6 +288,32 @@ func (mo MessageOptions) DHCP4oDHCP6Server() *OptDHCP4oDHCP6Server {
 	return nil
 }
 
+// NTPServers returns the NTP server addresses contained in the
+// NTP_SUBOPTION_SRV_ADDR of an OPTION_NTP_SERVER.
+// If multiple NTP server options exist, the function will return all the NTP
+// server addresses it finds, as defined by RFC 5908.
+func (mo MessageOptions) NTPServers() []net.IP {
+	opts := mo.Options.Get(OptionNTPServer)
+	if opts == nil {
+		return nil
+	}
+	addrs := make([]net.IP, 0)
+	for _, opt := range opts {
+		ntp, ok := opt.(*OptNTPServer)
+		if !ok {
+			continue
+		}
+		for _, subopt := range ntp.Suboptions {
+			so, ok := subopt.(*NTPSuboptionSrvAddr)
+			if !ok {
+				continue
+			}
+			addrs = append(addrs, net.IP(*so))
+		}
+	}
+	return addrs
+}
+
 // Message represents a DHCPv6 Message as defined by RFC 3315 Section 6.
 type Message struct {
 	MessageType   MessageType

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv6/option_ntp_server.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv6/option_ntp_server.go
@@ -1,0 +1,155 @@
+package dhcpv6
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/insomniacslk/dhcp/rfc1035label"
+	"github.com/u-root/uio/uio"
+)
+
+// NTPSuboptionSrvAddr is NTP_SUBOPTION_SRV_ADDR according to RFC 5908.
+type NTPSuboptionSrvAddr net.IP
+
+// Code returns the suboption code.
+func (n *NTPSuboptionSrvAddr) Code() OptionCode {
+	return NTPSuboptionSrvAddrCode
+}
+
+// ToBytes returns the byte serialization of the suboption.
+func (n *NTPSuboptionSrvAddr) ToBytes() []byte {
+	buf := uio.NewBigEndianBuffer(nil)
+	buf.Write16(uint16(NTPSuboptionSrvAddrCode))
+	buf.Write16(uint16(net.IPv6len))
+	buf.WriteBytes(net.IP(*n).To16())
+	return buf.Data()
+}
+
+func (n *NTPSuboptionSrvAddr) String() string {
+	return fmt.Sprintf("Server Address: %s", net.IP(*n).String())
+}
+
+// NTPSuboptionMCAddr is NTP_SUBOPTION_MC_ADDR according to RFC 5908.
+type NTPSuboptionMCAddr net.IP
+
+// Code returns the suboption code.
+func (n *NTPSuboptionMCAddr) Code() OptionCode {
+	return NTPSuboptionMCAddrCode
+}
+
+// ToBytes returns the byte serialization of the suboption.
+func (n *NTPSuboptionMCAddr) ToBytes() []byte {
+	buf := uio.NewBigEndianBuffer(nil)
+	buf.Write16(uint16(NTPSuboptionMCAddrCode))
+	buf.Write16(uint16(net.IPv6len))
+	buf.WriteBytes(net.IP(*n).To16())
+	return buf.Data()
+}
+
+func (n *NTPSuboptionMCAddr) String() string {
+	return fmt.Sprintf("Multicast Address: %s", net.IP(*n).String())
+}
+
+// NTPSuboptionSrvFQDN is NTP_SUBOPTION_SRV_FQDN according to RFC 5908.
+type NTPSuboptionSrvFQDN rfc1035label.Labels
+
+// Code returns the suboption code.
+func (n *NTPSuboptionSrvFQDN) Code() OptionCode {
+	return NTPSuboptionSrvFQDNCode
+}
+
+// ToBytes returns the byte serialization of the suboption.
+func (n *NTPSuboptionSrvFQDN) ToBytes() []byte {
+	buf := uio.NewBigEndianBuffer(nil)
+	buf.Write16(uint16(NTPSuboptionSrvFQDNCode))
+	l := rfc1035label.Labels(*n)
+	buf.Write16(uint16(l.Length()))
+	buf.WriteBytes(l.ToBytes())
+	return buf.Data()
+}
+
+func (n *NTPSuboptionSrvFQDN) String() string {
+	l := rfc1035label.Labels(*n)
+	return fmt.Sprintf("Server FQDN: %s", l.String())
+}
+
+// NTPSuboptionSrvAddr is the value of NTP_SUBOPTION_SRV_ADDR according to RFC 5908.
+const (
+	NTPSuboptionSrvAddrCode = OptionCode(1)
+	NTPSuboptionMCAddrCode  = OptionCode(2)
+	NTPSuboptionSrvFQDNCode = OptionCode(3)
+)
+
+// parseNTPSuboption implements the OptionParser interface.
+func parseNTPSuboption(code OptionCode, data []byte) (Option, error) {
+	//var o Options
+	buf := uio.NewBigEndianBuffer(data)
+	length := len(data)
+	data, err := buf.ReadN(length)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %d bytes for suboption: %w", length, err)
+	}
+	switch code {
+	case NTPSuboptionSrvAddrCode, NTPSuboptionMCAddrCode:
+		if length != net.IPv6len {
+			return nil, fmt.Errorf("invalid suboption length, want %d, got %d", net.IPv6len, length)
+		}
+		var so Option
+		switch code {
+		case NTPSuboptionSrvAddrCode:
+			sos := NTPSuboptionSrvAddr(data)
+			so = &sos
+		case NTPSuboptionMCAddrCode:
+			som := NTPSuboptionMCAddr(data)
+			so = &som
+		}
+		return so, nil
+	case NTPSuboptionSrvFQDNCode:
+		l, err := rfc1035label.FromBytes(data)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse rfc1035 labels: %w", err)
+		}
+		// TODO according to rfc3315, this label must not be compressed.
+		// Need to add support for compression detection to the
+		// `rfc1035label` package in order to do that.
+		so := NTPSuboptionSrvFQDN(*l)
+		return &so, nil
+	default:
+		gopt := OptionGeneric{OptionCode: code, OptionData: data}
+		return &gopt, nil
+	}
+}
+
+// ParseOptNTPServer parses a sequence of bytes into an OptNTPServer object.
+func ParseOptNTPServer(data []byte) (*OptNTPServer, error) {
+	var so Options
+	if err := so.FromBytesWithParser(data, parseNTPSuboption); err != nil {
+		return nil, err
+	}
+	return &OptNTPServer{
+		Suboptions: so,
+	}, nil
+}
+
+// OptNTPServer is an option NTP server as defined by RFC 5908.
+type OptNTPServer struct {
+	Suboptions Options
+}
+
+// Code returns the option code
+func (op *OptNTPServer) Code() OptionCode {
+	return OptionNTPServer
+}
+
+// ToBytes returns the option serialized to bytes.
+func (op *OptNTPServer) ToBytes() []byte {
+	buf := uio.NewBigEndianBuffer(nil)
+	for _, so := range op.Suboptions {
+		buf.WriteBytes(so.ToBytes())
+	}
+	return buf.Data()
+}
+
+func (op *OptNTPServer) String() string {
+	return fmt.Sprintf("NTP: %v", op.Suboptions)
+}

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv6/options.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv6/options.go
@@ -81,6 +81,8 @@ func ParseOption(code OptionCode, optData []byte) (Option, error) {
 		opt, err = ParseOptRemoteID(optData)
 	case OptionFQDN:
 		opt, err = ParseOptFQDN(optData)
+	case OptionNTPServer:
+		opt, err = ParseOptNTPServer(optData)
 	case OptionBootfileURL:
 		opt, err = parseOptBootFileURL(optData)
 	case OptionBootfileParam:

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv6/server6/conn_unix.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv6/server6/conn_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package server6
 
 import (

--- a/vendor/github.com/insomniacslk/dhcp/dhcpv6/server6/conn_windows.go
+++ b/vendor/github.com/insomniacslk/dhcp/dhcpv6/server6/conn_windows.go
@@ -1,0 +1,13 @@
+// +build windows
+
+package server6
+
+import (
+	"errors"
+	"net"
+)
+
+// NewIPv6UDPConn fails on Windows. Use WithConn() to pass the connection.
+func NewIPv6UDPConn(iface string, addr *net.UDPAddr) (*net.UDPConn, error) {
+	return nil, errors.New("not implemented on Windows")
+}

--- a/vendor/github.com/insomniacslk/dhcp/interfaces/bindtodevice_darwin.go
+++ b/vendor/github.com/insomniacslk/dhcp/interfaces/bindtodevice_darwin.go
@@ -1,4 +1,4 @@
-// +build aix freebsd openbsd netbsd
+// +build darwin
 
 package interfaces
 
@@ -9,11 +9,11 @@ import (
 )
 
 // BindToInterface emulates linux's SO_BINDTODEVICE option for a socket by using
-// IP_RECVIF.
+// IP_BOUND_IF.
 func BindToInterface(fd int, ifname string) error {
 	iface, err := net.InterfaceByName(ifname)
 	if err != nil {
 		return err
 	}
-	return unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_RECVIF, iface.Index)
+	return unix.SetsockoptInt(fd, unix.IPPROTO_IP, unix.IP_BOUND_IF, iface.Index)
 }

--- a/vendor/github.com/insomniacslk/dhcp/interfaces/bindtodevice_windows.go
+++ b/vendor/github.com/insomniacslk/dhcp/interfaces/bindtodevice_windows.go
@@ -1,0 +1,8 @@
+package interfaces
+
+import "errors"
+
+// BindToInterface fails on Windows.
+func BindToInterface(fd int, ifname string) error {
+	return errors.New("not implemented on Windows")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -29,7 +29,7 @@ github.com/google/go-tpm/tpmutil/tbs
 github.com/google/goexpect
 # github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f
 github.com/google/goterm/term
-# github.com/insomniacslk/dhcp v0.0.0-20210528123148-fb4eaaa00ad2
+# github.com/insomniacslk/dhcp v0.0.0-20210817203519-d82598001386
 github.com/insomniacslk/dhcp/dhcpv4
 github.com/insomniacslk/dhcp/dhcpv4/client4
 github.com/insomniacslk/dhcp/dhcpv4/nclient4


### PR DESCRIPTION
Having valid time is important for HTTPS boot to work, as it prevents
certificate validation failures due to invalid system time.

This PR adds NTP support, enabled by default, to query NTP servers
hard-coded in the image or returned by DHCPv4/v6.

Failure to set time is not fatal and boot proceeds regardless.
With no additional configuration and assumiong no NTP servers
returned by the DHCP server, it's a no-op.

Example of successful execution: https://gist.github.com/rojer9-fb/893ac04361eb3da414d73e5b9befd7e5

Signed-off-by: Deomid "rojer" Ryabkov <rojer9@fb.com>