### PR TITLE
termios: make struct Termios contain unix.Termios, not *unix.Termios

### DIFF
--- a/pkg/termios/termios_darwin.go
+++ b/pkg/termios/termios_darwin.go
@@ -52,7 +52,7 @@ func GetTermios(fd uintptr) (*Termios, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Termios{Termios: t}, nil
+	return &Termios{Termios: *t}, nil
 }
 
 // Get terms a Termios from a TTYIO.
@@ -62,7 +62,7 @@ func (t *TTYIO) Get() (*Termios, error) {
 
 // SetTermios sets tty parameters for an fd from a Termios.
 func SetTermios(fd uintptr, ti *Termios) error {
-	return unix.IoctlSetTermios(int(fd), unix.TIOCSETA, ti.Termios)
+	return unix.IoctlSetTermios(int(fd), unix.TIOCSETA, &ti.Termios)
 }
 
 // Set sets tty parameters for a TTYIO from a Termios.

--- a/pkg/termios/termios_linux.go
+++ b/pkg/termios/termios_linux.go
@@ -57,7 +57,7 @@ func GetTermios(fd uintptr) (*Termios, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Termios{Termios: t}, nil
+	return &Termios{Termios: *t}, nil
 }
 
 // Get terms a Termios from a TTYIO.
@@ -67,7 +67,7 @@ func (t *TTYIO) Get() (*Termios, error) {
 
 // SetTermios sets tty parameters for an fd from a Termios.
 func SetTermios(fd uintptr, ti *Termios) error {
-	return unix.IoctlSetTermios(int(fd), unix.TCSETS, ti.Termios)
+	return unix.IoctlSetTermios(int(fd), unix.TCSETS, &ti.Termios)
 }
 
 // Set sets tty parameters for a TTYIO from a Termios.

--- a/pkg/termios/termios_test.go
+++ b/pkg/termios/termios_test.go
@@ -105,6 +105,23 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestChangeTermios(t *testing.T) {
+	tty, err := New()
+	if os.IsNotExist(err) {
+		t.Skipf("No /dev/tty here.")
+	} else if err != nil {
+		t.Fatalf("TestRaw new: want nil, got %v", err)
+	}
+	term, err := tty.Get()
+	if err != nil {
+		t.Fatalf("TestRaw get: want nil, got %v", err)
+	}
+	raw := MakeRaw(term)
+	if reflect.DeepEqual(raw, term) {
+		t.Fatalf("reflect.DeepEqual(%v, %v): true != false", term, raw)
+	}
+}
+
 func TestRaw(t *testing.T) {
 	// TestRaw no longer works in CircleCi, Restrict to only VM tests.
 	testutil.SkipIfNotRoot(t)

--- a/pkg/termios/var_unix.go
+++ b/pkg/termios/var_unix.go
@@ -15,7 +15,7 @@ import (
 
 // Termios is a struct for Termios operations.
 type Termios struct {
-	*unix.Termios
+	unix.Termios
 }
 
 type bit struct {


### PR DESCRIPTION
The Termios type is intended to be a value, not a reference,
so that it can be modified or saved and reused. Dereferencing
a *Termios should yield a value that, when changed, does not
affect the original.

For example, the Raw() function returns a Termios intended
to be used later to reset the terminal state, and modifies
a copy.

As part of bc40a4c6c, "make termios less linux/unix-specific.",
a Termios struct was created containing the *unix.Termios that
had been passed around directly.

This broke semantics of functions like Raw and MakeRaw,
which depend on being able to return an unmodified struct value
while modifying a copy of the one passed in. Since the passed-in
*Termios contained a *unix.Termios, copying just mean we had two
Termios using the same *unix.Termios.

This change fixes a problem we observed in the cpu command, and includes
a test to avoid future regressions.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>