### PR TITLE
testing: use `T.TempDir` to create temporary test directory

### DIFF
--- a/cmds/core/cat/cat_test.go
+++ b/cmds/core/cat/cat_test.go
@@ -78,7 +78,6 @@ func TestRunFiles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setup has failed, %v", err)
 	}
-	defer os.RemoveAll(dir)
 
 	for i := range someData {
 		files = append(files, fmt.Sprintf("%v%d", filepath.Join(dir, "file"), i))
@@ -101,7 +100,6 @@ func TestRunFilesError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("setup has failed, %v", err)
 	}
-	defer os.RemoveAll(dir)
 
 	for i := range someData {
 		files = append(files, fmt.Sprintf("%v%d", filepath.Join(dir, "file"), i))

--- a/cmds/core/hexdump/hexdump_test.go
+++ b/cmds/core/hexdump/hexdump_test.go
@@ -14,11 +14,7 @@ import (
 
 func TestHexdump(t *testing.T) {
 	// Creating file and write content into it for testing purposes
-	d, err := os.MkdirTemp(os.TempDir(), "hexdump.dir")
-	if err != nil {
-		t.Errorf("failed to create tmp folder: %v", err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 	f, err := os.Create(filepath.Join(d, "testfile"))
 	if err != nil {
 		t.Errorf("failed to create tmp file: %v", err)

--- a/cmds/core/ls/ls_linux_test.go
+++ b/cmds/core/ls/ls_linux_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"bytes"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,7 +30,6 @@ func TestListNameLinux(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	// Create a directory
 	d := t.TempDir()
-	defer os.RemoveAll(d)
 	if err := unix.Mknod(filepath.Join(d, "large_node"), 0o660|unix.S_IFBLK, 0x12345678); err != nil {
 		t.Fatalf("err in unix.Mknod: %v", err)
 	}

--- a/cmds/core/ls/ls_test.go
+++ b/cmds/core/ls/ls_test.go
@@ -31,7 +31,6 @@ func TestListName(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(tmpDir, "d1"), 0777); err != nil {
 		t.Fatalf("err in os.Mkdir: %v", err)
 	}
-	defer os.RemoveAll(tmpDir)
 	// Create some files.
 	files := []string{"f1", "f2", "f3\nline 2", ".f4", "d1/f4"}
 	for _, file := range files {
@@ -140,10 +139,6 @@ func TestListName(t *testing.T) {
 
 // Test list func
 func TestList(t *testing.T) {
-	// Create some directorys.
-	tmpDir := t.TempDir()
-	defer os.RemoveAll(tmpDir)
-
 	// Creating test table
 	for _, tt := range []struct {
 		name   string

--- a/cmds/core/mkdir/mkdir_test.go
+++ b/cmds/core/mkdir/mkdir_test.go
@@ -21,11 +21,7 @@ type flags struct {
 }
 
 func TestMkdir(t *testing.T) {
-	d, err := os.MkdirTemp(os.TempDir(), "mk.dir")
-	if err != nil {
-		t.Errorf("failed to create tmp folder")
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 	for _, tt := range []struct {
 		name      string
 		flags     flags

--- a/cmds/core/mknod/mknod_linux_test.go
+++ b/cmds/core/mknod/mknod_linux_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -24,11 +23,7 @@ import (
 //     = 0x12345678
 
 func TestMknod(t *testing.T) {
-	d, err := os.MkdirTemp(os.TempDir(), "mk.nod")
-	if err != nil {
-		t.Errorf("failed to create tmp folder: %v", err)
-	}
-	defer os.RemoveAll(d)
+	d := t.TempDir()
 
 	// Creating testtable and run tests
 	for _, tt := range []struct {

--- a/cmds/core/mv/mv_test.go
+++ b/cmds/core/mv/mv_test.go
@@ -51,7 +51,6 @@ func TestMove(t *testing.T) {
 	if err != nil {
 		t.Errorf("File setup failed: %v", err)
 	}
-	defer os.RemoveAll(d)
 
 	for _, tt := range []struct {
 		name  string
@@ -91,7 +90,6 @@ func TestMv(t *testing.T) {
 	if err != nil {
 		t.Errorf("File setup failed: %v", err)
 	}
-	defer os.RemoveAll(d)
 
 	for _, tt := range []struct {
 		name  string
@@ -130,7 +128,6 @@ func TestMoveFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("File setup failed: %v", err)
 	}
-	defer os.RemoveAll(d)
 
 	var testTable = []struct {
 		name string

--- a/cmds/core/sync/sync_test.go
+++ b/cmds/core/sync/sync_test.go
@@ -14,10 +14,7 @@ import (
 
 func TestSync(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
-	d, err := os.MkdirTemp(os.TempDir(), "sync")
-	if err != nil {
-		t.Errorf("Failed to create tmp folder: %v", err)
-	}
+	d := t.TempDir()
 	file1, err := os.CreateTemp(d, "file1")
 	if err != nil {
 		t.Errorf("failed to create tmp file1: %v", err)
@@ -26,7 +23,7 @@ func TestSync(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to create tmp file2: %v", err)
 	}
-	defer os.RemoveAll(d)
+
 	for _, tt := range []struct {
 		name       string
 		input      []string

--- a/pkg/cp/cp_test.go
+++ b/pkg/cp/cp_test.go
@@ -21,17 +21,9 @@ var (
 )
 
 func TestCopySimple(t *testing.T) {
-	tmpdirDst, err := os.MkdirTemp("", "dst-directory")
-	if err != nil {
-		t.Errorf("failed to create tmp directorty: %q", err)
-	}
-	defer os.RemoveAll(tmpdirDst)
-
-	tmpdirSrc, err := os.MkdirTemp("", "src-directory")
-	if err != nil {
-		t.Errorf("failed to create tmp src directorty: %q", err)
-	}
-	defer os.RemoveAll(tmpdirSrc)
+	var err error
+	tmpdirDst := t.TempDir()
+	tmpdirSrc := t.TempDir()
 
 	srcfiles := make([]*os.File, 2)
 	dstfiles := make([]*os.File, 2)

--- a/pkg/memio/ports_linux_test.go
+++ b/pkg/memio/ports_linux_test.go
@@ -131,7 +131,6 @@ func TestNewPortSucceed(t *testing.T) {
 	if _, err := file.Write(fdata); err != nil {
 		t.Errorf("TestPortDev failed: %q", err)
 	}
-	defer os.RemoveAll(tmpDir)
 
 	linuxPath = file.Name()
 	defer func() { linuxPath = "/dev/port" }()

--- a/tools/vpdbootmanager/add_test.go
+++ b/tools/vpdbootmanager/add_test.go
@@ -168,7 +168,7 @@ func TestAddBootEntry(t *testing.T) {
 	if err := os.MkdirAll(path.Join(vpdDir, "rw"), 0o700); err != nil {
 		t.Errorf(`os.MkdirAll(path.Join(%q, "rw"), 0o700) = %v, want nil`, vpdDir, err)
 	}
-	defer os.RemoveAll(vpdDir)
+
 	if err := addBootEntry(&systembooter.LocalBooter{
 		Method: "grub",
 	}, vpdDir); err != nil {
@@ -195,7 +195,6 @@ func TestAddBootEntryMultiple(t *testing.T) {
 	if err != nil {
 		t.Errorf(`os.MkdirAll(path.Join(%q, "rw"), 0o700) = %v, want nil`, vpdDir, err)
 	}
-	defer os.RemoveAll(vpdDir)
 
 	for i := 1; i < 5; i++ {
 		if err := addBootEntry(&systembooter.LocalBooter{

--- a/tools/vpdbootmanager/main_test.go
+++ b/tools/vpdbootmanager/main_test.go
@@ -36,7 +36,7 @@ func TestAddNetbootEntryFull(t *testing.T) {
 	if err := os.MkdirAll(path.Join(dir, "rw"), 0o700); err != nil {
 		t.Errorf(`os.MkdirAll(path.Join(%q, "rw"), 0o700) = %v, want nil`, dir, err)
 	}
-	defer os.RemoveAll(dir)
+
 	args := []string{
 		"add",
 		"netboot",
@@ -66,7 +66,7 @@ func TestAddLocalbootEntryFull(t *testing.T) {
 	if err := os.MkdirAll(path.Join(dir, "rw"), 0o700); err != nil {
 		t.Errorf(`os.MkdirAll(path.Join(%q, "rw"), 0o700) = %v, want nil`, dir, err)
 	}
-	defer os.RemoveAll(dir)
+
 	args := []string{
 		"add",
 		"localboot",


### PR DESCRIPTION
A small testing enhancement.

Use `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir