### PR TITLE
improve string handling

### DIFF
--- a/cmds/core/elvish/getopt/getopt.go
+++ b/cmds/core/elvish/getopt/getopt.go
@@ -244,7 +244,7 @@ func (g *Getopt) Parse(elems []string) ([]*ParsedOption, []string, *Context) {
 	} else if elem == "--" {
 		ctx.Type = NewLongOption
 	} else if hasPrefix("--") {
-		if strings.IndexRune(elem, '=') == -1 {
+		if !strings.ContainsRune(elem, '=') {
 			ctx.Type, ctx.Text = LongOption, elem[2:]
 		} else {
 			newopt, _ := g.parseLong(elem[2:])
@@ -252,7 +252,7 @@ func (g *Getopt) Parse(elems []string) ([]*ParsedOption, []string, *Context) {
 		}
 	} else if hasPrefix("-") {
 		if g.Config.HasAll(LongOnly) {
-			if strings.IndexRune(elem, '=') == -1 {
+			if !strings.ContainsRune(elem, '=') {
 				ctx.Type, ctx.Text = LongOption, elem[1:]
 			} else {
 				newopt, _ := g.parseLong(elem[1:])

--- a/cmds/core/ps/ps_test.go
+++ b/cmds/core/ps/ps_test.go
@@ -22,7 +22,7 @@ import (
 // If no errors returns, it's okay
 func TestPsExecution(t *testing.T) {
 	t.Logf("TestPsExecution")
-	d, err := ioutil.TempDir("", fmt.Sprintf("ps"))
+	d, err := ioutil.TempDir("", "ps")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmds/core/readlink/readlink_test.go
+++ b/cmds/core/readlink/readlink_test.go
@@ -83,7 +83,7 @@ func TestReadlink(t *testing.T) {
 		{
 			flags:      []string{"-v", "foo.bar"},
 			out:        "",
-			stdErr:     fmt.Sprintf("readlink foo.bar: no such file or directory\n"),
+			stdErr:     "readlink foo.bar: no such file or directory\n",
 			exitStatus: 1,
 		},
 	}

--- a/cmds/core/scp/scp_test.go
+++ b/cmds/core/scp/scp_test.go
@@ -47,7 +47,7 @@ func TestScpSink(t *testing.T) {
 	}
 	defer os.Remove(tf.Name())
 
-	r.Write([]byte(fmt.Sprintf("C0600 18 test\ntest-file-contents")))
+	r.Write([]byte("C0600 18 test\ntest-file-contents"))
 	// Post IO-copy success status
 	r.Write([]byte{0})
 

--- a/cmds/exp/ash/parse.go
+++ b/cmds/exp/ash/parse.go
@@ -98,7 +98,7 @@ func tok(b *bufio.Reader) (string, string) {
 			if c == 0 {
 				break
 			}
-			if strings.Index(punct, string(c)) > -1 {
+			if strings.Contains(punct, string(c)) {
 				pushback(b)
 				break
 			}
@@ -143,7 +143,7 @@ func tok(b *bufio.Reader) (string, string) {
 			if c == 0 {
 				return "ARG", arg
 			}
-			if strings.Index(punct, string(c)) > -1 {
+			if strings.Contains(punct, string(c)) {
 				pushback(b)
 				return "ARG", arg
 			}

--- a/cmds/exp/rush/parse.go
+++ b/cmds/exp/rush/parse.go
@@ -98,7 +98,7 @@ func tok(b *bufio.Reader) (string, string) {
 			if c == 0 {
 				break
 			}
-			if strings.Index(punct, string(c)) > -1 {
+			if strings.Contains(punct, string(c)) {
 				pushback(b)
 				break
 			}
@@ -143,7 +143,7 @@ func tok(b *bufio.Reader) (string, string) {
 			if c == 0 {
 				return "ARG", arg
 			}
-			if strings.Index(punct, string(c)) > -1 {
+			if strings.Contains(punct, string(c)) {
 				pushback(b)
 				return "ARG", arg
 			}

--- a/cmds/exp/validate/validate.go
+++ b/cmds/exp/validate/validate.go
@@ -120,10 +120,7 @@ func main() {
 	}
 
 	if *alg != "" {
-		try = []string{}
-		for _, v := range strings.Split(*alg, ",") {
-			try = append(try, v)
-		}
+		try = append(try, strings.Split(*alg, ",")...)
 	}
 
 	log.Printf("Try %v", try)

--- a/pkg/mount/scuzz/control.go
+++ b/pkg/mount/scuzz/control.go
@@ -93,7 +93,7 @@ func (d DiskSecurityStatus) SecurityCountExpired() bool {
 }
 
 func (d DiskSecurityStatus) String() string {
-	s := fmt.Sprint("Security Status: ")
+	s := "Security Status: "
 	for v, name := range securityStatusStrings {
 		if d&v != 0 {
 			s += name + ", "

--- a/pkg/txtlog/txtlog.go
+++ b/pkg/txtlog/txtlog.go
@@ -238,7 +238,7 @@ func getHandoffTablePointers(eventData []byte) (*string, error) {
 		}
 	}
 
-	eventInfo := fmt.Sprint("Tables: ")
+	eventInfo := "Tables: "
 	for _, table := range handoffTablePointers.tableEntry {
 		guid := fmt.Sprintf("%x-%x-%x-%x-%x", table.vendorGUID.blockA, table.vendorGUID.blockB, table.vendorGUID.blockC, table.vendorGUID.blockD, table.vendorGUID.blockE)
 		eventInfo += fmt.Sprintf("At address 0x%d with Guid %s", table.vendorTable, guid)
@@ -304,7 +304,7 @@ func getGPTEventString(eventData []byte) (*string, error) {
 
 	// Stop here we only want to know which device was used here.
 
-	eventInfo := fmt.Sprint("Disk Guid - ")
+	eventInfo := "Disk Guid - "
 	eventInfo += gptEvent.uefiPartitionHeader.DiskGUID.String()
 	return &eventInfo, nil
 }


### PR DESCRIPTION
Housecleaning of string handling:

- removing unneeded function calls
- replace for loop with automatic appending
- replace `strings.Index(X, Y) == -1 {` constructs with `strings.Contain(X,Y)`