### PR TITLE
Change zstd decompressor to use Go package instead of forking a command.

### DIFF
--- a/pkg/boot/bzimage/bzimage.go
+++ b/pkg/boot/bzimage/bzimage.go
@@ -61,7 +61,7 @@ var (
 		// LZO
 		{[]byte{0x89, 0x4C, 0x5A, 0x4F, 0x00, 0x0D, 0x0A, 0x1A, 0x0A}, stripSize(execer("lzop", "-c", "-d"))},
 		// ZSTD
-		{[]byte{0x28, 0xB5, 0x2F, 0xFD}, stripSize(execer("unzstd"))},
+		{[]byte{0x28, 0xB5, 0x2F, 0xFD}, stripSize(unzstd)},
 		// BZIP2
 		{[]byte{0x42, 0x5A, 0x68}, stripSize(unbzip2)},
 		// LZ4 - Note that there are *two* file formats for LZ4 (http://fileformats.archiveteam.org/wiki/LZ4).

--- a/pkg/boot/bzimage/bzimage_decompress.go
+++ b/pkg/boot/bzimage/bzimage_decompress.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os/exec"
 
+	"github.com/klauspost/compress/zstd"
 	"github.com/pierrec/lz4/v4"
 	"github.com/ulikunitz/xz/lzma"
 )
@@ -107,6 +108,21 @@ func unbzip2(w io.Writer, r io.Reader) error {
 	bzip2Reader := bzip2.NewReader(r)
 
 	if _, err := io.Copy(w, bzip2Reader); err != nil {
+		return fmt.Errorf("failed writing decompressed bytes to writer: %v", err)
+	}
+	return nil
+}
+
+// unzstd reads compressed bytes from the io.Reader and writes the uncompressed bytes to the
+// writer. unzstd satisfies the decompressor interface.
+func unzstd(w io.Writer, r io.Reader) error {
+	zstdReader, err := zstd.NewReader(r)
+	if err != nil {
+		return fmt.Errorf("failed to create new reader: %v", err)
+	}
+	defer zstdReader.Close()
+
+	if _, err := io.Copy(w, zstdReader); err != nil {
 		return fmt.Errorf("failed writing decompressed bytes to writer: %v", err)
 	}
 	return nil

--- a/pkg/boot/bzimage/bzimage_test.go
+++ b/pkg/boot/bzimage/bzimage_test.go
@@ -6,6 +6,7 @@ package bzimage
 
 import (
 	"fmt"
+	"hash/crc32"
 	"os"
 	"testing"
 
@@ -13,18 +14,21 @@ import (
 )
 
 type testImage struct {
-	name string
-	path string
+	name  string
+	path  string
+	crc32 uint32
 }
 
 var testImages = []testImage{
 	{
-		name: "basic bzImage",
-		path: "testdata/bzImage",
+		name:  "basic bzImage",
+		path:  "testdata/bzImage",
+		crc32: 1646619772,
 	},
 	{
-		name: "a little larger bzImage, 64k random generated image",
-		path: "testdata/bzimage-64kurandominitramfs",
+		name:  "a little larger bzImage, 64k random generated image",
+		path:  "testdata/bzimage-64kurandominitramfs",
+		crc32: 76993350,
 	},
 }
 
@@ -45,16 +49,15 @@ func TestUnmarshal(t *testing.T) {
 
 	compressedTests := []testImage{
 		// These test files have been created using .circleci/images/test-image-amd6/config_linux5.10_x86_64.txt
-		{name: "bzip2", path: "testdata/bzImage-linux5.10-x86_64-bzip2"},
-		{name: "gzip", path: "testdata/bzImage-linux5.10-x86_64-gzip"},
-		{name: "xz", path: "testdata/bzImage-linux5.10-x86_64-xz"},
-		{name: "lz4", path: "testdata/bzImage-linux5.10-x86_64-lz4"},
-		{name: "lzma", path: "testdata/bzImage-linux5.10-x86_64-lzma"},
-		// These tests do not pass because the CirclCI environment does not include the `lzop` and `unzstd` commands.
-		// TODO: Fix the CircleCI environment or (preferably) change these decompressors to use Go packages instead
-		//       of forking and executing a command.
+		{name: "bzip2", path: "testdata/bzImage-linux5.10-x86_64-bzip2", crc32: 1083155033},
+		{name: "gzip", path: "testdata/bzImage-linux5.10-x86_64-gzip", crc32: 4192009363},
+		{name: "xz", path: "testdata/bzImage-linux5.10-x86_64-xz", crc32: 3062624786},
+		{name: "lz4", path: "testdata/bzImage-linux5.10-x86_64-lz4", crc32: 2177238538},
+		{name: "lzma", path: "testdata/bzImage-linux5.10-x86_64-lzma", crc32: 3062624786},
+		// This test does not pass because the CircleCI environment does not include the `lzop` command.
+		// TODO: Fix the CircleCI environment or (preferably) find a Go package which provides this functionality.
 		//		{name: "lzo", path: "testdata/bzImage-linux5.10-x86_64-lzo"},
-		//		{name: "zstd", path: "testdata/bzImage-linux5.10-x86_64-zstd"},
+		{name: "zstd", path: "testdata/bzImage-linux5.10-x86_64-zstd", crc32: 1773835837},
 	}
 
 	for _, tc := range append(testImages, compressedTests...) {
@@ -63,6 +66,12 @@ func TestUnmarshal(t *testing.T) {
 			var b BzImage
 			if err := b.UnmarshalBinary(image); err != nil {
 				t.Fatal(err)
+			}
+			// Verify that the IEEE CRC32 hash has not changed.
+			// This ensures that we can swap out the decompressor with confidence that the
+			// decompressed payload does not change.
+			if got, want := crc32.ChecksumIEEE(b.KernelCode), tc.crc32; got != want {
+				t.Fatalf("IEEE CRC32 hash of decompressed kernel code has changed from %v to %v", want, got)
 			}
 			// Corrupt a byte in the CRC32 and verify that an error is returned.
 			image[len(image)-1] ^= 0xff


### PR DESCRIPTION
* Pull #2480 added a Go zstd package. Let's use that instead of forking out to a comand to decompress these payloads.
* Add a CRC32 hash check to all test cases to ensure that the decompressed payload doesn't change if we swap out decompressors in the future.

Signed-off-by: Avi Brender <abrender@google.com>