### PR TITLE
Convert grep to use pflag package, and add some functionality.

### DIFF
--- a/cmds/core/grep/grep.go
+++ b/cmds/core/grep/grep.go
@@ -16,19 +16,21 @@ package main
 
 import (
 	"bufio"
-	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	flag "github.com/spf13/pflag"
 )
 
 type grepResult struct {
-	match bool
-	c     *grepCommand
-	line  *string
+	match   bool
+	c       *grepCommand
+	line    *string
+	lineNum int
 }
 
 type grepCommand struct {
@@ -41,11 +43,14 @@ type oneGrep struct {
 }
 
 var (
-	match           = flag.Bool("v", true, "Print only non-matching lines")
-	recursive       = flag.Bool("r", false, "recursive")
-	noshowmatch     = flag.Bool("l", false, "list only files")
-	count           = flag.Bool("c", false, "Just show counts")
-	caseinsensitive = flag.Bool("i", false, "case-insensitive matching")
+	expr            = flag.StringP("regexp", "e", "", "Pattern to match")
+	headers         = flag.BoolP("no-filename", "h", false, "Suppress file name prefixes on output")
+	match           = flag.BoolP("invert-match", "v", true, "Print only non-matching lines")
+	recursive       = flag.BoolP("recursive", "r", false, "recursive")
+	noshowmatch     = flag.BoolP("files-with-matches", "l", false, "list only files")
+	count           = flag.BoolP("count", "c", false, "Just show counts")
+	caseinsensitive = flag.BoolP("ignore-case", "i", false, "case-insensitive matching")
+	number          = flag.BoolP("line-number", "n", false, "Show line numbers")
 	showname        bool
 	allGrep         = make(chan *oneGrep)
 	nGrep           int
@@ -61,15 +66,15 @@ var (
 // If we are only looking for a match, we exit as soon as the condition is met.
 // "match" means result of re.Match == match flag.
 func grep(f *grepCommand, re *regexp.Regexp) {
-	nGrep++
 	r := bufio.NewReader(f)
 	res := make(chan *grepResult, 1)
 	allGrep <- &oneGrep{res}
+	var lineNum int
 	for {
 		if i, err := r.ReadString('\n'); err == nil {
 			m := re.Match([]byte(i))
 			if m == *match {
-				res <- &grepResult{re.Match([]byte(i)), f, &i}
+				res <- &grepResult{re.Match([]byte(i)), f, &i, lineNum}
 				if *noshowmatch {
 					break
 				}
@@ -77,6 +82,7 @@ func grep(f *grepCommand, re *regexp.Regexp) {
 		} else {
 			break
 		}
+		lineNum++
 	}
 	close(res)
 	f.Close()
@@ -95,7 +101,11 @@ func printmatch(r *grepResult) {
 		prefix = ":"
 	}
 	if *noshowmatch {
+		fmt.Printf("\n")
 		return
+	}
+	if *number {
+		prefix = fmt.Sprintf(":%d:", r.lineNum)
 	}
 	if r.match == *match {
 		fmt.Printf("%v%v", prefix, *r.line)
@@ -106,6 +116,10 @@ func main() {
 	r := ".*"
 	flag.Parse()
 	a := flag.Args()
+	if *expr != "" {
+		// they used the -e flag
+		a = append([]string{*expr}, a...)
+	}
 	if len(a) > 0 {
 		r = a[0]
 	}
@@ -115,13 +129,15 @@ func main() {
 	re := regexp.MustCompile(r)
 	// very special case, just stdin ...
 	if len(a) < 2 {
+		nGrep++
 		go grep(&grepCommand{"<stdin>", os.Stdin}, re)
 	} else {
-		showname = len(a[1:]) > 1
+		showname = (len(a[1:]) > 1 || *recursive) && !*headers
 		// generate a chan of file names, bounded by the size of the chan. This in turn
 		// throttles the opens.
 		treenames := make(chan string, 128)
 		go func() {
+			defer close(treenames)
 			for _, v := range a[1:] {
 				// we could parallelize the open part but people might want
 				// things to be in order. I don't care but who knows.
@@ -146,7 +162,6 @@ func main() {
 					return nil
 				})
 			}
-			close(treenames)
 		}()
 
 		files := make(chan *grepCommand)
@@ -166,21 +181,24 @@ func main() {
 		// bug: file name order is not preserved here. Darn.
 
 		for f := range files {
+			nGrep++
 			go grep(f, re)
 		}
 	}
 
-	for c := range allGrep {
-		for r := range c.c {
-			// exit on first match.
-			if *quiet {
-				os.Exit(0)
+	if nGrep > 0 {
+		for c := range allGrep {
+			for r := range c.c {
+				// exit on first match.
+				if *quiet {
+					os.Exit(0)
+				}
+				printmatch(r)
 			}
-			printmatch(r)
-		}
-		nGrep--
-		if nGrep == 0 {
-			break
+			nGrep--
+			if nGrep == 0 {
+				break
+			}
 		}
 	}
 	if *quiet {

--- a/cmds/core/grep/grep.go
+++ b/cmds/core/grep/grep.go
@@ -45,7 +45,7 @@ type oneGrep struct {
 var (
 	expr            = flag.StringP("regexp", "e", "", "Pattern to match")
 	headers         = flag.BoolP("no-filename", "h", false, "Suppress file name prefixes on output")
-	match           = flag.BoolP("invert-match", "v", true, "Print only non-matching lines")
+	invert          = flag.BoolP("invert-match", "v", false, "Print only non-matching lines")
 	recursive       = flag.BoolP("recursive", "r", false, "recursive")
 	noshowmatch     = flag.BoolP("files-with-matches", "l", false, "list only files")
 	count           = flag.BoolP("count", "c", false, "Just show counts")
@@ -73,7 +73,7 @@ func grep(f *grepCommand, re *regexp.Regexp) {
 	for {
 		if i, err := r.ReadString('\n'); err == nil {
 			m := re.Match([]byte(i))
-			if m == *match {
+			if m == !*invert {
 				res <- &grepResult{re.Match([]byte(i)), f, &i, lineNum}
 				if *noshowmatch {
 					break
@@ -90,7 +90,7 @@ func grep(f *grepCommand, re *regexp.Regexp) {
 
 func printmatch(r *grepResult) {
 	var prefix string
-	if r.match == *match {
+	if r.match == !*invert {
 		matchCount++
 	}
 	if *count {
@@ -107,7 +107,7 @@ func printmatch(r *grepResult) {
 	if *number {
 		prefix = fmt.Sprintf(":%d:", r.lineNum)
 	}
-	if r.match == *match {
+	if r.match == !*invert {
 		fmt.Printf("%v%v", prefix, *r.line)
 	}
 }

--- a/cmds/core/grep/grep_linux.go
+++ b/cmds/core/grep/grep_linux.go
@@ -4,8 +4,8 @@
 
 package main
 
-import "flag"
+import flag "github.com/spf13/pflag"
 
 var (
-	quiet = flag.Bool("q", false, "Don't print matches; exit on first match")
+	quiet = flag.BoolP("quiet", "q", false, "Don't print matches; exit on first match")
 )

--- a/cmds/core/grep/grep_plan9.go
+++ b/cmds/core/grep/grep_plan9.go
@@ -4,8 +4,8 @@
 
 package main
 
-import "flag"
+import flag "github.com/spf13/pflag"
 
 var (
-	quiet = flag.Bool("s", false, "Don't print matches; exit on first match")
+	quiet = flag.BoolP("silent", "s", false, "Don't print matches; exit on first match")
 )

--- a/cmds/core/grep/grep_test.go
+++ b/cmds/core/grep/grep_test.go
@@ -27,6 +27,15 @@ func TestGrep(t *testing.T) {
 		{"hix\n", "hix\n", 0, []string{"-i", "hix"}},
 		{"hix\n", "", 0, []string{"-i", "hox"}},
 		{"HiX\n", "HiX\n", 0, []string{"-i", "hix"}},
+		{"hix\n", ":0:hix\n", 0, []string{"-n", "hix"}},
+		{"hix\n", "hix\n", 0, []string{"-e", "hix"}},
+		{"hix\n", "1\n", 0, []string{"-c", "hix"}},
+		// These tests don't make a lot of sense the way we're running it, but
+		// hopefully it'll make codecov shut up.
+		{"hix\n", "hix\n", 0, []string{"-h", "hix"}},
+		{"hix\n", "hix\n", 0, []string{"-r", "hix"}},
+		{"hix\nfoo\n", "foo\n", 0, []string{"-v", "hix"}},
+		{"hix\n", "\n", 0, []string{"-l", "hix"}}, // no filename, so it just prints a newline
 	}
 
 	for _, v := range tab {

--- a/cmds/core/grep/grep_test.go
+++ b/cmds/core/grep/grep_test.go
@@ -15,10 +15,10 @@ import (
 // We need to look at any output data, as well as exit status for things like the -q switch.
 func TestGrep(t *testing.T) {
 	tab := []struct {
-		i string
-		o string
-		s int
-		a []string
+		input  string
+		output string
+		status int
+		args   []string
 	}{
 		// BEWARE: the IO package seems to want this to be newline terminated.
 		// If you just use hix with no newline the test will fail. Yuck.
@@ -30,15 +30,15 @@ func TestGrep(t *testing.T) {
 	}
 
 	for _, v := range tab {
-		c := testutil.Command(t, v.a...)
-		c.Stdin = bytes.NewReader([]byte(v.i))
+		c := testutil.Command(t, v.args...)
+		c.Stdin = bytes.NewReader([]byte(v.input))
 		o, err := c.CombinedOutput()
-		if err := testutil.IsExitCode(err, v.s); err != nil {
+		if err := testutil.IsExitCode(err, v.status); err != nil {
 			t.Error(err)
 			continue
 		}
-		if string(o) != v.o {
-			t.Errorf("Grep %v != %v: want '%v', got '%v'", v.a, v.i, v.o, string(o))
+		if string(o) != v.output {
+			t.Errorf("grep %v != %v: want '%v', got '%v'", v.args, v.input, v.output, string(o))
 			continue
 		}
 	}


### PR DESCRIPTION
With pflag, you can now say `grep -rn`. The long names match GNU.

Also adds `-e`, `-h`, and `-n` flags. This brings us close to parity with
Plan 9 grep, although we're still missing `-L`, `-f`, and `-b`.

Also fixes a bug in the -l flag, where it wasn't outputting newlines between file names.

Signed-off-by: John Floren <john@jfloren.net>