### PR TITLE
Fix flaky ls test

### DIFF
--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -142,14 +142,14 @@ func indicator(fi ls.FileInfo) string {
 	return ""
 }
 
-func list(names []string) error {
+func list(w io.Writer, names []string) error {
 	if len(names) == 0 {
 		names = []string{"."}
 	}
 	// Write output in tabular form.
-	w := &tabwriter.Writer{}
-	w.Init(os.Stdout, 0, 0, 1, ' ', 0)
-	defer w.Flush()
+	tw := &tabwriter.Writer{}
+	tw.Init(w, 0, 0, 1, ' ', 0)
+	defer tw.Flush()
 
 	var s ls.Stringer = ls.NameStringer{}
 	if *quoted {
@@ -161,17 +161,17 @@ func list(names []string) error {
 	// Is a name a directory? If so, list it in its own section.
 	prefix := len(names) > 1
 	for _, d := range names {
-		if err := listName(s, d, w, prefix); err != nil {
+		if err := listName(s, d, tw, prefix); err != nil {
 			return fmt.Errorf("error while listing %q: %v", d, err)
 		}
-		w.Flush()
+		tw.Flush()
 	}
 	return nil
 }
 
 func main() {
 	flag.Parse()
-	if err := list(flag.Args()); err != nil {
+	if err := list(os.Stdout, flag.Args()); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmds/core/ls/ls_linux_test.go
+++ b/cmds/core/ls/ls_linux_test.go
@@ -37,21 +37,17 @@ func TestListNameLinux(t *testing.T) {
 	// Setting the flags
 	*long = true
 	// Running the tests
-	t.Run("ls with large node", func(t *testing.T) {
-		// Write output in buffer.
-		var buf bytes.Buffer
-		var s ls.Stringer = ls.NameStringer{}
-		if *quoted {
-			s = ls.QuotedStringer{}
-		}
-		if *long {
-			s = ls.LongStringer{Human: *human, Name: s}
-		}
-		_ = listName(s, d, &buf, false)
-		if !strings.Contains(buf.String(), "1110, 74616") {
-			t.Errorf("Expected value: %s, got: %s", "1110, 74616", buf.String())
-		}
-
-	})
-
+	// Write output in buffer.
+	var buf bytes.Buffer
+	var s ls.Stringer = ls.NameStringer{}
+	if *quoted {
+		s = ls.QuotedStringer{}
+	}
+	if *long {
+		s = ls.LongStringer{Human: *human, Name: s}
+	}
+	_ = listName(s, d, &buf, false)
+	if !strings.Contains(buf.String(), "1110, 74616") {
+		t.Errorf("Expected value: %s, got: %s", "1110, 74616", buf.String())
+	}
 }

--- a/cmds/core/ls/ls_test.go
+++ b/cmds/core/ls/ls_test.go
@@ -169,7 +169,8 @@ func TestList(t *testing.T) {
 
 		// Running the tests
 		t.Run(tt.name, func(t *testing.T) {
-			if got := list(tt.input); got != nil {
+			var buf bytes.Buffer
+			if got := list(&buf, tt.input); got != nil {
 				if got.Error() != tt.want.Error() {
 					t.Errorf("list() = '%v', want: '%v'", got, tt.want)
 				}


### PR DESCRIPTION
Test was flaky due to how test output was written out and how it is parsed.

cmds/core/ls: collect output via io.Writer so test infra can parse test output correctly

Otherwise, the output of the command interferes with our test infra's
parsing of test state:

```
    integration.go:145: 2022/02/21 00:22:24 serial: === RUN   TestListName/ls_classify_=_true~
    integration.go:145: 2022/02/21 00:22:24 serial:     --- PASS: TestListName/ls_classify_=_true (0.00s)~
    integration.go:145: 2022/02/21 00:22:24 serial: -rw-r--r--{"Time":"2022-02-21T00:22:22.771036451Z","Action":"pass","Package":"github.com/u-root/u-root/cmds/core/ls","Test":"TestListName/ls_directory_=_true","Elapsed":0}~
    integration.go:145: 2022/02/21 00:22:24 serial:  circleci {"Time":"2022-02-21T00:22:22.774185019Z","Action":"pass","Package":"github.com/u-root/u-root/cmds/core/ls","Test":"TestListName/ls_classify_=_true","Elapsed":0}~
    integration.go:145: 2022/02/21 00:22:24 serial: circleci 3824    Feb 21 00:21 "ls.go"~
```

... later ...

```
    gotest.go:171: Test github.com/u-root/u-root/cmds/core/ls.TestListName/ls_classify_=_true left in state running:
        === RUN   TestListName/ls_classify_=_true
            --- PASS: TestListName/ls_classify_=_true (0.00s)
```

gotest did not detect that ls_classify_=_true finished because it could
not parse the JSON output due to the "-rw-r--r--"/" circleci " prefix
printed by the ls command to stdout.