### PR TITLE
Add fdsrv

### DIFF
--- a/pkg/fdsrv/fdsrv.go
+++ b/pkg/fdsrv/fdsrv.go
@@ -1,0 +1,220 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Serves a file descriptor over an AF_UNIX socket when presented with a nonce.
+//
+// You must pass the socket path and nonce to the client via some out-of-band
+// mechanism, such as gRPC or a bash script.
+//
+// Notes:
+// - Uses the unix domain socket abstract namespace
+// - Picks its own path in the abstract namespace for the socket.
+// - Shared FDs are essentially duped, and they point to the same struct file:
+// they share offsets and whatnot.
+//
+// Options:
+// - WithServeOnce: serve once and shuts down (default is forever)
+// - WithTimeout: cancel itself after a timeout (default none)
+//
+// Usage Server:
+//
+//	fds, err := NewServer(fd_to_share, "some_nonce", WithServeOnce())
+//	var s path = fds.UDSPath()
+//
+//	// Pass path and some_nonce to the client via an out of band mechanism
+//
+//	fds.Serve(); // Blocks until the server is done
+//	fds.Close()
+//
+// Usage Client:
+//
+//	sfd, err := GetSharedFD("uds_path", "some_nonce")
+package fdsrv
+
+import (
+	"errors"
+	"io"
+	"net"
+	"syscall"
+	"time"
+)
+
+var (
+	ErrTruncatedWrite   = errors.New("truncated write")
+	ErrEmptyNonce       = errors.New("nonce must not be empty")
+	ErrMissingSCM       = errors.New("missing socket control message")
+	ErrNotOneUnixRights = errors.New("expected exactly one unix rights")
+)
+
+type Server struct {
+	dupedFD   int
+	nonce     string
+	listener  *net.UnixListener
+	timeout   time.Duration
+	serveOnce bool
+}
+
+// Serves the fd, returns true if successful, err for a server error.
+// "false, nil" means the client was wrong, not the server.
+func (fds *Server) handleConnection(uc *net.UnixConn) (bool, error) {
+	defer uc.Close()
+
+	buf := make([]byte, 4096)
+	n, err := uc.Read(buf)
+	if err != nil {
+		return false, err
+	}
+	query := string(buf[:n])
+	if query != fds.nonce {
+		io.WriteString(uc, "BAD NONCE")
+		return false, nil
+	}
+	oob := syscall.UnixRights(fds.dupedFD)
+	good := []byte("GOOD NONCE")
+	goodn, oobn, err := uc.WriteMsgUnix(good, oob, nil)
+	if err != nil {
+		return false, err
+	}
+	if goodn != len(good) || oobn != len(oob) {
+		return false, ErrTruncatedWrite
+	}
+	return true, nil
+}
+
+// NewServer creates a server.  Close() it when you're done.
+func NewServer(fd int, nonce string, options ...func(*Server) error) (*Server, error) {
+	var err error
+	fds := &Server{}
+
+	if len(nonce) == 0 {
+		return nil, ErrEmptyNonce
+	}
+	fds.nonce = nonce
+
+	for _, op := range options {
+		if err := op(fds); err != nil {
+			return nil, err
+		}
+	}
+
+	// An empty addr tells Linux to "autobind" to an available path in the
+	// abstract unix domain socket namespace
+	ua, err := net.ResolveUnixAddr("unix", "")
+	if err != nil {
+		return nil, err
+	}
+	fds.listener, err = net.ListenUnix("unix", ua)
+	if err != nil {
+		return nil, err
+	}
+
+	// Caller could close the file while we are running.  Keep our own copy.
+	fds.dupedFD, err = syscall.Dup(int(fd))
+	if err != nil {
+		fds.listener.Close()
+		return nil, err
+	}
+
+	return fds, nil
+}
+
+// WithTimeOut adds a timeout option to NewServer
+func WithTimeout(timeout time.Duration) func(*Server) error {
+	return func(fds *Server) error {
+		fds.timeout = timeout
+		return nil
+	}
+}
+
+// WithServeOnce sets the "serve once and exit" option to NewServer
+func WithServeOnce() func(*Server) error {
+	return func(fds *Server) error {
+		fds.serveOnce = true
+		return nil
+	}
+}
+
+// UDSPath returns the Unix Domain Socket path the server is listening on
+func (fds *Server) UDSPath() string {
+	return fds.listener.Addr().String()
+}
+
+// Close closes the server
+func (fds *Server) Close() {
+	fds.listener.Close()
+	syscall.Close(fds.dupedFD)
+}
+
+// Serve serves the FD
+func (fds *Server) Serve() error {
+	var deadline time.Time
+	if fds.timeout != 0 {
+		deadline = time.Now().Add(fds.timeout)
+	}
+	fds.listener.SetDeadline(deadline)
+	for {
+		conn, err := fds.listener.AcceptUnix()
+		if err != nil {
+			return err
+		}
+		conn.SetDeadline(deadline)
+		succeeded, err := fds.handleConnection(conn)
+		if err != nil {
+			return err
+		}
+		if succeeded && fds.serveOnce {
+			break
+		}
+	}
+	return nil
+}
+
+// GetSharedFD gets an FD served at udsPath with nonce
+func GetSharedFD(udsPath, nonce string) (int, error) {
+	ua, err := net.ResolveUnixAddr("unix", udsPath)
+	if err != nil {
+		return 0, err
+	}
+	uc, err := net.DialUnix("unix", nil, ua)
+	if err != nil {
+		return 0, err
+	}
+	var nonceb = []byte(nonce)
+
+	n, err := uc.Write(nonceb)
+	if err != nil {
+		return 0, err
+	}
+	// If you don't send at least a byte, the server won't recvmsg.  This
+	// is a Linux UDS SOCK_STREAM thing.  It's possible that nonce is "",
+	// and len(nonceb) == 0.  We could check earlier for an empty string,
+	// but test code uses this method to make sure the server can handle an
+	// empty nonce (BadEmptyNonce).
+	if n == 0 {
+		return 0, ErrEmptyNonce
+	}
+	if n != len(nonceb) {
+		return 0, ErrTruncatedWrite
+	}
+	oob := make([]byte, 1024)
+	_, oobn, _, _, err := uc.ReadMsgUnix(nil, oob)
+	if err != nil {
+		return 0, err
+	}
+	scm, err := syscall.ParseSocketControlMessage(oob[:oobn])
+	if err != nil {
+		return 0, err
+	}
+	if len(scm) != 1 {
+		return 0, ErrMissingSCM
+	}
+	urs, err := syscall.ParseUnixRights(&scm[0])
+	if err != nil {
+		return 0, err
+	}
+	if len(urs) != 1 {
+		return 0, ErrNotOneUnixRights
+	}
+	return urs[0], nil
+}

