### PR TITLE
retract versions v1.0.0-v7.0.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,10 +10,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    # Environment variables
-    env:
-      # Turn off modules because we are broken.
-      GO111MODULE: off
 
     steps:
     - uses: actions/checkout@v2
@@ -24,7 +20,7 @@ jobs:
         go-version: 1.17
 
     - name: Build
-      run: go build -v ./...
+      run: go build -mod=mod -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -mod=mod -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/u-root/u-root
 
-go 1.13
+go 1.17
 
 require (
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be // indirect
@@ -17,29 +17,50 @@ require (
 	github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f // indirect
 	github.com/insomniacslk/dhcp v0.0.0-20210817203519-d82598001386
 	github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2
+	github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c // indirect
 	github.com/kaey/framebuffer v0.0.0-20140402104929-7b385489a1ff // indirect
 	github.com/klauspost/compress v1.10.6 // indirect
 	github.com/klauspost/pgzip v1.2.4
 	github.com/kr/pty v1.1.8
+	github.com/mattn/go-isatty v0.0.12 // indirect
+	github.com/mdlayher/ethernet v0.0.0-20190606142754-0394541c37b7 // indirect
+	github.com/mdlayher/netlink v1.1.1 // indirect
+	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065 // indirect
 	github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330
 	github.com/pborman/getopt/v2 v2.1.0
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rck/unit v0.0.3
 	github.com/rekby/gpt v0.0.0-20200219180433-a930afbc6edc
 	github.com/safchain/ethtool v0.0.0-20200218184317-f459e2d13664
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	github.com/u-root/iscsinl v0.1.1-0.20210528121423-84c32645822a
+	github.com/u-root/uio v0.0.0-20210528114334-82958018845c // indirect
 	github.com/ulikunitz/xz v0.5.8
 	github.com/vishvananda/netlink v1.1.1-0.20200221165523-c79a4b7b4066
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f // indirect
 	github.com/vtolstov/go-ioctl v0.0.0-20151206205506-6be9cced4810
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/mod v0.4.2 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210820121016-41cdb8703e55
 	golang.org/x/term v0.0.0-20210317153231-de623e64d2a6
 	golang.org/x/text v0.3.3
 	golang.org/x/tools v0.1.1
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/grpc v1.29.1 // indirect
 	gopkg.in/yaml.v2 v2.2.2
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 	pack.ag/tftp v1.0.1-0.20181129014014-07909dfbde3c
 	src.elv.sh v0.16.3
+)
+
+retract (
+	v7.0.0+incompatible
+	v6.0.0+incompatible
+	v5.0.0+incompatible
+	v4.0.0+incompatible
+	v3.0.0+incompatible
+	v2.0.0+incompatible
+	v1.0.0
 )


### PR DESCRIPTION
In our defense, this was done before go modules existed.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>