### PR TITLE
Revert 83ffd49111fcae42d80f8d9e21a282fa5b99cd8c: restore cmds/exp/rush

### DIFF
--- a/cmds/exp/rush/attr.go
+++ b/cmds/exp/rush/attr.go
@@ -1,0 +1,14 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !linux
+// +build !linux
+
+package main
+
+func builtinAttr(c *Command) {
+}
+
+func forkAttr(c *Command) {
+}

--- a/cmds/exp/rush/attr_linux.go
+++ b/cmds/exp/rush/attr_linux.go
@@ -1,0 +1,26 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux
+// +build linux
+
+package main
+
+import (
+	"syscall"
+)
+
+func builtinAttr(c *Command) {
+	c.Cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNS
+}
+
+func forkAttr(c *Command) {
+	c.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+	if c.BG {
+		c.Cmd.SysProcAttr.Setpgid = true
+	} else {
+		c.Cmd.SysProcAttr.Foreground = true
+		c.Cmd.SysProcAttr.Ctty = int(ttyf.Fd())
+	}
+}

--- a/cmds/exp/rush/attr_linux_test.go
+++ b/cmds/exp/rush/attr_linux_test.go
@@ -1,0 +1,47 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+func TestAttr(t *testing.T) {
+	var err error
+	ttyf, err = os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		t.Skipf("can not open /dev/tty, skipping test")
+		return
+	}
+
+	c := &Command{Cmd: exec.Command("true")}
+
+	forkAttr(c)
+
+	if !c.Cmd.SysProcAttr.Foreground {
+		t.Errorf("forkAttr(&c): c.Cmd.SysProcAttr.Foreground is false")
+	}
+
+	fd := int(ttyf.Fd())
+	if c.Cmd.SysProcAttr.Ctty != fd {
+		t.Errorf("forkAttr(&c): c.Cmd.SysProcAttr.Ctty %d != %d", c.Cmd.SysProcAttr.Ctty, fd)
+	}
+
+	c.BG = true
+	forkAttr(c)
+	if !c.Cmd.SysProcAttr.Setpgid {
+		t.Errorf("forkAttr(&c): c.Cmd.SysProcAttr.Setpgid is not true although BG (BackGround) was set")
+	}
+
+	builtinAttr(c)
+	// make sure the right struct member is set.
+	if c.Cmd.SysProcAttr.Cloneflags&syscall.CLONE_NEWNS != syscall.CLONE_NEWNS {
+		t.Errorf("builtinAttr(&c): c.Cmd.SysProcAttr.Cloneflags did not have syscall.CLONE_NEWNS set")
+	}
+
+}

--- a/cmds/exp/rush/cd.go
+++ b/cmds/exp/rush/cd.go
@@ -1,0 +1,26 @@
+// Copyright 2012 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// our first builtin: cd
+package main
+
+import (
+	"errors"
+	"os"
+)
+
+var errCdUsage = errors.New("usage: cd one-path")
+
+func init() {
+	addBuiltIn("cd", cd)
+}
+
+func cd(c *Command) error {
+	if len(c.argv) != 1 {
+		return errCdUsage
+	}
+
+	err := os.Chdir(c.argv[0])
+	return err
+}

