### PR TITLE
pkg/pci: add a Reset function

### DIFF
--- a/pkg/pci/devices.go
+++ b/pkg/pci/devices.go
@@ -9,7 +9,9 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 )
 
 // Devices contains a slice of one or more PCI devices
@@ -133,6 +135,22 @@ func (d Devices) WriteConfigRegister(offset, size int64, val uint64) error {
 		if err := p.WriteConfigRegister(offset, size, val); err != nil {
 			return err
 		}
+	}
+	return nil
+}
+
+// Reset makes a best-effort attempt to reset devices.
+func (d Devices) Reset() error {
+	var e []error
+	for _, p := range d {
+		reset := filepath.Join(p.FullPath, "reset")
+		// This is purely best effort.
+		if err := ioutil.WriteFile(reset, []byte("1\n"), 0); err != nil {
+			e = append(e, err)
+		}
+	}
+	if len(e) > 0 {
+		return fmt.Errorf("%v", e)
 	}
 	return nil
 }

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -15,10 +15,6 @@ import (
 	"strings"
 )
 
-const (
-	pciPath = "/sys/bus/pci/devices"
-)
-
 type bus struct {
 	Devices []string
 }
@@ -126,6 +122,16 @@ func BaseLimType(bar string) (uint64, uint64, uint64, error) {
 // If it can't glob in pciPath/g then it returns an error.
 // For convenience, we use * as the glob if none are supplied.
 func NewBusReader(globs ...string) (BusReader, error) {
+	// NewBusReader returns a BusReader, given a ...glob to match PCI devices against.
+	// If it can't glob in pciPath/g then it returns an error.
+	const (
+		pciPath = "/sys/bus/pci/devices"
+	)
+	// For convenience, we use * as the glob if none are supplied.
+	return newBusReader(pciPath, globs...)
+}
+
+func newBusReader(pciPath string, globs ...string) (BusReader, error) {
 	if len(globs) == 0 {
 		globs = []string{"*"}
 	}

--- a/pkg/pci/pci_linux_test.go
+++ b/pkg/pci/pci_linux_test.go
@@ -11,6 +11,24 @@ import (
 	"testing"
 )
 
+func TestNewBusReaderBadBaseGlob(t *testing.T) {
+	_, err := newBusReader("[")
+	if err == nil {
+		t.Fatalf(`newBusReader("[") = nil, not glob error`)
+	}
+}
+
+func TestNewBusReaderBadBase(t *testing.T) {
+	n, err := newBusReader("nothingtoseeheremovealongXXX")
+	if err != nil {
+		t.Fatalf(`newBusReader("nothingtoseeheremovealongXXX") = %v, not nil`, err)
+	}
+	if n == nil {
+		t.Fatalf(`newBusReader("nothingtoseeheremovealongXXX") = returns nil, not a BusReader`)
+	}
+	// Other busreader functions are tested elsewhere
+}
+
 func TestNewBusReaderNoGlob(t *testing.T) {
 	n, err := NewBusReader()
 	if err != nil {
@@ -109,6 +127,26 @@ func TestBusReadConfig(t *testing.T) {
 	}
 	if !fullread && err == nil {
 		log.Fatalf("Doing a full config read as ! root: got nil, want %v", os.ErrPermission)
+	}
+}
+
+// TestBusReset. Dangerous.
+func TestBusReset(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skipf("Skipping bus reset test, as we are root")
+	}
+
+	r, err := NewBusReader()
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	d, err := r.Read()
+	if err != nil {
+		log.Fatalf("Read: %v", err)
+	}
+	if err := d.Reset(); err == nil {
+		log.Fatalf("d.Reset(): nil != permission denied")
 	}
 }
 

--- a/pkg/pci/reset.go
+++ b/pkg/pci/reset.go
@@ -1,0 +1,25 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package pci
+
+// ResetAllDevices resets all devices found in the path /sys/bus/pci*/devices/reset.
+// While this is *techhically* only found on Linux, any system which puts
+// that path in the namespace could work. Which, incidentally, demonstrates
+// why putting stuff like this in the name space is portable and resilient.
+// How could this work on a non-linux system? Pretend we're on plan 9:
+// import linuxhost /dev /dev
+// note this mount only applies to this process and its children
+// run this reset code, and reset the linux devices.
+func ResetAllDevices(n ...string) error {
+	r, err := NewBusReader(n...)
+	if err != nil {
+		return err
+	}
+	d, err := r.Read()
+	if err != nil {
+		return err
+	}
+	return d.Reset()
+}


### PR DESCRIPTION
For kexec, it looks like we'll need to be able to reset devices.

It's possible that we'll need to extend this further for, e.g., power and
rescan; it looks like we might be able to trivial do retraining that way.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>