### PR TITLE
Remove unused error.

### DIFF
--- a/cmds/core/timeout/main.go
+++ b/cmds/core/timeout/main.go
@@ -45,9 +45,8 @@ type cmd struct {
 }
 
 var (
-	timeout        = flag.Duration("t", 30*time.Second, "Timeout for command")
-	errNoArgs      = errors.New("Need at least a command to run")
-	errBadDuration = errors.New("timeout must be a duration")
+	timeout   = flag.Duration("t", 30*time.Second, "Timeout for command")
+	errNoArgs = errors.New("Need at least a command to run")
 )
 
 func main() {


### PR DESCRIPTION
This error was used in previous iterations of the code but was not used in the final iteration. My "thorough review" did not catch this unused variable :)

Signed-off-by: Avi Brender <abrender@google.com>