### PR TITLE
spi: Improve GC safety in spidev test

### DIFF
--- a/pkg/spi/spidev_linux_test.go
+++ b/pkg/spi/spidev_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
+	"runtime"
 	"testing"
 	"unsafe"
 
@@ -65,12 +66,13 @@ func (s *mockSpidev) syscall(trap, a1, a2 uintptr, a3 unsafe.Pointer) (r1, r2 ui
 		s.transfers = make([]iocTransfer, size/binary.Size(iocTransfer{}))
 
 		// Re-create the slice from the array.
-		sh := (*reflect.SliceHeader)(unsafe.Pointer(&a3))
-		sh.Data = uintptr(a3)
-		sh.Len = len(s.transfers)
-		sh.Cap = len(s.transfers)
+		defer runtime.KeepAlive(a3)
+		sh := &reflect.SliceHeader{
+			Data: uintptr(a3),
+			Len:  len(s.transfers),
+			Cap:  len(s.transfers),
+		}
 		transfers := *(*[]iocTransfer)(unsafe.Pointer(sh))
-		//defer runtime.KeepAlive(a3)
 
 		// Copy to another slice since the GC will clean it up once the
 		// references disappear.


### PR DESCRIPTION
This corrects the following:

* The original code's cast from a3 to `*reflect.SliceHeader` does not
  make sense. Doubly so since the `Data` field also gets set to a3.
* Added a `KeepAlive` for `a3` since it is cast to a uintptr and has
  nothing to keep it alive. It looks like this was the original intent,
  but the line was commented out for some reason.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>