### PR TITLE
kexec: Add the ability to use multiple cpio files

### DIFF
--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	flag "github.com/spf13/pflag"
 
@@ -102,7 +103,11 @@ func main() {
 		} else {
 			var i io.ReaderAt
 			if opts.initramfs != "" {
-				i = uio.NewLazyFile(opts.initramfs)
+				var files []io.ReaderAt
+				for _, n := range strings.Fields(opts.initramfs) {
+					files = append(files, uio.NewLazyFile(n))
+				}
+				i = boot.CatInitrds(files...)
 			}
 			image = &boot.LinuxImage{
 				Kernel:  uio.NewLazyFile(kernelpath),


### PR DESCRIPTION
Sometimes users need to add files to the kexec cpio. A common
request is to pass the kernel log buffer along.

Modify kexec so that initramfs can now specify multiple
cpio files, e.g.
kexec -i 'a.cpio b.cpio c.cpio'
The code uses strings.Fields, as that nicely handles the case
of superfluous seperators, i.e. '   a  b  c   ' returns [a b c].

Now, should someone desire to pass along, e.g., dmesg output, they can
do this via script or programatically:

mkdir /tmp/messageinabottle
dmesg > /tmp/messageinabottle/log
(cd /tmp && find messageinabottle -print | cpio -H newc -o > /tmp/m.cpio)
kexec -i 'inird.cpio /tmp/m.cpio'

A remaining question is how much of this work we ought to do in kexec.
It could, for example, take a switch called extrafiles:
kexec -extrafiles 'a b c' ...
and build an in-memory cpio archive to be appended to the initrd.

At some point, a line needs to be draw, however.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>