### PR TITLE
GPT: Read/Write GPT header in whole-sector increment.

### DIFF
--- a/pkg/mount/gpt/gpt.go
+++ b/pkg/mount/gpt/gpt.go
@@ -41,20 +41,19 @@ type (
 	MBR    [BlockSize]byte
 	Header struct {
 		Signature  uint64
-		Revision   uint32                       // (for GPT version 1.0 (through at least UEFI version 2.7 (May 2017)), the value is 00h 00h 01h 00h)
-		HeaderSize uint32                       // size in little endian (in bytes, usually 5Ch 00h 00h 00h or 92 bytes)
-		CRC        uint32                       // CRC32/zlib of header (offset +0 up to header size) in little endian, with this field zeroed during calculation
-		Reserved   uint32                       // ; must be zero
-		CurrentLBA uint64                       // (location of this header copy)
-		BackupLBA  uint64                       // (location of the other header copy)
-		FirstLBA   uint64                       // usable LBA for partitions (primary partition table last LBA + 1)
-		LastLBA    uint64                       // usable LBA (secondary partition table first LBA - 1)
-		DiskGUID   GUID                         // (also referred as UUID on UNIXes)
-		PartStart  uint64                       // LBA of array of partition entries (always 2 in primary copy)
-		NPart      uint32                       // Number of partition entries in array
-		PartSize   uint32                       // Size of a single partition entry (usually 80h or 128)
-		PartCRC    uint32                       // CRC32/zlib of partition array in little endian
-		_          [BlockSize - HeaderSize]byte // Reserved; must be zero.
+		Revision   uint32 // (for GPT version 1.0 (through at least UEFI version 2.7 (May 2017)), the value is 00h 00h 01h 00h)
+		HeaderSize uint32 // size in little endian (in bytes, usually 5Ch 00h 00h 00h or 92 bytes)
+		CRC        uint32 // CRC32/zlib of header (offset +0 up to header size) in little endian, with this field zeroed during calculation
+		Reserved   uint32 // ; must be zero
+		CurrentLBA uint64 // (location of this header copy)
+		BackupLBA  uint64 // (location of the other header copy)
+		FirstLBA   uint64 // usable LBA for partitions (primary partition table last LBA + 1)
+		LastLBA    uint64 // usable LBA (secondary partition table first LBA - 1)
+		DiskGUID   GUID   // (also referred as UUID on UNIXes)
+		PartStart  uint64 // LBA of array of partition entries (always 2 in primary copy)
+		NPart      uint32 // Number of partition entries in array
+		PartSize   uint32 // Size of a single partition entry (usually 80h or 128)
+		PartCRC    uint32 // CRC32/zlib of partition array in little endian
 	}
 )
 
@@ -214,7 +213,7 @@ func Table(r io.ReaderAt, off int64) (*GPT, error) {
 		which = "Backup"
 	}
 	g := &GPT{}
-	if err := binary.Read(io.NewSectionReader(r, off, BlockSize), binary.LittleEndian, &g.Header); err != nil {
+	if err := binary.Read(io.NewSectionReader(r, off, HeaderSize), binary.LittleEndian, &g.Header); err != nil {
 		return nil, err
 	}
 
@@ -307,20 +306,17 @@ func writeGPT(w io.WriterAt, g *GPT) error {
 		return err
 	}
 
-	h = make([]byte, BlockSize)
-	// Copy the non-reserved portions of the header. The remaining (reserved)
-	// bytes do not need to be zeroed out because the default zero value for
-	// a byte is 0.
-	copy(h[0:g.HeaderSize], b.Bytes())
-	g.CRC = crc32.ChecksumIEEE(h[0:g.HeaderSize])
+	var block [BlockSize]byte
+	copy(block[:], b.Bytes())
+	g.CRC = crc32.ChecksumIEEE(block[0:g.HeaderSize])
 
 	b.Reset()
 	if err := binary.Write(&b, binary.LittleEndian, g.CRC); err != nil {
 		return err
 	}
-	copy(h[16:], b.Bytes())
+	copy(block[16:], b.Bytes())
 
-	_, err := w.WriteAt(h, int64(g.CurrentLBA*BlockSize))
+	_, err := w.WriteAt(block[:], int64(g.CurrentLBA*BlockSize))
 	return err
 }
 

