### PR TITLE
Re-enable pkg/bb test.

### DIFF
--- a/pkg/bb/bb_test.go
+++ b/pkg/bb/bb_test.go
@@ -12,8 +12,7 @@ import (
 	"github.com/u-root/u-root/pkg/golang"
 )
 
-// Turn this off until we are done moving to modules.
-func testPackageRewriteFile(t *testing.T) {
+func TestPackageRewriteFile(t *testing.T) {
 	bin := filepath.Join(t.TempDir(), "foo")
 	if err := BuildBusybox(golang.Default(), []string{"github.com/u-root/u-root/pkg/uroot/test/foo"}, false, bin); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
There's no reason to disable this test. It does not interfere with
gobusybox or modules.