### PR TITLE
Append the smbios_entry_point to the end of DMI

### DIFF
--- a/cmds/exp/smbios_transfer/smbios_transfer.go
+++ b/cmds/exp/smbios_transfer/smbios_transfer.go
@@ -79,7 +79,13 @@ func getSmbiosData() ([]uint8, error) {
 		return nil, fmt.Errorf("error reading DMI data: %v", err)
 	}
 
-	return tables, nil
+	entryPoint, err := os.ReadFile(filepath.Join(sysfsPath, "smbios_entry_point"))
+	if err != nil {
+		return nil, fmt.Errorf("error reading smbios_entry_point data: %v", err)
+	}
+
+	data := append(tables, entryPoint...)
+	return data, nil
 }
 
 func transferSmbiosData() error {


### PR DESCRIPTION
The main user of smbios - openbmc/smbios-mdr has made some changes where they require `smbios_entry_point` (https://github.com/openbmc/smbios-mdr/commit/0435a483afb10a5eabe7ae93f07fbb2d2265e53f) to be appended to the end of the DMI as found while working on https://gerrit.openbmc-project.xyz/c/openbmc/smbios-mdr/+/51500.