--- a/cmds/exp/rush/cmd_test.go
+++ b/cmds/exp/rush/cmd_test.go
@@ -1,0 +1,67 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+)
+
+// TestCmd tests the implementation of builtin commands.
+func TestCmd(t *testing.T) {
+
+	var tests = []struct {
+		name string
+		line string
+		out  string
+		err  error
+	}{
+		{name: "cd no args", line: "cd", err: errCdUsage},
+		{name: "cd bad dir", line: "cd ZARDOX", err: os.ErrNotExist},
+		{name: "cd .", line: "cd ."},
+		{name: "rushinfo", line: "rushinfo", err: nil, out: "ama"},
+	}
+
+	for _, tt := range tests {
+		c, _, err := getCommand(bufio.NewReader(bytes.NewReader([]byte(tt.line))))
+		if err != nil && !errors.Is(err, tt.err) {
+			t.Errorf("%s: getCommand(%q): %v is not %v", tt.name, tt.line, err, tt.err)
+			continue
+		}
+		// We don't test broken parsing here, just that we get some expected
+		// arrays
+		doArgs(c)
+		if err := commands(c); err != nil {
+			t.Errorf("commands: %v != nil", err)
+			continue
+		}
+		t.Logf("cmd %q", c)
+		// We don't do pipelines in this test.
+		// We don't usually care about output.
+		o, e := &bytes.Buffer{}, &bytes.Buffer{}
+		c[0].Cmd.Stdout, c[0].Cmd.Stderr = o, e
+		err = command(c[0])
+		t.Logf("Command output: %q, %q", o.String(), e.String())
+		if err == nil && tt.err == nil {
+			continue
+		}
+		if err == nil && tt.err != nil {
+			t.Errorf("%q: got nil, want %v", c, tt.err)
+		}
+		if !errors.Is(err, tt.err) {
+			t.Errorf("%q: got %v, want %v", c, err, tt.err)
+		}
+		if len(tt.out) == 0 {
+			continue
+		}
+		if o.Len() == 0 {
+			t.Errorf("%q: stdout: got no data, want something", c)
+		}
+		t.Logf("Command stdout is %s", o.String())
+	}
+}

--- a/cmds/exp/rush/info.go
+++ b/cmds/exp/rush/info.go
@@ -1,0 +1,35 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// info command
+//
+// Synopsis:
+//     info
+//
+// Description:
+//     Print out info about our environment.
+//
+// Example:
+//     $ info
+//     Version, goos, etc.
+//
+// Note:
+//
+// Bugs:
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+)
+
+func init() {
+	addBuiltIn("rushinfo", infocmd)
+}
+
+func infocmd(c *Command) error {
+	_, err := fmt.Fprintf(c.Stdout, "%s %s %s %q: builtins %v\n", runtime.Version(), runtime.GOOS, runtime.GOARCH, os.Args, builtins)
+	return err
+}