--- a/pkg/mount/gpt/gpt.go
+++ b/pkg/mount/gpt/gpt.go
@@ -41,19 +41,20 @@ type (
 	MBR    [BlockSize]byte
 	Header struct {
 		Signature  uint64
-		Revision   uint32 // (for GPT version 1.0 (through at least UEFI version 2.7 (May 2017)), the value is 00h 00h 01h 00h)
-		HeaderSize uint32 // size in little endian (in bytes, usually 5Ch 00h 00h 00h or 92 bytes)
-		CRC        uint32 // CRC32/zlib of header (offset +0 up to header size) in little endian, with this field zeroed during calculation
-		Reserved   uint32 // ; must be zero
-		CurrentLBA uint64 // (location of this header copy)
-		BackupLBA  uint64 // (location of the other header copy)
-		FirstLBA   uint64 // usable LBA for partitions (primary partition table last LBA + 1)
-		LastLBA    uint64 // usable LBA (secondary partition table first LBA - 1)
-		DiskGUID   GUID   // (also referred as UUID on UNIXes)
-		PartStart  uint64 // LBA of array of partition entries (always 2 in primary copy)
-		NPart      uint32 // Number of partition entries in array
-		PartSize   uint32 // Size of a single partition entry (usually 80h or 128)
-		PartCRC    uint32 // CRC32/zlib of partition array in little endian
+		Revision   uint32    // (for GPT version 1.0 (through at least UEFI version 2.7 (May 2017)), the value is 00h 00h 01h 00h)
+		HeaderSize uint32    // size in little endian (in bytes, usually 5Ch 00h 00h 00h or 92 bytes)
+		CRC        uint32    // CRC32/zlib of header (offset +0 up to header size) in little endian, with this field zeroed during calculation
+		Reserved   uint32    // ; must be zero
+		CurrentLBA uint64    // (location of this header copy)
+		BackupLBA  uint64    // (location of the other header copy)
+		FirstLBA   uint64    // usable LBA for partitions (primary partition table last LBA + 1)
+		LastLBA    uint64    // usable LBA (secondary partition table first LBA - 1)
+		DiskGUID   GUID      // (also referred as UUID on UNIXes)
+		PartStart  uint64    // LBA of array of partition entries (always 2 in primary copy)
+		NPart      uint32    // Number of partition entries in array
+		PartSize   uint32    // Size of a single partition entry (usually 80h or 128)
+		PartCRC    uint32    // CRC32/zlib of partition array in little endian
+		_          [420]byte // Reserved; must be zero.
 	}
 )
 
@@ -213,7 +214,7 @@ func Table(r io.ReaderAt, off int64) (*GPT, error) {
 		which = "Backup"
 	}
 	g := &GPT{}
