### PR TITLE
Update rsdpgetter order

### DIFF
--- a/pkg/acpi/rsdp_linux.go
+++ b/pkg/acpi/rsdp_linux.go
@@ -56,4 +56,4 @@ func GetRSDPEFI() (*RSDP, error) {
 }
 
 // You can change the getters if you wish for testing.
-var rsdpgetters = []func() (*RSDP, error){GetRSDPEFI, GetRSDPEBDA, GetRSDPMem}
+var rsdpgetters = []func() (*RSDP, error){GetRSDPEBDA, GetRSDPMem, GetRSDPEFI}


### PR DESCRIPTION
fixrsdp wants to get rsdp from EBDA or low memory region. 
The searching priority of EFI system table should be the lowest.