### PR TITLE
cmds/core/timeout: add a timeout command

### DIFF
--- a/cmds/core/timeout/main.go
+++ b/cmds/core/timeout/main.go
@@ -1,0 +1,80 @@
+// Copyright 2012-2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Run a command and kill it if it runs more than a specified duration
+//
+// Synopsis:
+//	timeout [-t duration-string] command [args...]
+//
+// Description:
+//	timeout will run the command until it succeeds or too much time has passed.
+//	The default timeout is 30s.
+//	If no args are given, it will print a usage error.
+//
+// Example:
+//	$ timeout echo hi
+//	hi
+//	$
+//	$./timeout -t 5s bash -c 'sleep 40'
+//	$ 2022/03/31 14:47:32 signal: killed
+//	$./timeout  -t 5s bash -c 'sleep 40'
+//	$ 2022/03/31 14:47:40 signal: killed
+//	$./timeout  -t 5s bash -c 'sleep 1'
+//	$
+
+//go:build !test
+// +build !test
+
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"log"
+	"os"
+	"os/exec"
+	"time"
+)
+
+type cmd struct {
+	args         []string
+	timeout      time.Duration
+	in, out, err *os.File
+}
+
+var (
+	timeout        = flag.Duration("t", 30*time.Second, "Timeout for command")
+	errNoArgs      = errors.New("Need at least a command to run")
+	errBadDuration = errors.New("timeout must be a duration")
+)
+
+func main() {
+	flag.Parse()
+	c := &cmd{args: flag.Args(), in: os.Stdin, out: os.Stdout, err: os.Stderr, timeout: *timeout}
+	if errno, err := c.run(); err != nil || errno != 0 {
+		log.Printf("timeout(%v):%v", *timeout, err)
+		os.Exit(errno)
+	}
+}
+
+func (c *cmd) run() (int, error) {
+	if len(c.args) == 0 {
+		return 1, errNoArgs
+	}
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	defer cancel()
+	proc := exec.CommandContext(ctx, c.args[0], c.args[1:]...)
+	proc.Stdin, proc.Stdout, proc.Stderr = c.in, c.out, c.err
+	if err := proc.Run(); err != nil {
+		errno := 1
+		var e *exec.ExitError
+		if errors.As(err, &e) {
+			errno = e.ExitCode()
+		}
+		return errno, err
+	}
+	return 0, nil
+}

--- a/cmds/core/timeout/main_test.go
+++ b/cmds/core/timeout/main_test.go
@@ -1,0 +1,108 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/u-root/u-root/pkg/testutil"
+)
+
+func TestBadInvocation(t *testing.T) {
+	var tests = []struct {
+		cmd   cmd
+		err   error
+		errno int
+	}{
+		{cmd: cmd{args: []string{}}, err: errNoArgs, errno: 1},
+	}
+
+	for _, v := range tests {
+		t.Logf("Run %v", v.cmd)
+		if errno, err := v.cmd.run(); !errors.Is(err, v.err) || errno != v.errno {
+			t.Errorf("run %v: got (%d, %v), want (%d, %v)", v.cmd, errno, err, v.errno, v.err)
+		}
+	}
+}
+
+func TestRun(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skipf("Skipping this test as sleep is not in the path")
+	}
+
+	var tests = []struct {
+		cmd cmd
+		ok  bool
+	}{
+		{cmd: cmd{args: []string{"sleep", "4"}, timeout: 2 * time.Minute}, ok: true},
+		{cmd: cmd{args: []string{"sleep", "30"}, timeout: time.Second}},
+	}
+	for _, v := range tests {
+		t.Logf("Run %v", v.cmd)
+		// Return errors from running sleep are not guaranteed across all kernels.
+		// Just see if it succeeded or not.
+		if _, err := v.cmd.run(); err == nil != v.ok {
+			t.Errorf("run %v: got %v, want %v", v.cmd, err == nil, v.ok)
+		}
+	}
+
+}
+
+// Test real execution. Why do this if we covered all the code above?
+// Because not long ago, someone working on a different u-root
+// command got good coverage numbers but never tried
+// running the program, and they had completely broken it.
+// Tests worked, coverage was good, program was broken for real use.
+// It pays to test real operation..
+func TestProg(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skipf("Skipping this test as sleep is not in the path")
+	}
+
+	c := testutil.Command(t, "-t=30s", "sleep", "4")
+	c.Stdout, c.Stderr = &bytes.Buffer{}, &bytes.Buffer{}
+	if err := c.Run(); err != nil {
+		t.Errorf("Running -t=30 sleep 4: got %v, want nil", err)
+	}
+
+	c = testutil.Command(t, "-t=1s", "sleep", "30")
+	c.Stdout, c.Stderr = &bytes.Buffer{}, &bytes.Buffer{}
+	if err := c.Run(); err == nil {
+		t.Errorf("Running -t=1 sleep 30: got nil, want err")
+	}
+}
+
+func TestBashExit(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skipf("Skipping test because there is no bash")
+	}
+	c := testutil.Command(t, "bash", "-c", "exit 20")
+	c.Stdout, c.Stderr = &bytes.Buffer{}, &bytes.Buffer{}
+
+	err := c.Run()
+	if err == nil {
+		t.Fatalf(`Running "bash", "-c", "exit 20": got nil, want err`)
+	}
+
+	var errno int
+	var e *exec.ExitError
+	if errors.As(err, &e) {
+		errno = e.ExitCode()
+	} else {
+		t.Fatalf(`Running "bash", "-c", "exit 20": got %T, want *exec.ExitError`, err)
+	}
+	if errno != 20 {
+		t.Fatalf(`Running "bash", "-c", "exit 20": got %d, want 20`, errno)
+	}
+
+}
+
+func TestMain(m *testing.M) {
+	testutil.Run(m, main)
+}


### PR DESCRIPTION
usage:
timeout [-t duration] command [args...]

Runs a command and, if it takes too long, kills it.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>