### PR TITLE
bzImage: Add CRC32 checking and setting.

### DIFF
--- a/pkg/boot/bzimage/header.go
+++ b/pkg/boot/bzimage/header.go
@@ -258,11 +258,14 @@ var (
 
 // BzImage represents sections extracted from a kernel.
 type BzImage struct {
-	Header       LinuxHeader
-	BootCode     []byte
-	HeadCode     []byte
-	KernelCode   []byte
-	TailCode     []byte
+	Header     LinuxHeader
+	BootCode   []byte
+	HeadCode   []byte
+	KernelCode []byte
+	TailCode   []byte
+	// This field contains the CRC read from the image while unmarshaling.
+	// This value is *not* used while marshaling the data to binary; a new CRC32 is calculated.
+	CRC32        uint32
 	KernelBase   uintptr
 	KernelOffset uintptr
 	compressed   []byte


### PR DESCRIPTION
Each bzImage file contains a CRC32 checksum appended to the end of the
file. This change adds checking of the CRC32 and updating the CRC32 when
marshaling the image to binary.

Tests are added to ensure that this works as intended. Existing code
which modified the versions needed to be updated to
unmarshal -> marshal to ensure that the new CRC32 is written.

Signed-off-by: Avi Brender <abrender@google.com>