### PR TITLE
codecov.yml : Add codecov file

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+parsers:
+  go:
+    partials_as_hits: true #false by default


### PR DESCRIPTION
Codecov and Golang does quite has some issues. Golangs native coverage
processor counts partial lines as full hits. Codecov's default behaviour
in the event of partial coverage is to store the line as partial.

Therefore Golangs coverage will alwyas be slightly higher. This is to
make both equal.

Signed-off-by: Christian Walter <christian.walter@9elements.com>