### PR TITLE
System call filter package and sample command

### DIFF
--- a/cmds/exp/syscallfilter/main_linux.go
+++ b/cmds/exp/syscallfilter/main_linux.go
@@ -1,0 +1,100 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && amd64
+// +build linux,amd64
+
+// syscallfilter runs a command with a possibly empty set of filters:
+//
+// Synopsis:
+// syscallfilter [event]* [--] command [arguments]
+//
+// Description:
+//
+// The command name at least is mandatory. If no filters are specified,
+// then the command runs as normal.
+// Filters can be used to manage events.
+// Events are specified as triples: eventRE,action,value
+// The event is a regular expression, matching a system call name, at entry or exit,
+// e.g. E.*read.* will match all variants of read at entry; or an strace
+// event, e.g. NewChild will match strace events concerning new process creation.
+// For more details, see the syscallfilter package.
+//
+// Should we wish to bar date from getting the time of day, for example:
+// syscallfilter E.*time.*,error,-1
+//
+// And the result is:
+// ./syscallfilter E.*timeof.*,error,-1 -- date
+// 2022/01/13 11:50:47 Filtering ["date"]: -1
+//
+// You can deny echo from fulfilling its destiny:
+// syscallfilter E.*write.*,error,-1 -- echo hi
+// 2022/01/13 11:52:03 Filtering ["echo" "hi"]: -1
+//
+// You can enforce limits on population growth:
+// syscallfilter NewChild,error,-1 -- bash -c date
+// 2022/01/13 11:53:21 Filtering ["bash" "-c" "date"]: -1
+//
+// Note that the syscallfilter command can not currently tell if the error was a real error or
+// filtered error. There is a case to be made that it should not be possible to tell,
+// so, for now, we do not make it possible to distinguish real errors and fake errors.
+package main
+
+import (
+	"bytes"
+	"flag"
+	"log"
+	"os"
+
+	"github.com/u-root/u-root/pkg/syscallfilter"
+	"github.com/u-root/u-root/pkg/uroot/util"
+)
+
+var logactions = flag.Bool("l", false, "Log actions output from the filter")
+
+const cmdUsage = "Usage: syscallfilter [-l] [action... --] command [args]"
+
+func main() {
+	// TODO: fill this in from arguments.
+	util.Usage(cmdUsage)
+	flag.Parse()
+
+	// By default, there are no actions, and this becomes just "run a program"
+	var args, events []string
+	for _, a := range flag.Args() {
+		if a == "--" {
+			events = args
+			args = []string{}
+			continue
+		}
+		args = append(args, a)
+	}
+
+	if len(args) == 0 {
+		flag.Usage()
+		log.Fatal(1)
+	}
+	c := syscallfilter.Command(args[0], args[1:]...)
+	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
+
+	if err := c.AddActions(events...); err != nil {
+		log.Fatal(err)
+	}
+	var b bytes.Buffer
+	if *logactions {
+		c.Log = &b
+	}
+	// There's a bit of question here about printing errors.
+	// Did the command get an error because it got an error,
+	// for other reasons, or because we forced the error?
+	// Anyway, for now, we'll print the error and hope the
+	// user knows that they got an error because they asked
+	// for an error.
+	if err := c.Run(); err != nil {
+		log.Printf("Error filtering %q with events %q: %v", c, events, err)
+	}
+	if *logactions {
+		log.Printf("Actions Log:\n%v", b.String())
+	}
+}