--- a/pkg/fdsrv/fdsrv_test.go
+++ b/pkg/fdsrv/fdsrv_test.go
@@ -1,0 +1,201 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package fdsrv
+
+import (
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// Returns an fd of the read side of a pipe that has the value 'x' written in
+// it.
+func xPipe(t *testing.T) int {
+	var p [2]int
+	if err := syscall.Pipe(p[:]); err != nil {
+		t.Fatal("pipe:", err)
+	}
+	if _, err := syscall.Write(p[1], []byte("x")); err != nil {
+		t.Fatal("write:", err)
+	}
+	if err := syscall.Close(p[1]); err != nil {
+		t.Fatal("close:", err)
+	}
+	return p[0]
+}
+
+// Returns an *Server, serving an xPipe with "some_nonce"
+func allocPipeFDs(t *testing.T, options ...func(*Server) error) *Server {
+	fd := xPipe(t)
+	fds, err := NewServer(fd, "some_nonce", options...)
+	if err != nil {
+		t.Fatal("alloc:", err)
+	}
+	if err := syscall.Close(fd); err != nil {
+		t.Fatal("close:", err)
+	}
+	return fds
+}
+
+// Read a string from an fd
+func readString(t *testing.T, fd int) string {
+	buf := make([]byte, 128)
+	n, err := syscall.Read(fd, buf)
+	if err != nil {
+		t.Fatal("read:", err)
+	}
+	return string(buf[:n])
+}
+
+// Gets a shared fd, makes sure we can read "x" from it
+func testSharedOK(t *testing.T, udspath, nonce string) {
+	sfd, err := GetSharedFD(udspath, nonce)
+	if err != nil {
+		t.Error("getsharedfd:", err)
+	}
+	got := readString(t, sfd)
+	if got != "x" {
+		t.Errorf("expected x, got %s", got)
+	}
+	if err := syscall.Close(sfd); err != nil {
+		t.Error("close:", err)
+	}
+}
+
+func TestPassFD(t *testing.T) {
+	fds := allocPipeFDs(t, WithServeOnce())
+
+	go func() {
+		if err := fds.Serve(); err != nil {
+			t.Error("serve:", err)
+		}
+		fds.Close()
+	}()
+
+	testSharedOK(t, fds.UDSPath(), "some_nonce")
+}
+
+func TestBadNonce(t *testing.T) {
+	fds := allocPipeFDs(t, WithServeOnce())
+
+	go func() {
+		if err := fds.Serve(); err != nil {
+			t.Error("serve:", err)
+		}
+		fds.Close()
+	}()
+
+	sfd, err := GetSharedFD(fds.UDSPath(), "bad_nonce")
+	if err == nil {
+		t.Errorf("should have failed, but got sfd %d", sfd)
+	}
+}
+
+func TestBadSubsetNonce(t *testing.T) {
+	fds := allocPipeFDs(t, WithServeOnce())
+
+	go func() {
+		if err := fds.Serve(); err != nil {
+			t.Error("serve:", err)
+		}
+		fds.Close()
+	}()
+
+	sfd, err := GetSharedFD(fds.UDSPath(), "some_non")
+	if err == nil {
+		t.Errorf("should have failed, but got sfd %d", sfd)
+	}
+}
+
+func TestBadEmptyNonce(t *testing.T) {
+	fds := allocPipeFDs(t, WithServeOnce())
+
+	go func() {
+		if err := fds.Serve(); err != nil {
+			t.Error("serve:", err)
+		}
+		fds.Close()
+	}()
+
+	sfd, err := GetSharedFD(fds.UDSPath(), "")
+	if err == nil {
+		t.Errorf("should have failed, but got sfd %d", sfd)
+	}
+}
+
+func TestEmptyNonce(t *testing.T) {
+	fds, err := NewServer(0, "")
+	if err == nil {
+		t.Error("should have failed to alloc")
+		fds.Close()
+	}
+}
+
+// Might flake, based on timing
+func TestTimeoutDoesntFire(t *testing.T) {
+	fds := allocPipeFDs(t, WithServeOnce(), WithTimeout(time.Second))
+
+	go func() {
+		if err := fds.Serve(); err != nil {
+			t.Error("serve:", err)
+		}
+		fds.Close()
+	}()
+
+	testSharedOK(t, fds.UDSPath(), "some_nonce")
+}
+
+// Might flake, based on timing
+func TestTimeoutFires(t *testing.T) {
+	fds := allocPipeFDs(t, WithServeOnce(), WithTimeout(time.Microsecond))
+
+	go func() {
+		if err := fds.Serve(); err != nil && !os.IsTimeout(err) {
+			t.Error("serve:", err)
+		}
+		fds.Close()
+	}()
+
+	time.Sleep(time.Millisecond * 100)
+
+	sfd, err := GetSharedFD(fds.UDSPath(), "some_nonce")
+	if err == nil {
+		t.Errorf("should have timed out, but got sfd %d", sfd)
+	}
+}
+
+func TestWaitTimeout(t *testing.T) {
+	fds := allocPipeFDs(t, WithServeOnce(),
+		WithTimeout(time.Millisecond*10))
+
+	err := fds.Serve()
+	if err == nil || !os.IsTimeout(err) {
+		t.Error("expected timeout:", err)
+	}
+	fds.Close()
+}
+
+func TestMultiServe(t *testing.T) {
+	fds := allocPipeFDs(t, WithTimeout(time.Second*5))
+
+	go func() {
+		// We'll eventually time out, or the whole test will exit
+		if err := fds.Serve(); err != nil && !os.IsTimeout(err) {
+			t.Error("serve:", err)
+		}
+		fds.Close()
+	}()
+
+	testSharedOK(t, fds.UDSPath(), "some_nonce")
+	// The second reader won't see 'x', the pipe was already drained
+	sfd, err := GetSharedFD(fds.UDSPath(), "some_nonce")
+	if err != nil {
+		t.Error("getsharedfd:", err)
+	}
+	if err := syscall.Close(sfd); err != nil {
+		t.Error("close:", err)
+	}
+}


### PR DESCRIPTION
Serves a file descriptor over an AF_UNIX socket when presented with a nonce.

Signed-off-by: Barret Rhoden <brho@google.com>