--- a/cmds/exp/rush/parse.go
+++ b/cmds/exp/rush/parse.go
@@ -1,0 +1,261 @@
+// Copyright 2014-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The u-root shell is intended to be very simple, since builtins and extensions
+// are written in Go. It should not need YACC. As in the JSON parser, we hope this
+// simple state machine will do the job.
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+type arg struct {
+	val string
+	mod string
+}
+
+// The Command struct is initially filled in by the parser. The shell itself
+// adds to it as processing continues, and then uses it to creates os.Commands
+type Command struct {
+	*exec.Cmd
+	// These are filled in by the parser.
+	Args  []arg
+	fdmap map[int]string
+	files map[int]io.Closer
+	Link  string
+	BG    bool
+
+	// These are set up by the shell as it evaluates the Commands
+	// provided by the parser.
+	// we separate the command so people don't have to put checks for the length
+	// of argv in their builtins. We do that for them.
+	cmd  string
+	argv []string
+}
+
+var (
+	cmds  []Command
+	punct = "<>|&$ \t\n"
+)
+
+func pushback(b *bufio.Reader) {
+	// If we can't UnreadByte it will get us an obscure error, but
+	// it is hard to tell what else to do.
+	_ = b.UnreadByte()
+}
+
+func one(b *bufio.Reader) byte {
+	c, err := b.ReadByte()
+	// On any kind of error, just return 0.
+	// This is not a serious kind of shell any more, it
+	// is more for diagnostics when things are really broken,
+	// so we need not be too picky about errors.
+	if err != nil {
+		return 0
+	}
+	return c
+}
+
+func next(b *bufio.Reader) byte {
+	c := one(b)
+	if c == '\\' {
+		return one(b)
+	}
+	return byte(c)
+}
+
+// Tokenize stuff coming in from the stream. For everything but an arg, the
+// type is just the thing itself, since we can switch on strings.
+func tok(b *bufio.Reader) (string, string) {
+	var tokType, arg string
+	c := next(b)
+
+	switch c {
+	case 0, 4:
+		return "EOF", ""
+	case '>':
+		return "FD", "1"
+	case '<':
+		return "FD", "0"
+	// yes, I realize $ handling is still pretty hokey.
+	// And, again, this is a diagnostic tool now, not a general
+	// purpose shell, so the hell with it.
+	case '$':
+		arg = ""
+		return "ENV", arg
+	case '\'':
+		for {
+			nc := next(b)
+			if nc == '\'' {
+				return "ARG", arg
+			}
+			arg = arg + string(nc)
+		}
+	case ' ', '\t':
+		return "white", string(c)
+	case '\n', '\r':
+		return "EOL", ""
+	case '|', '&':
+		// peek ahead. We need the literal, so don't use next()
+		nc := one(b)
+		if nc == c {
+			return "LINK", string(c) + string(c)
+		}
+		if nc != 0 {
+			pushback(b)
+		}
+		if c == '&' {
+			tokType = "BG"
+			if nc == 0 {
+				tokType = "EOL"
+			}
+			return "BG", tokType
+		}
+		return "LINK", string(c)
+	default:
+		for {
+			if c == 0 {
+				return "ARG", arg
+			}
+			if strings.Contains(punct, string(c)) {
+				pushback(b)
+				return "ARG", arg
+			}
+			arg = arg + string(c)
+			c = next(b)
+		}
+
+	}
+}
+
+// get an ARG. It has to work.
+func getArg(b *bufio.Reader, what string) string {
+	for {
+		nt, s := tok(b)
+		if nt == "EOF" || nt == "EOL" {
+			// We used to panic here, but what's the sense in that?
+			return ""
+		}
+		if nt == "white" {
+			continue
+		}
+		// It has to work, but if not ... too bad.
+		if nt != "ARG" {
+			return ""
+		}
+		return s
+	}
+}
+
+func parsestring(b *bufio.Reader, c *Command) (*Command, string) {
+	t, s := tok(b)
+	if s == "\n" || t == "EOF" || t == "EOL" {
+		return nil, t
+	}
+	for {
+		switch t {
+		// In old rush, env strings were substituted wholesale, and
+		// parsed in line. This was very useful, but nobody uses it so...
+		// for now, screw it. Do environment later.
+		case "ENV":
+		case "ARG":
+			c.Args = append(c.Args, arg{s, t})
+		case "white":
+		case "FD":
+			x := 0
+			_, err := fmt.Sscanf(s, "%v", &x)
+			if err != nil {
+				panic(fmt.Errorf("bad FD on redirect: %v, %v", s, err))
+			}
+			// whitespace is allowed
+			c.fdmap[x] = getArg(b, t)
+		// LINK and BG are similar save that LINK requires another command. If we don't get one, well.
+		case "LINK":
+			c.Link = s
+			return c, t
+		case "BG":
+			c.BG = true
+			return c, t
+		case "EOF":
+			return c, t
+		case "EOL":
+			return c, t
+		default:
+			panic(fmt.Errorf("unknown token type %v", t))
+		}
+		t, s = tok(b)
+	}
+}
+
+func parse(b *bufio.Reader) (*Command, string) {
+	c := newCommand()
+	return parsestring(b, c)
+}
+
+func newCommand() *Command {
+	return &Command{Cmd: exec.Command(""), fdmap: make(map[int]string), files: make(map[int]io.Closer)}
+}
+
+// Just eat it up until you have all the commands you need.
+func parsecommands(b *bufio.Reader) ([]*Command, string) {
+	cmds := make([]*Command, 0)
+	for {
+		c, t := parse(b)
+		if c == nil {
+			return cmds, t
+		}
+		cmds = append(cmds, c)
+		if t == "EOF" || t == "EOL" {
+			return cmds, t
+		}
+	}
+}
+
+func getCommand(b *bufio.Reader) (c []*Command, t string, err error) {
+	defer func() {
+		if e := recover(); e != nil {
+			err = e.(error)
+		}
+	}()
+
+	// TODO: put a recover here that just returns an error.
+	c, t = parsecommands(b)
+	// the rules.
+	// For now, no empty commands.
+	// Can't have a redir and a redirect for fd1.
+	for i, v := range c {
+		if len(v.Args) == 0 {
+			return nil, "", errors.New("empty commands not allowed (yet)")
+		}
+		if v.Link == "|" && v.fdmap[1] != "" {
+			return nil, "", errors.New("Can't have a pipe and > on one command")
+		}
+		if v.Link == "|" && i == len(c)-1 {
+			return nil, "", errors.New("Can't have a pipe to nowhere")
+		}
+		if i < len(c)-1 && v.Link == "|" && c[i+1].fdmap[0] != "" {
+			return nil, "", errors.New("Can't have a pipe to command with redirect on stdin")
+		}
+	}
+	return c, t, err
+}
+
+/*
+func main() {
+	b := bufio.NewReader(os.Stdin)
+	for {
+	    c, t, err := getCommand(b)
+		fmt.Printf("%v %v %v\n", c, t, err)
+	    if t == "EOF" {
+	       break
+	       }
+	       }
+}
+*/

