### PR TITLE
ldd: Ignore symlinks that lead to the same file

### DIFF
--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -25,7 +25,6 @@ package ldd
 import (
 	"debug/elf"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -80,11 +79,14 @@ func runinterp(interp, file string) ([]string, error) {
 		return nil, err
 	}
 	for _, p := range strings.Split(string(o), "\n") {
-		f := strings.Split(p, " ")
+		f := strings.Split(strings.TrimSpace(p), " ")
 		if len(f) < 3 {
 			continue
 		}
 		if f[1] != "=>" || len(f[2]) == 0 {
+			continue
+		}
+		if f[0] == f[2] {
 			continue
 		}
 		names = append(names, f[2])
@@ -186,9 +188,9 @@ func Ldd(names []string) ([]*FileInfo, error) {
 		if err != nil {
 			return nil, err
 		}
-		for i := range n {
-			if err := follow(n[i], list); err != nil {
-				log.Fatalf("ldd: %v", err)
+		for _, soname := range n {
+			if err := follow(soname, list); err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -67,19 +67,10 @@ func follow(l string, names map[string]*FileInfo) error {
 	}
 }
 
-// runinterp runs the interpreter with the --list switch
-// and the file as an argument. For each returned line
-// it looks for => as the second field, indicating a
-// real .so (as opposed to the .vdso or a string like
-// 'not a dynamic executable'.
-func runinterp(interp, file string) ([]string, error) {
+func parseinterp(input string) ([]string, error) {
 	var names []string
-	o, err := exec.Command(interp, "--list", file).Output()
-	if err != nil {
-		return nil, err
-	}
-	for _, p := range strings.Split(string(o), "\n") {
-		f := strings.Split(strings.TrimSpace(p), " ")
+	for _, p := range strings.Split(input, "\n") {
+		f := strings.Fields(p)
 		if len(f) < 3 {
 			continue
 		}
@@ -92,6 +83,19 @@ func runinterp(interp, file string) ([]string, error) {
 		names = append(names, f[2])
 	}
 	return names, nil
+}
+
+// runinterp runs the interpreter with the --list switch
+// and the file as an argument. For each returned line
+// it looks for => as the second field, indicating a
+// real .so (as opposed to the .vdso or a string like
+// 'not a dynamic executable'.
+func runinterp(interp, file string) ([]string, error) {
+	o, err := exec.Command(interp, "--list", file).Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseinterp(string(o))
 }
 
 type FileInfo struct {

--- a/pkg/ldd/ldd_unix_test.go
+++ b/pkg/ldd/ldd_unix_test.go
@@ -1,0 +1,59 @@
+// Copyright 2009-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build freebsd || linux
+// +build freebsd linux
+
+package ldd
+
+import (
+	"testing"
+)
+
+var (
+	cases = []struct {
+		name   string
+		input  string
+		output []string
+	}{
+		{
+			name: "single vdso entry",
+			input: `	linux-vdso.so.1`,
+			output: []string{},
+		},
+		{
+			name: "duplicate vdso symlink",
+			input: `	linux-vdso.so.1 => linux-vdso.so.1`,
+			output: []string{},
+		},
+		{
+			name: "multiple entries",
+			input: `	linux-vdso.so.1 => linux-vdso.so.1
+	libc.so.6 => /usr/lib/libc.so.6
+	/lib64/ld-linux-x86-64.so.2 => /usr/lib64/ld-linux-x86-64.so.2`,
+			output: []string{"/usr/lib/libc.so.6", "/usr/lib64/ld-linux-x86-64.so.2"},
+		},
+	}
+)
+
+func cmp(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, v := range a {
+		if v != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestParseInterp(t *testing.T) {
+	for _, c := range cases {
+		out, _ := parseinterp(c.input)
+		if !cmp(out, c.output) {
+			t.Fatalf("'%s' expected %v, but got %v", c.name, c.output, out)
+		}
+	}
+}


### PR DESCRIPTION
Usually virtual libraries like `vdso` is printed on the same line,
howeve this doesn't seem to always be the case.

Implement a check to see if the symlink is pointing at the same file and
ignore the entry if it does.

We also return an error instead of failing with a printed message.

Signed-off-by: Morten Linderud <morten.linderud@mullvad.net>