### PR TITLE
systemboot: add Quanta S9S to supported OEM product list

### DIFF
--- a/cmds/boot/systemboot/main.go
+++ b/cmds/boot/systemboot/main.go
@@ -55,7 +55,7 @@ const VpdBmcBootOrderOverride = "bmc_bootorder_override"
 var bmcBootOverride bool
 
 // Product list for running IPMI OEM commands
-var productList = [4]string{"Tioga Pass", "Mono Lake", "Delta Lake", "CraterLake"}
+var productList = [5]string{"Tioga Pass", "Mono Lake", "Delta Lake", "CraterLake", "S9S"}
 
 var selRecorded bool
 


### PR DESCRIPTION
Signed-off-by: Tim Chu <Tim.Chu@quantatw.com>