### PR TITLE
pci: Replace bus string with uint8

### DIFF
--- a/pkg/pci/devices.go
+++ b/pkg/pci/devices.go
@@ -40,7 +40,7 @@ func (d Devices) Print(o io.Writer, verbose, confSize int) error {
 				if _, err := fmt.Fprintf(o, ", Cache Line Size: %d bytes", c[CacheLineSize]); err != nil {
 					return err
 				}
-				if _, err := fmt.Fprintf(o, "\n\tBus: primary=%s, secondary=%s, subordinate=%s, sec-latency=%s",
+				if _, err := fmt.Fprintf(o, "\n\tBus: primary=%02x, secondary=%02x, subordinate=%02x, sec-latency=%s",
 					pci.Primary, pci.Secondary, pci.Subordinate, pci.SecLatency); err != nil {
 					return err
 				}

--- a/pkg/pci/devices_test.go
+++ b/pkg/pci/devices_test.go
@@ -47,7 +47,7 @@ func TestPrint(t *testing.T) {
 	Control: I/O- Memory- DMA- Special- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisInt-
 	Status: INTx- Cap- 66MHz- UDF- FastB2b- ParErr- DEVSEL- DEVSEL=fast <MABORT- >SERR- <PERR-
 	Latency: 0, Cache Line Size: 255 bytes
-	Bus: primary=, secondary=, subordinate=, sec-latency=
+	Bus: primary=00, secondary=00, subordinate=00, sec-latency=
 	I/O behind bridge: 0x00000040-0x00000000 [size=0xffffffffffffffc1]
 	Memory behind bridge:  [disabled]
 	Prefetchable memory behind bridge:  [disabled]

--- a/pkg/pci/pci.go
+++ b/pkg/pci/pci.go
@@ -41,9 +41,9 @@ type PCI struct {
 	BARS     []BAR  `json:"omitempty"`
 
 	// Type 1
-	Primary     string
-	Secondary   string
-	Subordinate string
+	Primary     uint8
+	Secondary   uint8
+	Subordinate uint8
 	SecLatency  string
 	IO          BAR
 	Mem         BAR
@@ -191,9 +191,9 @@ iter:
 			p.Bridge = true
 		}
 		p.IRQPin = c[IRQPin]
-		p.Primary = fmt.Sprintf("%02x", c[Primary])
-		p.Secondary = fmt.Sprintf("%02x", c[Secondary])
-		p.Subordinate = fmt.Sprintf("%02x", c[Subordinate])
+		p.Primary = c[Primary]
+		p.Secondary = c[Secondary]
+		p.Subordinate = c[Subordinate]
 		p.SecLatency = fmt.Sprintf("%02x", c[SecondaryLatency])
 
 		devices = append(devices, p)


### PR DESCRIPTION
It is far easier to make use of the int in code.

Signed-off-by: Ryan O'Leary <ryanoleary@google.com>