--- a/cmds/exp/rush/parse_test.go
+++ b/cmds/exp/rush/parse_test.go
@@ -1,0 +1,146 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+)
+
+func compare(got, want []*Command) error {
+	if len(got) != len(want) {
+		return fmt.Errorf("got %d commands, want %d commands", len(got), len(want))
+	}
+	for i := range got {
+		g := got[i]
+		w := want[i]
+		if len(g.Args) != len(w.Args) {
+			return fmt.Errorf("%q: Got %d Args, want %d Args", g, len(g.Args), len(w.Args))
+		}
+		if !reflect.DeepEqual(g.Args, w.Args) {
+			return fmt.Errorf("%q: got %q commands, want %q commands", g, g.Args, w.Args)
+		}
+		if g.Link != w.Link {
+			return fmt.Errorf("%q: Link is %q, want %q", g, g.Link, w.Link)
+		}
+		if g.BG != w.BG {
+			return fmt.Errorf("%q: BG is %v, want %v", g, g.BG, w.BG)
+		}
+		// Just check simple stdin/out redirection.
+		if g.fdmap[1] != w.fdmap[1] {
+			return fmt.Errorf("%q: fdmap[1] is %v, want %v", g, g.fdmap[1], w.fdmap[1])
+		}
+		if g.fdmap[0] != w.fdmap[0] {
+			return fmt.Errorf("%q: fdmap[0] is %v, want %v", g, g.fdmap[0], w.fdmap[0])
+		}
+	}
+	return nil
+}
+func TestParsing(t *testing.T) {
+
+	var tests = []struct {
+		name string
+		line string
+		c    []*Command
+		typ  string
+		err  error
+	}{
+		{name: "EOF", line: "", c: []*Command{}, typ: "EOF", err: io.EOF},
+		{name: "singlequote", line: "'gadate a'", c: []*Command{
+			{Args: []arg{{"gadate a", "ARG"}}, Link: "", BG: false},
+		}, typ: "EOF", err: io.EOF},
+		{name: "backslash", line: "\\\\\\gadate", c: []*Command{
+			{Args: []arg{{"\\gadate", "ARG"}}, Link: "", BG: false},
+		}, typ: "EOF", err: io.EOF},
+		{name: "env", line: "adate $a", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}, {"a", "ARG"}}, Link: "", BG: false},
+		}, typ: "EOF", err: io.EOF},
+		{name: "No EOL", line: "adate", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}}, Link: "", BG: false},
+		}, typ: "EOF", err: io.EOF},
+		{name: "redir>/dev/null", line: "redir > /dev/null", c: []*Command{
+			{Args: []arg{{"redir", "ARG"}}, Link: "", BG: false, fdmap: map[int]string{1: "/dev/null"}},
+		}, typ: "EOF", err: io.EOF},
+		{name: "redir</dev/null", line: "redir</dev/null", c: []*Command{
+			{Args: []arg{{"redir", "ARG"}}, Link: "", BG: false, fdmap: map[int]string{0: "/dev/null"}},
+		}, typ: "EOF", err: io.EOF},
+		{name: "Single", line: "adate\n", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}}, Link: "", BG: false},
+		}, typ: "EOL", err: nil},
+		{name: "BG", line: "adate&\n", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}}, Link: "", BG: true},
+		}, typ: "EOL", err: nil},
+		{name: "BG", line: "adate&", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}}, Link: "", BG: true},
+		}, typ: "EOF", err: nil},
+		{name: "one BG one not", line: "adate&bdate\n", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}}, Link: "", BG: true},
+			{Args: []arg{{"bdate", "ARG"}}, Link: "", BG: false},
+		}, typ: "EOL", err: nil},
+		{name: "two BG", line: "adate&bdate&\n", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}}, Link: "", BG: true},
+			{Args: []arg{{"bdate", "ARG"}}, Link: "", BG: true},
+		}, typ: "EOL", err: nil},
+		{name: "AND", line: "adate&&bdate\n", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}}, Link: "&&"},
+			{Args: []arg{{"bdate", "ARG"}}, Link: ""},
+		}, typ: "EOL", err: nil},
+		{name: "OR", line: "adate||bdate\n", c: []*Command{
+			{Args: []arg{{"adate", "ARG"}}, Link: "||"},
+			{Args: []arg{{"bdate", "ARG"}}, Link: ""},
+		}, typ: "EOL", err: nil},
+		{name: "BG_OR", line: "zdate & adate||bdate\n", c: []*Command{
+			{Args: []arg{{"zdate", "ARG"}}, Link: "", BG: true},
+			{Args: []arg{{"adate", "ARG"}}, Link: "||"},
+			{Args: []arg{{"bdate", "ARG"}}, Link: ""},
+		}, typ: "EOL", err: nil},
+		{name: "BG_PIPE", line: "zdate & adate|bdate\n", c: []*Command{
+			{Args: []arg{{"zdate", "ARG"}}, Link: "", BG: true},
+			{Args: []arg{{"adate", "ARG"}}, Link: "|"},
+			{Args: []arg{{"bdate", "ARG"}}, Link: ""},
+		}, typ: "EOL", err: nil},
+		{name: "BG_PIPE_AND", line: "zdate & adate|bdate&&cdate\n", c: []*Command{
+			{Args: []arg{{"zdate", "ARG"}}, Link: "", BG: true},
+			{Args: []arg{{"adate", "ARG"}}, Link: "|"},
+			{Args: []arg{{"bdate", "ARG"}}, Link: "&&"},
+			{Args: []arg{{"cdate", "ARG"}}, Link: ""},
+		}, typ: "EOL", err: nil},
+	}
+
+	for _, tt := range tests {
+		c, typ, err := getCommand(bufio.NewReader(bytes.NewReader([]byte(tt.line))))
+		if err != nil && !errors.Is(err, tt.err) {
+			t.Errorf("%s: getCommand(%q): %v is not %v", tt.name, tt.line, err, tt.err)
+			continue
+		}
+		if typ != tt.typ {
+			t.Errorf("%s: getCommand(%q): got %s want %s", tt.name, tt.line, typ, tt.typ)
+			continue
+		}
+		// We don't test broken parsing here, just that we get some expected
+		// arrays
+		doArgs(c)
+		if err := commands(c); err != nil {
+			t.Errorf("commands: %v != nil", err)
+			continue
+		}
+		if err := wire(c); err != nil {
+			t.Errorf("wire: %v != nil", err)
+			continue
+		}
+		for _, cmd := range c {
+			t.Logf("{Args: %q, Link: %q, BG: %v, fdmap: %v},", cmd.Args, cmd.Link, cmd.BG, cmd.fdmap)
+		}
+		if err := compare(c, tt.c); err != nil {
+			t.Errorf("%s: getCommand(%q): %v", tt.name, tt.line, err)
+		}
+
+	}
+}

