### PR TITLE
Add logutil package with log writer wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/kevinburke/ssh_config v1.1.0
 	github.com/klauspost/pgzip v1.2.4
 	github.com/kr/pty v1.1.8
+	github.com/nanmu42/limitio v1.0.0
 	github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330
 	github.com/pborman/getopt/v2 v2.1.0
 	github.com/pierrec/lz4/v4 v4.1.14

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/nanmu42/limitio v1.0.0 h1:dpopBYPwUyLOPv+vsGja0iax+dG0SP9paTEmz+Sy7KU=
+github.com/nanmu42/limitio v1.0.0/go.mod h1:8H40zQ7pqxzbwZ9jxsK2hDoE06TH5ziybtApt1io8So=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330 h1:zJBTzBuTR7EdFzmCGx0xp0pbOOb82sAh0+YUK4JTDEI=

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -1,0 +1,32 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package logutil implements utilities for recording log output.
+package logutil
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/nanmu42/limitio"
+)
+
+// NewWriterToFile creates a Writer that writes out output to a file path up to a maximum limit maxSize.
+func NewWriterToFile(maxSize int, dirPath, name string) (io.Writer, error) {
+	logFile, err := os.OpenFile(filepath.Join(dirPath, name), os.O_CREATE|os.O_APPEND|os.O_RDWR, 0666)
+	if err != nil {
+		return nil, err
+	}
+
+	fi, err := logFile.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	lw := limitio.NewWriter(logFile, maxSize-(int)(fi.Size()), true)
+
+	return lw, nil
+
+}

--- a/pkg/logutil/logutil_test.go
+++ b/pkg/logutil/logutil_test.go
@@ -1,0 +1,111 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package logutil
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewFileWriter(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		dirPath       string
+		filename      string
+		maxSize       int
+		startContent  []byte
+		appendContent []byte
+		wantContent   []byte
+		wantError     bool
+	}{
+		{
+			name:          "append to file",
+			dirPath:       "",
+			filename:      "file.log",
+			maxSize:       1024,
+			startContent:  []byte("foo"),
+			appendContent: []byte("bar"),
+			wantContent:   []byte("foobar"),
+			wantError:     false,
+		},
+		{
+			name:          "append to file too large",
+			dirPath:       "",
+			filename:      "file.log",
+			maxSize:       -1,
+			startContent:  []byte("foo"),
+			appendContent: []byte("bar"),
+			wantContent:   []byte("foo"),
+			wantError:     false,
+		},
+		{
+			name:          "append overflow",
+			dirPath:       "",
+			filename:      "file.log",
+			maxSize:       5,
+			startContent:  []byte("foo"),
+			appendContent: []byte("bar"),
+			wantContent:   []byte("fooba"),
+			wantError:     false,
+		},
+		{
+			name:          "dir missing",
+			dirPath:       "dir",
+			filename:      "file.log",
+			maxSize:       1024,
+			startContent:  []byte(""),
+			appendContent: []byte("bar"),
+			wantContent:   []byte(""),
+			wantError:     true,
+		},
+	} {
+		dir, err := os.MkdirTemp("", "testdir")
+		if err != nil {
+			t.Errorf("TestNewFileWriter(%s): MkdirTemp errored: %v", tt.name, err)
+		}
+		defer os.RemoveAll(dir)
+		if tt.dirPath != "" {
+			dir = filepath.Join(dir, tt.dirPath)
+		}
+		if len(tt.startContent) > 0 {
+			f, err := os.Create(filepath.Join(dir, tt.filename))
+			if err != nil {
+				t.Errorf("TestNewFileWriter(%s): Creating start file errored: %v", tt.name, err)
+			}
+			n, err := f.Write(tt.startContent)
+			if err != nil {
+				t.Errorf("TestNewFileWriter(%s): Start file errored: %v", tt.name, err)
+			}
+			if n != len(tt.startContent) {
+				t.Errorf("TestNewFileWriter(%s): Start file Write() got %v, expected %v", tt.name, n, len(tt.startContent))
+			}
+			f.Close()
+		}
+		w, err := NewWriterToFile(tt.maxSize, dir, tt.filename)
+		if (err != nil) != tt.wantError {
+			t.Errorf("TestNewFileWriter(%s): NewWriterToFile errored: %v, expected error: %v", tt.name, err, tt.wantError)
+		}
+		if tt.wantError {
+			continue
+		}
+		n, err := w.Write(tt.appendContent)
+		if err != nil {
+			t.Errorf("TestNewFileWriter(%s): Write errored: %v", tt.name, err)
+		}
+		if n != len(tt.appendContent) {
+			t.Errorf("TestNewFileWriter(%s): Write() got %v, want %v", tt.name, n, len(tt.appendContent))
+		}
+
+		dat, err := os.ReadFile(filepath.Join(dir, tt.filename))
+		if err != nil {
+			t.Errorf("TestNewFileWriter(%s): ReadFile errored with: %v", tt.name, err)
+		}
+		if !bytes.Equal(dat, tt.wantContent) {
+			t.Errorf("TestNewFileWriter(%s): got %v, expected %v", tt.name, dat, tt.wantContent)
+		}
+	}
+}