-	if err := binary.Read(io.NewSectionReader(r, off, HeaderSize), binary.LittleEndian, &g.Header); err != nil {
+	if err := binary.Read(io.NewSectionReader(r, off, BlockSize), binary.LittleEndian, &g.Header); err != nil {
 		return nil, err
 	}
 
@@ -305,9 +306,14 @@ func writeGPT(w io.WriterAt, g *GPT) error {
 	if err := binary.Write(&b, binary.LittleEndian, &g.Header); err != nil {
 		return err
 	}
-	h = make([]byte, g.HeaderSize)
-	copy(h, b.Bytes())
-	g.CRC = crc32.ChecksumIEEE(h[:])
+
+	h = make([]byte, BlockSize)
+	// Copy the non-reserved portions of the header. The remaining (reserved)
+	// bytes do not need to be zeroed out because the default zero value for
+	// a byte is 0.
+	copy(h[0:g.HeaderSize], b.Bytes())
+	g.CRC = crc32.ChecksumIEEE(h[0:g.HeaderSize])
+
 	b.Reset()
 	if err := binary.Write(&b, binary.LittleEndian, g.CRC); err != nil {
 		return err

--- a/pkg/mount/gpt/gpt.go
+++ b/pkg/mount/gpt/gpt.go
@@ -41,20 +41,20 @@ type (
 	MBR    [BlockSize]byte
 	Header struct {
 		Signature  uint64
-		Revision   uint32    // (for GPT version 1.0 (through at least UEFI version 2.7 (May 2017)), the value is 00h 00h 01h 00h)
-		HeaderSize uint32    // size in little endian (in bytes, usually 5Ch 00h 00h 00h or 92 bytes)
-		CRC        uint32    // CRC32/zlib of header (offset +0 up to header size) in little endian, with this field zeroed during calculation
-		Reserved   uint32    // ; must be zero
-		CurrentLBA uint64    // (location of this header copy)
-		BackupLBA  uint64    // (location of the other header copy)
-		FirstLBA   uint64    // usable LBA for partitions (primary partition table last LBA + 1)
-		LastLBA    uint64    // usable LBA (secondary partition table first LBA - 1)
-		DiskGUID   GUID      // (also referred as UUID on UNIXes)
-		PartStart  uint64    // LBA of array of partition entries (always 2 in primary copy)
-		NPart      uint32    // Number of partition entries in array
-		PartSize   uint32    // Size of a single partition entry (usually 80h or 128)
-		PartCRC    uint32    // CRC32/zlib of partition array in little endian
-		_          [420]byte // Reserved; must be zero.
+		Revision   uint32                       // (for GPT version 1.0 (through at least UEFI version 2.7 (May 2017)), the value is 00h 00h 01h 00h)
+		HeaderSize uint32                       // size in little endian (in bytes, usually 5Ch 00h 00h 00h or 92 bytes)
+		CRC        uint32                       // CRC32/zlib of header (offset +0 up to header size) in little endian, with this field zeroed during calculation
+		Reserved   uint32                       // ; must be zero
+		CurrentLBA uint64                       // (location of this header copy)
+		BackupLBA  uint64                       // (location of the other header copy)
+		FirstLBA   uint64                       // usable LBA for partitions (primary partition table last LBA + 1)
+		LastLBA    uint64                       // usable LBA (secondary partition table first LBA - 1)
+		DiskGUID   GUID                         // (also referred as UUID on UNIXes)
+		PartStart  uint64                       // LBA of array of partition entries (always 2 in primary copy)
+		NPart      uint32                       // Number of partition entries in array
+		PartSize   uint32                       // Size of a single partition entry (usually 80h or 128)
+		PartCRC    uint32                       // CRC32/zlib of partition array in little endian
+		_          [BlockSize - HeaderSize]byte // Reserved; must be zero.
 	}
 )
 

--- a/pkg/mount/gpt/gpt_test.go
+++ b/pkg/mount/gpt/gpt_test.go
@@ -246,7 +246,7 @@ func TestWrite(t *testing.T) {
 		size   int64
 	}{
 		{
-			desc:   "MBR",
+			desc:   "Protective MBR",
 			offset: 0x00000000,
 			size:   BlockSize,
 		},


### PR DESCRIPTION
The current code reads/writes GPT headers in 92-byte `HeaderSize`
increments. Changing the code to read/write GPT headers in sector
increments is a tradeoff with the following pros/cons:

Reading the whole sector:
* Pro: Removes a use of hard coded 0x5c value of `HeaderSize`.
       Makes it simpler to support different header sizes in the future.
* Con: Requires reading an additional 820 bytes (420 for primary, 420
       for secondary).

Writing the whole sector:
* Pro: Enforces the expectation/requirement that the unused 420 reserved
       bytes are zeroed out.
* Con: May overwrite any data that is sneakily being stored in the
       reserved bytes for some other (non-compliant) use case.

Also:
  * Add test code that succeeds with this change but fails with the
    existing code.
  	* Change iodisk to a struct which logs write requests for
	  verification.

Fixes: #2326 

Signed-off-by: Avi Brender <abrender@google.com>