### PR TITLE
boot/kexec: log accurate syscall for file load.

### DIFF
--- a/pkg/boot/kexec/kexec_linux_implemented.go
+++ b/pkg/boot/kexec/kexec_linux_implemented.go
@@ -28,7 +28,7 @@ func FileLoad(kernel, ramfs *os.File, cmdline string) error {
 	}
 
 	if err := unix.KexecFileLoad(int(kernel.Fd()), ramfsfd, cmdline, flags); err != nil {
-		return fmt.Errorf("sys_kexec(%d, %d, %s, %x) = %v", kernel.Fd(), ramfsfd, cmdline, flags, err)
+		return fmt.Errorf("SYS_kexec_file_load(%d, %d, %s, %x) = %v", kernel.Fd(), ramfsfd, cmdline, flags, err)
 	}
 	return nil
 }


### PR DESCRIPTION
`sys_kexec` does not distinguish if it made a file
load call or classic kexec call.

We now have code path for classic kexec call, we
need lore accurately.

We were pondering why console log saying the classic
sys call function not implemented, even after we
enabled it during build (CONFIG_KEXEC). But it
turns out that was a file load call, and our test
kernel did not have it enabled (CONFIG_KEXEC_FILE).

Signed-off-by: David Hu <xuehaohu@google.com>