### PR TITLE
Add Block device filter checking for required partitions 

### DIFF
--- a/pkg/mount/block/blockdev.go
+++ b/pkg/mount/block/blockdev.go
@@ -487,6 +487,26 @@ func (b BlockDevices) FilterPartType(guid string) BlockDevices {
 	return b.FilterNames(names...)
 }
 
+// FilterHavingPartitions returns BlockDevices with have the specified
+// partitions. (e.g. f(1, 2) {sda, sda1, sda2, sdb} -> {sda})
+func (b BlockDevices) FilterHavingPartitions(parts []int) BlockDevices {
+	devices := make(BlockDevices, 0)
+	for _, device := range b {
+		hasParts := true
+		for _, part := range parts {
+			if _, err := os.Stat(filepath.Join("/sys/class/block",
+				composePartName(device.Name, part))); err != nil {
+				hasParts = false
+				break
+			}
+		}
+		if hasParts {
+			devices = append(devices, device)
+		}
+	}
+	return devices
+}
+
 // FilterPartLabel returns a list of BlockDev objects whose underlying block
 // device has the given partition label. The name comparison is case-insensitive.
 func (b BlockDevices) FilterPartLabel(label string) BlockDevices {

--- a/pkg/mount/mount_linux_test.go
+++ b/pkg/mount/mount_linux_test.go
@@ -158,6 +158,47 @@ func TestFilterPartType(t *testing.T) {
 	}
 }
 
+func TestFilterHavingPartitions(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+
+	prefix := getDevicePrefix()
+
+	devs, err := block.GetBlockDevices()
+	if err != nil {
+		t.Fatal(err)
+	}
+	devs = devs.FilterZeroSize()
+
+	want := block.BlockDevices{
+		&block.BlockDev{Name: "nvme0n1"},
+		&block.BlockDev{Name: "nvme0n1p1"},
+		&block.BlockDev{Name: "nvme0n1p2"},
+		&block.BlockDev{Name: prefix + "a"},
+		&block.BlockDev{Name: prefix + "a1", FsUUID: "2183ead8-a510-4b3d-9777-19c7090f66d9"},
+		&block.BlockDev{Name: prefix + "a2", FsUUID: "ace5-5144"},
+		&block.BlockDev{Name: prefix + "b"},
+		&block.BlockDev{Name: prefix + "b1"},
+		&block.BlockDev{Name: prefix + "c"},
+		&block.BlockDev{Name: prefix + "c1"},
+		&block.BlockDev{Name: prefix + "c2"},
+	}
+	if !reflect.DeepEqual(devs, want) {
+		t.Fatalf("BlockDevices() = \n\t%v want\n\t%v", devs, want)
+	}
+
+	block.Debug = log.Printf
+	devs = devs.FilterHavingPartitions([]int{1, 2})
+
+	want = block.BlockDevices{
+		&block.BlockDev{Name: "nvme0n1"},
+		&block.BlockDev{Name: prefix + "a"},
+		&block.BlockDev{Name: prefix + "c"},
+	}
+	if !reflect.DeepEqual(devs, want) {
+		t.Fatalf("BlockDevices() = \n\t%v want\n\t%v", devs, want)
+	}
+}
+
 func TestFilterBlockPCI(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 


### PR DESCRIPTION
This allows filtering for block devices that have a partitions 1,2,4

Signed-off-by: Colin Mitchell <colinmitchell@google.com>