--- a/cmds/exp/rush/rush.go
+++ b/cmds/exp/rush/rush.go
@@ -1,0 +1,218 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Rush is an interactive shell similar to sh.
+//
+// Description:
+//     Prompt is '% '.
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+type builtin func(c *Command) error
+
+// TODO: probably have one builtin map and use it for both types?
+var (
+	urpath = "/go/bin:/ubin:/buildbin:/bbin:/bin:/usr/local/bin:"
+
+	builtins map[string]builtin
+)
+
+func addBuiltIn(name string, f builtin) error {
+	if builtins == nil {
+		builtins = make(map[string]builtin)
+	}
+	if _, ok := builtins[name]; ok {
+		return fmt.Errorf("%v already a builtin", name)
+	}
+	builtins[name] = f
+	return nil
+}
+
+func wire(cmds []*Command) error {
+	for i, c := range cmds {
+		// IO defaults.
+		var err error
+		if c.Stdin == nil {
+			if c.Stdin, err = openRead(c, os.Stdin, 0); err != nil {
+				return err
+			}
+		}
+		if c.Link != "|" {
+			if c.Stdout, err = openWrite(c, os.Stdout, 1); err != nil {
+				return err
+			}
+		}
+		if c.Stderr, err = openWrite(c, os.Stderr, 2); err != nil {
+			return err
+		}
+		// The validation is such that "|" is not set on the last one.
+		// Also, there won't be redirects and "|" inappropriately.
+		if c.Link != "|" {
+			continue
+		}
+		w, err := cmds[i+1].StdinPipe()
+		if err != nil {
+			return err
+		}
+		r, err := cmds[i].StdoutPipe()
+		if err != nil {
+			return err
+		}
+		// Oh, yuck.
+		// There seems to be no way to do the classic
+		// inherited pipes thing in Go. Hard to believe.
+		go func() {
+			io.Copy(w, r)
+			w.Close()
+		}()
+	}
+	return nil
+}
+
+func runit(c *Command) error {
+	defer func() {
+		for fd, f := range c.files {
+			f.Close()
+			delete(c.files, fd)
+		}
+	}()
+	if b, ok := builtins[c.cmd]; ok {
+		if err := b(c); err != nil {
+			return err
+		}
+	} else {
+
+		forkAttr(c)
+		if err := c.Start(); err != nil {
+			return fmt.Errorf("%v: Path %v", err, os.Getenv("PATH"))
+		}
+		if err := c.Wait(); err != nil {
+			return fmt.Errorf("wait: %v", err)
+		}
+	}
+	return nil
+}
+
+func openRead(c *Command, r io.Reader, fd int) (io.Reader, error) {
+	if c.fdmap[fd] != "" {
+		f, err := os.Open(c.fdmap[fd])
+		c.files[fd] = f
+		return f, err
+	}
+	return r, nil
+}
+
+func openWrite(c *Command, w io.Writer, fd int) (io.Writer, error) {
+	if c.fdmap[fd] != "" {
+		f, err := os.OpenFile(c.fdmap[fd], os.O_CREATE|os.O_WRONLY, 0o666)
+		c.files[fd] = f
+		return f, err
+	}
+	return w, nil
+}
+
+func doArgs(cmds []*Command) {
+	for _, c := range cmds {
+		globargv := []string{}
+		for _, v := range c.Args {
+			if v.mod == "ENV" {
+				globargv = append(globargv, os.Getenv(v.val))
+			} else if globs, err := filepath.Glob(v.val); err == nil && len(globs) > 0 {
+				globargv = append(globargv, globs...)
+			} else {
+				globargv = append(globargv, v.val)
+			}
+		}
+
+		c.cmd = globargv[0]
+		c.argv = globargv[1:]
+	}
+}
+
+// There seems to be no harm in creating a Cmd struct
+// even for builtins, so for now, we do.
+// It will, however, do a path lookup, which we really don't need,
+// and we may change it later.
+func commands(cmds []*Command) error {
+	for _, c := range cmds {
+		c.Cmd = exec.Command(c.cmd, c.argv[:]...)
+		// this is a Very Special Case related to a Go issue.
+		// we're not able to unshare correctly in builtin.
+		// Not sure of the issue but this hack will have to do until
+		// we understand it. Barf.
+		if c.cmd == "builtin" {
+			builtinAttr(c)
+		}
+	}
+	return nil
+}
+
+func command(c *Command) error {
+	// for now, bg will just happen in background.
+	if c.BG {
+		go func() {
+			if err := runit(c); err != nil {
+				fmt.Fprintf(os.Stderr, "%v", err)
+			}
+		}()
+	}
+	return runit(c)
+}
+
+func main() {
+	if len(os.Args) != 1 {
+		fmt.Println("no scripts/args yet")
+		os.Exit(1)
+	}
+
+	b := bufio.NewReader(os.Stdin)
+	tty()
+	fmt.Printf("%% ")
+	for {
+		foreground()
+		cmds, status, err := getCommand(b)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+		}
+		doArgs(cmds)
+		if err := commands(cmds); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			continue
+		}
+		if err := wire(cmds); err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			continue
+		}
+		for _, c := range cmds {
+			if err := command(c); err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+				if c.Link == "||" {
+					continue
+				}
+				// yes, not needed, but useful so you know
+				// what goes on here.
+				if c.Link == "&&" {
+					break
+				}
+				break
+			} else {
+				if c.Link == "||" {
+					break
+				}
+			}
+		}
+		if status == "EOF" {
+			break
+		}
+		fmt.Printf("%% ")
+	}
+}

