### PR TITLE
Delete one part of recursive test that flakes testing package

### DIFF
--- a/cmds/core/chmod/chmod_test.go
+++ b/cmds/core/chmod/chmod_test.go
@@ -124,7 +124,11 @@ func TestChmodRecursive(t *testing.T) {
 		"a=rrrrrwx": {before: 0o777, after: 0o777},
 		"a+w":       {before: 0o700, after: 0o722},
 		"g+xr":      {before: 0o700, after: 0o750},
-		"a=rx":      {before: 0o777, after: 0o555},
+		// This last step is causing a flake in the testing package, somehow.
+		// testing.go:967: TempDir RemoveAll cleanup: unlinkat /tmp/TestChmodRecursive2303678599/001/L1_A/L2_A: permission denied
+		// It's not always, but i is frequent enough to break things.
+		// Just disable it; recursion is tested here, and a=rx elsewhere.
+		// "a=rx":      {before: 0o777, after: 0o555},
 	} {
 
 		// Set up the 'before' state


### PR DESCRIPTION
Ending up with the entire tree as 555 causes, sometimes:
    testing.go:967: TempDir RemoveAll cleanup: unlinkat /tmp/TestChmodRecursive2303678599/001/L1_A/L2_A: permission denied

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>