### PR TITLE
tools/makebb: add -c switch so it lists commands

### DIFF
--- a/tools/makebb/makebb.go
+++ b/tools/makebb/makebb.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -16,7 +17,10 @@ import (
 	"github.com/u-root/u-root/pkg/uroot"
 )
 
-var outputPath = flag.String("o", "bb", "Path to busybox binary")
+var (
+	outputPath = flag.String("o", "bb", "Path to busybox binary")
+	showCmds   = flag.Bool("c", false, "Show commands -- useful in scripts")
+)
 
 func main() {
 	flag.Parse()
@@ -46,5 +50,10 @@ func main() {
 
 	if err := bb.BuildBusybox(env, pkgs, false /* noStrip */, o); err != nil {
 		l.Fatal(err)
+	}
+	if *showCmds {
+		for _, p := range pkgs {
+			fmt.Println(filepath.Base(p))
+		}
 	}
 }


### PR DESCRIPTION
In scripts, as used in, e.g., Harvey, it is important to
know what commands are built into a bb.

The glob passed to makebb will not always be the same
as the actual commands that get built (there might be a
match for a command that does not get built due to build
constraints).

The -c switch to bb will now list the commands that get built in.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>