### PR TITLE
Bump up integration tests timeout.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,16 @@ templates:
     environment:
       - UROOT_SOURCE: /go/src/github.com/u-root/u-root
       - CGO_ENABLED: 0
-      # Triple all timeouts for QEMU VM tests since they run without KVM.
-      - UROOT_QEMU_TIMEOUT_X: 3
+      # x7 all timeouts for QEMU VM tests since they run without KVM.
+      - UROOT_QEMU_TIMEOUT_X: 7
 
   integration-template: &integration-template
     working_directory: /go/src/github.com/u-root/u-root
     environment:
       - UROOT_SOURCE: /go/src/github.com/u-root/u-root
       - CGO_ENABLED: 0
-      # x5 all timeouts for QEMU VM tests since they run without KVM.
-      - UROOT_QEMU_TIMEOUT_X: 5
+      # x7 all timeouts for QEMU VM tests since they run without KVM.
+      - UROOT_QEMU_TIMEOUT_X: 7
     steps:
       - checkout
       - run:
@@ -156,8 +156,8 @@ jobs:
     environment:
       - UROOT_SOURCE: /home/circleci/go/src/github.com/u-root/u-root
       - CGO_ENABLED: 0
-      # x5 all timeouts for QEMU VM tests since they run without KVM.
-      - UROOT_QEMU_TIMEOUT_X: 5
+      # x7 all timeouts for QEMU VM tests since they run without KVM.
+      - UROOT_QEMU_TIMEOUT_X: 7
     steps:
       - checkout
       - run:


### PR DESCRIPTION
a few runs from recent PRs showes they were
flapping between succeeded and failed due to
timeout. Bumping up the max time in hopes they
will be more reliable.