### PR TITLE
Change default Busybox backend to GBB

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,18 +48,19 @@ workflows:
 
 jobs:
   test:
-    <<: *golang-template
     <<: *beefy-template
+    environment:
+      - GOMAXPROCS: 1
     steps:
       - checkout
       - run:
           name: Test Packages
-          command: go test -v -a -timeout 15m -ldflags '-s' -coverprofile=coverage_pkg.txt -covermode=atomic -coverpkg=./pkg/... ./pkg/...
+          command: go test -v -a -timeout=20m -ldflags='-s' -failfast -coverprofile=coverage_pkg.txt -covermode=atomic -coverpkg=./pkg/... ./pkg/...
           no_output_timeout: 15m
 
       - run:
           name: Test coverage
-          command: UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -timeout=15m -coverprofile=coverage.txt -covermode=atomic -cover ./cmds/... ./pkg/...
+          command: UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -timeout=20m -failfast -coverprofile=coverage.txt -covermode=atomic -cover ./cmds/... ./pkg/...
 
       - run:
           name: Upload coverage
@@ -71,20 +72,19 @@ jobs:
       - checkout
       - run:
           name: Test u-root build
-          command: go test -a -timeout 15m .
+          command: go test -a -timeout=15m .
           no_output_timeout: 15m
 
   race:
-    <<: *golang-template
-    resource_class: large
+    <<: *beefy-template
     environment:
       - CGO_ENABLED: 1
-      - GO111MODULE: "off"
+      - GOMAXPROCS: 1
     steps:
       - checkout
       - run:
           name: Race detector
-          command: go test -race ./cmds/... ./pkg/...
+          command: go test -race -timeout=15m -failfast ./cmds/... ./pkg/...
 
   compile_cmds:
     <<: *golang-template
@@ -97,6 +97,7 @@ jobs:
             go install -a ./...
             cd ../tools
             go install -a ./...
+
   check_licenses:
     <<: *golang-template
     steps:
@@ -104,6 +105,7 @@ jobs:
       - run:
           name: Check licenses
           command: go run tools/checklicenses/checklicenses.go -c tools/checklicenses/config.json
+
   check_symlinks:
     <<: *golang-template
     steps:
@@ -111,6 +113,7 @@ jobs:
       - run:
           name: Symbol tests to ensure we do not break symlink handling
           command: mkdir /tmp/usr && ln -s /tmp/usr/x /tmp/usr/y && go run u-root.go -build=bb -files /tmp/usr minimal
+
   check_templates:
     <<: *golang-template
     steps:
@@ -134,14 +137,17 @@ jobs:
           name: Store build stats
           path: /tmp/stats.json
           destination: stats.json
+
   test-integration-amd64:
     <<: *integration-template
     docker:
       - image: uroottest/test-image-amd64:v4.4.0
+
   test-integration-arm:
     <<: *integration-template
     docker:
       - image: uroottest/test-image-arm:v4.4.0
+
   test-integration-arm64:
     <<: *integration-template
     docker:

--- a/pkg/uroot/builder/builder.go
+++ b/pkg/uroot/builder/builder.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	BusyBox = BBBuilder{}
+	BusyBox = GBBBuilder{}
 	Binary  = BinaryBuilder{}
 )
 

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -241,6 +241,11 @@ func CreateInitramfs(logger ulog.Logger, opts Opts) error {
 		opts.Commands[index].Packages = importPaths
 	}
 
+	// Make sure this isn't a nil pointer
+	if opts.BuildOpts == nil {
+		opts.BuildOpts = &gbbgolang.BuildOpts{}
+	}
+
 	// Add each build mode's commands to the archive.
 	for _, cmds := range opts.Commands {
 		builderTmpDir, err := os.MkdirTemp(opts.TempDir, "builder")


### PR DESCRIPTION
This is an attempt to trace down a CI issue probably occuring because of memory pressure or locking.

EDIT: As the go.mod file gets locked by the go toolchain, it was necessary to run highly parallel tests with GOMAXPROCS=1 which is the major change of this PR.