### PR TITLE
linux kexec: skip kernel / initrd copying when source is a regular file. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 templates:
   golang-template: &golang-template
     docker:
-      - image: uroottest/test-image-amd64:v4.2.2
+      - image: uroottest/test-image-amd64:v4.3.0
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - CGO_ENABLED: 0
@@ -203,7 +203,7 @@ jobs:
   test-integration-amd64:
     <<: *integration-template
     docker:
-      - image: uroottest/test-image-amd64:v4.2.2
+      - image: uroottest/test-image-amd64:v4.3.0
   test-integration-arm:
     <<: *integration-template
     docker:

--- a/pkg/boot/linux_test.go
+++ b/pkg/boot/linux_test.go
@@ -109,7 +109,7 @@ func TestLinuxLabel(t *testing.T) {
 func TestCopyToFile(t *testing.T) {
 	buf := bytes.NewBufferString("abcdefg hijklmnop")
 
-	f, err := copyToFile(buf)
+	f, err := copyToFileIfNotRegular(buf)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/mount/magic.go
+++ b/pkg/mount/magic.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux
 // +build linux
 
 package mount
@@ -11,6 +12,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 const blocksize = 65536
@@ -214,4 +218,13 @@ func FSFromBlock(n string) (fs string, flags uintptr, err error) {
 		}
 	}
 	return "", 0, fmt.Errorf("no suitable filesystem for %q, from magics %q", n, magics)
+}
+
+// IsTmpfs tells if the file path given is under a tmpfs.
+func IsTmpfs(path string) (bool, error) {
+	var s syscall.Statfs_t
+	if err := syscall.Statfs(path, &s); err != nil {
+		return false, err
+	}
+	return s.Type == unix.TMPFS_MAGIC, nil
 }


### PR DESCRIPTION
...and under tmpfs.

One caveat discussed is original file may be opened
for writting, which kexec file load does not like.
This change does not proactively prevent that from
happening within linux.go, but now allow it to fail
in that case.

One thing I can do is write, in golang, lsof, and matching
/proc/\*/fd/\* sym linked file against original file name
and see if there is any currently opening it, and throw
an error to kexec load caller, but that is not giving
any advantage over let kexec file load propogating up
the error. One benefit being we can do sth custom when
that happens, say proactively purging / closing them.
That just lead us into another hole of mess. So I prefer
to "Leap Before You Look" here for simplicity.

Signed-off-by: David Hu <xuehaohu@google.com>