--- a/cmds/exp/rush/rush_test.go
+++ b/cmds/exp/rush/rush_test.go
@@ -1,0 +1,66 @@
+// Copyright 2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/testutil"
+)
+
+var tests = []struct {
+	stdin  string // input
+	stdout string // output (regular expression)
+	stderr string // output (regular expression)
+	ret    int    // output
+}{
+	// TODO: Create a `-c` flag for rush so stdout does not contain
+	// prompts, or have the prompt be derived from $PS1.
+	{"echo|wc\n", ".*", "", 0},
+	{"true\n", "% % ", "", 0},
+	{"false\n", "% % ", "wait: exit status 1\n", 0},
+}
+
+func TestRush(t *testing.T) {
+	// Table-driven testing
+	for i, tt := range tests {
+		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
+			// Run command
+			cmd := testutil.Command(t)
+			cmd.Stdin = strings.NewReader(tt.stdin)
+			var stdout bytes.Buffer
+			cmd.Stdout = &stdout
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+			err := cmd.Run()
+
+			// Check stdout
+			strout := stdout.String()
+			// If you need the ^$ anchor put it in the test array.
+			if !regexp.MustCompile(tt.stdout).MatchString(strout) {
+				t.Errorf("Want: %#v; Got: %#v", tt.stdout, strout)
+			}
+
+			// Check stderr
+			strerr := stderr.String()
+			if !regexp.MustCompile("^" + tt.stderr + "$").MatchString(strerr) {
+				t.Errorf("Want: %#v; Got: %#v", tt.stderr, strerr)
+			}
+
+			// Check return code
+			if err := testutil.IsExitCode(err, tt.ret); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func TestMain(m *testing.M) {
+	testutil.Run(m, main)
+}

--- a/cmds/exp/rush/tty.go
+++ b/cmds/exp/rush/tty.go
@@ -1,0 +1,14 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !linux
+// +build !linux
+
+package main
+
+func tty() {
+}
+
+func foreground() {
+}

--- a/cmds/exp/rush/tty_linux.go
+++ b/cmds/exp/rush/tty_linux.go
@@ -1,0 +1,61 @@
+// Copyright 2012-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+var (
+	ttypgrp int
+	ttyf    *os.File
+)
+
+// tty does whatever needs to be done to set up a tty for GOOS.
+func tty() {
+	var err error
+
+	sigs := make(chan os.Signal, 512)
+	signal.Notify(sigs, os.Interrupt)
+	signal.Ignore(unix.SIGTTOU)
+	go func() {
+		for i := range sigs {
+			fmt.Println(i)
+		}
+	}()
+
+	// N.B. We can continue to use this file, in the foreground function,
+	// but the runtime closes it on exec for us.
+	ttyf, err = os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		log.Printf("rush: Can't open a console; no job control in this session")
+		return
+	}
+	// Get the current pgrp, and the pgrp on the tty.
+	// get current pgrp
+	ttypgrp, err = unix.IoctlGetInt(int(ttyf.Fd()), unix.TIOCGPGRP)
+	if err != nil {
+		log.Printf("Can't get foreground: %v", err)
+		ttyf.Close()
+		ttyf = nil
+		ttypgrp = 0
+	}
+}
+
+func foreground() {
+	// Place process group in foreground.
+	if ttypgrp != 0 {
+		_, _, errno := unix.RawSyscall(unix.SYS_IOCTL, ttyf.Fd(), uintptr(unix.TIOCSPGRP), uintptr(unsafe.Pointer(&ttypgrp)))
+		if errno != 0 {
+			log.Printf("rush pid %v: Can't set foreground to %v: %v", os.Getpid(), ttypgrp, errno)
+		}
+	}
+}

