### PR TITLE
fs_test: skip TestFSGoodFile is not run as root.

### DIFF
--- a/pkg/efivarfs/fs_test.go
+++ b/pkg/efivarfs/fs_test.go
@@ -9,10 +9,13 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/u-root/u-root/pkg/testutil"
 	"golang.org/x/sys/unix"
 )
 
 func TestFSGoodFile(t *testing.T) {
+	// Temporary folder cleanup can require root.
+	testutil.SkipIfNotRoot(t)
 	d := t.TempDir()
 	f, err := os.Create(filepath.Join(d, "x"))
 	if err != nil {


### PR DESCRIPTION
...as cleanup temporary folder can require root
after we temper with file I node flags.

e.g.

```
--- FAIL: TestFSGoodFile (0.00s)
    testing.go:967: TempDir RemoveAll cleanup: unlinkat /tmp/TestFSGoodFile214938004/001/x: operation not permitted
FAIL
```

Temporary folder is created from testing pkg.
If test fail to cleanup the temporary folder, it
will [fail the test](https://source.corp.google.com/piper///depot/google3/third_party/go/gc/src/testing/testing.go;l=1125;bpv=0;rcl=478263875)