### PR TITLE
bzimage: Use payload_offset to find compressed kernel.

### DIFF
--- a/pkg/boot/bzimage/bzimage_test.go
+++ b/pkg/boot/bzimage/bzimage_test.go
@@ -96,8 +96,9 @@ func TestSupportedVersions(t *testing.T) {
 			copy(newImage[0x0206:], b.Bytes())
 
 			// Try to unmarshal the image with the modified version.
-			if gotErr := ((&BzImage{}).UnmarshalBinary(newImage) != nil); gotErr != tc.wantErr {
-				t.Fatalf("got error: %v, expected error: %t", gotErr, tc.wantErr)
+			err := (&BzImage{}).UnmarshalBinary(newImage)
+			if gotErr := err != nil; gotErr != tc.wantErr {
+				t.Fatalf("got error: %v, expected error: %t", err, tc.wantErr)
 			}
 		})
 	}

--- a/pkg/boot/bzimage/bzimage_test.go
+++ b/pkg/boot/bzimage/bzimage_test.go
@@ -29,14 +29,21 @@ var testImages = []testImage{
 
 var badmagic = []byte("hi there")
 
+func mustReadFile(t *testing.T, path string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("error reading %q: %v", path, err)
+	}
+	return data
+}
+
 func TestUnmarshal(t *testing.T) {
 	Debug = t.Logf
 	for _, tc := range testImages {
 		t.Run(tc.name, func(t *testing.T) {
-			image, err := os.ReadFile(tc.path)
-			if err != nil {
-				t.Fatal(err)
-			}
+			image := mustReadFile(t, tc.path)
 			var b BzImage
 			if err := b.UnmarshalBinary(image); err != nil {
 				t.Fatal(err)
@@ -49,16 +56,13 @@ func TestMarshal(t *testing.T) {
 	Debug = t.Logf
 	for _, tc := range testImages {
 		t.Run(tc.name, func(t *testing.T) {
-			image, err := os.ReadFile(tc.path)
-			if err != nil {
-				t.Fatal(err)
-			}
+			image := mustReadFile(t, tc.path)
 			var b BzImage
 			if err := b.UnmarshalBinary(image); err != nil {
 				t.Fatal(err)
 			}
 			t.Logf("b header is %s", b.Header.String())
-			image, err = b.MarshalBinary()
+			image, err := b.MarshalBinary()
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -127,10 +131,7 @@ func TestBadMagic(t *testing.T) {
 func TestAddInitRAMFS(t *testing.T) {
 	t.Logf("TestAddInitRAMFS")
 	Debug = t.Logf
-	initramfsimage, err := os.ReadFile("testdata/bzimage-64kurandominitramfs")
-	if err != nil {
-		t.Fatal(err)
-	}
+	initramfsimage := mustReadFile(t, "testdata/bzimage-64kurandominitramfs")
 	var b BzImage
 	if err := b.UnmarshalBinary(initramfsimage); err != nil {
 		t.Fatal(err)
@@ -176,10 +177,7 @@ func TestHeaderString(t *testing.T) {
 	Debug = t.Logf
 	for _, tc := range testImages {
 		t.Run(tc.name, func(t *testing.T) {
-			initramfsimage, err := os.ReadFile(tc.path)
-			if err != nil {
-				t.Fatal(err)
-			}
+			initramfsimage := mustReadFile(t, tc.path)
 			var b BzImage
 			if err := b.UnmarshalBinary(initramfsimage); err != nil {
 				t.Fatal(err)
@@ -193,10 +191,7 @@ func TestExtract(t *testing.T) {
 	Debug = t.Logf
 	for _, tc := range testImages {
 		t.Run(tc.name, func(t *testing.T) {
-			initramfsimage, err := os.ReadFile(tc.path)
-			if err != nil {
-				t.Fatal(err)
-			}
+			initramfsimage := mustReadFile(t, tc.path)
 			var b BzImage
 			if err := b.UnmarshalBinary(initramfsimage); err != nil {
 				t.Fatal(err)
@@ -219,10 +214,7 @@ func TestELF(t *testing.T) {
 	Debug = t.Logf
 	for _, tc := range testImages {
 		t.Run(tc.name, func(t *testing.T) {
-			initramfsimage, err := os.ReadFile(tc.path)
-			if err != nil {
-				t.Fatal(err)
-			}
+			initramfsimage := mustReadFile(t, tc.path)
 			var b BzImage
 			if err := b.UnmarshalBinary(initramfsimage); err != nil {
 				t.Fatal(err)
@@ -242,10 +234,7 @@ func TestInitRAMFS(t *testing.T) {
 	cpio.Debug = t.Logf
 	for _, tc := range testImages {
 		t.Run(tc.name, func(t *testing.T) {
-			initramfsimage, err := os.ReadFile(tc.path)
-			if err != nil {
-				t.Fatal(err)
-			}
+			initramfsimage := mustReadFile(t, tc.path)
 			var b BzImage
 			if err := b.UnmarshalBinary(initramfsimage); err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
The existing code already uses payload_size to read the compressed
kernel, but ignores payload_offset and instead uses magic numbers to try
and find the beginning of the compressed kernel code.

This change uses payload_offset to find the exact start of the
compressed code and modifies `findDecompressor` to check that the
compressed payload begins with a known magic number.

payload_size and payload_offset were added in protocol version 2.08
(https://www.kernel.org/doc/html/latest/x86/boot.html) so an explicit
version check has been added. This version requirement is not new,
because the existing code already relies on payload_size, it is just now
explicit.

All tests continue to pass, unmodified.

Signed-off-by: Avi Brender <abrender@google.com>