### PR TITLE
integrations: bump mem to 5G for gotests

### DIFF
--- a/integration/gotests/gotest_test.go
+++ b/integration/gotests/gotest_test.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !race
 // +build !race
 
 package integration
@@ -94,6 +95,15 @@ func TestGoTest(t *testing.T) {
 	o := &vmtest.Options{
 		QEMUOpts: qemu.Options{
 			Timeout: 120 * time.Second,
+			Devices: []qemu.Device{
+				// Bump this up so that some unit tests can happily
+				// and questionably pre-claim large bytes slices.
+				//
+				// e.g. pkg/mount/gpt/gpt_test.go need to claim 4.29G
+				//
+				//     disk = make([]byte, 0x100000000)
+				qemu.ArbitraryArgs{"-m", "6G"},
+			},
 		},
 	}
 	vmtest.GolangTest(t, pkgs, o)


### PR DESCRIPTION
One of the mount test alone need to claim large memory, e.g.
pkg/mount/gpt/gpt_test.go:

    disk = make([]byte, 0x100000000)

This would cause a OOM in test.

Example:

```
 fatal error: runtime: out of memory~
 ~
 runtime stack:~
 runtime.throw(0x172f2a, 0x16)~
 	/usr/local/go/src/runtime/panic.go:1116 +0x54~
 runtime.sysMap(0x4004000000, 0x100000000, 0x27cc58)~
 	/usr/local/go/src/runtime/mem_linux.go:169 +0xbc~
 runtime.(*mheap).sysAlloc(0x261240, 0x100000000, 0x4100400000, 0xffffffffffff)~
 	/usr/local/go/src/runtime/malloc.go:727 +0x42c~
 runtime.(*mheap).grow(0x261240, 0x80000, 0x0)~
 	/usr/local/go/src/runtime/mheap.go:1344 +0x98~
 runtime.(*mheap).allocSpan(0x261240, 0x80000, 0x7fc5220100, 0x27cc68, 0x7fc5229978)~
 	/usr/local/go/src/runtime/mheap.go:1160 +0x5f8~
 runtime.(*mheap).alloc.func1()~
 	/usr/local/go/src/runtime/mheap.go:907 +0x60~
 runtime.(*mheap).alloc(0x261240, 0x80000, 0x101, 0x784f0)~
 	/usr/local/go/src/runtime/mheap.go:901 +0x64~
 runtime.largeAlloc(0x100000000, 0x70101, 0x4000000180)~
 	/usr/local/go/src/runtime/malloc.go:1177 +0x90~
 runtime.mallocgc.func1()~
 	/usr/local/go/src/runtime/malloc.go:1071 +0x44~
 runtime.systemstack(0x24adc0)~
     /usr/local/go/src/runtime/asm_arm64.s:235 +0xa0~
 runtime.mstart()~
 	/usr/local/go/src/runtime/proc.go:1116~
 ~
 goroutine 1 [running, locked to thread]:~
 runtime.systemstack_switch()~
 	/usr/local/go/src/runtime/asm_arm64.s:180 +0x8 fp=0x4000039640 sp=0x4000039630 pc=0x78438~
 runtime.mallocgc(0x100000000, 0x142060, 0x100000001, 0x0)~
 	/usr/local/go/src/runtime/malloc.go:1070 +0x640 fp=0x4000039700 sp=0x4000039640 pc=0x1cf60~
 runtime.makeslice(0x142060, 0x100000000, 0x100000000, 0x40000a2a20)~
 	/usr/local/go/src/runtime/slice.go:98 +0x8c fp=0x4000039740 sp=0x4000039700 pc=0x5d7fc~
 github.com/u-root/u-root/pkg/mount/gpt.init()~
 	/home/circleci/go/src/github.com/u-root/u-root/pkg/mount/gpt/gpt_test.go:39 +0x8e94 fp=0x4000039ef0 sp=0x4000039740 pc=0x1289a4~
 runtime.doInit(0x233700)~
 	/usr/local/go/src/runtime/proc.go:5652 +0xc0 fp=0x4000039f30 sp=0x4000039ef0 pc=0x55f80~
 runtime.doInit(0x232340)~
 	/usr/local/go/src/runtime/proc.go:5647 +0x6c fp=0x4000039f70 sp=0x4000039f30 pc=0x55f2c~
 runtime.main()~
 	/usr/local/go/src/runtime/proc.go:191 +0x190 fp=0x4000039fd0 sp=0x4000039f70 pc=0x49030~
 runtime.goexit()~
 	/usr/local/go/src/runtime/asm_arm64.s:1136 +0x4 fp=0x4000039fd0 sp=0x4000039fd0 pc=0x7a744
```

Example run: https://app.circleci.com/pipelines/github/u-root/u-root/2589/workflows/683fa17f-142b-4ffc-8a8d-a37bbeeb09d4/jobs/60668