### PR TITLE
Re-enable the tests in pkg/uroot/builder

### DIFF
--- a/pkg/uroot/builder/bb_test.go
+++ b/pkg/uroot/builder/bb_test.go
@@ -5,14 +5,24 @@
 package builder
 
 import (
+	"debug/elf"
+	"errors"
+	"flag"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
+	gbb "github.com/u-root/gobusybox/src/pkg/bb"
+	gbbgolang "github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
 )
 
-// Disable this until we are done switching to modules.
-func testBBBuild(t *testing.T) {
+func TestBBBuildPreModules(t *testing.T) {
+	if os.Getenv("GO111MODULE") != "off" {
+		t.Skip("Skipping non-modular test")
+	}
 	dir := t.TempDir()
 
 	opts := Opts{
@@ -38,5 +48,74 @@ func testBBBuild(t *testing.T) {
 		if !af.Contains(name) {
 			t.Errorf("expected files to include %q; archive: %v", name, af)
 		}
+	}
+}
+
+// This is a simple test for use of the go busy box.
+// It technically need not be here, but it's not bad to make sure
+// things are still working.
+func TestBBBuildModules(t *testing.T) {
+	if os.Getenv("GO111MODULE") == "off" {
+		t.Skip("Skipping modular test")
+	}
+	dir := t.TempDir()
+
+	bopts := &gbbgolang.BuildOpts{}
+	bopts.RegisterFlags(flag.CommandLine)
+
+	o := filepath.Join(dir, "initramfs.cpio")
+
+	env := gbbgolang.Default()
+	if env.CgoEnabled {
+		t.Logf("Disabling CGO for u-root...")
+		env.CgoEnabled = false
+	}
+	t.Logf("Build environment: %s", env)
+
+	tmpDir, err := ioutil.TempDir("", "bb-")
+	if err != nil {
+		t.Fatalf("Could not create busybox source directory: %v", err)
+	}
+
+	opts := &gbb.Opts{
+		Env:       env,
+		GenSrcDir: tmpDir,
+		CommandPaths: []string{
+			"../test/foo",
+			"../../..//cmds/core/elvish",
+		},
+		BinaryPath:  o,
+		GoBuildOpts: bopts,
+	}
+	if err := gbb.BuildBusybox(opts); err != nil {
+		var errGopath *gbb.ErrGopathBuild
+		var errGomod *gbb.ErrModuleBuild
+		if errors.As(err, &errGopath) {
+			t.Fatalf("preserving bb generated source directory at %s due to error. To reproduce build, `cd %s` and `GO111MODULE=off GOPATH=%s go build`", tmpDir, errGopath.CmdDir, errGopath.GOPATH)
+		} else if errors.As(err, &errGomod) {
+			t.Fatalf("preserving bb generated source directory at %s due to error. To debug build, `cd %s` and use `go build` to build, or `go mod [why|tidy|graph]` to debug dependencies, or `go list -m all` to list all dependency versions", tmpDir, errGomod.CmdDir)
+		} else {
+			t.Fatalf("preserving bb generated source directory at %s due to error", tmpDir)
+		}
+	}
+
+	// The gobusybox code we use does not build an initramfs. It builds an elf program.
+	// The only test, therefore, is if the output file can be read as an ELF.
+	f, err := elf.Open(o)
+	if err != nil {
+		t.Fatalf("Opening initramfs(%v): got %v, want nil", o, err)
+	}
+
+	// A valid ELF file has at least one loadable Program.
+	// More than this, we can not say.
+	var foundLoadable bool
+	for _, p := range f.Progs {
+		if p.Type != elf.PT_LOAD {
+			continue
+		}
+		foundLoadable = true
+	}
+	if !foundLoadable {
+		t.Errorf("ELF check: %q has no segments with PT_LOAD flag, want at least one", o)
 	}
 }

--- a/pkg/uroot/builder/builder.go
+++ b/pkg/uroot/builder/builder.go
@@ -9,6 +9,8 @@ import (
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
 )
 
+// These two exported variables begin life empty and are filled in
+// as external code "fills in the blanks."
 var (
 	BusyBox = BBBuilder{}
 	Binary  = BinaryBuilder{}


### PR DESCRIPTION
We had temporarily turned these off as we made the move to modules.

The test still runs even if gobusybox is enabled, though it uses
no code in this directory.  It is convenient and confidence-building to
have a single test for building the gobusybox binary.

The test uses GO111MODULE to determine what test to skip. If GO111MODULE
is unset, the test assumes it is on.

rminnich@a300:~/go/src/github.com/u-root/u-root/pkg/uroot/builder$ go test
PASS
ok  	github.com/u-root/u-root/pkg/uroot/builder	6.184s
rminnich@a300:~/go/src/github.com/u-root/u-root/pkg/uroot/builder$ GO111MODULE=off go test
PASS
ok  	github.com/u-root/u-root/pkg/uroot/builder	2.662s
rminnich@a300:~/go/src/github.com/u-root/u-root/pkg/uroot/builder$ GO111MODULE=on go test
PASS
ok  	github.com/u-root/u-root/pkg/uroot/builder	6.383s
rminnich@a300:~/go/src/github.com/u-root/u-root/pkg/uroot/builder$ GO111MODULE=barf go test
go: unknown environment setting GO111MODULE=barf
rminnich@a300:~/go/src/github.com/u-root/u-root/pkg/uroot/builder$

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>