### PR TITLE
pkg/vpd, tools/vpdbootmanager: add FlashromVpdSet method for 'set' an…

### DIFF
--- a/cmds/boot/systemboot/main.go
+++ b/cmds/boot/systemboot/main.go
@@ -92,7 +92,7 @@ func checkCMOSClear(ipmi *ipmi.IPMI) error {
 		if err = cmosClear(); err != nil {
 			return err
 		}
-		if err = ocp.ClearRwVpd(); err != nil {
+		if err = vpd.ClearRwVpd(); err != nil {
 			return err
 		}
 

--- a/pkg/ipmi/ocp/bootorder.go
+++ b/pkg/ipmi/ocp/bootorder.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/u-root/u-root/pkg/boot/systembooter"
 	"github.com/u-root/u-root/pkg/ipmi"
+	"github.com/u-root/u-root/pkg/vpd"
 )
 
 const (
@@ -101,14 +102,14 @@ func updateVPDBootOrder(i *ipmi.IPMI, BootOrder *BootOrder) error {
 		if bootType == NETWORK_BOOT {
 			log.Printf("VPD set %s to %s", key, NETBOOTER_CONFIG)
 			BootEntries = append(BootEntries, systembooter.BootEntry{Name: key, Config: []byte(NETBOOTER_CONFIG)})
-			if err = Set(key, []byte(NETBOOTER_CONFIG)); err != nil {
+			if err = vpd.FlashromRWVpdSet(key, []byte(NETBOOTER_CONFIG), false); err != nil {
 				return err
 			}
 			idx++
 		} else if bootType == LOCAL_BOOT {
 			log.Printf("VPD set %s to %s", key, LOCALBOOTER_CONFIG)
 			BootEntries = append(BootEntries, systembooter.BootEntry{Name: key, Config: []byte(LOCALBOOTER_CONFIG)})
-			if err = Set(key, []byte(LOCALBOOTER_CONFIG)); err != nil {
+			if err = vpd.FlashromRWVpdSet(key, []byte(LOCALBOOTER_CONFIG), false); err != nil {
 				return err
 			}
 			idx++

--- a/tools/vpdbootmanager/add.go
+++ b/tools/vpdbootmanager/add.go
@@ -146,3 +146,11 @@ func addBootEntry(cfg systembooter.Booter, vpdDir string) error {
 	}
 	return errors.New("Maximum number of boot entries already set")
 }
+
+func set(key string, value string) error {
+	return vpd.FlashromRWVpdSet(key, []byte(value), false)
+}
+
+func delete(key string) error {
+	return vpd.FlashromRWVpdSet(key, []byte("dummy"), true)
+}

--- a/tools/vpdbootmanager/main.go
+++ b/tools/vpdbootmanager/main.go
@@ -19,6 +19,8 @@ add localboot grub
 add netboot dhcpv6 AA:BB:CC:DD:EE:FF
 get
 get firmware_version
+set systemboot_log_level 6
+delete systemboot_log_level
 
 Flags for netboot:
 
@@ -59,6 +61,22 @@ func cli(args []string) error {
 		}
 		getter := NewGetter()
 		return getter.Print(varname)
+	case "set":
+		if len(args) == 3 {
+			err := set(args[1], args[2])
+			if err == nil {
+				fmt.Println("Successfully set, it will take effect after reboot")
+			}
+			return err
+		}
+	case "delete":
+		if len(args) == 2 {
+			err := delete(args[1])
+			if err == nil {
+				fmt.Println("Successfully deleted, it will take effect after reboot")
+			}
+			return err
+		}
 	}
 	return fmt.Errorf("Unrecognized action")
 }

--- a/tools/vpdbootmanager/main.go
+++ b/tools/vpdbootmanager/main.go
@@ -13,6 +13,8 @@ func getUsage(progname string) string {
 	return fmt.Sprintf(`Usage:
 %s add [netboot [dhcpv6|dhcpv4] [MAC] | localboot [grub|path [Device GUID] [Kernel Path]]]
 %s get [variable name]
+%s set [variable name] [variable value]
+%s delete [variable name]
 
 Ex.
 add localboot grub
@@ -36,7 +38,7 @@ Global flags:
 
 -vpd-dir - VPD dir to use
 
-`, progname, progname)
+`, progname, progname, progname, progname)
 }
 
 func main() {


### PR DESCRIPTION
…d 'delete'

By calling flashrom and vpd executables to set and delete vpd key-value.
The ideal long-term method could be employing Linux mtd driver for writing
flash VPD but this PR can provide a temporary workaround.

Move pkg/ipmi/ocp/set_vpd.go to pkg/vpd/flashromvpd.go

To set an existing vpd key to value:
vpdbootmanager set key value
If the key doesn't exist it would add it.

To delete a key:
vpdbootmanager delete key

Signed-off-by: Johnny Lin <johnny_lin@wiwynn.com>