### PR TITLE
Increase uefiboot's memory to 4096

### DIFF
--- a/integration/generic-tests/uefiboot_test.go
+++ b/integration/generic-tests/uefiboot_test.go
@@ -41,7 +41,7 @@ func TestUefiBoot(t *testing.T) {
 			Devices: []qemu.Device{
 				qemu.IDEBlockDevice{File: src},
 				qemu.ArbitraryArgs{"-machine", "q35"},
-				qemu.ArbitraryArgs{"-m", "2048"},
+				qemu.ArbitraryArgs{"-m", "4096"},
 			},
 		},
 	})


### PR DESCRIPTION
Temporary increase QEMU memory to 4GB to unblock the flaky integration
test. This is because payload assume some memory mapping after APIC and
it may not be accessible in QEMU6. We will need to root cause this.