### PR TITLE
u-root: make shellbang the default instead of symlinks

### DIFF
--- a/u-root.go
+++ b/u-root.go
@@ -80,7 +80,7 @@ func init() {
 	flag.Var(&extraFiles, "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be speficified multiple times.")
 
 	noStrip = flag.Bool("no-strip", false, "Build unstripped binaries")
-	shellbang = flag.Bool("shellbang", false, "Use #! instead of symlinks for busybox")
+	shellbang = flag.Bool("shellbang", true, "Use #! instead of symlinks for busybox")
 
 	statsOutputPath = flag.String("stats-output-path", "", "Write build stats to this file (JSON)")
 	statsLabel = flag.String("stats-label", "", "Use this statsLabel when writing stats")


### PR DESCRIPTION
Since the beginning, u-root has used symlinks to point from
a command (e.g. /bbin/sh) to the common program that implements
all commands (e.g. /bbin/bb).

This was arguably a mistake for a small reason and a large reason.
The small reason is simple: not all file systems support
symlinks. FAT-32, 9p, 9p2000, and some FLASH file systems do not.
Not all kernels support symlinks either.

Were the lack of universal file system support the only issue,
this change would not be that compelling. But the large reason
concerns a bigger issue.

Consider, e.g., the ip command in a u-root system.
Today, it looks like this:
/bbin/ip -> /bbin/bb
i.e., it is a symlink.

What happens should someone wish, for some reason, to replace /bbin/ip
with some better version? They might do this:
cp my-shiney-ip /bbin/ip

At that moment, the single command will replace, not /bbin/ip, but
/bbin/bb, and at that point all u-root commands now become the ip
command.

shellbang files are a lot simpler. They are just files, looking
like this:
```#!/bbin/bb #!backoff```

They are not signicantly larger than the symlinks, and they work
on any file system and any kernel that supports #!, which believe
it or not are more common than the number that support symlinks.
If the file is replaced, by overwriting, the replacement
affects just that one command, not all commands. shellbang files
seem inherently safer than symlinks.

Note that this shellbang file invokes /bin/bb as the shell. It does
not use a shell as an intermediary, which would have been terribly
inefficient. There is no measurable loss in efficiency with the use
of shellbang files as compared to symlinks. Also, this particular
formulation, with the second argument preceded by #!, has been
determined to work across a wide range of kernels and, when
invoked by a shell, works for them too.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>