### PR TITLE
Fix flaky tests of cmds/core/date

### DIFF
--- a/cmds/core/date/date_unix.go
+++ b/cmds/core/date/date_unix.go
@@ -13,8 +13,8 @@ import (
 	"time"
 )
 
-func setDate(d string, z *time.Location) error {
-	t, err := getTime(z, d)
+func setDate(d string, z *time.Location, clocksource Clock) error {
+	t, err := getTime(z, d, clocksource)
 	if err != nil {
 		log.Fatalf("%v: %v", d, err)
 	}


### PR DESCRIPTION
cmds/core/date:
* Adatp TestGetTime to not be flaky.

Signed-off-by: Christopher Meis <christopher.meis@9elements.com>