### PR TITLE
cpio: fix to allow a same file as source for multiple extra files

### DIFF
--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -208,13 +208,14 @@ type Recorder struct {
 // If not, we get a new inumber for it and save the inode away.
 // This eliminates two of the messier parts of creating reproducible
 // output streams.
+// The second return value indicates whether it is a hardlink or not.
 func (r *Recorder) inode(i Info) (Info, bool) {
 	d := devInode{dev: i.Dev, ino: i.Ino}
 	i.Dev = 0
 
 	if d, ok := r.inodeMap[d]; ok {
 		i.Ino = d.Ino
-		return i, true
+		return i, d.Name != i.Name
 	}
 
 	i.Ino = r.inumber


### PR DESCRIPTION
If a same file is specified as source for multiple extra files,
e.g. -files 'README.md:a.txt' -files 'README.md:b.txt', the
contents of the second and subsequent files, e.g. b.txt, are empty.
This is because `ReaderAt` is not initialized after the second time
if the inode of source is duplicated.

```bash
$ go run . -files 'README.md:a.txt' -files 'README.md:b.txt' cmds/core/{init,elvish}
$ lsinitramfs -l /tmp/initramfs.linux_amd64.cpio
-rw-rw-r--   0 root     root        16228 Jan  1  1970 a.txt # file is written successfully.
-rw-rw-r--   0 root     root            0 Jan  1  1970 b.txt # file is empty.
```