### PR TITLE
strace: use syscall.Timespec.Unix

### DIFF
--- a/pkg/strace/syscall_linux.go
+++ b/pkg/strace/syscall_linux.go
@@ -117,7 +117,7 @@ func stat(t Task, addr Addr) string {
 	if _, err := t.Read(addr, &stat); err != nil {
 		return fmt.Sprintf("%#x (error decoding stat: %s)", addr, err)
 	}
-	return fmt.Sprintf("%#x {dev=%d, ino=%d, mode=%s, nlink=%d, uid=%d, gid=%d, rdev=%d, size=%d, blksize=%d, blocks=%d, atime=%s, mtime=%s, ctime=%s}", addr, stat.Dev, stat.Ino, fileMode(stat.Mode), stat.Nlink, stat.Uid, stat.Gid, stat.Rdev, stat.Size, stat.Blksize, stat.Blocks, time.Unix(int64(stat.Atim.Sec), int64(stat.Atim.Nsec)), time.Unix(int64(stat.Mtim.Sec), int64(stat.Mtim.Nsec)), time.Unix(int64(stat.Ctim.Sec), int64(stat.Ctim.Nsec)))
+	return fmt.Sprintf("%#x {dev=%d, ino=%d, mode=%s, nlink=%d, uid=%d, gid=%d, rdev=%d, size=%d, blksize=%d, blocks=%d, atime=%s, mtime=%s, ctime=%s}", addr, stat.Dev, stat.Ino, fileMode(stat.Mode), stat.Nlink, stat.Uid, stat.Gid, stat.Rdev, stat.Size, stat.Blksize, stat.Blocks, time.Unix(stat.Atim.Unix()), time.Unix(stat.Mtim.Unix()), time.Unix(stat.Ctim.Unix()))
 }
 
 func itimerval(t Task, addr Addr) string {


### PR DESCRIPTION
Use the syscall method instead of repeating the type conversions for
the syscall.Stat_t Atim/Ctim/Mtim members.