### PR TITLE
pkg/cmdline: make it more idiomatic and testable

### DIFF
--- a/cmds/boot/boot/boot.go
+++ b/cmds/boot/boot/boot.go
@@ -59,7 +59,7 @@ var (
 // the 'append' and 'reuse' flags
 func updateBootCmdline(cl string) string {
 	f := cmdline.NewUpdateFilter(*appendCmdline, strings.Split(*removeCmdlineItem, ","), strings.Split(*reuseCmdlineItem, ","))
-	return f.Update(cl)
+	return f.Update(cmdline.NewCmdLine(), cl)
 }
 
 func main() {

--- a/pkg/cmdline/cmdline_linux.go
+++ b/pkg/cmdline/cmdline_linux.go
@@ -1,0 +1,31 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cmdline
+
+import (
+	"os"
+)
+
+const cmdLinePath = "/proc/cmdline"
+
+var procCmdLine *CmdLine
+
+func cmdLine(n string) *CmdLine {
+	procCmdLine = &CmdLine{AsMap: map[string]string{}}
+	r, err := os.Open(n)
+	if err != nil {
+		procCmdLine.Err = err
+		return procCmdLine
+	}
+
+	defer r.Close()
+
+	procCmdLine = parse(r)
+	return procCmdLine
+}
+
+func getCmdLine() *CmdLine {
+	return cmdLine(cmdLinePath)
+}

--- a/pkg/cmdline/cmdline_other.go
+++ b/pkg/cmdline/cmdline_other.go
@@ -1,0 +1,21 @@
+// Copyright 2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !linux
+// +build !linux
+
+package cmdline
+
+import "os"
+
+var procCmdLine *CmdLine
+
+func cmdLine(f string) *CmdLine {
+	procCmdLine = &CmdLine{AsMap: map[string]string{}, Err: os.ErrNotExist}
+	return procCmdLine
+}
+
+func getCmdLine() *CmdLine {
+	return cmdLine("")
+}

--- a/pkg/cmdline/filters.go
+++ b/pkg/cmdline/filters.go
@@ -38,8 +38,8 @@ func removeFilter(input string, variables []string) string {
 
 // Filter represents and kernel commandline filter
 type Filter interface {
-	// Update filters a given space-separated kernel commandline
-	Update(cmdline string) string
+	// Update filters given a space-separated kernel commandline
+	Update(c *CmdLine, cmdline string) string
 }
 
 type updater struct {
@@ -60,13 +60,13 @@ func NewUpdateFilter(appendCmd string, removeVar, reuseVar []string) Filter {
 	}
 }
 
-func (u *updater) Update(cmdline string) string {
+func (u *updater) Update(c *CmdLine, cmdline string) string {
 	acl := ""
 	if len(u.appendCmd) > 0 {
 		acl = " " + u.appendCmd
 	}
 	for _, f := range u.reuseVar {
-		value, present := Flag(f)
+		value, present := c.Flag(f)
 		if present {
 			acl = fmt.Sprintf("%s %s=%s", acl, f, value)
 		}

--- a/pkg/cmdline/filters_test.go
+++ b/pkg/cmdline/filters_test.go
@@ -30,14 +30,7 @@ func TestUpdateFilter(t *testing.T) {
 		`systemd.unified_cgroup_hierarchy=1 cgroup_no_v1=all console=tty0 ` +
 		`console=ttyS0,115200 security=selinux selinux=1 enforcing=0`
 
-	// Do this once, we'll over-write soon
-	once.Do(cmdLineOpener)
-	cmdLineReader := strings.NewReader(exampleCmdLine)
-	procCmdLine = parse(cmdLineReader)
-
-	if procCmdLine.Err != nil {
-		t.Errorf("procCmdLine threw an error: %v", procCmdLine.Err)
-	}
+	c := parse(strings.NewReader(exampleCmdLine))
 
 	toRemove := []string{"console", "earlyconsole"}
 	toReuse := []string{"console", "not-present"}
@@ -47,8 +40,8 @@ func TestUpdateFilter(t *testing.T) {
 	want := `keep=5 keep2 append=me console=ttyS0,115200`
 
 	filter := NewUpdateFilter(toAppend, toRemove, toReuse)
-	got := filter.Update(cl)
+	got := filter.Update(c, cl)
 	if got != want {
-		t.Errorf("Update(%v) = %v, want %v", cl, got, want)
+		t.Errorf("Update(%q) = %q, want %q", cl, got, want)
 	}
 }


### PR DESCRIPTION
Remove log.Prints from the package.

Change NewCmdLine to return a *CmdLine.

Split out the cmdline reader into an os-dependent part.
Other kernels have linux-like command lines.

Remove use of once.Do, it is a pointless saving that impedes
tests.

Define operators on the CmdLine struct.

Call those operators from the package functions, e.g.
cmdline.Flag will call getCmdLine().Flag().

Require that filters take a *CmdLine parameter, rather than
using a package variable.

This change makes writing tests for other packages much easier, and
much less dependent on running tests on Linux.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>