### PR TITLE
pkg/mount: do not MkdirAll the mountpoint by default

### DIFF
--- a/integration/testcmd/common/common.go
+++ b/integration/testcmd/common/common.go
@@ -69,7 +69,11 @@ func collectKernelCoverage(filename string) error {
 	}
 
 	// Mount debugfs.
-	if err := unix.Mount("debugfs", "/sys/kernel/debug", "debugfs", 0, ""); err != nil {
+	dfs := "/sys/kernel/debug"
+	if err := os.MkdirAll(dfs, 0o666); err != nil {
+		return fmt.Errorf("os.MkdirAll(%v): %v != nil", dfs, err)
+	}
+	if err := unix.Mount("debugfs", dfs, "debugfs", 0, ""); err != nil {
 		return fmt.Errorf("failed to mount debugfs: %v", err)
 	}
 
@@ -107,6 +111,11 @@ func MountSharedDir() (func(), error) {
 		mp  *mount.MountPoint
 		err error
 	)
+
+	if err := os.MkdirAll(sharedDir, 0o644); err != nil {
+		return nil, err
+	}
+
 	if os.Getenv(envUse9P) == "1" {
 		mp, err = mount.Mount("tmpdir", sharedDir, "9p", fmt.Sprintf("9P2000.L,msize=%d", msize9P), 0)
 	} else {

--- a/pkg/mount/mount_linux_test.go
+++ b/pkg/mount/mount_linux_test.go
@@ -5,6 +5,7 @@
 package mount_test
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -40,7 +41,7 @@ func TestTryMount(t *testing.T) {
 
 	sda1 := filepath.Join(d, prefix+"a1")
 	deva1 := fmt.Sprintf("/dev/%sa1", prefix)
-	if mp, err := mount.TryMount(deva1, sda1, "", mount.ReadOnly); err != nil {
+	if mp, err := mount.TryMount(deva1, sda1, "", mount.ReadOnly, func() error { return os.MkdirAll(sda1, 0o666) }); err != nil {
 		t.Errorf("TryMount(%s) = %v, want nil", deva1, err)
 	} else {
 		want := &mount.MountPoint{
@@ -60,7 +61,7 @@ func TestTryMount(t *testing.T) {
 
 	sda2 := filepath.Join(d, prefix+"a2")
 	deva2 := fmt.Sprintf("/dev/%sa2", prefix)
-	if mp, err := mount.TryMount(deva2, sda2, "", mount.ReadOnly); err != nil {
+	if mp, err := mount.TryMount(deva2, sda2, "", mount.ReadOnly, func() error { return os.MkdirAll(sda2, 0o666) }); err != nil {
 		t.Errorf("TryMount(%s) = %v, want nil", deva2, err)
 	} else {
 		want := &mount.MountPoint{
@@ -80,13 +81,13 @@ func TestTryMount(t *testing.T) {
 
 	sdb1 := filepath.Join(d, prefix+"b1")
 	devb1 := fmt.Sprintf("/dev/%sb1", prefix)
-	if _, err := mount.TryMount(devb1, sdb1, "", mount.ReadOnly); !strings.Contains(err.Error(), "no suitable filesystem") {
+	if _, err := mount.TryMount(devb1, sdb1, "", mount.ReadOnly, func() error { return os.MkdirAll(sdb1, 0o666) }); !strings.Contains(err.Error(), "no suitable filesystem") {
 		t.Errorf("TryMount(%s) = %v, want an error containing 'no suitable filesystem'", devb1, err)
 	}
 
 	sdz1 := filepath.Join(d, prefix+"z1")
 	devz1 := fmt.Sprintf("/dev/%sz1", prefix)
-	if _, err := mount.TryMount(devz1, sdz1, "", mount.ReadOnly); !os.IsNotExist(err) {
+	if _, err := mount.TryMount(devz1, sdz1, "", mount.ReadOnly, func() error { return os.MkdirAll(sdz1, 0o666) }); !os.IsNotExist(err) {
 		t.Errorf("TryMount(%s) = %v, want an error equivalent to Does Not Exist", devz1, err)
 	}
 }
@@ -147,9 +148,13 @@ func TestIsTmpRamfs(t *testing.T) {
 
 	testRoot := t.TempDir()
 
+	// This test assumes the old mount.Mount behavior of automagically
+	// creating the mountpoint directory.
+	// This is a good chance to test using the option to create
+	// the destination directory ...
 	// Is a tmpfs.
 	tmpfsMount := filepath.Join(testRoot, "tmpfs")
-	mp1, err := mount.Mount("somedevice", tmpfsMount, "tmpfs", "", 0)
+	mp1, err := mount.Mount("somedevice", tmpfsMount, "tmpfs", "", 0, func() error { return os.MkdirAll(tmpfsMount, 0o666) })
 	if err != nil {
 		t.Fatalf("mount.Mount(somedevice, %s, tmpfs, 0) returned with error: %v", tmpfsMount, err)
 	}
@@ -166,7 +171,7 @@ func TestIsTmpRamfs(t *testing.T) {
 
 	// Not a tmpfs.
 	nottmpfsMount := filepath.Join(testRoot, "nottmpfs")
-	mp2, err := mount.Mount("none", nottmpfsMount, "proc", "", 0)
+	mp2, err := mount.Mount("none", nottmpfsMount, "proc", "", 0, func() error { return os.MkdirAll(nottmpfsMount, 0o666) })
 	if err != nil {
 		t.Fatalf("mount.Mount(somedevice, %s, \"\", \"\", 0)", err)
 	}
@@ -178,5 +183,26 @@ func TestIsTmpRamfs(t *testing.T) {
 	}
 	if r {
 		t.Errorf("mount.IsTmpRamfs(%s) = true, want false", nottmpfsMount)
+	}
+}
+
+func TestOpt(t *testing.T) {
+	var (
+		j      int
+		errVal = fmt.Errorf("got it")
+	)
+
+	m, err := mount.Mount("", "", "", "", 0, func() error {
+		j++
+		return errVal
+	})
+	if !errors.Is(err, errVal) {
+		t.Fatalf(`mount.Mount("", "", "", "", 0, func): %v != %v`, err, errVal)
+	}
+	if m != nil {
+		t.Errorf(`mount.Mount("", "", "", "", 0, func): %v != nil`, m)
+	}
+	if j != 1 {
+		t.Fatalf(`mount.Mount("", "", "", "", 0, func): %d != 1`, j)
 	}
 }


### PR DESCRIPTION
Remove the code that always does a MkdirAll in mount.Mount.

Making the mountpoint by default is nonstandard behavior.
It was introduced in 74c94c.
It must have been useful, I assume, else we would not have done it?

This code can have all kinds of confusing consequences, e.g.
imagine a script that does this:
mount /dev/sda1 /mnnt
ls -l /dev/mnt

/mnnt will be created, but it's not what the caller intended by
any means!

Further, mount.Mount does not allow callers to set the mode to other than
666.

At the same time, the behavior can be useful, so change
mount.Mount as follows:
func Mount(dev, path, fsType, data string, flags uintptr, opts ...func() error)

Then, callers wishing to do a few things ahead of time can do so:
mount.Mount("none", dst, fstype, "", 0, os.Mount(dst, 0o644))

Note that the fixed default mode is no longer the case: callers can
set the mode as needed.

This is a breaking change, possibly, for users of this package :-(
But current behavior is not good, so this change may be worth the pain.

Includes an extra test for the opts.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>