--- a/cmds/exp/rush/tty_test.go
+++ b/cmds/exp/rush/tty_test.go
@@ -1,0 +1,15 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestTTY(t *testing.T) {
+	tty()
+	foreground()
+	t.Logf("tty testing done")
+}


### PR DESCRIPTION
While elvish is the standard shell, and gosh is the shell we want
to have, rush still has its uses: it's simple, and uses the
most basic tty line discipline, resulting in minimal stress
on potentially flaky hardware.

We are seeing strange lockups on the serial console on some risc-v
boards, and it would be useful to have a simple shell, running
with no overly fancy usage of the serial console, because the
plethora of escape sequences elvish and similar shells send has
been shown to occasionally lockup the FIFOs on the hardware.

In at least one case, the lockup comes and goes depending on Go
version, which is also concerning. We need a fallback, dead simple
shell, to see if the problem is related to one of the tty packages
or some other IO problem on serial lines..

Finally, when using workspaces, with replace directives, elvish
gets strange compile errors that are hard to understand:
/Users/rminnich/go/src/github.com/u-root/u-root/cmds/core/elvish/elvish.go:26:65: Composite not declared by package prog
/Users/rminnich/go/src/github.com/u-root/u-root/cmds/core/elvish/elvish.go:35:14: ErrNotSuitable not declared by package prog
and, more weirdly, don't seem to break the build?

While gosh might be useful in future, it has issues with serial consoles
and does at least as much fiddling with raw mode and ANSI sequences
as elvish, leading to similar concerns about FIFO debaudery.

We removed rush for coverage reasons, and I expect this PR will
see a few iterations to have no impact on coverage, but rush itself
still has its uses, as a simple shell with simple needs.

This reverts commit 83ffd49111fcae42d80f8d9e21a282fa5b99cd8c.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>