### PR TITLE
pkg/uroot/util: change usage to return func() wrapping a func()

### DIFF
--- a/cmds/core/chmod/chmod.go
+++ b/cmds/core/chmod/chmod.go
@@ -22,6 +22,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/u-root/u-root/pkg/uroot/util"
 )
 
 const (
@@ -30,6 +32,10 @@ const (
 )
 
 var errBadUsage = errors.New(usage)
+
+func init() {
+	flag.Usage = util.Usage(flag.Usage, usage)
+}
 
 func changeMode(path string, mode os.FileMode, octval uint64, mask uint64) (fs.FileMode, error) {
 	// A special value for mask means the mode is fully described

--- a/cmds/core/echo/echo.go
+++ b/cmds/core/echo/echo.go
@@ -81,7 +81,7 @@ func echo(w io.Writer, s ...string) error {
 }
 
 func init() {
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 }
 
 func main() {

--- a/cmds/core/md5sum/md5sum.go
+++ b/cmds/core/md5sum/md5sum.go
@@ -19,7 +19,7 @@ import (
 var usage = "md5sum: md5sum <File Name>"
 
 func init() {
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 }
 
 func calculateMd5Sum(r io.Reader) ([]byte, error) {

--- a/cmds/core/mkdir/mkdir.go
+++ b/cmds/core/mkdir/mkdir.go
@@ -38,7 +38,7 @@ var (
 )
 
 func init() {
-	util.Usage(cmd)
+	flag.Usage = util.Usage(flag.Usage, cmd)
 }
 
 func mkdir(args []string) error {

--- a/cmds/core/mv/mv.go
+++ b/cmds/core/mv/mv.go
@@ -94,7 +94,7 @@ func move(files []string) error {
 }
 
 func main() {
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 	flag.Parse()
 	if flag.NArg() < 2 {
 		flag.Usage()

--- a/cmds/core/netcat/netcat.go
+++ b/cmds/core/netcat/netcat.go
@@ -25,7 +25,7 @@ var (
 )
 
 func init() {
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 }
 
 func main() {

--- a/cmds/core/ping/ping.go
+++ b/cmds/core/ping/ping.go
@@ -179,7 +179,7 @@ func ping(host string) error {
 }
 
 func main() {
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 	flag.Parse()
 	// options without parameters (right now just: -hV)
 	if flag.NArg() != 1 {

--- a/cmds/core/rm/rm.go
+++ b/cmds/core/rm/rm.go
@@ -86,7 +86,7 @@ func rm(stdin io.Reader, files []string) error {
 }
 
 func main() {
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 	flag.Parse()
 	if err := rm(os.Stdin, flag.Args()); err != nil {
 		log.Fatal(err)

--- a/cmds/core/sync/sync.go
+++ b/cmds/core/sync/sync.go
@@ -31,7 +31,7 @@ var (
 var usage = "Usage: %s [OPTION] [FILE]...\n"
 
 func init() {
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 }
 
 func doSyscall(syscallNum uintptr, args []string) error {

--- a/cmds/core/truncate/truncate.go
+++ b/cmds/core/truncate/truncate.go
@@ -36,7 +36,7 @@ var (
 
 func init() {
 	flag.Var(size, "s", "Size in bytes, prefixes +/- are allowed")
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 }
 
 func truncate(args ...string) error {

--- a/cmds/exp/bzimage/bzimage.go
+++ b/cmds/exp/bzimage/bzimage.go
@@ -194,7 +194,7 @@ func run(w io.Writer, args ...string) error {
 }
 
 func main() {
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 	flag.Parse()
 	if err := run(os.Stdout, flag.Args()...); err != nil {
 		log.Fatal(err)

--- a/cmds/exp/ed/ed.go
+++ b/cmds/exp/ed/ed.go
@@ -43,7 +43,7 @@ var (
 func init() {
 	flag.BoolVar(&fsuppress, "s", false, "suppress counts")
 	flag.StringVar(&fprompt, "p", "*", "specify a command prompt")
-	util.Usage(usage)
+	flag.Usage = util.Usage(flag.Usage, usage)
 }
 
 // current FileBuffer

--- a/cmds/exp/syscallfilter/main_linux.go
+++ b/cmds/exp/syscallfilter/main_linux.go
@@ -57,7 +57,7 @@ const cmdUsage = "Usage: syscallfilter [-l] [action... --] command [args]"
 
 func main() {
 	// TODO: fill this in from arguments.
-	util.Usage(cmdUsage)
+	flag.Usage = util.Usage(flag.Usage, cmdUsage)
 	flag.Parse()
 
 	// By default, there are no actions, and this becomes just "run a program"

--- a/pkg/uroot/util/pkg_test.go
+++ b/pkg/uroot/util/pkg_test.go
@@ -4,8 +4,22 @@
 
 package util
 
-import "testing"
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+)
 
 func TestTODO(t *testing.T) {
-	// TODO: Write a unit test.
+	b := &bytes.Buffer{}
+	f := func() {
+		fmt.Fprintf(b, "hi %s", os.Args[0])
+	}
+
+	f = Usage(f, "there")
+	f()
+	if b.String() != "hi there" {
+		t.Errorf("f(): Got %q, want %q", b.String(), "hi there")
+	}
 }

--- a/pkg/uroot/util/usage.go
+++ b/pkg/uroot/util/usage.go
@@ -5,14 +5,22 @@
 package util
 
 import (
-	"flag"
 	"os"
 )
 
-func Usage(cmd string) {
-	defUsage := flag.Usage
-	flag.Usage = func() {
-		os.Args[0] = cmd
-		defUsage()
+// Usage wraps a passed in func() with a func() that sets
+// os.Args[0] to a string and then calls the func().
+//
+// It is intended to be called with Usage function from a flag package,
+// such as flag or spf13/pflag.
+// E.g., flag.usage = util.Usage(flag.Usage, "some message")
+//
+// Usage must not import "flag", since callers might use an alternate flags
+// package such as spf13/pflag, and would set Usage for a flag
+// package that the caller is not using.
+func Usage(wrapUsage func(), message string) func() {
+	return func() {
+		os.Args[0] = message
+		wrapUsage()
 	}
 }


### PR DESCRIPTION
Usage used to import "flag", and modify flag.Usage. This failed badly
if the caller was using a different flag package, e.g. spf13/pflag.

Users of Usage must now explicitly provide whatever Usage func
they are using, and must set the Usage function, e.g.:

flag.Usage = util.Usage(flag.Usage, "usage message")

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>