### PR TITLE
pkg/efivar, cmds/exp/efivarfs: fix to run local and use errors package

### DIFF
--- a/cmds/exp/efivarfs/efivarfs.go
+++ b/cmds/exp/efivarfs/efivarfs.go
@@ -40,7 +40,7 @@ func run(list bool, read, delete, write, content string) error {
 	if list {
 		l, err := efivarfs.SimpleListVariables()
 		if err != nil {
-			return fmt.Errorf("list failed: %v", err)
+			return fmt.Errorf("list failed: %w", err)
 		}
 		for _, s := range l {
 			log.Println(s)
@@ -50,18 +50,18 @@ func run(list bool, read, delete, write, content string) error {
 	if read != "" {
 		attr, data, err := efivarfs.SimpleReadVariable(read)
 		if err != nil {
-			return fmt.Errorf("read failed: %v", err)
+			return fmt.Errorf("read failed: %w", err)
 		}
 		b, err := io.ReadAll(data)
 		if err != nil {
-			return fmt.Errorf("reading buffer failed: %v", err)
+			return fmt.Errorf("reading buffer failed: %w", err)
 		}
 		log.Printf("Name: %s, Attributes: %d, Data: %s", read, attr, b)
 	}
 
 	if delete != "" {
 		if err := efivarfs.SimpleRemoveVariable(delete); err != nil {
-			return fmt.Errorf("delete failed: %v", err)
+			return fmt.Errorf("delete failed: %w", err)
 		}
 	}
 
@@ -69,22 +69,22 @@ func run(list bool, read, delete, write, content string) error {
 		if strings.ContainsAny(write, "-") {
 			v := strings.SplitN(write, "-", 2)
 			if _, err := guid.Parse(v[1]); err != nil {
-				return fmt.Errorf("var name malformed: Must be either Name-GUID or just Name")
+				return fmt.Errorf("%qmalformed: Must be either Name-GUID or just Name:%w", v[1], os.ErrInvalid)
 			}
 		}
 		path, err := filepath.Abs(content)
 		if err != nil {
-			return fmt.Errorf("could not resolve path: %v", err)
+			return fmt.Errorf("could not resolve path: %w", err)
 		}
 		b, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("failed to read file: %v", err)
+			return fmt.Errorf("failed to read file: %w", err)
 		}
 		if !strings.ContainsAny(write, "-") {
 			write = write + "-" + guid.New().String()
 		}
 		if err = efivarfs.SimpleWriteVariable(write, 7, bytes.NewBuffer(b)); err != nil {
-			return fmt.Errorf("write failed: %v", err)
+			return fmt.Errorf("write failed: %w", err)
 		}
 	}
 	return nil

--- a/integration/GET_KERNEL_QEMU
+++ b/integration/GET_KERNEL_QEMU
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# This script is intended to run, locally, the tests we run at circleci,
+# precisely as they are run there.
+#
+# to do so, it:
+# o creates a directory to store local artifacts retrieved from docker
+#   see TMP= below
+# o runs a the standard test container to retrieve a the qemu, kernel, and bios image
+# o runs go test with a default set of tests (./...)
+#
+# NOTE: if you want more complex behavior, don't make this script more
+# complex. Convert it to Go. Complex shell scripts suck.
+
+# These docker artifacts should not persist. Place them in tmp.
+# tmp is in .gitignore
+# I would prefer /tmp/$$.
+# Docker really doesn't like this for some reason, even when
+# I map it to /out inside the container.
+# TMP=/tmp/$$
+TMP=`pwd`/tmp
+mkdir -p $TMP
+chmod 777 $TMP
+
+# The default value is AMD64, but you can override it, e.g.
+# UROOT_TESTARCH=arm64 bash RUNLOCAL
+export ${UROOT_TESTARCH:=amd64}
+
+case $UROOT_TESTARCH in
+
+  "amd64")
+    export UROOT_QEMU="qemu-system-x86_64"
+    export UROOT_QEMU_OPTS="-L $TMP/pc-bios -m 1G"
+    export UROOT_KERNEL=bzImage
+    export UROOT_BIOS=pc-bios
+    ;;
+
+  "arm64")
+    export UROOT_QEMU=qemu-system-aarch64
+    export UROOT_KERNEL=Image
+    export UROOT_BIOS=""
+    export UROOT_QEMU_OPTS=""
+    ;;
+
+  *)
+    echo "$UROOT_TESTARCH is not a supported architecture"
+    exit 1
+    ;;
+
+esac
+
+# We no longer allow you to pick a kernel to run.
+# Since we wish to exactly mirror what circleci does, we always use the
+# kernel and qemu in the container.
+# Note the docker pull only hurts a lot the first time.
+# After you have run it once, further cp operations take a second or so.
+# By doing it this way, we always use the latest Docker files.
+DOCKER=uroottest/test-image-${UROOT_TESTARCH}
+
+docker run -v $TMP:/out $DOCKER cp -a $UROOT_KERNEL  $UROOT_BIOS $UROOT_QEMU /out
+
+ls -l $TMP
+
+# now adjust paths and such
+UROOT_KERNEL=$TMP/$UROOT_KERNEL
+UROOT_QEMU="$TMP/$UROOT_QEMU $UROOT_QEMU_OPTS"
+UROOT_BIOS=$TMP/$UROOT_BIOS