--- a/integration/gotests/gotest_test.go
+++ b/integration/gotests/gotest_test.go
@@ -73,6 +73,7 @@ func testPkgs(t *testing.T) []string {
 
 		// ??
 		"github.com/u-root/u-root/pkg/tss",
+		"github.com/u-root/u-root/pkg/syscallfilter",
 	}
 	if vmtest.TestArch() == "arm64" {
 		blocklist = append(

--- a/pkg/syscallfilter/doc.go
+++ b/pkg/syscallfilter/doc.go
@@ -1,0 +1,32 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The syscallfilter package supports filtering child process events
+// by system call or strace event.  Strace events include
+// SyscallEnter, SyscallExit, SignalExit, Exit, SignalStop, and
+// NewChild.  System call events are for an explicit system call, and
+// can be a regexp. They follow the naming pattern of the u-root
+// strace package (which came from gvisor, which came from the plan 9
+// "ratrace" command, described in
+// https://www.osti.gov/biblio/1028390), i.e.  Esyscallname means
+// system call entry; Xsyscallname means system call exit.  Thus you
+// can, if you wish, allow the system call to run but force an error
+// return by specifying Xsyscall, or force the entry to fail
+// immediately by specifying Esyscall.
+//
+// For each event, an action can be specified.  These actions can in
+// principle be set up at any time, although, currently, the package
+// only supports setting them up before the process is started.
+//
+// Actions are specified as a triple: event,action,value.
+// For example, if we wish to block any kind of fork, we would specify the action:
+//
+// NewChild,error,-1
+//
+// which would cause a -1 to be returned from any action that causes a
+// new child to be created.  If we wish to block all reads, we
+// might specify
+//
+// E.*read,error,-1
+package syscallfilter

--- a/pkg/syscallfilter/syscallfilter_linux.go
+++ b/pkg/syscallfilter/syscallfilter_linux.go
@@ -1,0 +1,214 @@
+// Copyright 2012-2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && amd64
+// +build linux,amd64
+
+package syscallfilter
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/u-root/u-root/pkg/strace"
+)
+
+const cmdUsage = "Usage: strace [-o <outputfile>] <command> [args...]"
+
+type event struct {
+	Name   string
+	Pat    string
+	Action string
+	Value  int
+}
+
+// Cmd contains a command and a filter.
+// The filter is allowed to be empty.
+type Cmd struct {
+	*exec.Cmd
+	// if Log is non-nil, actions take are written to it.
+	Log io.Writer
+	// events is a simple array.
+	// It was a map in earlier versions, but:
+	// o it is usually going to be short
+	// o we want to support regexp matching (part of keeping it short and convenient!)
+	// So we iterate it on every system call. The cost of doing the strace is so high that
+	// iterating over this array is not significant.
+	events []*event
+	// The strace package has its limitations and we don't expect to use it for long.
+	// It's not capable of returning a value to the process from a system call,
+	// and it may not be appropriate to extend it in that way.
+	// We keep this function here to allow us to kill the child on error.
+	cancel func()
+}
+
+var eventNames = map[string]strace.EventType{
+	"SyscallEnter": strace.SyscallEnter,
+	"SyscallExit":  strace.SyscallExit,
+	"SignalExit":   strace.SignalExit,
+	"Exit":         strace.Exit,
+	"SignalStop":   strace.SignalStop,
+	"NewChild":     strace.NewChild,
+}
+
+var allActions = map[string]interface{}{
+	// Error will end the strace, expeditiously, unless the value is 0
+	"error": nil,
+	// log will log the record
+	"log": nil,
+}
+
+func findEvent(events []*event, n string) *event {
+	for _, e := range events {
+		m, err := regexp.MatchString(e.Pat, n)
+		if err != nil {
+			log.Fatalf("Can't happen: %q is bad: %v", e.Pat, err)
+		}
+		if m {
+			return e
+		}
+	}
+	return nil
+}
+
+// eventName returns an event name. There should never be an event name
+// we do not known and, if we encounter one, we panic.
+func eventName(r *strace.TraceRecord) string {
+	// form up a reasonable name for a system call.
+	// If there is no name, then it will be Exxxx or Xxxxx, where x
+	// is the system call number as %04x.
+	// Note that users can specify this: E0x0000, for example
+	var sysname string
+
+	switch r.Event {
+	case strace.SyscallEnter, strace.SyscallExit:
+		var err error
+		if sysname, err = strace.ByNumber(uintptr(r.Syscall.Sysno)); err != nil {
+			sysname = fmt.Sprintf("%04x", r.Syscall.Sysno)
+		}
+	}
+	switch r.Event {
+	case strace.SyscallEnter:
+		return "E" + sysname
+	case strace.SyscallExit:
+		return "X" + sysname
+	case strace.SignalExit:
+		return fmt.Sprintf("SignalExit")
+	case strace.Exit:
+		return fmt.Sprintf("Exit")
+	case strace.SignalStop:
+		return fmt.Sprintf("SignalStop")
+	case strace.NewChild:
+		return fmt.Sprintf("NewChild")
+	}
+	log.Panicf("Unknown event %#x from record %v", r.Event, r)
+	return ""
+}
+
+func (c *Cmd) handleEvent(t strace.Task, r *strace.TraceRecord, e []*event) error {
+	// All attempts to use defer for printing got ... weird.
+	var ret error
+	n := eventName(r)
+	act := findEvent(e, n)
+	if act == nil {
+		return nil
+	}
+	switch act.Action {
+	case "error":
+		ret = fmt.Errorf("%v", act.Value)
+		if c.Log != nil {
+			fmt.Fprintf(c.Log, "%v act %v error %v\n", n, act.Name, ret)
+		}
+		// And, since we can't really return an error to the process, but only to strace
+		// and, since this is more about killing it than anything else ...
+		// bye bye
+		c.cancel()
+
+	// Actually, for now, log is the same as error,0 but we are keeping this
+	// name as we expect it to evolve.
+	case "log":
+		if c.Log != nil {
+			fmt.Fprintf(c.Log, "%v act %v error %v\n", n, act.Name, ret)
+		}
+	}
+	return ret
+}
+
+// Run implements cmd.Run, filtering strace events
+// as created by AddActions. The slice can be empty, in which case the command
+// runs as normal.
+func (c *Cmd) Run() error {
+	defer func() {
+		// This wait may or may not be needed, since the process
+		// can end normally or be stopped by a filter. Hence,
+		// we will not check for an error.
+		c.Wait()
+	}()
+	if err := strace.Trace(c.Cmd, func(t strace.Task, r *strace.TraceRecord) error {
+		ret := c.handleEvent(t, r, c.events)
+		return ret
+	}); err != nil {
+		return fmt.Errorf("%v", err)
+	}
+	return nil
+}
+
+// AddActions creates an []event as defined by a possibly empty set of actions, and
+// installs it in the Cmd.
+// The action is a string, with comma-separated fields,
+// designed to be convenient to be used on a command line.
+//
+// Actions have 3 fields.
+//
+// The first is a regexp to match against the system call name, e.g.,
+// E.*imeofday. The first character, E or X,
+// indicates Entry or eXit.
+//
+// The second parameter indications an action to take. Currently there
+// are only two: error, and log.
+//
+// The third value indicates a value to return. It can be empty.
+// For the error action, the third parameter
+// indicates the error to return. For the log action, the third
+// parameter is currently unused.
+
+func (c *Cmd) AddActions(actions ...string) error {
+	var events []*event
+	for i, a := range actions {
+		f := strings.Split(a, ",")
+		if len(f) != 3 {
+			return fmt.Errorf("%d of actions: %q needs to have 3 fields, has %d(%v)", i, a, len(f), f)
+		}
+		if _, ok := allActions[f[1]]; !ok {
+			return fmt.Errorf("%q of actions %v: unknown action, not one of %q", f[0], f, allActions)
+		}
+		if check := findEvent(events, f[0]); check != nil {
+			return fmt.Errorf("%q of actions %v: repeat action, already %q", f[0], f, check)
+		}
+		var value int
+		if len(f[2]) > 0 {
+			v, err := strconv.ParseInt(f[2], 0, 32)
+			if err != nil {
+				return err
+			}
+			value = int(v)
+		}
+
+		events = append(events, &event{Name: a, Pat: f[0], Action: f[1], Value: value})
+	}
+	c.events = events
+	return nil
+}
+
+// Command creates a new Cmd, with a context, embedding an exec.Cmd, with an empty set of events.
+func Command(name string, args ...string) *Cmd {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Cmd{Cmd: exec.CommandContext(ctx, name, args...), cancel: cancel}
+}

--- a/pkg/syscallfilter/syscallfilter_linux_test.go
+++ b/pkg/syscallfilter/syscallfilter_linux_test.go
@@ -1,0 +1,271 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package syscallfilter
+
+import (
+	"bytes"
+	"io/ioutil"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/strace"
+)
+
+// If we are being traced, none of this will work.
+// Be conservative: if anything at all fails, just return
+// true, i.e. assume we're being traced somehow..
+// Yep, this is a kludge.
+func traced() bool {
+	b, err := ioutil.ReadFile("/proc/self/status")
+	if err != nil {
+		return true
+	}
+
+	s := strings.SplitN(string(b), "TracerPid:\t", 2)
+	// There should be two pieces, the bit before TracerPid:
+	// and the bit after, included the value of TracerPid.
+	// If we can't find this then we have no way to know.
+	// Assume traced: somebody could be messing with us.
+	//log.Printf("split %s", s)
+	if len(s) < 2 {
+		return true
+	}
+
+	tracerPid, err := strconv.Atoi(strings.Fields(s[1])[0])
+
+	if err != nil || tracerPid != 0 {
+		return true
+	}
+
+	return false
+}
+
+func TestEventMap(t *testing.T) {
+	var tests = []struct {
+		v    string
+		find string
+		err  error
+	}{
+		{"NewChild,error,-1", "NewChild", nil},
+		{"E.*timeof.*,error,-1", "Egettimeofday", nil},
+	}
+	for _, tt := range tests {
+		c := Command("date")
+		err := c.AddActions(tt.v)
+		if err != nil && tt.err == nil {
+			t.Errorf("%v.AddActions(%s): err %v != %v", c, tt.v, err, tt.err)
+			continue
+		}
+		fe := findEvent(c.events, tt.find)
+		if fe == nil {
+			t.Errorf(`findEvent(%v, %v): is nil`, c, tt.find)
+		}
+	}
+}
+
+func TestNoActions(t *testing.T) {
+	if traced() {
+		t.Skipf("Skipping, we're being traced already")
+	}
+
+	c := Command("echo", "hi")
+	var stdout, stderr bytes.Buffer
+	c.Stdout, c.Stderr = &stdout, &stderr
+
+	if err := c.Run(); err != nil {
+		t.Fatalf(`%v.Run(), "echo", "hi"): %v != nil`, c, err)
+	}
+	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
+	if stdout.String() != "hi\n" {
+		t.Errorf("stdout: string is %q, not %q", stdout.String(), "hi\n")
+	}
+	if len(stderr.String()) != 0 {
+		t.Errorf("stderr.String: got %q, want %q", stderr.String(), "")
+	}
+}
+
+func TestNoActionsDoubleWait(t *testing.T) {
+	if traced() {
+		t.Skipf("Skipping, we're being traced already")
+	}
+
+	c := Command("echo", "hi")
+	var stdout, stderr bytes.Buffer
+	c.Stdout, c.Stderr = &stdout, &stderr
+
+	if err := c.Run(); err != nil {
+		t.Fatalf(`%v.Run(), "echo", "hi"): %v != nil`, c, err)
+	}
+
+	// Through one path or another, c.Wait() should have been called.
+	// If we get no error here, that is a problem.
+	if err := c.Wait(); err == nil {
+		t.Errorf("c.Wait(): got nil, want an error")
+	}
+
+	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
+	if stdout.String() != "hi\n" {
+		t.Errorf("stdout: string is %q, not %q", stdout.String(), "hi\n")
+	}
+	if len(stderr.String()) != 0 {
+		t.Errorf("stderr.String: got %q, want %q", stderr.String(), "")
+	}
+}
+
+func TestNoErrorExit(t *testing.T) {
+	if traced() {
+		t.Skipf("Skipping, we're being traced already")
+	}
+
+	c := Command("date")
+	var stdout, stderr bytes.Buffer
+	c.Stdout, c.Stderr = &stdout, &stderr
+
+	if err := c.Run(); err != nil {
+		t.Fatalf(`%v.Run(): %v != nil`, c, err)
+	}
+	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
+	if len(stdout.String()) == 0 {
+		t.Errorf("stdout.String: got %q, want output", "")
+	}
+	if len(stderr.String()) != 0 {
+		t.Errorf("stderr.String: got %q, want %q", stderr.String(), "")
+	}
+}
+
+func TestErrorExitLog(t *testing.T) {
+	if traced() {
+		t.Skipf("Skipping, we're being traced already")
+	}
+
+	filter := "E.*open.*,error,-2"
+	c := Command("date")
+	var stdout, stderr bytes.Buffer
+	c.Stdout, c.Stderr = &stdout, &stderr
+	err := c.AddActions(filter)
+	if err != nil {
+		t.Fatalf("addactions(%s): err %v != %v", filter, err, nil)
+	}
+	var b bytes.Buffer
+	c.Log = &b
+	if err := c.Run(); err == nil {
+		t.Fatalf(`%v.Run(): nil != %v`, c, "exit status 1")
+	}
+	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
+	if b.Len() == 0 {
+		t.Errorf("%v.Run(): Log is zero, not > 0", c)
+	}
+	t.Logf("Log: %v", b.String())
+}
+
+func TestErrorExitLogAll(t *testing.T) {
+	if traced() {
+		t.Skipf("Skipping, we're being traced already")
+	}
+
+	filter := "E.*open.*,error,-2"
+	c := Command("date")
+	var stdout, stderr bytes.Buffer
+	c.Stdout, c.Stderr = &stdout, &stderr
+	if err := c.AddActions(filter); err != nil {
+		t.Fatalf("addactions(%s): err %v != %v", filter, err, nil)
+	}
+	var b bytes.Buffer
+	c.Log = &b
+	if err := c.Run(); err == nil {
+		t.Fatalf(`%v.Run(): nil != %v`, c, "exit status 1")
+	}
+	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
+	if b.Len() == 0 {
+		t.Errorf("%v.Run(): Log is zero, not > 0", c)
+	}
+	t.Logf("Log: %v", b.String())
+	// OK, now run it again, with LogAllActions set; the new log should be longer.
+	c = Command("date")
+	c.Stdout, c.Stderr = &stdout, &stderr
+	if err := c.AddActions("E.*read.*,log,0", "E.*exit.*,error,-2"); err != nil {
+		t.Fatalf("addactions(%s): err %v != %v", filter, err, nil)
+	}
+	var b2 bytes.Buffer
+	c.Log = &b2
+	if err := c.Run(); err == nil {
+		t.Fatalf(`%v.Run(): nil != %v`, c, "exit status 1")
+	}
+	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
+	if b2.Len() == 0 {
+		t.Errorf("%v.Run(): Log is zero bytes, not > 0", c)
+	}
+	if b.Len() >= b2.Len() {
+		t.Errorf("%v.Run() with LogAllRecords: Log is %d bytes, not > %d", c, b2.Len(), b.Len())
+	}
+	t.Logf("Log: %v", b2.String())
+}
+
+// This is a simple example of how you might test the reboot command
+// without being root and without using qemu.
+// It is disabled because it's just a bit too dangerous.
+func testRebootOK(t *testing.T) {
+	filter := ".*reboot,error,0"
+	c := Command("reboot", "-f", "-f")
+	var stdout, stderr bytes.Buffer
+	c.Stdout, c.Stderr = &stdout, &stderr
+	err := c.AddActions(filter)
+	if err != nil {
+		t.Fatalf("addactions(%s): err %v != %v", filter, err, nil)
+	}
+
+	if err := c.Run(); err == nil {
+		t.Fatalf(`%v.Run(): nil != %v`, c, "exit status 1")
+	}
+	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
+}
+
+func testRebootFail(t *testing.T) {
+	if traced() {
+		t.Skipf("Skipping, we're being traced already")
+	}
+
+	filter := ".*reboot,error,-1"
+	c := Command("reboot", "-f", "-f")
+	var stdout, stderr bytes.Buffer
+	c.Stdout, c.Stderr = &stdout, &stderr
+	err := c.AddActions(filter)
+	if err != nil {
+		t.Fatalf("addactions(%s): err %v != %v", filter, err, nil)
+	}
+
+	if err := c.Run(); err == nil {
+		t.Fatalf(`%v.Run(): nil != %v`, c, "exit status 1")
+	}
+	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
+}
+
+func TestEventName(t *testing.T) {
+	if traced() {
+		t.Skipf("Skipping, we're being traced already")
+	}
+
+	for _, test := range []struct {
+		r *strace.TraceRecord
+		n string
+	}{
+		{r: &strace.TraceRecord{Event: strace.SyscallEnter, Syscall: &strace.SyscallEvent{Sysno: 0}}, n: "Eread"},
+		{r: &strace.TraceRecord{Event: strace.SyscallExit, Syscall: &strace.SyscallEvent{Sysno: 0}}, n: "Xread"},
+		{r: &strace.TraceRecord{Event: strace.SyscallEnter, Syscall: &strace.SyscallEvent{Sysno: 0xabcd}}, n: "Eabcd"},
+		{r: &strace.TraceRecord{Event: strace.SyscallExit, Syscall: &strace.SyscallEvent{Sysno: 0xbcde}}, n: "Xbcde"},
+		{r: &strace.TraceRecord{Event: strace.SignalExit}, n: "SignalExit"},
+		{r: &strace.TraceRecord{Event: strace.Exit}, n: "Exit"},
+		{r: &strace.TraceRecord{Event: strace.SignalStop}, n: "SignalStop"},
+		{r: &strace.TraceRecord{Event: strace.NewChild}, n: "NewChild"},
+	} {
+		n := eventName(test.r)
+		// There's a problem testing the system call name: linux system call numbers to names
+		// vary, widely, across architectures. But read at 0 seems safe, so ...
+		if test.n != n {
+			t.Errorf("eventName(%v): %v != %v ", test, n, test.n)
+		}
+	}
+}


### PR DESCRIPTION
    system call filter

    This commit includes the systemcallfilter package and a command which uses it.

    The package defines a type, Cmd, which embeds an exec.Cmd and a set of event filters.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>