### PR TITLE
gosh: fix ambiguous info message

### DIFF
--- a/cmds/exp/gosh/gosh.go
+++ b/cmds/exp/gosh/gosh.go
@@ -73,7 +73,7 @@ func (s shell) runAll(narg int) error {
 				return s.runInteractiveTabCompletion(r, os.Stdout)
 			}
 
-			fmt.Println("Do get tabcompletion run 'gosh -tabcomp'\nThis will only work with a working framebuffer for now")
+			fmt.Println("To get tab completion run 'gosh -tabcomp'.\nTab completion will only work with a working framebuffer.")
 
 			return s.runInteractive(r, os.Stdin, os.Stdout)
 		}


### PR DESCRIPTION
I started gosh for the first time and was greeted with

"This will only work with a working framebuffer for now"

and I wasn't sure if it meant that the shell altogether would only work
with a framebuffer.