### PR TITLE
CONTRIBUTE: Add a suggestion for disabling test(s).

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -282,6 +282,50 @@ func main() {
 }
 ```
 
+### Disable a Test Temporarily.
+
+When you are disabling test(s) in a test file, if there are no open / public test functions
+left in the end, consider simply deleting the test file. You can always find original code
+from revision history.
+
+For example, if you have a test file, `bb_test.go` with single test functin, and you need
+to disable it now, you may end up with
+
+```
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bb
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/golang"
+)
+
+// Turn this off until we are done moving to modules.
+func testPackageRewriteFile(t *testing.T) {
+	bin := filepath.Join(t.TempDir(), "foo")
+	if err := BuildBusybox(golang.Default(), []string{"github.com/u-root/u-root/pkg/uroot/test/foo"}, false, bin); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command(bin)
+	o, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("foo failed: %v %v", string(o), err)
+	}
+}
+```
+
+Consider simply deleting this file to make it clean.
+
+Alternatively, leave the function as public, but commented out
+all lines within the function.
+
 ### Integration Tests
 To test integration with other code/packages without mocking, write integration test in a file `integration_test.go`.
 

--- a/pkg/bb/bb_test.go
+++ b/pkg/bb/bb_test.go
@@ -5,23 +5,20 @@
 package bb
 
 import (
-	"os/exec"
-	"path/filepath"
 	"testing"
-
-	"github.com/u-root/u-root/pkg/golang"
 )
 
-// Turn this off until we are done moving to modules.
-func testPackageRewriteFile(t *testing.T) {
-	bin := filepath.Join(t.TempDir(), "foo")
-	if err := BuildBusybox(golang.Default(), []string{"github.com/u-root/u-root/pkg/uroot/test/foo"}, false, bin); err != nil {
-		t.Fatal(err)
-	}
+func TestPackageRewriteFile(t *testing.T) {
+	// TODO: re-enable this after we are done moving to modules.
+	//
+	//bin := filepath.Join(t.TempDir(), "foo")
+	//if err := BuildBusybox(golang.Default(), []string{"github.com/u-root/u-root/pkg/uroot/test/foo"}, false, bin); err != nil {
+	//	t.Fatal(err)
+	//}
 
-	cmd := exec.Command(bin)
-	o, err := cmd.CombinedOutput()
-	if err != nil {
-		t.Fatalf("foo failed: %v %v", string(o), err)
-	}
+	//cmd := exec.Command(bin)
+	//o, err := cmd.CombinedOutput()
+	//if err != nil {
+	//	t.Fatalf("foo failed: %v %v", string(o), err)
+	//}
 }


### PR DESCRIPTION
Certain build systems from users of u-root, e.g. Google
does not like a test file with zero public test functions.
That creates build errors for them.

Might as well have a guideline on test disabling that makes
it easier for users to import in new u-root.