### PR TITLE
Set FullPath in OnePCI function

### DIFF
--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -156,8 +156,6 @@ iter:
 		if err != nil {
 			return nil, err
 		}
-		p.Addr = filepath.Base(d)
-		p.FullPath = d
 		for _, f := range filters {
 			if !f(p) {
 				continue iter

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -44,6 +44,7 @@ func readUint(dir, file string, base, bits int) (uint64, error) {
 // PCI files and returns a filled-in *PCI.
 func OnePCI(dir string) (*PCI, error) {
 	pci := PCI{
+		Addr:     filepath.Base(dir),
 		FullPath: dir,
 	}
 	var err error

--- a/pkg/pci/pci_linux.go
+++ b/pkg/pci/pci_linux.go
@@ -43,7 +43,9 @@ func readUint(dir, file string, base, bits int) (uint64, error) {
 // OnePCI takes the name of a directory containing linux-style
 // PCI files and returns a filled-in *PCI.
 func OnePCI(dir string) (*PCI, error) {
-	pci := PCI{}
+	pci := PCI{
+		FullPath: dir,
+	}
 	var err error
 	var n uint64
 


### PR DESCRIPTION
FullPath should be set, otherwise the caller has has to set this before being able to call PCI methods relying on FullPath.  
(f.e.: ReadConfigRegister / WriteConfigRegister)