### PR TITLE
Fix rm

### DIFF
--- a/cmds/core/rm/rm.go
+++ b/cmds/core/rm/rm.go
@@ -41,8 +41,7 @@ const usage = "rm [-Rrvif] file..."
 
 func rm(stdin io.Reader, files []string) error {
 	if len(files) < 1 {
-		flag.Usage()
-		return nil
+		return fmt.Errorf("%v", usage)
 	}
 	f := os.Remove
 	if *recursive || *r {

--- a/cmds/core/rm/rm_test.go
+++ b/cmds/core/rm/rm_test.go
@@ -69,7 +69,7 @@ func TestRm(t *testing.T) {
 		{
 			name: "no args",
 			file: "",
-			want: "",
+			want: usage,
 		},
 		{
 			name: "rm one file",


### PR DESCRIPTION
I don't know how this ever passed our CI, but rm was broken for the case of no
args. Code that calls it assumes it returns (main, tests) but if no args are
given, it calls flag.Usage(), which exits.

This was breaking other tests.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>