### PR TITLE
cmds/core/kill: Create an unused port for testing kill

### DIFF
--- a/cmds/core/kill/kill_test.go
+++ b/cmds/core/kill/kill_test.go
@@ -7,9 +7,18 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"os/exec"
 	"strings"
 	"testing"
 )
+
+func getUnusedPID() string {
+	cmd := exec.Command("true")
+	cmd.Start()
+	pid := cmd.Process.Pid
+	cmd.Wait()
+	return fmt.Sprintf("%d", pid)
+}
 
 func TestKillProcess(t *testing.T) {
 	for _, tt := range []struct {
@@ -54,7 +63,7 @@ func TestKillProcess(t *testing.T) {
 		},
 		{
 			name: "kill signal with signal and wrong pid",
-			args: []string{"kill", "--signal", "50", "9999"},
+			args: []string{"kill", "--signal", "50", getUnusedPID()},
 			want: "some processes could not be killed",
 		},
 		{


### PR DESCRIPTION
The kill test might fail because PID 9999 exists. This commit create a PID that will be unused temporarily for testing purpose.

Signed-off-by: Medicine Yeh <medicinehy@gmail.com>