### PR TITLE
CI/Integrate IPMI capabilities to kernel and qemu for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 templates:
   golang-template: &golang-template
     docker:
-      - image: uroottest/test-image-amd64:v4.4.0
+      - image: uroottest/test-image-amd64:v4.5.0
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - CGO_ENABLED: 0

--- a/.circleci/images/test-image-amd64/config_linux5.10_x86_64.txt
+++ b/.circleci/images/test-image-amd64/config_linux5.10_x86_64.txt
@@ -105,3 +105,9 @@ CONFIG_ISCSI_TCP=y
 # NBD (Network Block Device) support: will automatically re-read partitions when
 # iSCSI disk is mounted.
 CONFIG_BLK_DEV_NBD=y
+
+# Add ipmi protocol for integration tests of pkg/ipmi
+CONFIG_IPMI=y
+CONFIG_IPMI_DEVICE_INTERFACE=y
+CONFIG_IPMI_WATCHDOG=y
+CONFIG_IPMI_SI=y


### PR DESCRIPTION
Add ipmi capabilities to amd64 kernel
Add bmc emulation and ipmi support to qemu for test-image-amd64

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>