--- a/integration/RUNLOCAL
+++ b/integration/RUNLOCAL
@@ -12,61 +12,13 @@
 # NOTE: if you want more complex behavior, don't make this script more
 # complex. Convert it to Go. Complex shell scripts suck.
 
+# Take a guess: they are likely running it in this directory
+UROOT_SOURCE=${UROOT_SOURCE:-${PWD}/..}
+export UROOT_SOURCE
+
 set -e
 set -x
 
-# These docker artifacts should not persist. Place them in tmp.
-# tmp is in .gitignore
-# I would prefer /tmp/$$.
-# Docker really doesn't like this for some reason, even when
-# I map it to /out inside the container.
-# TMP=/tmp/$$
-TMP=`pwd`/tmp
-mkdir -p $TMP
-chmod 777 $TMP
-
-# The default value is AMD64, but you can override it, e.g.
-# UROOT_TESTARCH=arm64 bash RUNLOCAL
-export ${UROOT_TESTARCH:=amd64}
-
-case $UROOT_TESTARCH in
-
-  "amd64")
-    export UROOT_QEMU="qemu-system-x86_64"
-    export UROOT_QEMU_OPTS="-L $TMP/pc-bios -m 1G"
-    export UROOT_KERNEL=bzImage
-    export UROOT_BIOS=pc-bios
-    ;;
-
-  "arm64")
-    export UROOT_QEMU=qemu-system-aarch64
-    export UROOT_KERNEL=Image
-    export UROOT_BIOS=""
-    export UROOT_QEMU_OPTS=""
-    ;;
-
-  *)
-    echo "$UROOT_TESTARCH is not a supported architecture"
-    exit 1
-    ;;
-
-esac
-
-# We no longer allow you to pick a kernel to run.
-# Since we wish to exactly mirror what circleci does, we always use the
-# kernel and qemu in the container.
-# Note the docker pull only hurts a lot the first time.
-# After you have run it once, further cp operations take a second or so.
-# By doing it this way, we always use the latest Docker files.
-DOCKER=uroottest/test-image-${UROOT_TESTARCH}
-
-docker run -v $TMP:/out $DOCKER cp -a $UROOT_KERNEL  $UROOT_BIOS $UROOT_QEMU /out
-
-ls -l $TMP
-
-# now adjust paths and such
-UROOT_KERNEL=$TMP/$UROOT_KERNEL
-UROOT_QEMU="$TMP/$UROOT_QEMU $UROOT_QEMU_OPTS"
-UROOT_BIOS=$TMP/$UROOT_BIOS
+. GET_KERNEL_QEMU
 
 go test "$@" ./...

