### PR TITLE
retract v6.0.1+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,6 +63,7 @@ require (
 retract (
 	v7.0.0+incompatible
 	v6.0.0+incompatible
+	v6.0.1+incompatible
 	v5.0.0+incompatible
 	v4.0.0+incompatible
 	v3.0.0+incompatible


### PR DESCRIPTION
Modules are hell on a good day. It's just impossible to see why
go mod tidy does what it does. In this case, in the cpu tree,
it insists on bringing in v6.0.1 -- which, as far as I know,
was never even tagged.

Let's see if this retract fixes go mod tidy's insistence on bringing
in v6.0.1 in the cpu command.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>