### PR TITLE
retract versions v1.0.0-v7.0.0 2nd try

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,11 +61,18 @@ require (
 )
 
 retract (
-	v7.0.0+incompatible
+	// Published v7 too early (before migrating to go modules)
+	[v7.0.0+incompatible, v7.0.1]
+	// Published v6 too early (before migrating to go modules)
 	v6.0.0+incompatible
+	// Published v5 too early (before migrating to go modules)
 	v5.0.0+incompatible
+	// Published v4 too early (before migrating to go modules)
 	v4.0.0+incompatible
+	// Published v3 too early (before migrating to go modules)
 	v3.0.0+incompatible
+	// Published v2 too early (before migrating to go modules)
 	v2.0.0+incompatible
+	// Published v1 too early (before migrating to go modules)
 	v1.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -62,17 +62,17 @@ require (
 
 retract (
 	// Published v7 too early (before migrating to go modules)
-	[v7.0.0+incompatible, v7.0.1]
+	v7.0.0
 	// Published v6 too early (before migrating to go modules)
-	v6.0.0+incompatible
+	v6.0.0
 	// Published v5 too early (before migrating to go modules)
-	v5.0.0+incompatible
+	v5.0.0
 	// Published v4 too early (before migrating to go modules)
-	v4.0.0+incompatible
+	v4.0.0
 	// Published v3 too early (before migrating to go modules)
-	v3.0.0+incompatible
+	v3.0.0
 	// Published v2 too early (before migrating to go modules)
-	v2.0.0+incompatible
+	v2.0.0
 	// Published v1 too early (before migrating to go modules)
-	v1.0.0
+	[v1.0.0, v1.0.1]
 )

--- a/go.mod
+++ b/go.mod
@@ -62,17 +62,17 @@ require (
 
 retract (
 	// Published v7 too early (before migrating to go modules)
-	v7.0.0
+	v7.0.0+incompatible
 	// Published v6 too early (before migrating to go modules)
-	v6.0.0
+	v6.0.0+incompatible
 	// Published v5 too early (before migrating to go modules)
-	v5.0.0
+	v5.0.0+incompatible
 	// Published v4 too early (before migrating to go modules)
-	v4.0.0
+	v4.0.0+incompatible
 	// Published v3 too early (before migrating to go modules)
-	v3.0.0
+	v3.0.0+incompatible
 	// Published v2 too early (before migrating to go modules)
-	v2.0.0
+	v2.0.0+incompatible
 	// Published v1 too early (before migrating to go modules)
 	[v1.0.0, v1.0.1]
 )


### PR DESCRIPTION
This versions were done before migrating to modules. **This
commit must be taged with ~~v7.0.1~~ v1.0.1**and retracts versions
v{1,2,3,4,5,6,7}.0.0 and ~~v7.0.1~~ v1.0.1 too.

Comments at the retract statements will show up when using
go get, go list, etc.

Publishing v1, v2, ... will be possible as v1.0.1, v2.0.1, ...

Signed-off-by: Jens Drenhaus <jens.drenhaus@9elements.com>