### PR TITLE
Change print to commit directly before the merge of #2256

### DIFF
--- a/u-root.go
+++ b/u-root.go
@@ -282,7 +282,7 @@ func Main(l ulog.Logger, buildOpts *gbbgolang.BuildOpts) error {
 		var b builder.Builder
 		switch *build {
 		case "bb", "gbb":
-			l.Printf("NOTE: building with the new gobusybox; to get the old behavior check out commit e415592")
+			l.Printf("NOTE: building with the new gobusybox; to get the old behavior check out commit 8b790de")
 			b = builder.GBBBuilder{ShellBang: *shellbang}
 		case "binary":
 			b = builder.BinaryBuilder{}


### PR DESCRIPTION
As 2256 got merged, this adjusts the print of the previous "version" accordingly.