--- a/vendor/github.com/nanmu42/limitio/.gitignore
+++ b/vendor/github.com/nanmu42/limitio/.gitignore
@@ -1,0 +1,18 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# IDEs
+/.idea/
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/vendor/github.com/nanmu42/limitio/LICENSE
+++ b/vendor/github.com/nanmu42/limitio/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 LI Zhennan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/nanmu42/limitio/README.md
+++ b/vendor/github.com/nanmu42/limitio/README.md
@@ -1,0 +1,78 @@
+# LimitIO
+
+[![GoDoc](https://godoc.org/github.com/nanmu42/limitio?status.svg)](https://pkg.go.dev/github.com/nanmu42/limitio)
+[![Build status](https://github.com/nanmu42/limitio/workflows/test/badge.svg)](https://github.com/nanmu42/limitio/actions)
+[![codecov](https://codecov.io/gh/nanmu42/limitio/branch/master/graph/badge.svg)](https://codecov.io/gh/nanmu42/limitio)
+[![Go Report Card](https://goreportcard.com/badge/github.com/nanmu42/limitio)](https://goreportcard.com/report/github.com/nanmu42/limitio)
+
+`io.Reader` and `io.Writer` with limit.
+
+```bash
+go get github.com/nanmu42/limitio
+```
+
+## Rationale and Usage
+
+There are times when a limited reader or writer comes in handy.
+
+1. wrap upstream so that reading is metered and limited:
+
+```go
+// request is an incoming http.Request
+request.Body = limitio.NewReadCloser(c.Request.Body, maxRequestBodySize, false)
+
+// deal with the body now with easy mind. It's maximum size is assured.
+```
+
+Yes, `io.LimitReader` works the same way, but throws `EOF` on exceeding limit, which is confusing.
+
+LimitIO provides error that can be identified.
+
+```go
+decoder := json.NewDecoder(request.Body)
+err := decoder.Decode(&myStruct)
+if err != nil {
+    if errors.Is(err, limitio.ErrThresholdExceeded) {
+        // oops, we reached the limit
+    }
+
+    err = fmt.Errorf("other error happened: %w", err)
+    return
+}
+```
+
+2. wrap downstream so that writing is metered and limited(or instead, just pretending writing):
+
+```go
+// request is an incoming http.Request.
+// Say, we want to record its body somewhere in the middleware,
+// but feeling uneasy since its body might be HUGE, which may
+// result in OOM and a successful DDOS...
+
+var reqBuf bytes.buffer
+
+// a limited writer comes to rescue!
+// `true` means after reaching `RequestBodyMaxLength`,
+// `limitedReqBuf` will start pretending writing so that
+// io.TeeReader continues working while reqBuf stays unmodified.
+limitedReqBuf := limitio.NewWriter(&reqBuf, RequestBodyMaxLength, true)
+
+request.Body = &readCloser{
+    Reader: io.TeeReader(request.Body, limitedReqBuf), 
+    Closer: c.Request.Body,
+}
+```
+
+LimitIO provides Reader, Writer and their Closer versions, for details, see [docs](https://pkg.go.dev/github.com/nanmu42/limitio).
+
+## Status: Stable
+
+LimitIO is well battle tested under production environment.
+
+APIs are subjected to change in backward compatible way during 1.x releases.
+
+## License
+
+MIT License
+
+Copyright (c) 2021 LI Zhennan

--- a/vendor/github.com/nanmu42/limitio/limitio.go
+++ b/vendor/github.com/nanmu42/limitio/limitio.go
@@ -1,0 +1,175 @@
+// Package limitio brings `io.Reader` and `io.Writer` with limit.
+package limitio
+
+import (
+	"errors"
+	"fmt"
+	"io"
+)
+
+// ErrThresholdExceeded indicates stream size exceeds threshold
+var ErrThresholdExceeded = errors.New("stream size exceeds threshold")
+
+// AtMostFirstNBytes takes at more n bytes from s
+func AtMostFirstNBytes(s []byte, n int) []byte {
+	if len(s) <= n {
+		return s
+	}
+
+	return s[:n]
+}
+
+// NewReader creates a Reader works like io.LimitedReader
+// but may be tuned to report oversize read as
+// a distinguishable error other than io.EOF.
+func NewReader(r io.Reader, limit int, regardOverSizeEOF bool) *Reader {
+	return &Reader{
+		r:                 r,
+		left:              limit,
+		originalLimit:     limit,
+		regardOverSizeEOF: regardOverSizeEOF,
+	}
+}
+
+var _ io.Reader = (*Reader)(nil)
+
+// Reader works like io.LimitedReader but may be tuned to report
+// oversize read as a distinguishable error other than io.EOF.
+//
+// Use NewReader() to create Reader.
+type Reader struct {
+	r                 io.Reader
+	left              int
+	originalLimit     int
+	regardOverSizeEOF bool
+}
+
+// Read implements io.Reader
+func (lr *Reader) Read(p []byte) (n int, err error) {
+	if lr.left <= 0 {
+		if lr.regardOverSizeEOF {
+			return 0, io.EOF
+		}
+		return 0, fmt.Errorf("threshold is %d bytes: %w", lr.originalLimit, ErrThresholdExceeded)
+	}
+	if len(p) > lr.left {
+		p = p[0:lr.left]
+	}
+	n, err = lr.r.Read(p)
+	lr.left -= n
+	return
+}
+
+var _ io.ReadCloser = (*ReadCloser)(nil)
+
+// ReadCloser works like io.LimitedReader( but with a Close() method)
+// but may be tuned to report oversize read as
+// a distinguishable error other than io.EOF.
+//
+// User NewReadCloser() to create ReadCloser.
+type ReadCloser struct {
+	*Reader
+	io.Closer
+}
+
+// NewReadCloser creates a ReadCloser that
+// works like io.LimitedReader(but with a Close() method)
+// and it may be tuned to report oversize read as
+// a distinguishable error other than io.EOF.
+func NewReadCloser(r io.ReadCloser, limit int, regardOverSizeEOF bool) *ReadCloser {
+	return &ReadCloser{
+		Closer: r,
+		Reader: NewReader(r, limit, regardOverSizeEOF),
+	}
+}
+
+var _ io.Writer = (*Writer)(nil)
+
+// Writer wraps w with writing length limit.
+//
+// To create Writer, use NewWriter().
+type Writer struct {
+	w                    io.Writer
+	written              int
+	limit                int
+	regardOverSizeNormal bool
+}
+
+// NewWriter create a writer that writes at most n bytes.
+//
+// regardOverSizeNormal controls whether Writer.Write() returns error
+// when writing totally more bytes than n, or do no-op to inner w,
+// pretending writing is processed normally.
+func NewWriter(w io.Writer, n int, regardOverSizeNormal bool) *Writer {
+	return &Writer{
+		w:                    w,
+		written:              0,
+		limit:                n,
+		regardOverSizeNormal: regardOverSizeNormal,
+	}
+}
+
+// Writer implements io.Writer
+func (lw *Writer) Write(p []byte) (n int, err error) {
+	if lw.written >= lw.limit {
+		if lw.regardOverSizeNormal {
+			n = len(p)
+			lw.written += n
+			return
+		}
+
+		err = fmt.Errorf("threshold is %d bytes: %w", lw.limit, ErrThresholdExceeded)
+		return
+	}
+
+	var (
+		overSized   bool
+		originalLen int
+	)
+
+	left := lw.limit - lw.written
+	if originalLen = len(p); originalLen > left {
+		overSized = true
+		p = p[0:left]
+	}
+	n, err = lw.w.Write(p)
+	lw.written += n
+	if overSized && err == nil {
+		// Write must return a non-nil error if it returns n < len(p).
+		if lw.regardOverSizeNormal {
+			return originalLen, nil
+		}
+
+		err = fmt.Errorf("threshold is %d bytes: %w", lw.limit, ErrThresholdExceeded)
+		return
+	}
+
+	return
+}
+
+// Written returns number of bytes written
+func (lw *Writer) Written() int {
+	return lw.written
+}
+
+var _ io.WriteCloser = (*WriteCloser)(nil)
+
+// WriteCloser wraps w with writing length limit.
+//
+// To create WriteCloser, use NewWriteCloser().
+type WriteCloser struct {
+	*Writer
+	io.Closer
+}
+
+// NewWriteCloser create a WriteCloser that writes at most n bytes.
+//
+// regardOverSizeNormal controls whether Writer.Write() returns error
+// when writing totally more bytes than n, or do no-op to inner w,
+// pretending writing is processed normally.
+func NewWriteCloser(w io.WriteCloser, n int, silentWhenOverSize bool) *WriteCloser {
+	return &WriteCloser{
+		Writer: NewWriter(w, n, silentWhenOverSize),
+		Closer: w,
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -110,6 +110,9 @@ github.com/mdlayher/netlink/nlenc
 # github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
 ## explicit; go 1.12
 github.com/mdlayher/raw
+# github.com/nanmu42/limitio v1.0.0
+## explicit; go 1.16
+github.com/nanmu42/limitio
 # github.com/orangecms/go-framebuffer v0.0.0-20200613202404-a0700d90c330
 ## explicit; go 1.14
 github.com/orangecms/go-framebuffer/framebuffer


### PR DESCRIPTION
The logutil package will contain a writer wrapper implementation that
creates a file for logging purposes. It will use a limited writer to
ensure that the log doesn't grow unboundedly.

Signed-off-by: Andrew <andrewsun@google.com>