### PR TITLE
u-root.go: set a reasonable and checked default for -uroot-source

### DIFF
--- a/u-root.go
+++ b/u-root.go
@@ -94,7 +94,8 @@ func init() {
 	genDir = flag.String("gen-dir", "", "Directory to generate source in")
 
 	// Flag for the new filepath only mode. This will be required to find the u-root commands and make templates work
-	urootSourceDir = flag.String("uroot-source", "", "Path to the locally checked out u-root source tree in case commands from there are desired.")
+	// In almost every case, "." is fine.
+	urootSourceDir = flag.String("uroot-source", ".", "Path to the locally checked out u-root source tree in case commands from there are desired.")
 }
 
 type buildStats struct {
@@ -204,6 +205,14 @@ func isRecommendedVersion(v string) bool {
 	return false
 }
 
+func canFindSource(dir string) error {
+	d := filepath.Join(dir, "cmds", "core")
+	if _, err := os.Stat(d); err != nil {
+		return fmt.Errorf("can not build u-root in %q:%w (-uroot-source may be incorrect or not set)", *urootSourceDir, os.ErrNotExist)
+	}
+	return nil
+}
+
 // Main is a separate function so defers are run on return, which they wouldn't
 // on exit.
 func Main(l ulog.Logger, buildOpts *gbbgolang.BuildOpts) error {
@@ -296,7 +305,7 @@ func Main(l ulog.Logger, buildOpts *gbbgolang.BuildOpts) error {
 		//
 		// Currently allowed format:
 		//   Paths to Go package directories; e.g. $GOPATH/src/github.com/u-root/u-root/cmds/*
-		//   u-root templates; e.g. all, core, minimal (requires uroot-source)
+		//   u-root templates; e.g. all, core, minimal (requires uroot-source be valid)
 		//   Import paths of u-root commands; e.g. github.com/u-root/u-root/cmds/* (requires uroot-source)
 		var pkgs []string
 		for _, a := range flag.Args() {
@@ -310,22 +319,22 @@ func Main(l ulog.Logger, buildOpts *gbbgolang.BuildOpts) error {
 				continue
 			}
 			// This is reached if a template was selected, so check uroot source path
-			if *urootSourceDir != "" {
-				for _, pkg := range p {
-					pkg = strings.TrimPrefix(pkg, "github.com/u-root/u-root/")
-					pkgs = append(pkgs, filepath.Join(*urootSourceDir, pkg))
-				}
-			} else {
-				return fmt.Errorf("specify the path to u-root's source directory with -uroot-source when using templates")
+			// To make things a easier on our poor users, do
+			// validation so the error is a little less mysterious.
+			if err := canFindSource(*urootSourceDir); err != nil {
+				return err
+			}
+			for _, pkg := range p {
+				pkg = strings.TrimPrefix(pkg, "github.com/u-root/u-root/")
+				pkgs = append(pkgs, filepath.Join(*urootSourceDir, pkg))
 			}
 			pkgs = append(pkgs, p...)
 		}
 		if len(pkgs) == 0 {
-			if *urootSourceDir != "" {
-				pkgs = []string{filepath.Join(*urootSourceDir, "cmds/core/*")}
-			} else {
-				return fmt.Errorf("specify either the path to u-root's source with -uroot-source or the path to at least one Golang command")
+			if err := canFindSource(*urootSourceDir); err != nil {
+				return err
 			}
+			pkgs = []string{filepath.Join(*urootSourceDir, "cmds/core/*")}
 		}
 
 		// The command-line tool only allows specifying one build mode


### PR DESCRIPTION
The current value of -uroot-source is now "."

For almost all users, this will be the right value. This is
preferable to the previous value, "", which was wrong for
ALL users, and, when not set, resulted in a confusing
error message.

Further, perform a simple test to see if the directory
cmds/core exists at -uroot-source, and print a hopefully
helpful error message if it does not.

This will lessen another surprise that came with modules support.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>