--- a/integration/generic-tests/main_test.go
+++ b/integration/generic-tests/main_test.go
@@ -12,10 +12,10 @@ import (
 
 func TestMain(m *testing.M) {
 	if len(os.Getenv("UROOT_KERNEL")) == 0 {
-		log.Fatalf("Failed to run tests: no kernel provided")
+		log.Fatalf("Failed to run tests: no kernel provide: source integration/GET_KERNEL_QEMU to get a kernel")
 	}
 	if len(os.Getenv("UROOT_QEMU")) == 0 {
-		log.Fatalf("Failed to run tests: no QEMU binary provided")
+		log.Fatalf("Failed to run tests: no QEMU binary provided: source integration/GET_KERNEL_QEMU to get a qemu")
 	}
 
 	log.Printf("Starting generic tests...")

--- a/pkg/efivarfs/varfs.go
+++ b/pkg/efivarfs/varfs.go
@@ -7,7 +7,6 @@ package efivarfs
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,17 +25,17 @@ var EfiVarFs = "/sys/firmware/efi/efivars/"
 
 var (
 	// ErrFsNotMounted is caused if no vailed efivarfs magic is found
-	ErrFsNotMounted = errors.New("no efivarfs magic found, is it mounted?")
+	ErrFsNotMounted = fmt.Errorf("no efivarfs magic found, is it mounted?:%w", os.ErrNotExist)
 
 	// ErrVarsUnavailable is caused by not having a valid backend
-	ErrVarsUnavailable = errors.New("no variable backend is available")
+	ErrVarsUnavailable = fmt.Errorf("no variable backend is available:%w", os.ErrNotExist)
 
 	// ErrVarNotExist is caused by accessing a non-existing variable
-	ErrVarNotExist = errors.New("variable does not exist")
+	ErrVarNotExist = fmt.Errorf("variable does not exist%w", os.ErrNotExist)
 
 	// ErrVarPermission is caused by not haven the right permissions either
 	// because of not being root or xattrs not allowing changes
-	ErrVarPermission = errors.New("permission denied")
+	ErrVarPermission = fmt.Errorf("permission denied:%w", os.ErrPermission)
 )
 
 // efivarfs represents the real efivarfs of the Linux kernel

--- a/pkg/mount/mount_integration_test.go
+++ b/pkg/mount/mount_integration_test.go
@@ -8,21 +8,43 @@
 package mount
 
 import (
+	"io/ioutil"
+	"path/filepath"
 	"testing"
 
+	"github.com/u-root/u-root/pkg/cp"
 	"github.com/u-root/u-root/pkg/qemu"
 	"github.com/u-root/u-root/pkg/vmtest"
 )
 
 func TestIntegration(t *testing.T) {
+	// qemu likes to lock files.
+	// In practice we've seen issues with multiple instantiations of
+	// qemu getting into lock wars. To avoid this, copy data files to
+	// a temp directory.
+	// Don't use this, we want to let the test decide whether to delete it. tmp := t.TempDir()
+	tmp, err := ioutil.TempDir("", "MountTestIntegration")
+	if err != nil {
+		t.Fatalf("Creating TempDir: %v", tmp)
+	}
+	// We do not use CopyTree as it (1) recreates the full path in the tmp directory,
+	// and (2) we want to only copy what we want to copy.
+	for _, f := range []string{"1MB.ext4_vfat", "12Kzeros", "gptdisk", "gptdisk2"} {
+		s := filepath.Join("./testdata", f)
+		d := filepath.Join(tmp, f)
+		if err := cp.Copy(s, d); err != nil {
+			t.Fatalf("Copying %q to %q: got %v, want nil", s, d, err)
+		}
+	}
 	o := &vmtest.Options{
+		TmpDir: tmp,
 		QEMUOpts: qemu.Options{
 			Devices: []qemu.Device{
 				// CONFIG_ATA_PIIX is required for this option to work.
-				qemu.ArbitraryArgs{"-hda", "testdata/1MB.ext4_vfat"},
-				qemu.ArbitraryArgs{"-hdb", "testdata/12Kzeros"},
-				qemu.ArbitraryArgs{"-hdc", "testdata/gptdisk"},
-				qemu.ArbitraryArgs{"-drive", "file=testdata/gptdisk2,if=none,id=NVME1"},
+				qemu.ArbitraryArgs{"-hda", filepath.Join(tmp, "1MB.ext4_vfat")},
+				qemu.ArbitraryArgs{"-hdb", filepath.Join(tmp, "12Kzeros")},
+				qemu.ArbitraryArgs{"-hdc", filepath.Join(tmp, "gptdisk")},
+				qemu.ArbitraryArgs{"-drive", "file=" + filepath.Join(tmp, "gptdisk2") + ",if=none,id=NVME1"},
 				// use-intel-id uses the vendor=0x8086 and device=0x5845 ids for NVME
 				qemu.ArbitraryArgs{"-device", "nvme,drive=NVME1,serial=nvme-1,use-intel-id"},
 			},


### PR DESCRIPTION
Make the errors wrap standard error values from os so the errors package can be used.

Use errors.Is in tests so we don't have to use string compares.

Skip any tests that need root when we are not root.

With these changes, the tests now run locally.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>