### PR TITLE
update golang version of project and testimages to 1.19

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,19 +4,19 @@ templates:
   golang-template:
     &golang-template
     docker:
-      - image: uroottest/test-image-amd64:v5.0.0
-    working_directory: /go/src/github.com/u-root/u-root
+      - image: uroottest/test-image-amd64:v5.1.0
+    working_directory: /home/circleci/go/src/github.com/u-root/u-root
     environment:
-      - UROOT_SOURCE: /go/src/github.com/u-root/u-root
+      - UROOT_SOURCE: /home/circleci/go/src/github.com/u-root/u-root
       - CGO_ENABLED: 0
       # x7 all timeouts for QEMU VM tests since they run without KVM.
       - UROOT_QEMU_TIMEOUT_X: 7
 
   integration-template:
     &integration-template
-    working_directory: /go/src/github.com/u-root/u-root
+    working_directory: /home/circleci/go/src/github.com/u-root/u-root
     environment:
-      - UROOT_SOURCE: /go/src/github.com/u-root/u-root
+      - UROOT_SOURCE: /home/circleci/go/src/github.com/u-root/u-root
       - CGO_ENABLED: 0
       # x7 all timeouts for QEMU VM tests since they run without KVM.
       - UROOT_QEMU_TIMEOUT_X: 7
@@ -24,7 +24,7 @@ templates:
       - checkout
       - run:
           name: Test integration
-          command: UROOT_SOURCE=/go/src/github.com/u-root/u-root
+          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root
             UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=15m
             -ldflags='-s' -failfast ./integration/...
           no_output_timeout: 15m
@@ -60,14 +60,14 @@ jobs:
       - checkout
       - run:
           name: Test Packages
-          command: UROOT_SOURCE=/go/src/github.com/u-root/u-root go test -v -a
+          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root go test -v -a
             -timeout=20m -ldflags='-s' -failfast -coverprofile=coverage_pkg.txt
             -covermode=atomic -coverpkg=./pkg/... ./pkg/...
           no_output_timeout: 15m
 
       - run:
           name: Test coverage
-          command: UROOT_SOURCE=/go/src/github.com/u-root/u-root
+          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root
             UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -timeout=20m
             -failfast -coverprofile=coverage.txt -covermode=atomic -cover
             ./cmds/... ./pkg/...
@@ -94,7 +94,7 @@ jobs:
       - checkout
       - run:
           name: Race detector
-          command: UROOT_SOURCE=/go/src/github.com/u-root/u-root go test -race
+          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root go test -race
             -timeout=15m -failfast ./cmds/... ./pkg/...
 
   compile_cmds:
@@ -154,14 +154,14 @@ jobs:
   test-integration-amd64:
     <<: *integration-template
     docker:
-      - image: uroottest/test-image-amd64:v5.0.0
+      - image: uroottest/test-image-amd64:v5.1.0
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
     resource_class: large
 
   test-integration-arm:
     <<: *integration-template
     docker:
-      - image: uroottest/test-image-arm:v5.0.0
+      - image: uroottest/test-image-arm:v5.1.0
 
   # This arch needs a different working dir, so don't use integration-template
   test-integration-arm64:

--- a/.circleci/images/test-image-amd64/Dockerfile
+++ b/.circleci/images/test-image-amd64/Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM circleci/golang:1.17
+FROM cimg/go:1.19
 
 # Install dependencies
 RUN sudo apt-get update &&                          \
@@ -73,13 +73,13 @@ RUN set -eux;                                                          \
 
 # Build Multiboot kernel
 RUN set -eux;                                                          \
-    git clone --depth=1 --branch=v1.01                                 \
-           https://github.com/u-root/multiboot-test-kernel;            \
+    git clone --depth=1                                                \
+    https://github.com/u-root/multiboot-test-kernel;                   \
     cd multiboot-test-kernel;                                          \
+    git checkout 1c7e4f4722077dcab308cd1df9818eab011e58c4;             \
     make;                                                              \
     cd ~;                                                              \
-    cp multiboot-test-kernel/kernel ./;                                \
-    gzip -k kernel;                                                    \
+    cp multiboot-test-kernel/kernel.gz ./;                             \
     rm -rf multiboot-test-kernel/
 
 SHELL ["/bin/bash", "-c"]

--- a/.circleci/images/test-image-arm/Dockerfile
+++ b/.circleci/images/test-image-arm/Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM circleci/golang:1.17
+FROM cimg/go:1.19
 
 # Install dependencies
 RUN sudo apt-get update &&                          \

--- a/.circleci/images/test-image-arm64/Dockerfile
+++ b/.circleci/images/test-image-arm64/Dockerfile
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-FROM cimg/go:1.17
+FROM cimg/go:1.19
 
 # Install dependencies
 RUN sudo apt-get update &&                          \

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,14 +16,14 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
     - name: Install golangci-lint
       run: |
         cd ..
-        go get golang.org/x/lint/golint
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.30.0
+        go install golang.org/x/lint/golint@latest
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.50.0
     - name: Install ineffassign
-      run: (cd .. && go get github.com/gordonklaus/ineffassign)
+      run: (cd .. && go install github.com/gordonklaus/ineffassign@latest)
     - name: Check vendored dependencies
       run: |
         go mod tidy
@@ -63,7 +63,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
 
     - name: Build
       run: go build -mod=mod -v ./...
@@ -83,7 +83,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17
+        go-version: 1.19
 
     - name: Build fail
       id: buildfail

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ like `./u-root -uroot-source ./`
 
 # Usage
 
-Make sure your Go version is >=1.17.
+Make sure your Go version is >=1.19.
 
 Download and install u-root either via git:
 

--- a/cmds/boot/pxeboot/pxeboot.go
+++ b/cmds/boot/pxeboot/pxeboot.go
@@ -11,12 +11,12 @@
 // ServerName options (which may be embedded in the original BOOTP message, or
 // as option codes) to find something to boot.
 //
-// This BootFileName may point to
+// This BootFileName may point to:
 //
 // - an iPXE script beginning with #!ipxe
 //
-// - a pxelinux.0, in which case we will ignore the pxelinux and try to parse
-//   pxelinux.cfg/<files>
+//   - a pxelinux.0, in which case we will ignore the pxelinux and try to parse
+//     pxelinux.cfg/<files>
 package main
 
 import (

--- a/cmds/contrib/flash/flash.go
+++ b/cmds/contrib/flash/flash.go
@@ -5,33 +5,37 @@
 // flash reads and writes to a flash chip.
 //
 // Synopsis:
-//     flash -p PROGRAMMER[:parameter[,parameter[...]]] [-r FILE|-w FILE]
+//
+//	flash -p PROGRAMMER[:parameter[,parameter[...]]] [-r FILE|-w FILE]
 //
 // Options:
-//     -p PROGRAMMER: Specify the programmer with zero or more parameters (see
-//                    below).
-//     -r FILE: Read flash data into the file.
-//     -w FILE: Write the file to the flash chip. First, the flash chip is read
-//              and then diffed against the file. The differing blocks are
-//              erased and written. Finally, the contents are verified.
+//
+//	-p PROGRAMMER: Specify the programmer with zero or more parameters (see
+//	               below).
+//	-r FILE: Read flash data into the file.
+//	-w FILE: Write the file to the flash chip. First, the flash chip is read
+//	         and then diffed against the file. The differing blocks are
+//	         erased and written. Finally, the contents are verified.
 //
 // Programmers:
-//     dummy
-//       Virtual flash programmer for testing in a memory buffer.
 //
-//       dummy:image=image.rom
-//         File to memmap for the memory buffer.
+//	dummy
+//	  Virtual flash programmer for testing in a memory buffer.
 //
-//     linux_spi:dev=/dev/spidev0.0
-//       Use Linux's spidev driver. This is only supported on Linux. The dev
-//       parameter is required.
+//	  dummy:image=image.rom
+//	    File to memmap for the memory buffer.
 //
-//       linux_spi:dev=/dev/spidev0.0,spispeed=5000
-//         Set the SPI controller's speed. The frequency is in kilohertz.
+//	linux_spi:dev=/dev/spidev0.0
+//	  Use Linux's spidev driver. This is only supported on Linux. The dev
+//	  parameter is required.
+//
+//	  linux_spi:dev=/dev/spidev0.0,spispeed=5000
+//	    Set the SPI controller's speed. The frequency is in kilohertz.
 //
 // Description:
-//     flash is u-root's implementation of flashrom. It has a very limited
-//     feature set and depends on the the flash chip implementing the SFDP.
+//
+//	flash is u-root's implementation of flashrom. It has a very limited
+//	feature set and depends on the the flash chip implementing the SFDP.
 package main
 
 import (

--- a/cmds/contrib/spidev/spidev.go
+++ b/cmds/contrib/spidev/spidev.go
@@ -5,17 +5,20 @@
 // spidev communicates with the Linux spidev driver.
 //
 // Synopsis:
-//     spidev [OPTIONS] raw < tx.bin > rx.bin
-//     spidev [OPTIONS] sfdp
+//
+//	spidev [OPTIONS] raw < tx.bin > rx.bin
+//	spidev [OPTIONS] sfdp
 //
 // Options:
-//     -D DEV: spidev device (default /dev/spidev0.0)
-//     -s SPEED: max speed in Hz (default 500000)
+//
+//	-D DEV: spidev device (default /dev/spidev0.0)
+//	-s SPEED: max speed in Hz (default 500000)
 //
 // Description:
-//     raw: The binary data from stdin is transmitted over the SPI bus.
-//          Received data is printed to stdout.
-//     sfdp: Parse and print the parameters in the SFDP.
+//
+//	raw: The binary data from stdin is transmitted over the SPI bus.
+//	     Received data is printed to stdout.
+//	sfdp: Parse and print the parameters in the SFDP.
 package main
 
 import (

--- a/cmds/core/basename/basename.go
+++ b/cmds/core/basename/basename.go
@@ -5,8 +5,8 @@
 // Basename return name with leading path information removed.
 //
 // Synopsis:
-//     basename NAME [SUFFIX]
 //
+//	basename NAME [SUFFIX]
 package main
 
 import (

--- a/cmds/core/cat/cat.go
+++ b/cmds/core/cat/cat.go
@@ -5,13 +5,16 @@
 // cat concatenates files and prints them to stdout.
 //
 // Synopsis:
-//     cat [-u] [FILES]...
+//
+//	cat [-u] [FILES]...
 //
 // Description:
-//     If no files are specified, read from stdin.
+//
+//	If no files are specified, read from stdin.
 //
 // Options:
-//     -u: ignored flag
+//
+//	-u: ignored flag
 package main
 
 import (

--- a/cmds/core/chmod/chmod.go
+++ b/cmds/core/chmod/chmod.go
@@ -5,10 +5,12 @@
 // chmod changes mode bits (e.g. permissions) of a file.
 //
 // Synopsis:
-//     chmod MODE FILE...
+//
+//	chmod MODE FILE...
 //
 // Desription:
-//     MODE is a three character octal value or a string like a=rwx
+//
+//	MODE is a three character octal value or a string like a=rwx
 package main
 
 import (

--- a/cmds/core/cmp/cmp.go
+++ b/cmds/core/cmp/cmp.go
@@ -5,20 +5,23 @@
 // cmp compares two files and prints a message if their contents differ.
 //
 // Synopsis:
-//     cmp [–lLs] FILE1 FILE2 [OFFSET1 [OFFSET2]]
+//
+//	cmp [–lLs] FILE1 FILE2 [OFFSET1 [OFFSET2]]
 //
 // Description:
-//     If offsets are given, comparison starts at the designated byte position
-//     of the corresponding file.
 //
-//     Offsets that begin with 0x are hexadecimal; with 0, octal; with anything
-//     else, decimal.
+//	If offsets are given, comparison starts at the designated byte position
+//	of the corresponding file.
+//
+//	Offsets that begin with 0x are hexadecimal; with 0, octal; with anything
+//	else, decimal.
 //
 // Options:
-//     –l: Print the byte number (decimal) and the differing bytes (octal) for
-//         each difference.
-//     –L: Print the line number of the first differing byte.
-//     –s: Print nothing for differing files, but set the exit status.
+//
+//	–l: Print the byte number (decimal) and the differing bytes (octal) for
+//	    each difference.
+//	–L: Print the line number of the first differing byte.
+//	–s: Print nothing for differing files, but set the exit status.
 package main
 
 import (

--- a/cmds/core/comm/comm.go
+++ b/cmds/core/comm/comm.go
@@ -5,19 +5,22 @@
 // comm compares two files.
 //
 // Synopsis:
-//     comm [-123h] FILE1 FILE2
+//
+//	comm [-123h] FILE1 FILE2
 //
 // Descrption:
-//     Comm reads file1 and file2, which are in lexicographical order, and
-//     produces a three column output: lines only in file1; lines only in
-//     file2; and lines in both files. The file name – means the standard
-//     input.
+//
+//	Comm reads file1 and file2, which are in lexicographical order, and
+//	produces a three column output: lines only in file1; lines only in
+//	file2; and lines in both files. The file name – means the standard
+//	input.
 //
 // Options:
-//     -1: suppress printing of column 1
-//     -2: suppress printing of column 2
-//     -3: suppress printing of column 3
-//     -h: print this help message and exit
+//
+//	-1: suppress printing of column 1
+//	-2: suppress printing of column 2
+//	-3: suppress printing of column 3
+//	-h: print this help message and exit
 package main
 
 import (

--- a/cmds/core/cp/cp.go
+++ b/cmds/core/cp/cp.go
@@ -5,16 +5,18 @@
 // cp copies files.
 //
 // Synopsis:
-//     cp [-rRfivwP] FROM... TO
+//
+//	cp [-rRfivwP] FROM... TO
 //
 // Options:
-//     -w n: number of worker goroutines
-//     -R: copy file hierarchies
-//     -r: alias to -R recursive mode
-//     -i: prompt about overwriting file
-//     -f: force overwrite files
-//     -v: verbose copy mode
-//     -P: don't follow symlinks
+//
+//	-w n: number of worker goroutines
+//	-R: copy file hierarchies
+//	-r: alias to -R recursive mode
+//	-i: prompt about overwriting file
+//	-f: force overwrite files
+//	-v: verbose copy mode
+//	-P: don't follow symlinks
 package main
 
 import (

--- a/cmds/core/cpio/cpio.go
+++ b/cmds/core/cpio/cpio.go
@@ -5,17 +5,18 @@
 // cpio operates on cpio files using a cpio package
 // It only implements basic cpio options.
 //
-//
 // Synopsis:
-//     cpio
+//
+//	cpio
 //
 // Description:
 //
 // Options:
-//     o: output an archive to stdout given a pattern
-//     i: output files from a stdin stream
-//     t: print table of contents
-//     -v: debug prints
+//
+//	o: output an archive to stdout given a pattern
+//	i: output files from a stdin stream
+//	t: print table of contents
+//	-v: debug prints
 //
 // Bugs: in i mode, it can't use non-seekable stdin, i.e. a pipe. Yep, this sucks.
 // But if we implement seek on such things, we have to do it by reading, which

--- a/cmds/core/date/date.go
+++ b/cmds/core/date/date.go
@@ -5,7 +5,8 @@
 // date prints the date.
 //
 // Synopsis:
-//     date [-u] [+format] | date [-u] [MMDDhhmm[CC]YY[.ss]]
+//
+//	date [-u] [+format] | date [-u] [MMDDhhmm[CC]YY[.ss]]
 package main
 
 import (

--- a/cmds/core/dd/dd.go
+++ b/cmds/core/dd/dd.go
@@ -5,31 +5,35 @@
 // dd converts and copies a file.
 //
 // Synopsis:
-//     dd [OPTIONS...] [-inName FILE] [-outName FILE]
+//
+//	dd [OPTIONS...] [-inName FILE] [-outName FILE]
 //
 // Description:
-//     dd is modeled after dd(1).
+//
+//	dd is modeled after dd(1).
 //
 // Options:
-//     -ibs n:   input block size (default=1)
-//     -obs n:   output block size (default=1)
-//     -bs n:    input and output block size (default=0)
-//     -skip n:  skip n ibs-sized input blocks before reading (default=0)
-//     -seek n:  seek n obs-sized output blocks before writing (default=0)
-//     -conv s:  comma separated list of conversions (none|notrunc)
-//     -count n: copy only n ibs-sized input blocks
-//     -if:      defaults to stdin
-//     -of:      defaults to stdout
-//     -oflag:   comma separated list of out flags (none|sync|dsync)
-//     -status:  print transfer stats to stderr, can be one of:
-//         none:     do not display
-//         xfer:     print on completion (default)
-//         progress: print throughout transfer (GNU)
+//
+//	-ibs n:   input block size (default=1)
+//	-obs n:   output block size (default=1)
+//	-bs n:    input and output block size (default=0)
+//	-skip n:  skip n ibs-sized input blocks before reading (default=0)
+//	-seek n:  seek n obs-sized output blocks before writing (default=0)
+//	-conv s:  comma separated list of conversions (none|notrunc)
+//	-count n: copy only n ibs-sized input blocks
+//	-if:      defaults to stdin
+//	-of:      defaults to stdout
+//	-oflag:   comma separated list of out flags (none|sync|dsync)
+//	-status:  print transfer stats to stderr, can be one of:
+//	    none:     do not display
+//	    xfer:     print on completion (default)
+//	    progress: print throughout transfer (GNU)
 //
 // Notes:
-//     Because UTF-8 clashes with block-oriented copying, `conv=lcase` and
-//     `conv=ucase` will not be supported. Additionally, research showed these
-//     arguments are rarely useful. Use tr instead.
+//
+//	Because UTF-8 clashes with block-oriented copying, `conv=lcase` and
+//	`conv=ucase` will not be supported. Additionally, research showed these
+//	arguments are rarely useful. Use tr instead.
 package main
 
 import (

--- a/cmds/core/dhclient/dhclient.go
+++ b/cmds/core/dhclient/dhclient.go
@@ -8,12 +8,14 @@
 // dhclient sets up network config using DHCP.
 //
 // Synopsis:
-//     dhclient [OPTIONS...]
+//
+//	dhclient [OPTIONS...]
 //
 // Options:
-//     -timeout:  lease timeout in seconds
-//     -renewals: number of DHCP renewals before exiting
-//     -verbose:  verbose output
+//
+//	-timeout:  lease timeout in seconds
+//	-renewals: number of DHCP renewals before exiting
+//	-verbose:  verbose output
 package main
 
 import (

--- a/cmds/core/dmesg/dmesg.go
+++ b/cmds/core/dmesg/dmesg.go
@@ -7,11 +7,13 @@
 // dmesg reads the system log.
 //
 // Synopsis:
-//     dmesg [-clear|-read-clear]
+//
+//	dmesg [-clear|-read-clear]
 //
 // Options:
-//     -clear: clear the log
-//     -read-clear: clear the log after printing
+//
+//	-clear: clear the log
+//	-read-clear: clear the log after printing
 package main
 
 import (

--- a/cmds/core/echo/echo.go
+++ b/cmds/core/echo/echo.go
@@ -6,7 +6,8 @@
 // the standard output.
 //
 // Synopsis:
-//     echo [-e] [-n] [-E] [STRING]...
+//
+//	echo [-e] [-n] [-E] [STRING]...
 package main
 
 import (

--- a/cmds/core/false/false.go
+++ b/cmds/core/false/false.go
@@ -5,10 +5,12 @@
 // false returns 1.
 //
 // Synopsis:
-//     false
+//
+//	false
 //
 // Description:
-//     Command line arguments are ignored.
+//
+//	Command line arguments are ignored.
 package main
 
 import "os"

--- a/cmds/core/find/find.go
+++ b/cmds/core/find/find.go
@@ -6,11 +6,12 @@
 // for matching.
 //
 // OPTIONS:
-//     -d: enable debugging in the find package
-//     -mode integer-arg: match against mode, e.g. -mode 0755
-//     -type: match against a file type, e.g. -type f will match files
-//     -name: glob to match against file
-//     -l: long listing. It's not very good, yet, but it's useful enough.
+//
+//	-d: enable debugging in the find package
+//	-mode integer-arg: match against mode, e.g. -mode 0755
+//	-type: match against a file type, e.g. -type f will match files
+//	-name: glob to match against file
+//	-l: long listing. It's not very good, yet, but it's useful enough.
 package main
 
 import (

--- a/cmds/core/free/free.go
+++ b/cmds/core/free/free.go
@@ -8,19 +8,22 @@
 // free reports usage information for physical memory and swap space.
 //
 // Synopsis:
-//     free [-k] [-m] [-g] [-t] [-h] [-json]
+//
+//	free [-k] [-m] [-g] [-t] [-h] [-json]
 //
 // Description:
-//     Read memory information from /proc/meminfo and display a summary for
-//     physical memory and swap space. The unit options use powers of 1024.
+//
+//	Read memory information from /proc/meminfo and display a summary for
+//	physical memory and swap space. The unit options use powers of 1024.
 //
 // Options:
-//     -k: display the values in kibibytes
-//     -m: display the values in mebibytes
-//     -g: display the values in gibibytes
-//     -t: display the values in tebibytes
-//     -h: display the values in human-readable form
-//     -json: use JSON output
+//
+//	-k: display the values in kibibytes
+//	-m: display the values in mebibytes
+//	-g: display the values in gibibytes
+//	-t: display the values in tebibytes
+//	-h: display the values in human-readable form
+//	-json: use JSON output
 package main
 
 import (

--- a/cmds/core/fusermount/fusermount.go
+++ b/cmds/core/fusermount/fusermount.go
@@ -9,7 +9,8 @@
 // is invoked by other programs, or interactively only to unmount.
 //
 // Synopsis:
-//     fusermount [-u|--unmount] [-z|--lazy] [-v|--verbose] <mountpoint>
+//
+//	fusermount [-u|--unmount] [-z|--lazy] [-v|--verbose] <mountpoint>
 //
 // For mounting, per the FUSE model, the environment variable
 // _FUSE_COMMFD must have the value of a file descriptor variable on
@@ -20,6 +21,7 @@
 // kernels do.
 //
 // Description:
+//
 //	invoke fuse mount operations
 package main
 

--- a/cmds/core/gpgv/gpgv.go
+++ b/cmds/core/gpgv/gpgv.go
@@ -5,21 +5,25 @@
 // gpgv validates a signature against a file.
 //
 // Synopsis:
-//     gpgv [-v] KEY SIG CONTENT
+//
+//	gpgv [-v] KEY SIG CONTENT
 //
 // Description:
-//     It prints "OK\n" to stdout if the check succeeds and exits with 0. It
-//     prints an error message and exits with non-0 otherwise.
 //
-//     The openpgp package ReadKeyRing function does not completely implement
-//     RFC4880 in that it can't use a PublicSigningKey with 0 signatures. We
-//     use one from Eric Grosse instead.
+//	It prints "OK\n" to stdout if the check succeeds and exits with 0. It
+//	prints an error message and exits with non-0 otherwise.
+//
+//	The openpgp package ReadKeyRing function does not completely implement
+//	RFC4880 in that it can't use a PublicSigningKey with 0 signatures. We
+//	use one from Eric Grosse instead.
 //
 // Options:
-//     -v: verbose
+//
+//	-v: verbose
 //
 // Author:
-//     grosse@gmail.com.
+//
+//	grosse@gmail.com.
 package main
 
 import (

--- a/cmds/core/gpt/gpt.go
+++ b/cmds/core/gpt/gpt.go
@@ -5,13 +5,15 @@
 // gpt reads and writes GPT headers.
 //
 // Synopsis:
-//     gpt [-w] file
+//
+//	gpt [-w] file
 //
 // Description:
-//     For -w, it reads a JSON formatted GPT from stdin, and writes 'file'
-//     which is usually a device. It writes both primary and secondary headers.
 //
-//     Otherwise it just writes the headers to stdout in JSON format.
+//	For -w, it reads a JSON formatted GPT from stdin, and writes 'file'
+//	which is usually a device. It writes both primary and secondary headers.
+//
+//	Otherwise it just writes the headers to stdout in JSON format.
 package main
 
 import (

--- a/cmds/core/grep/grep.go
+++ b/cmds/core/grep/grep.go
@@ -5,13 +5,15 @@
 // grep searches file contents using regular expressions.
 //
 // Synopsis:
-//     grep [-vrlq] [FILE]...
+//
+//	grep [-vrlq] [FILE]...
 //
 // Options:
-//     -v: print only non-matching lines
-//     -r: recursive
-//     -l: list only files
-//     -q: don't print matches; exit on first match
+//
+//	-v: print only non-matching lines
+//	-r: recursive
+//	-l: list only files
+//	-q: don't print matches; exit on first match
 package main
 
 import (

--- a/cmds/core/hexdump/hexdump.go
+++ b/cmds/core/hexdump/hexdump.go
@@ -5,11 +5,13 @@
 // hexdump prints file content in hexadecimal.
 //
 // Synopsis:
-//     hexdump [FILES]...
+//
+//	hexdump [FILES]...
 //
 // Description:
-//     Concatenate the input files into a single hexdump. If there are no
-//     arguments, stdin is read.
+//
+//	Concatenate the input files into a single hexdump. If there are no
+//	arguments, stdin is read.
 package main
 
 import (

--- a/cmds/core/hostname/hostname.go
+++ b/cmds/core/hostname/hostname.go
@@ -5,10 +5,12 @@
 // hostname prints or changes the system's hostname.
 //
 // Synopsis:
-//     hostname [HOSTNAME]
+//
+//	hostname [HOSTNAME]
 //
 // Author:
-//     Beletti <rhiguita@gmail.com>
+//
+//	Beletti <rhiguita@gmail.com>
 package main
 
 import (

--- a/cmds/core/hwclock/hwclock.go
+++ b/cmds/core/hwclock/hwclock.go
@@ -5,14 +5,17 @@
 // hwclock reads or changes the hardware clock (RTC) in UTC format.
 //
 // Synopsis:
-//     hwclock [-w]
+//
+//	hwclock [-w]
 //
 // Description:
-//     It prints the current hwclock time in UTC if called without any flags.
-//     It sets the hwclock to the system clock in UTC if called with -w.
+//
+//	It prints the current hwclock time in UTC if called without any flags.
+//	It sets the hwclock to the system clock in UTC if called with -w.
 //
 // Options:
-//     -w: set hwclock to system clock in UTC
+//
+//	-w: set hwclock to system clock in UTC
 package main
 
 import (

--- a/cmds/core/id/id.go
+++ b/cmds/core/id/id.go
@@ -8,12 +8,15 @@
 // id displays the user id, group id, and groups of the calling process.
 //
 // Synopsis:
-//      id [-gGnu]
+//
+//	id [-gGnu]
 //
 // Description:
-//      id displays the uid, gid and groups of the calling process
+//
+//	id displays the uid, gid and groups of the calling process
 //
 // Options:
+//
 //	-g, --group     print only the effective group ID
 //	-G, --groups    print all group IDs
 //	-n, --name      print a name instead of a number, for -ugG

--- a/cmds/core/insmod/insmod_linux.go
+++ b/cmds/core/insmod/insmod_linux.go
@@ -5,9 +5,11 @@
 // insmod inserts a module into the running Linux kernel.
 //
 // Synopsis:
+//
 //	insmod [filename] [module options...]
 //
 // Description:
+//
 //	insmod is a clone of insmod(8)
 package main
 

--- a/cmds/core/io/io.go
+++ b/cmds/core/io/io.go
@@ -5,26 +5,30 @@
 // io reads and writes to physical memory and ports.
 //
 // Synopsis:
-//     io (r{b,w,l,q} address)...
-//     io (w{b,w,l,q} address value)...
-//     # x86 only:
-//     io (in{b,w,l} address)
-//     io (out{b,w,l} address value)
-//     io (cr index}
-//     io {cw index value}...
+//
+//	io (r{b,w,l,q} address)...
+//	io (w{b,w,l,q} address value)...
+//	# x86 only:
+//	io (in{b,w,l} address)
+//	io (out{b,w,l} address value)
+//	io (cr index}
+//	io {cw index value}...
 //
 // Description:
-//     io lets you read/write 1/2/4/8-bytes to memory with the {r,w}{b,w,l,q}
-//     commands respectively.
 //
-//     On x86 platforms, {in,out}{b,w,l} allow for port io.
+//	io lets you read/write 1/2/4/8-bytes to memory with the {r,w}{b,w,l,q}
+//	commands respectively.
 //
-//     Use cr / cw to write to cmos registers
+//	On x86 platforms, {in,out}{b,w,l} allow for port io.
+//
+//	Use cr / cw to write to cmos registers
+//
 // Examples:
-//     # Read 8-bytes from address 0x10000 and 0x10000
-//     io rq 0x10000 rq 0x10008
-//     # Write to the serial port on x86
-//     io outb 0x3f8 50
+//
+//	# Read 8-bytes from address 0x10000 and 0x10000
+//	io rq 0x10000 rq 0x10008
+//	# Write to the serial port on x86
+//	io outb 0x3f8 50
 package main
 
 import (

--- a/cmds/core/kill/kill.go
+++ b/cmds/core/kill/kill.go
@@ -8,16 +8,18 @@
 // Kill kills processes.
 //
 // Synopsis:
-//     kill -l
-//     kill [<-s | --signal | -> <isgname|signum>] pid [pid...]
+//
+//	kill -l
+//	kill [<-s | --signal | -> <isgname|signum>] pid [pid...]
 //
 // Options:
-//     -l:                       list the signal names
-//     -name, --signal name, -s: name is the message to send. On some systems
-//                               this is a string, on others a number. It is
-//                               optional and an OS-dependent value will be
-//                               used if it is not set. pid is a list of at
-//                               least one pid.
+//
+//	-l:                       list the signal names
+//	-name, --signal name, -s: name is the message to send. On some systems
+//	                          this is a string, on others a number. It is
+//	                          optional and an OS-dependent value will be
+//	                          used if it is not set. pid is a list of at
+//	                          least one pid.
 package main
 
 import (

--- a/cmds/core/lddfiles/lddfiles_linux.go
+++ b/cmds/core/lddfiles/lddfiles_linux.go
@@ -5,6 +5,7 @@
 // lddfiles prints the arguments and all .so dependencies of those arguments
 //
 // Description:
+//
 //	lddfiles prints the arguments on the command line and all .so's
 //	on which they depend. In some cases, those .so's are actually symlinks;
 //	in that case, the symlink and its value are printed.

--- a/cmds/core/ln/ln.go
+++ b/cmds/core/ln/ln.go
@@ -5,21 +5,24 @@
 // Ln makes links to files.
 //
 // Synopsis:
-//     ln [-svfTiLPrt] TARGET LINK
+//
+//	ln [-svfTiLPrt] TARGET LINK
 //
 // Options:
-//     -s: make symbolic links instead of hard links
-//     -v: print name of each linked file
-//     -f: remove destination files
-//     -T: treat linkname operand as a non-dir always
-//     -i: prompt if the user wants overwrite
-//     -L: dereference targets if are symbolic links
-//     -P: make hard links directly to symbolic links
-//     -r: create symlinks relative to link location
-//     -t: specify the directory to put the links
+//
+//	-s: make symbolic links instead of hard links
+//	-v: print name of each linked file
+//	-f: remove destination files
+//	-T: treat linkname operand as a non-dir always
+//	-i: prompt if the user wants overwrite
+//	-L: dereference targets if are symbolic links
+//	-P: make hard links directly to symbolic links
+//	-r: create symlinks relative to link location
+//	-t: specify the directory to put the links
 //
 // Author:
-//     Manoel Vilela <manoel_vilela@engineer.com>
+//
+//	Manoel Vilela <manoel_vilela@engineer.com>
 package main
 
 import (

--- a/cmds/core/losetup/losetup_linux.go
+++ b/cmds/core/losetup/losetup_linux.go
@@ -5,12 +5,14 @@
 // losetup sets up and controls loop devices.
 //
 // Synopsis:
-//     losetup [-Ad] FILE
-//     losetup [-Ad] DEV FILE
+//
+//	losetup [-Ad] FILE
+//	losetup [-Ad] DEV FILE
 //
 // Options:
-//     -A: pick any device
-//     -d: detach the device
+//
+//	-A: pick any device
+//	-d: detach the device
 package main
 
 import (

--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -5,16 +5,19 @@
 // ls prints the contents of a directory.
 //
 // Synopsis:
-//     ls [OPTIONS] [DIRS]...
+//
+//	ls [OPTIONS] [DIRS]...
 //
 // Options:
-//     -l: long form
-//     -Q: quoted
-//     -R: equivalent to findutil's find
-//     -F: append indicator (one of */=>@|) to entries
+//
+//	-l: long form
+//	-Q: quoted
+//	-R: equivalent to findutil's find
+//	-F: append indicator (one of */=>@|) to entries
 //
 // Bugs:
-//     With the `-R` flag, directories are only ever printed once.
+//
+//	With the `-R` flag, directories are only ever printed once.
 package main
 
 import (

--- a/cmds/core/lsdrivers/main_linux.go
+++ b/cmds/core/lsdrivers/main_linux.go
@@ -5,13 +5,16 @@
 // lsdrivers lists driver usage on Linux systems
 //
 // Synopsis:
-//     lsdrivers [-u]
+//
+//	lsdrivers [-u]
 //
 // Description:
-//     List driver usage. This program is mostly useful for scripts.
+//
+//	List driver usage. This program is mostly useful for scripts.
 //
 // Options:
-//     -u: list unused drivers
+//
+//	-u: list unused drivers
 package main
 
 import (

--- a/cmds/core/lsmod/lsmod_linux.go
+++ b/cmds/core/lsmod/lsmod_linux.go
@@ -5,13 +5,16 @@
 // lsmod list currently loaded Linux kernel modules.
 //
 // Synopsis:
+//
 //	lsmod
 //
 // Description:
+//
 //	lsmod is a clone of lsmod(8)
 //
 // Author:
-//     Roland Kammerer <dev.rck@gmail.com>
+//
+//	Roland Kammerer <dev.rck@gmail.com>
 package main
 
 import (

--- a/cmds/core/man/man.go
+++ b/cmds/core/man/man.go
@@ -5,7 +5,8 @@
 // man - print manual entry for command.
 //
 // Synopsis:
-//     man COMMAND
+//
+//	man COMMAND
 package main
 
 import (

--- a/cmds/core/mkdir/mkdir.go
+++ b/cmds/core/mkdir/mkdir.go
@@ -5,12 +5,14 @@
 // mkdir makes a new directory.
 //
 // Synopsis:
-//     mkdir [-m mode] [-v] [-p] DIRECTORY...
+//
+//	mkdir [-m mode] [-v] [-p] DIRECTORY...
 //
 // Options:
-//     -m: make all needed directories in the path
-//     -v: directory mode (ex: 666)
-//     -p: print each directory as it is made
+//
+//	-m: make all needed directories in the path
+//	-v: directory mode (ex: 666)
+//	-p: print each directory as it is made
 package main
 
 import (

--- a/cmds/core/mkfifo/mkfifo.go
+++ b/cmds/core/mkfifo/mkfifo.go
@@ -8,11 +8,12 @@
 // mkfifo creates a named pipe.
 //
 // Synopsis:
-//     mkfifo [OPTIONS] NAME...
+//
+//	mkfifo [OPTIONS] NAME...
 //
 // Options:
-//     -m: mode (default 0600)
 //
+//	-m: mode (default 0600)
 package main
 
 import (

--- a/cmds/core/mknod/mknod.go
+++ b/cmds/core/mknod/mknod.go
@@ -8,12 +8,14 @@
 // Unmount a filesystem at the specified path.
 //
 // Synopsis:
-//     mknod PATH TYPE [MAJOR MINOR]
+//
+//	mknod PATH TYPE [MAJOR MINOR]
 //
 // Description:
-//     Creates a special file at PATH of the given TYPE. If TYPE is b, c or u,
-//     the MAJOR and MINOR number must be specified. If the TYPE is p, they
-//     must not be specified.
+//
+//	Creates a special file at PATH of the given TYPE. If TYPE is b, c or u,
+//	the MAJOR and MINOR number must be specified. If the TYPE is p, they
+//	must not be specified.
 package main
 
 import (

--- a/cmds/core/mktemp/mktemp.go
+++ b/cmds/core/mktemp/mktemp.go
@@ -5,26 +5,27 @@
 // Mktemp makes a temporary file (or directory)
 //
 // Synopsis:
-//       mktemp [OPTION]... [TEMPLATE]
 //
-//       Create  a  temporary  file or directory, safely, and print its name.  TEMPLATE must contain at least 3 consecutive 'X's in last component.  If TEMPLATE is not specified, use tmp.XXXXXXXXXX, and --tmpdir is implied.  Files are
-//       created u+rw, and directories u+rwx, minus umask restrictions.
+//	mktemp [OPTION]... [TEMPLATE]
 //
-//       -d, --directory
-//              create a directory, not a file
+//	Create  a  temporary  file or directory, safely, and print its name.  TEMPLATE must contain at least 3 consecutive 'X's in last component.  If TEMPLATE is not specified, use tmp.XXXXXXXXXX, and --tmpdir is implied.  Files are
+//	created u+rw, and directories u+rwx, minus umask restrictions.
 //
-//       -u, --dry-run
-//              do not create anything; merely print a name (unsafe)
+//	-d, --directory
+//	       create a directory, not a file
 //
-//       -q, --quiet
-//              suppress diagnostics about file/dir-creation failure
+//	-u, --dry-run
+//	       do not create anything; merely print a name (unsafe)
 //
-//       --suffix=SUFF
-//              append SUFF to TEMPLATE; SUFF must not contain a slash.  This option is implied if TEMPLATE does not end in X
+//	-q, --quiet
+//	       suppress diagnostics about file/dir-creation failure
 //
-//       -p DIR, --tmpdir[=DIR]
-//              interpret TEMPLATE relative to DIR; if DIR is not specified, use $TMPDIR if set, else /tmp.  With this option, TEMPLATE must not be an absolute name; unlike with -t, TEMPLATE may contain  slashes,  but  mktemp  creates
-//              only the final component
+//	--suffix=SUFF
+//	       append SUFF to TEMPLATE; SUFF must not contain a slash.  This option is implied if TEMPLATE does not end in X
+//
+//	-p DIR, --tmpdir[=DIR]
+//	       interpret TEMPLATE relative to DIR; if DIR is not specified, use $TMPDIR if set, else /tmp.  With this option, TEMPLATE must not be an absolute name; unlike with -t, TEMPLATE may contain  slashes,  but  mktemp  creates
+//	       only the final component
 package main
 
 import (

--- a/cmds/core/more/more.go
+++ b/cmds/core/more/more.go
@@ -5,16 +5,19 @@
 // More pages through files without any terminal trickery.
 //
 // Synopsis:
-//     more [OPTIONS] FILE
+//
+//	more [OPTIONS] FILE
 //
 // Description:
-//     Admittedly, this does not follow the conventions of GNU more. Instead,
-//     it is built with the goal of not relying on any special ttys, ioctls or
-//     special ANSI escapes. This is ideal when your terminal is already
-//     borked. For bells and whistles, look at less.
+//
+//	Admittedly, this does not follow the conventions of GNU more. Instead,
+//	it is built with the goal of not relying on any special ttys, ioctls or
+//	special ANSI escapes. This is ideal when your terminal is already
+//	borked. For bells and whistles, look at less.
 //
 // Options:
-//     --lines NUMBER: screen size in number of lines
+//
+//	--lines NUMBER: screen size in number of lines
 package main
 
 import (

--- a/cmds/core/mount/mount.go
+++ b/cmds/core/mount/mount.go
@@ -8,10 +8,12 @@
 // mount mounts a filesystem at the specified path.
 //
 // Synopsis:
-//     mount [-r] [-o options] [-t FSTYPE] DEV PATH
+//
+//	mount [-r] [-o options] [-t FSTYPE] DEV PATH
 //
 // Options:
-//     -r: read only
+//
+//	-r: read only
 package main
 
 import (

--- a/cmds/core/mount/mount_plan9.go
+++ b/cmds/core/mount/mount_plan9.go
@@ -8,14 +8,17 @@
 // Mount mounts servename on old, with an optional keypattern spec
 //
 // Synopsis:
-//	 mount [ option ... ] servename old [ spec ]
+//
+//	mount [ option ... ] servename old [ spec ]
 //
 // Description:
+//
 //	Mount modifies the name space of the current
 //	process and other processes in the same name space group
 //	(see https://9p.io/magic/man2html/1/bind).
 //
 // Options:
+//
 //	–b:	Both files must be directories. Add the new directory to the beginning of the union directory represented by the old file.
 //	–a:	Both files must be directories. Add the new directory to the end of the union directory represented by the old file.
 //	–c:	This can be used in addition to any of the above to permit creation in a union directory.

--- a/cmds/core/msr/doc_linux.go
+++ b/cmds/core/msr/doc_linux.go
@@ -5,73 +5,75 @@
 // msr -- read and write MSRs with regular command or Forth
 //
 // Synopsis:
-//     msr [OPTIONS] r glob MSR
-//     msr [OPTIONS] w glob MSR value
-//     msr [OPTIONS] forth-word [forth-word ...]
+//
+//	msr [OPTIONS] r glob MSR
+//	msr [OPTIONS] w glob MSR value
+//	msr [OPTIONS] forth-word [forth-word ...]
 //
 // Description:
-//    This program reads and writes sets of MSRs, while allowing
-//    them to by changed on a core by core or collective basis.
 //
-//    To read the msrs for 0 (sorry, the command is msr and the forth command
-//    is msr, making this a bit confusing):
-//    sudo msr 0 msr 0x3a reg rd
-//    Breaking that down:
-//    0 - for cpu 0
-//    msr - for take the glob, in this case 0, and push all matching filenames on the stack
-//    0x3a - for register 0x3a
-//    reg - convert to 32-bit integer and push
-//    rd - pop a 32-bit int and a []string and use them to read 1 or more MSRs
+//	This program reads and writes sets of MSRs, while allowing
+//	them to by changed on a core by core or collective basis.
 //
-//    for all:
-//    sudo msr "'*" msr 0x3a reg rd
+//	To read the msrs for 0 (sorry, the command is msr and the forth command
+//	is msr, making this a bit confusing):
+//	sudo msr 0 msr 0x3a reg rd
+//	Breaking that down:
+//	0 - for cpu 0
+//	msr - for take the glob, in this case 0, and push all matching filenames on the stack
+//	0x3a - for register 0x3a
+//	reg - convert to 32-bit integer and push
+//	rd - pop a 32-bit int and a []string and use them to read 1 or more MSRs
 //
-//    The "'" is needed to quote the * so forth does not think we're multiplying.
+//	for all:
+//	sudo msr "'*" msr 0x3a reg rd
 //
-//    Here is a breakdown, running msr with each command in turn:
-//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0
-//    0
-//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0 msr
-//    [/dev/cpu/0/msr]
-//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0 msr 0x3a
-//    [[/dev/cpu/0/msr] 0x3a]
-//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0 msr 0x3a reg
-//    [[/dev/cpu/0/msr] 58]
-//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0 msr 0x3a reg rd
-//    [0]
-//    rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$
+//	The "'" is needed to quote the * so forth does not think we're multiplying.
 //
-//    To read, then write all of them
-//    (the dup is so we have the msr list at TOS -- it's just a convenience)
-//    sudo msr 0 msr dup 0x3a reg rd 0x3a reg swap 1 u64 or wr
-//    to just write them
+//	Here is a breakdown, running msr with each command in turn:
+//	rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0
+//	0
+//	rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0 msr
+//	[/dev/cpu/0/msr]
+//	rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0 msr 0x3a
+//	[[/dev/cpu/0/msr] 0x3a]
+//	rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0 msr 0x3a reg
+//	[[/dev/cpu/0/msr] 58]
+//	rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ ./msr 0 msr 0x3a reg rd
+//	[0]
+//	rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$
 //
-//    Also, note, all the types are checked by assertions. The reg has to be
-//    32 bits, the val 64
+//	To read, then write all of them
+//	(the dup is so we have the msr list at TOS -- it's just a convenience)
+//	sudo msr 0 msr dup 0x3a reg rd 0x3a reg swap 1 u64 or wr
+//	to just write them
 //
-//    more examples:
-//    read reg 0x3a and leave the least of MSRs and values on TOS, to be
-//    printed at exit.
+//	Also, note, all the types are checked by assertions. The reg has to be
+//	32 bits, the val 64
 //
-//    sudo msr "'"* msr dup 0x3a reg rd
-//    [[/dev/cpu/0/msr /dev/cpu/1/msr /dev/cpu/2/msr /dev/cpu/3/msr] [5 5 5 5]]
+//	more examples:
+//	read reg 0x3a and leave the least of MSRs and values on TOS, to be
+//	printed at exit.
 //
-//    From there, the write is easy:
-//    sudo msr "'"* msr dup 0x3a reg rd 0x3a reg swap wr
+//	sudo msr "'"* msr dup 0x3a reg rd
+//	[[/dev/cpu/0/msr /dev/cpu/1/msr /dev/cpu/2/msr /dev/cpu/3/msr] [5 5 5 5]]
 //
-//    For convenience, we maintain the old read and write commands:
-//    msr r <glob> <register>
-//    msr w <glob> <register> <value>
+//	From there, the write is easy:
+//	sudo msr "'"* msr dup 0x3a reg rd 0x3a reg swap wr
 //
-//    Yep, it's a bit inconvenient; the idea is that in the simple case,
-//    you will use the r and w commands. For programmatic cases, you can
-//    work to build up a working set of arguments.
+//	For convenience, we maintain the old read and write commands:
+//	msr r <glob> <register>
+//	msr w <glob> <register> <value>
 //
-//    For example, I started with
-//    msr "'"* msr
-//    and, once I saw the MSR selection was OK, built the command up from
-//    there. At each step I could see the stack and whether I was going the
-//    right direction.
+//	Yep, it's a bit inconvenient; the idea is that in the simple case,
+//	you will use the r and w commands. For programmatic cases, you can
+//	work to build up a working set of arguments.
+//
+//	For example, I started with
+//	msr "'"* msr
+//	and, once I saw the MSR selection was OK, built the command up from
+//	there. At each step I could see the stack and whether I was going the
+//	right direction.
 //
 // The old commands remain:
 // rminnich@xcpu:~/gopath/src/github.com/u-root/u-root/cmds/core/msr$ sudo ./msr r 0 0x3a

--- a/cmds/core/msr/msr_linux.go
+++ b/cmds/core/msr/msr_linux.go
@@ -8,36 +8,40 @@
 // msr reads and writes msrs using a Forth interpreter on argv
 //
 // Synopsis:
-//     To see what is available:
-//     msr words
+//
+//	To see what is available:
+//	msr words
 //
 // Description:
-//     msr provides a set of Forth words that let you manage MSRs.
-//     You can add new ones of your own.
-//     For a start, it provides some pre-defined words for well-known MSRs
 //
-//     push a [] of MSR names and the 0x3a register on the stack
-//     IA32_FEATURE_CONTROL -- equivalent to * msr 0x3a reg
-//     The next two commands use IA32_FEATURE_CONTROL:
-//     READ_IA32_FEATURE_CONTROL -- equivalent to IA32_FEATURE_CONTROL rd
-//     LOCK IA32_FEATURE_CONTROL -- equivalent to IA32_FEATURE_CONTROL rd IA32_FEATURE_CONTROL 1 u64 or wr
-//     e.g.
-//./msr IA32_FEATURE_CONTROL
+//	msr provides a set of Forth words that let you manage MSRs.
+//	You can add new ones of your own.
+//	For a start, it provides some pre-defined words for well-known MSRs
+//
+//	push a [] of MSR names and the 0x3a register on the stack
+//	IA32_FEATURE_CONTROL -- equivalent to * msr 0x3a reg
+//	The next two commands use IA32_FEATURE_CONTROL:
+//	READ_IA32_FEATURE_CONTROL -- equivalent to IA32_FEATURE_CONTROL rd
+//	LOCK IA32_FEATURE_CONTROL -- equivalent to IA32_FEATURE_CONTROL rd IA32_FEATURE_CONTROL 1 u64 or wr
+//	e.g.
+//
+// ./msr IA32_FEATURE_CONTROL
 // [[/dev/cpu/0/msr /dev/cpu/1/msr /dev/cpu/2/msr /dev/cpu/3/msr] 58]
 //
-//     As a special convenience, we have two useful cases:
-//     r glob register -- read the MSR 'register' from cores matching 'glob'
-//     w glob register value -- write the value to 'register' on all cores matching 'glob'
+//	As a special convenience, we have two useful cases:
+//	r glob register -- read the MSR 'register' from cores matching 'glob'
+//	w glob register value -- write the value to 'register' on all cores matching 'glob'
 //
 // Examples:
-//     Show the IA32 feature MSR on all cores
-//     sudo fio READ_IA32_FEATURE_CONTROL
-//     [[5 5 5 5]]
-//     lock the registers
-//     sudo fio LOCK_IA32_FEATURE_CONTROL
-//     Just see it one core 0 and 1
-//     sudo ./fio '[01]' msr 0x3a reg rd
-//     [[5 5]]
+//
+//	Show the IA32 feature MSR on all cores
+//	sudo fio READ_IA32_FEATURE_CONTROL
+//	[[5 5 5 5]]
+//	lock the registers
+//	sudo fio LOCK_IA32_FEATURE_CONTROL
+//	Just see it one core 0 and 1
+//	sudo ./fio '[01]' msr 0x3a reg rd
+//	[[5 5]]
 package main
 
 import (

--- a/cmds/core/mv/mv.go
+++ b/cmds/core/mv/mv.go
@@ -5,11 +5,13 @@
 // mv renames files and directories.
 //
 // Synopsis:
-//     mv SOURCE [-u] TARGET
-//     mv SOURCE... [-u] DIRECTORY
+//
+//	mv SOURCE [-u] TARGET
+//	mv SOURCE... [-u] DIRECTORY
 //
 // Author:
-//     Beletti (rhiguita@gmail.com)
+//
+//	Beletti (rhiguita@gmail.com)
 package main
 
 import (

--- a/cmds/core/ntpdate/ntpdate.go
+++ b/cmds/core/ntpdate/ntpdate.go
@@ -8,19 +8,22 @@
 // ntpdate uses NTP to adjust the system clock.
 //
 // Synopsis:
-//     ntpdate [--config=/etc/ntp.conf] [--rtc] [--verbose] [server ...]
+//
+//	ntpdate [--config=/etc/ntp.conf] [--rtc] [--verbose] [server ...]
 //
 // Description:
-//     ntpdate queries NTP server(s) for time and update susyem time.
-//     If --rtc is specified, it updates the hardware clock as well.
-//     Servers to query are obtained from /etc/ntp.conf and/or the command line.
-//     By default --config is set to /etc/ntp.conf, config lookup can be disabled
-//     by setting --confg to an empty string.
-//     If servers are specified on the command line, they are tried first.
-//     time.google.com is used as the last resort.
+//
+//	ntpdate queries NTP server(s) for time and update susyem time.
+//	If --rtc is specified, it updates the hardware clock as well.
+//	Servers to query are obtained from /etc/ntp.conf and/or the command line.
+//	By default --config is set to /etc/ntp.conf, config lookup can be disabled
+//	by setting --confg to an empty string.
+//	If servers are specified on the command line, they are tried first.
+//	time.google.com is used as the last resort.
 //
 // Options:
-//     -w: set hwclock to system clock in UTC
+//
+//	-w: set hwclock to system clock in UTC
 package main
 
 import (

--- a/cmds/core/pci/pci.go
+++ b/cmds/core/pci/pci.go
@@ -8,12 +8,14 @@
 // pci: show pci bus vendor ids and other info
 //
 // Description:
-//     List the PCI bus, with names if possible.
+//
+//	List the PCI bus, with names if possible.
 //
 // Options:
-//     -n: just show numbers
-//     -c: dump config space
-//     -s: specify glob for choosing devices.
+//
+//	-n: just show numbers
+//	-c: dump config space
+//	-s: specify glob for choosing devices.
 package main
 
 import (

--- a/cmds/core/ping/ping.go
+++ b/cmds/core/ping/ping.go
@@ -5,17 +5,19 @@
 // Send icmp packets to a server to test network connectivity.
 //
 // Synopsis:
-//     ping [-hV] [-c COUNT] [-i INTERVAL] [-s PACKETSIZE] [-w DEADLINE] DESTINATION
+//
+//	ping [-hV] [-c COUNT] [-i INTERVAL] [-s PACKETSIZE] [-w DEADLINE] DESTINATION
 //
 // Options:
-//     -6: use ipv6 (ip6:ipv6-icmp)
-//     -s: data size (default: 64)
-//     -c: # iterations, 0 to run forever (default)
-//     -i: interval in milliseconds (default: 1000)
-//     -V: version
-//     -w: wait time in milliseconds (default: 100)
-//     -a: Audible rings a bell when a packet is received
-//     -h: help
+//
+//	-6: use ipv6 (ip6:ipv6-icmp)
+//	-s: data size (default: 64)
+//	-c: # iterations, 0 to run forever (default)
+//	-i: interval in milliseconds (default: 1000)
+//	-V: version
+//	-w: wait time in milliseconds (default: 100)
+//	-a: Audible rings a bell when a packet is received
+//	-h: help
 package main
 
 import (

--- a/cmds/core/poweroff/poweroff_linux.go
+++ b/cmds/core/poweroff/poweroff_linux.go
@@ -5,11 +5,12 @@
 // poweroff turns the system off, without delay. There are no options.
 //
 // Synopsis:
-//     poweroff
+//
+//	poweroff
 //
 // Description:
-//     poweroff calls the kernel to power off the systems.
 //
+//	poweroff calls the kernel to power off the systems.
 package main
 
 import (

--- a/cmds/core/printenv/printenv.go
+++ b/cmds/core/printenv/printenv.go
@@ -5,7 +5,8 @@
 // Print environment variables.
 //
 // Synopsis:
-//     printenv
+//
+//	printenv
 package main
 
 import (

--- a/cmds/core/ps/ps.go
+++ b/cmds/core/ps/ps.go
@@ -8,19 +8,22 @@
 // Print process information.
 //
 // Synopsis:
-//     ps [-Aaex] [aux]
+//
+//	ps [-Aaex] [aux]
 //
 // Description:
-//     ps reads the /proc filesystem and prints nice things about what it
-//     finds.  /proc in linux has grown by a process of Evilution, so it's
-//     messy.
+//
+//	ps reads the /proc filesystem and prints nice things about what it
+//	finds.  /proc in linux has grown by a process of Evilution, so it's
+//	messy.
 //
 // Options:
-//     -A: select all processes. Identical to -e.
-//     -e: select all processes. Identical to -A.
-//     -x: BSD-Like style, with STAT Column and long CommandLine
-//     -a: print all process except whose are session leaders or unlinked with terminal
-//    aux: see every process on the system using BSD syntax
+//
+//	 -A: select all processes. Identical to -e.
+//	 -e: select all processes. Identical to -A.
+//	 -x: BSD-Like style, with STAT Column and long CommandLine
+//	 -a: print all process except whose are session leaders or unlinked with terminal
+//	aux: see every process on the system using BSD syntax
 package main
 
 import (

--- a/cmds/core/pwd/pwd.go
+++ b/cmds/core/pwd/pwd.go
@@ -5,13 +5,16 @@
 // Print name of current directory.
 //
 // Synopsis:
-//     pwd [-LP]
+//
+//	pwd [-LP]
 //
 // Options:
-//     -P: don't follow symlinks
+//
+//	-P: don't follow symlinks
 //
 // Author:
-//     created by Beletti (rhiguita@gmail.com)
+//
+//	created by Beletti (rhiguita@gmail.com)
 package main
 
 import (

--- a/cmds/core/readlink/readlink.go
+++ b/cmds/core/readlink/readlink.go
@@ -5,12 +5,14 @@
 // readlink display value of symbolic link file.
 //
 // Synopsis:
-//     readlink [OPTIONS] FILE
+//
+//	readlink [OPTIONS] FILE
 //
 // Options:
-//     -f: follow
-//     -n: nonewline
-//     -v: verbose
+//
+//	-f: follow
+//	-n: nonewline
+//	-v: verbose
 package main
 
 import (

--- a/cmds/core/rm/rm.go
+++ b/cmds/core/rm/rm.go
@@ -5,14 +5,16 @@
 // Delete files.
 //
 // Synopsis:
-//     rm [-Rrvif] FILE...
+//
+//	rm [-Rrvif] FILE...
 //
 // Options:
-//     -i: interactive mode
-//     -v: verbose mode
-//     -R: remove file hierarchies
-//     -r: equivalent to -R
-//     -f: ignore nonexistent files and never prompt
+//
+//	-i: interactive mode
+//	-v: verbose mode
+//	-R: remove file hierarchies
+//	-r: equivalent to -R
+//	-f: ignore nonexistent files and never prompt
 package main
 
 import (

--- a/cmds/core/rmmod/rmmod_linux.go
+++ b/cmds/core/rmmod/rmmod_linux.go
@@ -5,13 +5,16 @@
 // Remove a module from the Linux kernel
 //
 // Synopsis:
+//
 //	rmmod name
 //
 // Description:
+//
 //	rmmod is a clone of rmmod(8)
 //
 // Author:
-//     Roland Kammerer <dev.rck@gmail.com>
+//
+//	Roland Kammerer <dev.rck@gmail.com>
 package main
 
 import (

--- a/cmds/core/rsdp/rsdp.go
+++ b/cmds/core/rsdp/rsdp.go
@@ -11,12 +11,15 @@
 // the kernel messages which could be quickly filled up in some cases
 //
 // Synopsis:
+//
 //	rsdp [-f file]
 //
 // Description:
+//
 //	Look for rsdp value in a file, default /dev/kmsg
 //
 // Example:
+//
 //	rsdp
 //	rsdp -f /path/to/file
 package main

--- a/cmds/core/scp/scp.go
+++ b/cmds/core/scp/scp.go
@@ -5,16 +5,19 @@
 // Scp copies files between hosts on a network.
 //
 // Synopsis:
-//     scp [-t|-f] [FILE]
+//
+//	scp [-t|-f] [FILE]
 //
 // Description:
-//     If -t is given, decode SCP protocol from stdin and write to FILE.
-//     If -f is given, stream FILE over SCP protocol to stdout.
+//
+//	If -t is given, decode SCP protocol from stdin and write to FILE.
+//	If -f is given, stream FILE over SCP protocol to stdout.
 //
 // Options:
-//     -t: Act as the target
-//     -f: Act as the source
-//     -v: Passed if SCP is verbose, ignored
+//
+//	-t: Act as the target
+//	-f: Act as the source
+//	-v: Passed if SCP is verbose, ignored
 package main
 
 import (

--- a/cmds/core/seq/seq.go
+++ b/cmds/core/seq/seq.go
@@ -5,20 +5,23 @@
 // Print a sequence of numbers.
 //
 // Synopsis:
-//     seq [-f FORMAT] [-w] [-s SEPARATOR] [START [STEP [END]]]
+//
+//	seq [-f FORMAT] [-w] [-s SEPARATOR] [START [STEP [END]]]
 //
 // Examples:
-//    % seq -s=' ' 3
-//    1 2 3
-//    % seq -s=' ' 2 4
-//    2 3 4
-//    % seq -s=' ' 3 2 7
-//    3 5 7
+//
+//	% seq -s=' ' 3
+//	1 2 3
+//	% seq -s=' ' 2 4
+//	2 3 4
+//	% seq -s=' ' 3 2 7
+//	3 5 7
 //
 // Options:
-//     -f: use printf style floating-point FORMAT (default: %v)
-//     -s: use STRING to separate numbers (default: \n)
-//     -w: equalize width by padding with leading zeroes (default: false)
+//
+//	-f: use printf style floating-point FORMAT (default: %v)
+//	-s: use STRING to separate numbers (default: \n)
+//	-w: equalize width by padding with leading zeroes (default: false)
 package main
 
 import (

--- a/cmds/core/shasum/shasum.go
+++ b/cmds/core/shasum/shasum.go
@@ -28,11 +28,9 @@ func helpPrinter() {
 	pflag.PrintDefaults()
 }
 
-//
 // shaPrinter prints sha1/sha256 of given data. The
 // value of algorithm is expected to be 1 for SHA1
 // and 256 for SHA256
-//
 func shaGenerator(w io.Writer, r io.Reader, algo int) ([]byte, error) {
 	var h hash.Hash
 	switch algo {

--- a/cmds/core/shutdown/shutdown_linux.go
+++ b/cmds/core/shutdown/shutdown_linux.go
@@ -5,17 +5,20 @@
 // shutdown halts, suspends, or reboots at a specified time, or immediately.
 //
 // Synopsis:
-//     shutdown [<-h|-r|-s|halt|reboot|suspend> [time [message...]]]
+//
+//	shutdown [<-h|-r|-s|halt|reboot|suspend> [time [message...]]]
 //
 // Description:
-//     current operations are reboot (-r), suspend, and halt [-h].
-//     If no operation is specified halt is assumed.
-//     If a time is given, an opcode is not optional.
+//
+//	current operations are reboot (-r), suspend, and halt [-h].
+//	If no operation is specified halt is assumed.
+//	If a time is given, an opcode is not optional.
 //
 // Options:
-//     -r|reboot:	reboot the machine.
-//     -h|halt:		halt the machine.
-//     -s|suspend:	suspend the machine.
+//
+//	-r|reboot:	reboot the machine.
+//	-h|halt:		halt the machine.
+//	-s|suspend:	suspend the machine.
 //
 // Time is specified as "now", +minutes, or RFC3339 format.
 // All other arguments past time are printed as a message.

--- a/cmds/core/sleep/sleep.go
+++ b/cmds/core/sleep/sleep.go
@@ -5,21 +5,25 @@
 // Delay for the specified amount of time.
 //
 // Synopsis:
-//     sleep DURATION
+//
+//	sleep DURATION
 //
 // Description:
-//     If no units are given, the duration is assumed to be measured in
-//     seconds, otherwise any format parsed by Go's `time.ParseDuration` is
-//     accepted.
+//
+//	If no units are given, the duration is assumed to be measured in
+//	seconds, otherwise any format parsed by Go's `time.ParseDuration` is
+//	accepted.
 //
 // Examples:
-//     sleep 2.5
-//     sleep 300ms
-//     sleep 2h45m
+//
+//	sleep 2.5
+//	sleep 300ms
+//	sleep 2h45m
 //
 // Bugs:
-//     When sleep is first run, it must be compiled from source which creates a
-//     delay significantly longer than anticipated.
+//
+//	When sleep is first run, it must be compiled from source which creates a
+//	delay significantly longer than anticipated.
 package main
 
 import (

--- a/cmds/core/sort/sort.go
+++ b/cmds/core/sort/sort.go
@@ -5,16 +5,19 @@
 // Sort lines.
 //
 // Synopsis:
-//     sort [OPTIONS]... [INPUT]...
+//
+//	sort [OPTIONS]... [INPUT]...
 //
 // Description:
-//     Sort copies lines from the input to the output, sorting them in the
-//     process. This does nothing fancy (no multi-threading, compression,
-//     optiminzations, ...); it simply uses Go's sort.Sort function.
+//
+//	Sort copies lines from the input to the output, sorting them in the
+//	process. This does nothing fancy (no multi-threading, compression,
+//	optiminzations, ...); it simply uses Go's sort.Sort function.
 //
 // Options:
-//     -r:      reverse
-//     -o FILE: output file
+//
+//	-r:      reverse
+//	-o FILE: output file
 package main
 
 import (

--- a/cmds/core/strace/strace_linux.go
+++ b/cmds/core/strace/strace_linux.go
@@ -8,9 +8,11 @@
 // strace is a simple multi-process syscall & signal tracer.
 //
 // Synopsis:
-//     strace <command> [args...]
+//
+//	strace <command> [args...]
 //
 // Description:
+//
 //	trace a single process given a command name.
 package main
 

--- a/cmds/core/strings/strings.go
+++ b/cmds/core/strings/strings.go
@@ -5,16 +5,19 @@
 // Strings finds printable strings.
 //
 // Synopsis:
-//     strings OPTIONS [FILES]...
+//
+//	strings OPTIONS [FILES]...
 //
 // Description:
-//     Prints all sequences of `n` or more printable characters terminated by a
-//     non-printable character (or EOF).
 //
-//     If no files are specified, read from stdin.
+//	Prints all sequences of `n` or more printable characters terminated by a
+//	non-printable character (or EOF).
+//
+//	If no files are specified, read from stdin.
 //
 // Options:
-//     -n number: the minimum string length (default is 4)
+//
+//	-n number: the minimum string length (default is 4)
 package main
 
 import (

--- a/cmds/core/tar/tar.go
+++ b/cmds/core/tar/tar.go
@@ -5,21 +5,24 @@
 // Create and extract tar archives.
 //
 // Synopsis:
-//     tar [OPTION...] [FILE]...
+//
+//	tar [OPTION...] [FILE]...
 //
 // Description:
-//     This command line can be used only in the following ways:
-//        tar -cvf x.tar directory/         # create
-//        tar -cvf x.tar file1 file2 ...    # create
-//        tar -tvf x.tar                    # list
-//        tar -xvf x.tar directory/         # extract
+//
+//	This command line can be used only in the following ways:
+//	   tar -cvf x.tar directory/         # create
+//	   tar -cvf x.tar file1 file2 ...    # create
+//	   tar -tvf x.tar                    # list
+//	   tar -xvf x.tar directory/         # extract
 //
 // Options:
-//     -c: create a new tar archive from the given directory
-//     -x: extract a tar archive to the given directory
-//     -v: verbose, print each filename (optional)
-//     -f: tar filename (required)
-//     -t: list the contents of an archive
+//
+//	-c: create a new tar archive from the given directory
+//	-x: extract a tar archive to the given directory
+//	-v: verbose, print each filename (optional)
+//	-f: tar filename (required)
+//	-t: list the contents of an archive
 //
 // TODO: The arguments deviates slightly from gnu tar.
 package main

--- a/cmds/core/tee/tee.go
+++ b/cmds/core/tee/tee.go
@@ -6,11 +6,13 @@
 // in the files.
 //
 // Synopsis:
-//     tee [-ai] FILES...
+//
+//	tee [-ai] FILES...
 //
 // Options:
-//     -a, --append: append the output to the files rather than rewriting them
-//     -i, --ignore-interrupts: ignore the SIGINT signal
+//
+//	-a, --append: append the output to the files rather than rewriting them
+//	-i, --ignore-interrupts: ignore the SIGINT signal
 package main
 
 import (

--- a/cmds/core/time/time.go
+++ b/cmds/core/time/time.go
@@ -5,24 +5,29 @@
 // Time process execution.
 //
 // Synopsis:
-//     time CMD [ARG]...
+//
+//	time CMD [ARG]...
 //
 // Description:
-//     After executing CMD, its real, user and system times are printed to
-//     stderr in the POSIX format.
+//
+//	After executing CMD, its real, user and system times are printed to
+//	stderr in the POSIX format.
 //
 // Example:
-//     $ time sleep 1.23s
-//     real 1.230
-//     user 0.001
-//     sys 0.000
+//
+//	$ time sleep 1.23s
+//	real 1.230
+//	user 0.001
+//	sys 0.000
 //
 // Note:
-//     This is different from bash's time command which is built into the shell
-//     and can time the entire pipeline.
+//
+//	This is different from bash's time command which is built into the shell
+//	and can time the entire pipeline.
 //
 // Bugs:
-//     Time is not reported when exiting due to a signal.
+//
+//	Time is not reported when exiting due to a signal.
 package main
 
 import (

--- a/cmds/core/true/true.go
+++ b/cmds/core/true/true.go
@@ -5,10 +5,12 @@
 // Returns 0.
 //
 // Synopsis:
-//     true
+//
+//	true
 //
 // Description:
-//     Command line arguments are ignored.
+//
+//	Command line arguments are ignored.
 package main
 
 func main() {

--- a/cmds/core/truncate/truncate.go
+++ b/cmds/core/truncate/truncate.go
@@ -5,15 +5,18 @@
 // Truncate - shrink or extend the size of a file to the specified size
 //
 // Synopsis:
-//     truncate [OPTIONS] [FILE]...
+//
+//	truncate [OPTIONS] [FILE]...
 //
 // Options:
-//     -s: size in bytes
-//     -r: reference file for size
-//     -c: do not create any files
+//
+//	-s: size in bytes
+//	-r: reference file for size
+//	-c: do not create any files
 //
 // Author:
-//     Roland Kammerer <dev.rck@gmail.com>
+//
+//	Roland Kammerer <dev.rck@gmail.com>
 package main
 
 import (

--- a/cmds/core/ts/ts.go
+++ b/cmds/core/ts/ts.go
@@ -5,7 +5,8 @@
 // ts prepends each line of stdin with a timestamp.
 //
 // Synopsis:
-//     ts
+//
+//	ts
 package main
 
 import (

--- a/cmds/core/umount/umount.go
+++ b/cmds/core/umount/umount.go
@@ -8,11 +8,13 @@
 // Unmount a filesystem at the specified path.
 //
 // Synopsis:
-//     umount [-f | -l] PATH
+//
+//	umount [-f | -l] PATH
 //
 // Options:
-//     -f: force unmount
-//     -l: lazy unmount
+//
+//	-f: force unmount
+//	-l: lazy unmount
 package main
 
 import "log"

--- a/cmds/core/uname/uname.go
+++ b/cmds/core/uname/uname.go
@@ -8,16 +8,18 @@
 // Print build information about the kernel and machine.
 //
 // Synopsis:
-//     uname [-asnrvmd]
+//
+//	uname [-asnrvmd]
 //
 // Options:
-//     -a: print everything
-//     -s: print the kernel name
-//     -n: print the network node name
-//     -r: print the kernel release
-//     -v: print the kernel version
-//     -m: print the machine hardware name
-//     -d: print your domain name
+//
+//	-a: print everything
+//	-s: print the kernel name
+//	-n: print the network node name
+//	-r: print the kernel release
+//	-v: print the kernel version
+//	-m: print the machine hardware name
+//	-d: print your domain name
 package main
 
 import (

--- a/cmds/core/uniq/uniq.go
+++ b/cmds/core/uniq/uniq.go
@@ -5,24 +5,27 @@
 // Uniq removes repeated lines.
 //
 // Synopsis:
-//     uniq [OPTIONS...] [FILES]...
+//
+//	uniq [OPTIONS...] [FILES]...
 //
 // Description:
-//     Uniq copies the input file, or the standard input, to the standard
-//     output, comparing adjacent lines. In the normal case, the second and
-//     succeeding copies of repeated lines are removed. Repeated lines must be
-//     adjacent in order to be found.
+//
+//	Uniq copies the input file, or the standard input, to the standard
+//	output, comparing adjacent lines. In the normal case, the second and
+//	succeeding copies of repeated lines are removed. Repeated lines must be
+//	adjacent in order to be found.
 //
 // Options:
-//     –u:      Print unique lines.
-//     –d:      Print (one copy of) duplicated lines.
-//     –c:      Prefix a repetition count and a tab to each output line.
-//              Implies –u and –d.
-//     –f num:  The first num fields together with any blanks before each are
-//              ignored. A field is defined as a string of non–space, non–tab
-//              characters separated by tabs and spaces from its neighbors.
-//     -cn num: The first num characters are ignored. Fields are skipped before
-//              characters.
+//
+//	–u:      Print unique lines.
+//	–d:      Print (one copy of) duplicated lines.
+//	–c:      Prefix a repetition count and a tab to each output line.
+//	         Implies –u and –d.
+//	–f num:  The first num fields together with any blanks before each are
+//	         ignored. A field is defined as a string of non–space, non–tab
+//	         characters separated by tabs and spaces from its neighbors.
+//	-cn num: The first num characters are ignored. Fields are skipped before
+//	         characters.
 package main
 
 // TODO(aam): -num and +num are not implemented. they're easy to do, just not exactly the

--- a/cmds/core/unmount/unmount.go
+++ b/cmds/core/unmount/unmount.go
@@ -5,7 +5,8 @@
 // Unmount unmounts new from old, or everything mounted on old if new is omitted.
 //
 // Synopsis:
-//	 unmount [ new ] old
+//
+//	unmount [ new ] old
 package main
 
 import (

--- a/cmds/core/unshare/unshare_linux.go
+++ b/cmds/core/unshare/unshare_linux.go
@@ -5,31 +5,34 @@
 // Disassociate parts of the process execution context.
 //
 // Synopsis:
-//     unshare [OPTIONS] [PROGRAM [ARGS]...]
+//
+//	unshare [OPTIONS] [PROGRAM [ARGS]...]
 //
 // Description:
-//     Go applications use multiple processes, and the Go user level scheduler
-//     schedules goroutines onto those processes. For this reason, it is not
-//     possible to use syscall.Unshare. A goroutine can call `syscall.Unshare`
-//     from process m and the scheduler can resume that goroutine in process n,
-//     which has not had the unshare operation! This is a known problem with
-//     any system call that modifies the name space or file system context of
-//     only one process as opposed to the entire Go application, i.e. all of
-//     its processes. Examples include chroot and unshare. There has been
-//     lively discussion of this problem but no resolution as of yet. In sum:
-//     it is not possible to use `syscall.Unshare` from Go with any reasonable
-//     expectation of success.
 //
-//     If PROGRAM is not specified, unshare defaults to /ubin/elvish.
+//	Go applications use multiple processes, and the Go user level scheduler
+//	schedules goroutines onto those processes. For this reason, it is not
+//	possible to use syscall.Unshare. A goroutine can call `syscall.Unshare`
+//	from process m and the scheduler can resume that goroutine in process n,
+//	which has not had the unshare operation! This is a known problem with
+//	any system call that modifies the name space or file system context of
+//	only one process as opposed to the entire Go application, i.e. all of
+//	its processes. Examples include chroot and unshare. There has been
+//	lively discussion of this problem but no resolution as of yet. In sum:
+//	it is not possible to use `syscall.Unshare` from Go with any reasonable
+//	expectation of success.
+//
+//	If PROGRAM is not specified, unshare defaults to /ubin/elvish.
 //
 // Options:
-//     -ipc:           Unshare the IPC namespace
-//     -mount:         Unshare the mount namespace
-//     -pid:           Unshare the pid namespace
-//     -net:           Unshare the net namespace
-//     -uts:           Unshare the uts namespace
-//     -user:          Unshare the user namespace
-//     -map-root-user: Map current uid to root. Not working
+//
+//	-ipc:           Unshare the IPC namespace
+//	-mount:         Unshare the mount namespace
+//	-pid:           Unshare the pid namespace
+//	-net:           Unshare the net namespace
+//	-uts:           Unshare the uts namespace
+//	-user:          Unshare the user namespace
+//	-map-root-user: Map current uid to root. Not working
 package main
 
 import (

--- a/cmds/core/uptime/uptime.go
+++ b/cmds/core/uptime/uptime.go
@@ -4,7 +4,8 @@
 
 // Get the time the machine has been up
 // Synopsis:
-//     uptime
+//
+//	uptime
 package main
 
 import (

--- a/cmds/core/watchdog/watchdog_linux.go
+++ b/cmds/core/watchdog/watchdog_linux.go
@@ -5,17 +5,19 @@
 // watchdog interacts with /dev/watchdog.
 //
 // Synopsis:
-//     watchdog [--dev=DEV] keepalive
-//         Pet the watchdog. This resets the time left back to the timeout.
-//     watchdog [--dev=DEV] set[pre]timeout DURATION
-//         Set the watchdog timeout or pretimeout
-//     watchdog [--dev=DEV] get[pre]timeout
-//         Print the watchdog timeout or pretimeout
-//     watchdog [--dev=DEV] gettimeleft
-//         Print the amount of time left.
+//
+//	watchdog [--dev=DEV] keepalive
+//	    Pet the watchdog. This resets the time left back to the timeout.
+//	watchdog [--dev=DEV] set[pre]timeout DURATION
+//	    Set the watchdog timeout or pretimeout
+//	watchdog [--dev=DEV] get[pre]timeout
+//	    Print the watchdog timeout or pretimeout
+//	watchdog [--dev=DEV] gettimeleft
+//	    Print the amount of time left.
 //
 // Options:
-//     --dev DEV: Device (default /dev/watchdog)
+//
+//	--dev DEV: Device (default /dev/watchdog)
 package main
 
 import (

--- a/cmds/core/watchdogd/watchdogd_linux.go
+++ b/cmds/core/watchdogd/watchdogd_linux.go
@@ -5,23 +5,25 @@
 // watchdogd is a background daemon for petting the watchdog.
 //
 // Synopsis:
-//     watchdogd run [OPTIONS]
-//         Run the watchdogd in a child process (does not daemonize).
-//     watchdogd stop
-//         Send a signal to arm the running watchdog.
-//     watchdogd continue
-//         Send a signal to disarm the running watchdog.
-//     watchdogd arm
-//         Send a signal to arm the running watchdog.
-//     watchdogd disarm
-//         Send a signal to disarm the running watchdog.
+//
+//	watchdogd run [OPTIONS]
+//	    Run the watchdogd in a child process (does not daemonize).
+//	watchdogd stop
+//	    Send a signal to arm the running watchdog.
+//	watchdogd continue
+//	    Send a signal to disarm the running watchdog.
+//	watchdogd arm
+//	    Send a signal to arm the running watchdog.
+//	watchdogd disarm
+//	    Send a signal to disarm the running watchdog.
 //
 // Options:
-//     --dev DEV: Device (default /dev/watchdog)
-//     --timeout: Duration before timing out (default -1)
-//     --pre_timeout: Duration for pretimeout (default -1)
-//     --keep_alive: Duration between issuing keepalive (default 10)
-//     --monitors: comma separated list of monitors, ex: oops
+//
+//	--dev DEV: Device (default /dev/watchdog)
+//	--timeout: Duration before timing out (default -1)
+//	--pre_timeout: Duration for pretimeout (default -1)
+//	--keep_alive: Duration between issuing keepalive (default 10)
+//	--monitors: comma separated list of monitors, ex: oops
 package main
 
 import (

--- a/cmds/core/wc/wc.go
+++ b/cmds/core/wc/wc.go
@@ -5,41 +5,45 @@
 // Wc counts lines, words, runes, syntactically–invalid UTF codes.
 //
 // Synopsis:
-//     wc [OPTIONS...] [FILES]...
+//
+//	wc [OPTIONS...] [FILES]...
 //
 // Description:
-//     Wc counts lines, words, runes, syntactically–invalid UTF codes and bytes
-//     in the named files, or in the standard input if no file is named. A word
-//     is a maximal string of characters delimited by spaces, tabs or newlines.
-//     The count of runes includes invalid codes. If the optional argument is
-//     present, just the specified counts (lines, words, runes, broken UTF
-//     codes or bytes) are selected by the letters l, w, r, b, or c. Otherwise,
-//     lines, words and bytes (–lwc) are reported.
+//
+//	Wc counts lines, words, runes, syntactically–invalid UTF codes and bytes
+//	in the named files, or in the standard input if no file is named. A word
+//	is a maximal string of characters delimited by spaces, tabs or newlines.
+//	The count of runes includes invalid codes. If the optional argument is
+//	present, just the specified counts (lines, words, runes, broken UTF
+//	codes or bytes) are selected by the letters l, w, r, b, or c. Otherwise,
+//	lines, words and bytes (–lwc) are reported.
 //
 // Options:
-//     –l: count lines
-//     –w: count words
-//     –r: count runes
-//     –b: count broken UTF codes
-//     -c: count bytes
+//
+//	–l: count lines
+//	–w: count words
+//	–r: count runes
+//	–b: count broken UTF codes
+//	-c: count bytes
 //
 // Bugs:
-//     This wc differs from Plan 9's wc somewhat in word count (BSD's wc differs
-//     even more significantly):
 //
-//     $ unicode 0x0-0x10ffff | 9 wc -w
-//     2228221
-//     $ unicode 0x0-0x10ffff | gowc -w
-//     2228198
-//     $ unicode 0x0-0x10ffff | bsdwc -w
-//     2293628
+//	This wc differs from Plan 9's wc somewhat in word count (BSD's wc differs
+//	even more significantly):
 //
-//     This wc differs from Plan 9's wc significantly in bad rune count:
+//	$ unicode 0x0-0x10ffff | 9 wc -w
+//	2228221
+//	$ unicode 0x0-0x10ffff | gowc -w
+//	2228198
+//	$ unicode 0x0-0x10ffff | bsdwc -w
+//	2293628
 //
-//     $ unicode 0x0-0x10ffff | gowc -b
-//     6144
-//     $ unicode 0x0-0x10ffff | 9 wc -b
-//     1966080
+//	This wc differs from Plan 9's wc significantly in bad rune count:
+//
+//	$ unicode 0x0-0x10ffff | gowc -b
+//	6144
+//	$ unicode 0x0-0x10ffff | 9 wc -b
+//	1966080
 package main
 
 import (

--- a/cmds/exp/acpigrep/main.go
+++ b/cmds/exp/acpigrep/main.go
@@ -5,30 +5,33 @@
 // grep a stream of ACPI tables by regexp
 //
 // Synopsis:
-//     acpigrep [-v] [-d] regexp
+//
+//	acpigrep [-v] [-d] regexp
 //
 // Description:
-//	Read tables from stdin and write tables with ACPI signatures
-//	matching a pattern (or not matching, with -v, as in grep)
-//	to stdout.
 //
-//	Read all tables from sysfs and discard MADT
-//	sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -v MADT
+//		Read tables from stdin and write tables with ACPI signatures
+//		matching a pattern (or not matching, with -v, as in grep)
+//		to stdout.
 //
-//	Read a large blob and print out its tables
-//	acpigrep -d '.*' >/dev/null < blob
+//		Read all tables from sysfs and discard MADT
+//		sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -v MADT
 //
-//      Read all the files in /sys and discard any DSDT. Useful for coreboot work.
-// 	sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -v DSDT > nodsdt.bin
+//		Read a large blob and print out its tables
+//		acpigrep -d '.*' >/dev/null < blob
 //
-//	Read all the files, keeping only SRAT and MADT
-// 	sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep 'MADT|SRAT' > madtsrat.bin
+//	     Read all the files in /sys and discard any DSDT. Useful for coreboot work.
+//		sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -v DSDT > nodsdt.bin
 //
-//	Read all the files, keeping only SRAT and MADT, and print what is done
-// 	sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -d 'MADT|SRAT' > madtsrat.bin
+//		Read all the files, keeping only SRAT and MADT
+//		sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep 'MADT|SRAT' > madtsrat.bin
+//
+//		Read all the files, keeping only SRAT and MADT, and print what is done
+//		sudo cat /sys/firmware/acpi/tables/[A-Z]* | ./acpigrep -d 'MADT|SRAT' > madtsrat.bin
 //
 // Options:
-// 	-d print debug information about what is kept and what is discarded.
+//
+//	-d print debug information about what is kept and what is discarded.
 //	-v reverse the sense of the match to "discard is matching"
 package main
 

--- a/cmds/exp/ansi/ansi.go
+++ b/cmds/exp/ansi/ansi.go
@@ -5,14 +5,17 @@
 // Print ansi escape sequences.
 //
 // Synopsis:
-//     ansi COMMAND
+//
+//	ansi COMMAND
 //
 // Options:
-//     COMMAND must be one of:
-//         - clear: clear the screen and reset the cursor position
+//
+//	COMMAND must be one of:
+//	    - clear: clear the screen and reset the cursor position
 //
 // Author:
-//     Manoel Vilela <manoel_vilela@engineer.com>
+//
+//	Manoel Vilela <manoel_vilela@engineer.com>
 package main
 
 import (

--- a/cmds/exp/bzimage/bzimage.go
+++ b/cmds/exp/bzimage/bzimage.go
@@ -6,9 +6,11 @@
 // It reads the image in, applies an operator, and writes a new one out.
 //
 // Synopsis:
-//     bzImage [copy <in> <out> ] | [diff <image> <image> ] | [dump <file>] | [initramfs input-bzimage initramfs output-bzimage]
+//
+//	bzImage [copy <in> <out> ] | [diff <image> <image> ] | [dump <file>] | [initramfs input-bzimage initramfs output-bzimage]
 //
 // Description:
+//
 //	Read a bzImage in, change it, write it out, or print info.
 package main
 

--- a/cmds/exp/crc/crc.go
+++ b/cmds/exp/crc/crc.go
@@ -5,19 +5,22 @@
 // Prints crc checksum of a file.
 //
 // Synopsis:
-//     crc OPTIONS [FILE]
+//
+//	crc OPTIONS [FILE]
 //
 // Description:
-//     One of the crc types must be specified. If there is no file, stdin is
-//     read.
+//
+//	One of the crc types must be specified. If there is no file, stdin is
+//	read.
 //
 // Options:
-//     -f: CRC function to use. May be one of the following:
-//         crc32-ieee:       CRC-32 IEEE standard (default)
-//         crc32-castognoli: CRC-32 Castognoli standard
-//         crc32-koopman:    CRC-32 Koopman standard
-//         crc64-ecma:       CRC-64 ECMA standard
-//         crc64-iso:        CRC-64 ISO standard
+//
+//	-f: CRC function to use. May be one of the following:
+//	    crc32-ieee:       CRC-32 IEEE standard (default)
+//	    crc32-castognoli: CRC-32 Castognoli standard
+//	    crc32-koopman:    CRC-32 Koopman standard
+//	    crc64-ecma:       CRC-64 ECMA standard
+//	    crc64-iso:        CRC-64 ISO standard
 package main
 
 import (

--- a/cmds/exp/disk_unlock/disk_unlock.go
+++ b/cmds/exp/disk_unlock/disk_unlock.go
@@ -3,16 +3,16 @@
 // license that can be found in the LICENSE file.
 
 // The disk_unlock command is used to unlock a disk drive as follows:
-// 1. Via BMC, read a 32-byte secret seed known as the Host Secret Seed (HSS)
-//    using the OpenBMC IPMI blob transfer protocol
-// 2. Compute a password as follows:
-//	We get the deterministically computed 32-byte HDKF-SHA256 using:
-//	- salt: "SKM PROD_V2 ACCESS"
-//	- hss: 32-byte HSS
-//	- device identity: strings formed by concatenating the assembly serial
-//	  number, the _ character, and the assembly part number.
-// 3. Unlock the drive with the given password
-// 4. Update the partition table for the disk
+//  1. Via BMC, read a 32-byte secret seed known as the Host Secret Seed (HSS)
+//     using the OpenBMC IPMI blob transfer protocol
+//  2. Compute a password as follows:
+//     We get the deterministically computed 32-byte HDKF-SHA256 using:
+//     - salt: "SKM PROD_V2 ACCESS"
+//     - hss: 32-byte HSS
+//     - device identity: strings formed by concatenating the assembly serial
+//     number, the _ character, and the assembly part number.
+//  3. Unlock the drive with the given password
+//  4. Update the partition table for the disk
 package main
 
 import (

--- a/cmds/exp/fdtdump/fdtdump.go
+++ b/cmds/exp/fdtdump/fdtdump.go
@@ -5,10 +5,12 @@
 // fdtdump prints a readable version of Flattened Device Tree or dtb.
 //
 // Synopsis:
-//     fdtdump [-json] FILE
+//
+//	fdtdump [-json] FILE
 //
 // Options:
-//     -json: Print json with base64 encoded values.
+//
+//	-json: Print json with base64 encoded values.
 package main
 
 import (

--- a/cmds/exp/freq/freq.go
+++ b/cmds/exp/freq/freq.go
@@ -7,20 +7,23 @@
 // the –r option it instead counts UTF sequences, that is, runes.
 //
 // Synopsis:
-//     freq [-rdxoc] [FILES]...
+//
+//	freq [-rdxoc] [FILES]...
 //
 // Description:
-//     Each non–zero entry of the table is printed preceded by the byte value,
-//     in decimal, octal, hex, and Unicode character (if printable). If any
-//     options are given, the –d, –x, –o, –c flags specify a subset of value
-//     formats: decimal, hex, octal, and character, respectively.
+//
+//	Each non–zero entry of the table is printed preceded by the byte value,
+//	in decimal, octal, hex, and Unicode character (if printable). If any
+//	options are given, the –d, –x, –o, –c flags specify a subset of value
+//	formats: decimal, hex, octal, and character, respectively.
 //
 // Options:
-//     –r: treat input as UTF-8
-//     –d: print decimal value
-//     –x: print hex value
-//     –o: print octal value
-//     –c: print character/UTF value
+//
+//	–r: treat input as UTF-8
+//	–d: print decimal value
+//	–x: print hex value
+//	–o: print octal value
+//	–c: print character/UTF value
 package main
 
 import (

--- a/cmds/exp/getty/getty.go
+++ b/cmds/exp/getty/getty.go
@@ -8,7 +8,8 @@
 // is no more shell!
 //
 // Synopsis:
-//     getty <port> <baud> [term]
+//
+//	getty <port> <baud> [term]
 package main
 
 import (

--- a/cmds/exp/hdparm/hdparm.go
+++ b/cmds/exp/hdparm/hdparm.go
@@ -17,8 +17,8 @@
 // arguments for commands requiring a password.
 //
 // Synopsis:
-//     hdparm [--i] [--security-unlock[=password]] [--user-master|--timeout] [device ...]
 //
+//	hdparm [--i] [--security-unlock[=password]] [--user-master|--timeout] [device ...]
 package main
 
 import (

--- a/cmds/exp/ipmidump/ipmidump.go
+++ b/cmds/exp/ipmidump/ipmidump.go
@@ -3,17 +3,19 @@
 // license that can be found in the LICENSE file.
 
 // Synopsis:
-//     ipmidump [-option]
+//
+//	ipmidump [-option]
 //
 // Description:
 //
 // Options:
-//     -chassis : Print chassis power status.
-//     -sel     : Print SEL information.
-//     -lan     : Print IP information.
-//     -device  : Print device information.
-//     -raw     : Send raw command and print response.
-//     -help    : Print help message.
+//
+//	-chassis : Print chassis power status.
+//	-sel     : Print SEL information.
+//	-lan     : Print IP information.
+//	-device  : Print device information.
+//	-raw     : Send raw command and print response.
+//	-help    : Print help message.
 package main
 
 import (

--- a/cmds/exp/madeye/madeye.go
+++ b/cmds/exp/madeye/madeye.go
@@ -6,7 +6,8 @@
 // universal initramfs.
 //
 // Synopsis:
-//     madeye initramfs [initramfs...]
+//
+//	madeye initramfs [initramfs...]
 //
 // u-root was intended to be capable of function as a universal root, i.e. a
 // root file system that you could boot from different architectures. We call

--- a/cmds/exp/modprobe/modprobe_linux.go
+++ b/cmds/exp/modprobe/modprobe_linux.go
@@ -5,11 +5,13 @@
 // modprobe - Add and remove modules from the Linux Kernel
 //
 // Synopsis:
-//     modprobe [-n] modulename [parameters...]
-//     modprobe [-n] -a modulename...
+//
+//	modprobe [-n] modulename [parameters...]
+//	modprobe [-n] -a modulename...
 //
 // Author:
-//     Roland Kammerer <dev.rck@gmail.com>
+//
+//	Roland Kammerer <dev.rck@gmail.com>
 package main
 
 import (

--- a/cmds/exp/page/main.go
+++ b/cmds/exp/page/main.go
@@ -3,7 +3,8 @@
 // license that can be found in the LICENSE file.
 
 // Synopsis:
-//     page [file]
+//
+//	page [file]
 //
 // Description:
 // page prints a page at a time to stdout from either stdin or a named file.

--- a/cmds/exp/partprobe/partprobe.go
+++ b/cmds/exp/partprobe/partprobe.go
@@ -5,8 +5,8 @@
 // partprobe prompts the OS to re-read partition tables.
 //
 // Synopsis:
-//   partprobe [device]...
 //
+//	partprobe [device]...
 package main
 
 import (

--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -5,71 +5,76 @@
 // pox packages dynamic executable into an archive.
 //
 // Synopsis:
-//     pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-create]|c FILE [...FILE]
-//     pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-run|r] PROGRAM -- [...ARGS]
-//     pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-create]|c -[-run|r] PROGRAM -- [...ARGS]
+//
+//	pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-create]|c FILE [...FILE]
+//	pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-run|r] PROGRAM -- [...ARGS]
+//	pox [-[-verbose]|v] [-[-file]|f tcz-file] -[-create]|c -[-run|r] PROGRAM -- [...ARGS]
 //
 // Description:
-//     pox packages a dynamic executable into an archive for use on another
-//     machine. By default, it uses the tcz format compatible with tinycore.
 //
-//     pox supports 3 archive formats:
-//     1) squashfs (default): The tcz is a squashfs. This requires mksquashfs.
-//     2) zip
-//     3) elf+zip: Self-extracting.
+//	pox packages a dynamic executable into an archive for use on another
+//	machine. By default, it uses the tcz format compatible with tinycore.
+//
+//	pox supports 3 archive formats:
+//	1) squashfs (default): The tcz is a squashfs. This requires mksquashfs.
+//	2) zip
+//	3) elf+zip: Self-extracting.
 //
 // Options:
-//     create|c: create the TCZ file.
-//     verbose|d: verbose
-//     file|f FILE: file name (default /tmp/pox.tcz)
-//     run|r: Runs the first non-flag argument to pox.  Remaining arguments will
-//            be passed to the program.  Use '--' before any flag-like arguments
-//            to prevent pox from interpretting the flags.
-//     self|s: Create a self-extracting elf. This implies -z.
-//     zip|z: Use zip and unzip instead of a loopback mounted squashfs. Be sure
-//            to use -z for both creation and running, or not at all.
-//     For convenience and testing, you can create and run a pox in one command.
+//
+//	create|c: create the TCZ file.
+//	verbose|d: verbose
+//	file|f FILE: file name (default /tmp/pox.tcz)
+//	run|r: Runs the first non-flag argument to pox.  Remaining arguments will
+//	       be passed to the program.  Use '--' before any flag-like arguments
+//	       to prevent pox from interpretting the flags.
+//	self|s: Create a self-extracting elf. This implies -z.
+//	zip|z: Use zip and unzip instead of a loopback mounted squashfs. Be sure
+//	       to use -z for both creation and running, or not at all.
+//	For convenience and testing, you can create and run a pox in one command.
 //
 // Example:
-//     $ pox -c /bin/bash /bin/cat /bin/ls /etc/hosts
-//     Will build a squashfs, which will be /tmp/pox.tcz
 //
-//     $ sudo pox -r /bin/bash
-//     Will drop you into the /tmp/pox.tcz running bash
-//     You can use ls and cat on /etc/hosts.
+//	$ pox -c /bin/bash /bin/cat /bin/ls /etc/hosts
+//	Will build a squashfs, which will be /tmp/pox.tcz
 //
-//     Simpler example, with arguments:
-//     $ sudo pox -r /bin/ls -- -la
-//     will run `ls -la` and exit.
+//	$ sudo pox -r /bin/bash
+//	Will drop you into the /tmp/pox.tcz running bash
+//	You can use ls and cat on /etc/hosts.
 //
-//     $ sudo pox -r -- /bin/ls -la
-//     Syntactically easier: the program name can come after '--'
+//	Simpler example, with arguments:
+//	$ sudo pox -r /bin/ls -- -la
+//	will run `ls -la` and exit.
 //
-//     $ sudo pox -c -r /bin/bash
-//     Create a pox with a bash and run it.
+//	$ sudo pox -r -- /bin/ls -la
+//	Syntactically easier: the program name can come after '--'
 //
-//     $ pox -cvsf date /bin/date
-//     Creates a self-executing pox called "date".
-//     $ ./date --utc
+//	$ sudo pox -c -r /bin/bash
+//	Create a pox with a bash and run it.
+//
+//	$ pox -cvsf date /bin/date
+//	Creates a self-executing pox called "date".
+//	$ ./date --utc
 //
 // Notes:
-//     - When running a pox, you likely need sudo to chroot
 //
-//     - Binaries run out of a chroot often need files you are unaware of. For
+//   - When running a pox, you likely need sudo to chroot
+//
+//   - Binaries run out of a chroot often need files you are unaware of. For
 //     instance, if bash can't find terminfo files, it won't know to handle
 //     backspaces properly. (They occur, but are not shown). To fix this, pass
 //     pox all of the files you need.  For bash: `find /lib/terminfo -type f`.
 //
-//     - Other programs rely on helper functions, such as '/bin/man'. If your
+//   - Other programs rely on helper functions, such as '/bin/man'. If your
 //     program has built-in help commands that trigger man pages, e.g. "git
 //     help foo", you'll want to include /bin/man too. But you'll also need
 //     everything that man uses, such as /etc/manpath.config. My advice: skip
 //     it.
 //
-//     - When adding all files in a directory, the easiest thing to do is:
+//   - When adding all files in a directory, the easiest thing to do is:
 //     `find $DIR -type f` (Note the ticks: this is a bash command execution).
 //
-//     - When creating a pox with an executable with shared libraries that are
+//   - When creating a pox with an executable with shared libraries that are
 //     not installed on your system, such as for a project installed in your
 //     home directory, run pox from the installation prefix directory, such
 //     that the lib/ and bin/ are in pox's working directory. Pox will strip
@@ -78,7 +83,7 @@
 //     full path from your machine in the pox file makes it easier to extract a
 //     pox file to /usr/local/.
 //
-//     - pox is not a security boundary. chroot is well known to have holes.
+//   - pox is not a security boundary. chroot is well known to have holes.
 //     Pox is about enabling execution. Don't expect it to "wall things off".
 //     In fact, we mount /dev, /proc, and /sys; and you can add more things.
 //     Commands run under pox are just as dangerous as anything else.

--- a/cmds/exp/readpe/pe.go
+++ b/cmds/exp/readpe/pe.go
@@ -5,11 +5,13 @@
 // Dump the headers of a PE file.
 //
 // Synopsis:
-//     pe [FILENAME]
+//
+//	pe [FILENAME]
 //
 // Description:
-//     Windows and EFI executables are in the portable executable (PE) format.
-//     This command prints the headers in a JSON format.
+//
+//	Windows and EFI executables are in the portable executable (PE) format.
+//	This command prints the headers in a JSON format.
 package main
 
 import (

--- a/cmds/exp/run/run.go
+++ b/cmds/exp/run/run.go
@@ -5,13 +5,16 @@
 // Run executes its arguments as a Go program.
 //
 // Synopsis:
-//     run [-v] GO_CODE..
+//
+//	run [-v] GO_CODE..
 //
 // Examples:
-//     run {fmt.Println("hello")}
+//
+//	run {fmt.Println("hello")}
 //
 // Options:
-//     -v: verbose display of processing
+//
+//	-v: verbose display of processing
 package main
 
 import (

--- a/cmds/exp/rush/info.go
+++ b/cmds/exp/rush/info.go
@@ -5,14 +5,17 @@
 // info command
 //
 // Synopsis:
-//     info
+//
+//	info
 //
 // Description:
-//     Print out info about our environment.
+//
+//	Print out info about our environment.
 //
 // Example:
-//     $ info
-//     Version, goos, etc.
+//
+//	$ info
+//	Version, goos, etc.
 //
 // Note:
 //

--- a/cmds/exp/rush/rush.go
+++ b/cmds/exp/rush/rush.go
@@ -5,7 +5,8 @@
 // Rush is an interactive shell similar to sh.
 //
 // Description:
-//     Prompt is '% '.
+//
+//	Prompt is '% '.
 package main
 
 import (

--- a/cmds/exp/smbios_transfer/smbios_transfer.go
+++ b/cmds/exp/smbios_transfer/smbios_transfer.go
@@ -5,9 +5,11 @@
 // smbios_transfer sends SMBIOS tables to BMC through IPMI blob interfaces.
 //
 // Synopsis:
-//     smbios_tranfer [-num_retries]
+//
+//	smbios_tranfer [-num_retries]
 //
 // Options:
+//
 //	-num_retries: number of times to retry transferring SMBIOS tables
 package main
 

--- a/cmds/exp/smn/main.go
+++ b/cmds/exp/smn/main.go
@@ -5,14 +5,18 @@
 // smn: read or write registers in the System Management Network on AMD cpus
 //
 // Synopsis:
-//     snm [0 or more addresses]
+//
+//	snm [0 or more addresses]
+//
 // N.B. having no addresses is an easy way to see if you can
 // access PCI at all.
 //
 // Description:
-//     read and write System Management Network registers
+//
+//	read and write System Management Network registers
 //
 // Options:
+//
 //	-s: device glob in the form tttt:bb:dd.fn with * as needed
 //	-n: number of 32-bit words to dump.
 //	-v: 32-bit value to write

--- a/cmds/exp/srvfiles/srvfiles.go
+++ b/cmds/exp/srvfiles/srvfiles.go
@@ -5,12 +5,14 @@
 // Serve files on the network.
 //
 // Synopsis:
-//     srvfiles [--h=HOST] [--p=PORT] [--d=DIR]
+//
+//	srvfiles [--h=HOST] [--p=PORT] [--d=DIR]
 //
 // Options:
-//     --h: hostname (default: 127.0.0.1)
-//     --p: port number (default: 8080)
-//     --d: directory to serve (default: .)
+//
+//	--h: hostname (default: 127.0.0.1)
+//	--p: port number (default: 8080)
+//	--d: directory to serve (default: .)
 package main
 
 import (

--- a/cmds/exp/tac/tac.go
+++ b/cmds/exp/tac/tac.go
@@ -6,7 +6,8 @@
 // file by file
 //
 // Synopsis:
-//     tac <file...>
+//
+//	tac <file...>
 //
 // Description:
 //

--- a/cmds/exp/watch/watch.go
+++ b/cmds/exp/watch/watch.go
@@ -5,16 +5,19 @@
 // watch periodically executes the executable specified in argument.
 //
 // Synopsis:
-//     watch [-n] SEC [-t] cmd-exec
+//
+//	watch [-n] SEC [-t] cmd-exec
 //
 // Description:
-//    cmd-exec is executed every n seconds
-//    example, watch -n 5 dmesg >> log.txt
-//    : executes dmesg every 5 sec and stores the log in log.txt
+//
+//	cmd-exec is executed every n seconds
+//	example, watch -n 5 dmesg >> log.txt
+//	: executes dmesg every 5 sec and stores the log in log.txt
 //
 // Options:
-//     -n: time in seconds
-//     -t: do not print header
+//
+//	-n: time in seconds
+//	-t: do not print header
 package main
 
 import (

--- a/cmds/exp/zbi/zbi.go
+++ b/cmds/exp/zbi/zbi.go
@@ -5,10 +5,12 @@
 // zbi dumps the header of a Zircon boot image.
 //
 // Synopsis:
-//     zbi FILE
+//
+//	zbi FILE
 //
 // Description:
-//     Debugging purposes.
+//
+//	Debugging purposes.
 package main
 
 import (

--- a/cmds/exp/zimage/zimage.go
+++ b/cmds/exp/zimage/zimage.go
@@ -5,10 +5,12 @@
 // zimage dumps the header of a zImage.
 //
 // Synopsis:
-//     zimage FILE
+//
+//	zimage FILE
 //
 // Description:
-//     This is mainly for debugging purposes.
+//
+//	This is mainly for debugging purposes.
 package main
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/u-root/u-root
 
-go 1.17
+go 1.19
 
 require (
 	github.com/beevik/ntp v0.3.0

--- a/pkg/bb/bb.go
+++ b/pkg/bb/bb.go
@@ -179,10 +179,10 @@ func BuildBusybox(env golang.Environ, pkgs []string, noStrip bool, binaryPath st
 //
 // p must be the bb template.
 //
-// - For each pkg in pkgs, add
+//   - For each pkg in pkgs, add
 //     import _ "pkg"
-//   to astp's first file.
-// - Write source file out to destDir.
+//     to astp's first file.
+//   - Write source file out to destDir.
 func CreateBBMainSource(fset *token.FileSet, astp *ast.Package, pkgs []string, destDir string) error {
 	for _, pkg := range pkgs {
 		for _, sourceFile := range astp.Files {

--- a/pkg/bb/bbmain/cmd/main.go
+++ b/pkg/bb/bbmain/cmd/main.go
@@ -80,15 +80,15 @@ func main() {
 // and on Linux, they are not.
 //
 // This leads to a few conclusions:
-// - We can get around lack of symlinks by using #! (sh-bang) files with an absolute path to
-//   bb as the interpreter, e.g. #!/abs/path/to/bb argument.
-//   This achieves the "exec once" goal.
-// - We can specify which u-root tool to use via arguments to bb in the #! file.
-// - The argument to the interpreter (/bbin/bb) should be one token (e.g. ls) because of different
-//   behavior in different systems (some tokenize, some do not).
-// - Because of the differences in how arguments are presented to #! on different kernels,
-//   there should be a reasonably unique marker so that bb can have confidence that
-//   it is running as an interpreter.
+//   - We can get around lack of symlinks by using #! (sh-bang) files with an absolute path to
+//     bb as the interpreter, e.g. #!/abs/path/to/bb argument.
+//     This achieves the "exec once" goal.
+//   - We can specify which u-root tool to use via arguments to bb in the #! file.
+//   - The argument to the interpreter (/bbin/bb) should be one token (e.g. ls) because of different
+//     behavior in different systems (some tokenize, some do not).
+//   - Because of the differences in how arguments are presented to #! on different kernels,
+//     there should be a reasonably unique marker so that bb can have confidence that
+//     it is running as an interpreter.
 //
 // The conclusions lead to the following design:
 // #! files for bb specify their argument with #!. E.g., the file for ls looks like this:

--- a/pkg/boot/bzimage/kver.go
+++ b/pkg/boot/bzimage/kver.go
@@ -105,10 +105,12 @@ func nullterm(buf []byte) string {
 
 // KInfo struct holds info extracted from the kernel's embedded version string
 //
-//2.6.24.111 (bluebat@linux-vm-os64.site) #606 Mon Apr 14 00:06:11 CEST 2014
-//4.19.16-norm_boot (user@host) #300 SMP Fri Jan 25 16:32:19 UTC 2019
-//   release             (builder)         version
-//maj.min.patch-localver                #buildnum SMP buildtime
+// 2.6.24.111 (bluebat@linux-vm-os64.site) #606 Mon Apr 14 00:06:11 CEST 2014
+// 4.19.16-norm_boot (user@host) #300 SMP Fri Jan 25 16:32:19 UTC 2019
+//
+//	release             (builder)         version
+//
+// maj.min.patch-localver                #buildnum SMP buildtime
 type KInfo struct {
 	Release, Version string // uname -r, uname -v respectfully
 	Builder          string // user@hostname in parenthesis, shown by `file` but not `uname`

--- a/pkg/boot/ebda/ebda.go
+++ b/pkg/boot/ebda/ebda.go
@@ -5,10 +5,10 @@
 // Package ebda looks for the Extended Bios Data Area (EBDA) pointer in /dev/mem,
 // and provides access to the EBDA. This is useful for us to read or write to the EBDA,
 // for example to copy the RSDP into the EBDA.
-// * The address 0x40E contains the pointer to the start of the EBDA, shifted right by 4 bits
-// * We take that and find the EBDA, where the first byte usually encodes the length of the
-//   the area in KiB.
-// * If the pointer is not set, there may be no EBDA.
+//   - The address 0x40E contains the pointer to the start of the EBDA, shifted right by 4 bits
+//   - We take that and find the EBDA, where the first byte usually encodes the length of the
+//     the area in KiB.
+//   - If the pointer is not set, there may be no EBDA.
 package ebda
 
 import (

--- a/pkg/boot/grub/grub.go
+++ b/pkg/boot/grub/grub.go
@@ -53,8 +53,8 @@ var probeGrubFiles = []string{
 //
 // They add a special case to not escape hex sequences:
 //
-//     grub> echo hello \xff \xfg
-//     hello \xff xfg
+//	grub> echo hello \xff \xfg
+//	hello \xff xfg
 //
 // Their default installations depend on this functionality.
 var hexEscape = regexp.MustCompile(`\\x[0-9a-fA-F]{2}`)

--- a/pkg/boot/ibft/ibft.go
+++ b/pkg/boot/ibft/ibft.go
@@ -9,9 +9,9 @@
 //
 // An iBFT is typically placed in one of two places:
 //
-//  (1) an ACPI table named "iBFT", or
+//	(1) an ACPI table named "iBFT", or
 //
-//  (2) in the 512K-1M physical memory range identified by its first 4 bytes.
+//	(2) in the 512K-1M physical memory range identified by its first 4 bytes.
 //
 // However, this package doesn't concern itself with the placement, just the
 // marshaling of the table's bytes.

--- a/pkg/boot/kexec/object_test.go
+++ b/pkg/boot/kexec/object_test.go
@@ -50,10 +50,10 @@ func TestObject(t *testing.T) {
 var bogus = []byte{1, 2, 3, 4}
 
 // This is a 386 object from Plan9, from this source:
-//#include <u.h>
-//#include <libc.h>
-//main(int argc, char *argv[])
-//{return 0;}
+// #include <u.h>
+// #include <libc.h>
+// main(int argc, char *argv[])
+// {return 0;}
 var emptyAout = []byte{
 	0x00, 0x00, 0x01, 0xeb, 0x00, 0x00, 0x04, 0xb3, 0x00, 0x00, 0x00, 0x20,
 	0x00, 0x00, 0x01, 0x10, 0x00, 0x00, 0x08, 0x86, 0x00, 0x00, 0x10, 0x23,

--- a/pkg/boot/linux/doc.go
+++ b/pkg/boot/linux/doc.go
@@ -104,7 +104,8 @@
 // o use the ELF program header to tell us where to put the purgatory
 // o communicate arguments in the seven quadwords mentioned above
 // o rather than one does-it-all purgatory as we have today, we can provide several variants
-//   so we get one suited to the job at hand.
+//
+//	so we get one suited to the job at hand.
 //
 // This should result in a dramatically simpler purgatory implementation. Also,
 // being much simpler, it can be entirely Go assembly, obviating the need for a

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -76,7 +76,8 @@ func SetInitialTimeout(timeout time.Duration) {
 
 // Choose presents the user a menu on input to choose an entry from and returns that entry.
 // Note: This call can block if MenuTerminal or the underlying os.File does
-//       not support SetTimeout/SetDeadline.
+//
+//	not support SetTimeout/SetDeadline.
 func Choose(term MenuTerminal, allowEdit bool, entries ...Entry) Entry {
 	fmt.Println("")
 	for i, e := range entries {

--- a/pkg/boot/menu/menu_term.go
+++ b/pkg/boot/menu/menu_term.go
@@ -41,13 +41,13 @@ type xterm struct {
 // example minicom, the behavior is different. And you would
 // see something like:
 //
-//     Select a boot option to edit:
-//                                  >
+//	Select a boot option to edit:
+//	                             >
 //
 // Instead of:
 //
-//     Select a boot option to edit:
-//      >
+//	Select a boot option to edit:
+//	 >
 func NewTerminal(f *os.File) *xterm {
 	oldState, err := term.MakeRaw(int(f.Fd()))
 	if err != nil {

--- a/pkg/boot/multiboot/module.go
+++ b/pkg/boot/multiboot/module.go
@@ -74,17 +74,18 @@ func (m *multiboot) addMultibootModules() (uintptr, error) {
 // loadModules loads module files.
 // Returns loaded modules description and buffer storing loaded modules.
 // Memory layout of the loaded modules is following:
-//			cmdLine_1
-//			cmdLine_2
-//			...
-//			cmdLine_n
-//			<padding>
-//			modules_1
-//			<padding>
-//			modules_2
-//			...
-//			<padding>
-//			modules_n
+//
+//	cmdLine_1
+//	cmdLine_2
+//	...
+//	cmdLine_n
+//	<padding>
+//	modules_1
+//	<padding>
+//	modules_2
+//	...
+//	<padding>
+//	modules_n
 //
 // <padding> aligns the start of each module to a page beginning.
 func loadModules(rmods []Module) (loaded modules, data []byte, err error) {

--- a/pkg/boot/netboot/netboot.go
+++ b/pkg/boot/netboot/netboot.go
@@ -31,8 +31,8 @@ import (
 //
 // - to detect an iPXE script beginning with #!ipxe,
 //
-// - to detect a pxelinux.0, in which case we will ignore the pxelinux.0 and
-//   try to parse pxelinux.cfg/<files>.
+//   - to detect a pxelinux.0, in which case we will ignore the pxelinux.0 and
+//     try to parse pxelinux.cfg/<files>.
 func BootImages(ctx context.Context, l ulog.Logger, s curl.Schemes, lease dhclient.Lease) ([]boot.OSImage, error) {
 	uri, err := lease.Boot()
 	if err != nil {

--- a/pkg/boot/zimage/zimage.go
+++ b/pkg/boot/zimage/zimage.go
@@ -37,7 +37,8 @@ type ZImage struct {
 // Header appears near the beginning of the zImage.
 //
 // The layout is defined in Linux:
-//     arch/arm/boot/compressed/head.S
+//
+//	arch/arm/boot/compressed/head.S
 type Header struct {
 	Magic      uint32
 	Start      uint32
@@ -50,7 +51,8 @@ type Header struct {
 // TableEntry is an extension to Header. A zImage may have 0 or more entries.
 //
 // The layout is defined in Linux:
-//     arch/arm/boot/compressed/vmlinux.lds.S
+//
+//	arch/arm/boot/compressed/vmlinux.lds.S
 type TableEntry struct {
 	Tag  Tag
 	Data []uint32

--- a/pkg/cpio/cpio.go
+++ b/pkg/cpio/cpio.go
@@ -8,27 +8,26 @@
 //
 // Reading from or writing to a file:
 //
-//    f, err := os.Open(...)
-//    if err ...
-//    recReader := cpio.Newc.Reader(f)
-//    err := ForEachRecord(recReader, func(r cpio.Record) error {
+//	f, err := os.Open(...)
+//	if err ...
+//	recReader := cpio.Newc.Reader(f)
+//	err := ForEachRecord(recReader, func(r cpio.Record) error {
 //
-//    })
+//	})
 //
-//    // Or...
-//    recWriter := cpio.Newc.Writer(f)
-//
+//	// Or...
+//	recWriter := cpio.Newc.Writer(f)
 //
 // Reading from or writing to an in-memory archive:
 //
-//    a := cpio.InMemArchive()
-//    err := a.WriteRecord(...)
+//	a := cpio.InMemArchive()
+//	err := a.WriteRecord(...)
 //
-//    recReader := a.Reader() // Reads from the "beginning."
+//	recReader := a.Reader() // Reads from the "beginning."
 //
-//    if a.Contains("bar/foo") {
+//	if a.Contains("bar/foo") {
 //
-//    }
+//	}
 package cpio
 
 import (

--- a/pkg/cpio/newc.go
+++ b/pkg/cpio/newc.go
@@ -224,10 +224,12 @@ func (n newc) Reader(r io.ReaderAt) RecordReader {
 // If it only implements Read, then a discarder will be used
 // instead.
 // Note a complication:
-// 	r, _, _ := os.Pipe()
+//
+//	r, _, _ := os.Pipe()
 //	var b [2]byte
 //	_, err := r.ReadAt(b[:], 0)
 //	fmt.Printf("%v", err)
+//
 // Pipes claim to implement ReadAt; most Unix kernels
 // do not agree. Even a seek to the current position fails.
 // This means that

--- a/pkg/find/find.go
+++ b/pkg/find/find.go
@@ -122,11 +122,11 @@ func WithDebugLog(l func(string, ...interface{})) Set {
 //
 // e.g.
 //
-//   names := Find(ctx,
-//     WithRoot("/boot"),
-//     WithFilenameMatch("sda[0-9]"),
-//     WithDebugLog(log.Printf),
-//   )
+//	names := Find(ctx,
+//	  WithRoot("/boot"),
+//	  WithFilenameMatch("sda[0-9]"),
+//	  WithDebugLog(log.Printf),
+//	)
 func Find(ctx context.Context, opt ...Set) <-chan *File {
 	f := &finder{
 		root:       "/",

--- a/pkg/flash/sfdp/sfdp.go
+++ b/pkg/flash/sfdp/sfdp.go
@@ -109,11 +109,12 @@ var BasicTableLookup = []ParamLookupEntry{
 // SFDP (Serial Flash Discoverable Parameters) holds a copy of the tables of the SFDP.
 //
 // The structure is:
-//     SFDP
-//      |--> Header
-//      \--> []Parameter
-//              |--> ParameterHeader
-//              \--> Table: A copy of the table's contents.
+//
+//	SFDP
+//	 |--> Header
+//	 \--> []Parameter
+//	         |--> ParameterHeader
+//	         \--> Table: A copy of the table's contents.
 type SFDP struct {
 	Header
 	Parameters []Parameter

--- a/pkg/ipmi/ocp/ocp_linux.go
+++ b/pkg/ipmi/ocp/ocp_linux.go
@@ -233,9 +233,10 @@ func GetOemIpmiProcessorInfo(si *smbios.Info) ([]ProcessorInfo, error) {
 }
 
 // DIMM type: bit[7:6] for DDR3 00-Normal Voltage(1.5V), 01-Ultra Low Voltage(1.25V), 10-Low Voltage(1.35V), 11-Reserved
-//                     for DDR4 00~10-Reserved, 11-Normal Voltage(1.2V)
-//            bit[5:0] 0x00=SDRAM, 0x01=DDR1 RAM, 0x02-Rambus, 0x03-DDR2 RAM, 0x04-FBDIMM, 0x05-DDR3 RAM, 0x06-DDR4 RAM
-//		       , 0x07-DDR5 RAM
+//
+//	                    for DDR4 00~10-Reserved, 11-Normal Voltage(1.2V)
+//	           bit[5:0] 0x00=SDRAM, 0x01=DDR1 RAM, 0x02-Rambus, 0x03-DDR2 RAM, 0x04-FBDIMM, 0x05-DDR3 RAM, 0x06-DDR4 RAM
+//			       , 0x07-DDR5 RAM
 func detectDimmType(meminfo *DimmInfo, t17 *smbios.MemoryDevice) {
 	if t17.Type == smbios.MemoryDeviceTypeDDR3 {
 		switch t17.ConfiguredVoltage {

--- a/pkg/ldd/ldd_unix_test.go
+++ b/pkg/ldd/ldd_unix_test.go
@@ -18,13 +18,13 @@ var (
 		output []string
 	}{
 		{
-			name: "single vdso entry",
-			input: `	linux-vdso.so.1`,
+			name:   "single vdso entry",
+			input:  `	linux-vdso.so.1`,
 			output: []string{},
 		},
 		{
-			name: "duplicate vdso symlink",
-			input: `	linux-vdso.so.1 => linux-vdso.so.1`,
+			name:   "duplicate vdso symlink",
+			input:  `	linux-vdso.so.1 => linux-vdso.so.1`,
 			output: []string{},
 		},
 		{

--- a/pkg/mount/block/blockdev_linux.go
+++ b/pkg/mount/block/blockdev_linux.go
@@ -636,7 +636,8 @@ func parsePCIBlockList(blockList string) (pci.Devices, error) {
 // and partNo counting from 1. It is assumed that device names ending in a
 // number like nvme0n1 have partitions named like nvme0n1p1, nvme0n1p2, ...
 // and devices ending in a letter like sda have partitions named like
-//  sda1, sda2, ...
+//
+//	sda1, sda2, ...
 func composePartName(devName string, partNo int) string {
 	r := []rune(devName[len(devName)-1:])
 	if unicode.IsDigit(r[0]) {

--- a/pkg/mount/mount_linux.go
+++ b/pkg/mount/mount_linux.go
@@ -78,7 +78,8 @@ func (mp *MountPoint) Unmount(flags uintptr) error {
 // opts is usually empty, but if you want, e.g., to pre-create the mountpoint,
 // you can call Mount with a mkdirall, e.g.
 // mount.Mount("none", dst, fstype, "", 0,
-//		func() error { return os.MkdirAll(dst, 0o666)})
+//
+//	func() error { return os.MkdirAll(dst, 0o666)})
 func Mount(dev, path, fsType, data string, flags uintptr, opts ...func() error) (*MountPoint, error) {
 	for _, f := range opts {
 		if err := f(); err != nil {

--- a/pkg/mount/mtd/chips_test.go
+++ b/pkg/mount/mtd/chips_test.go
@@ -87,10 +87,10 @@ func TestChipFromVIDID(t *testing.T) {
 			wantChipString: "ZETTADEVICE/ZD25D20: 0 pages, 0 pagesize, 0x0 bytes",
 		},
 		{
-			vid:          0xDA,
-			vname:        "WINBOND",
-			cid:          0x7E1D01,
-			wantChipName: "W29GL032CHL",
+			vid:            0xDA,
+			vname:          "WINBOND",
+			cid:            0x7E1D01,
+			wantChipName:   "W29GL032CHL",
 			wantChipString: "WINBOND/W29GL032CHL: 0 pages, 0 pagesize, 0x0 bytes, remarks: 	/* Uniform Sectors, WP protects Top OR Bottom sector */",
 		},
 		{

--- a/pkg/mount/scuzz/doc.go
+++ b/pkg/mount/scuzz/doc.go
@@ -13,6 +13,7 @@
 // For now it only works on Linux.
 //
 // Other info:
-//       http://www.t13.org/ Technical Committee T13 AT Attachment (ATA/ATAPI) Interface.
-//       http://www.serialata.org/ Serial ATA International Organization.
+//
+//	http://www.t13.org/ Technical Committee T13 AT Attachment (ATA/ATAPI) Interface.
+//	http://www.serialata.org/ Serial ATA International Organization.
 package scuzz

--- a/pkg/namespace/parser.go
+++ b/pkg/namespace/parser.go
@@ -21,7 +21,6 @@ import (
 // will make your head hurt.
 //
 // http://man.cat-v.org/plan_9/1/ns
-//
 func Parse(r io.Reader) (File, error) {
 	scanner := bufio.NewScanner(r)
 

--- a/pkg/qemu/qemu.go
+++ b/pkg/qemu/qemu.go
@@ -9,7 +9,7 @@
 // The environment variable `UROOT_QEMU` overrides the path to QEMU and the
 // first few arguments (defaults to "qemu"). For example, I use:
 //
-//     UROOT_QEMU='qemu-system-x86_64 -L . -m 4096 -enable-kvm'
+//	UROOT_QEMU='qemu-system-x86_64 -L . -m 4096 -enable-kvm'
 //
 // For CI, this environment variable is set in `.circleci/images/integration/Dockerfile`.
 package qemu

--- a/pkg/securelaunch/policy/policy.go
+++ b/pkg/securelaunch/policy/policy.go
@@ -70,6 +70,7 @@ func scanKernelCmdLine() []byte {
 // the policy file as a byte slice.
 //
 //	e.g., if /dev/sda1 is mounted on /tmp/sda1, then mountPath would be
+//
 // /tmp/sda1 and searchPath would be /tmp/sda1/securelaunch.policy,
 // /tmp/sda1/efi/securelaunch.policy, and /tmp/sda1/boot/securelaunch.policy
 // respectively for each iteration of loop over SearchRoots slice.

--- a/pkg/securelaunch/tpm/tpm.go
+++ b/pkg/securelaunch/tpm/tpm.go
@@ -136,8 +136,8 @@ func extendPCR(pcr uint32, hash []byte) error {
 // the kernel of this measurement by sending an event via sysfs.
 //
 // In debug mode, it prints:
-//   1. The old PCR value before the hash is extended to the PCR
-//   2. The new PCR value after the hash is extended to the PCR
+//  1. The old PCR value before the hash is extended to the PCR
+//  2. The new PCR value after the hash is extended to the PCR
 func ExtendPCRDebug(pcr uint32, data io.Reader, eventDesc string) error {
 	oldPCRValue, err := readPCR(pcr)
 	if err != nil {

--- a/pkg/shlex/shlex.go
+++ b/pkg/shlex/shlex.go
@@ -6,7 +6,7 @@
 //
 // shlex will parse for example
 //
-//     start --append="foobar foobaz" --nogood 'food'
+//	start --append="foobar foobaz" --nogood 'food'
 //
 // into the appropriate argvs to start the command.
 package shlex

--- a/pkg/termios/termios_darwin.go
+++ b/pkg/termios/termios_darwin.go
@@ -134,12 +134,12 @@ func MakeSerialBaud(term *Termios, baud int) (*Termios, error) {
 }
 
 // MakeSerialDefault updates the Termios to typical serial configuration:
-// - Ignore all flow control (modem, hardware, software...)
-// - Translate carriage return to newline on input
-// - Enable canonical mode: Input is available line by line, with line editing
-//   enabled (ERASE, KILL are supported)
-// - Local ECHO is added (and handled by line editing)
-// - Map newline to carriage return newline on output
+//   - Ignore all flow control (modem, hardware, software...)
+//   - Translate carriage return to newline on input
+//   - Enable canonical mode: Input is available line by line, with line editing
+//     enabled (ERASE, KILL are supported)
+//   - Local ECHO is added (and handled by line editing)
+//   - Map newline to carriage return newline on output
 func MakeSerialDefault(term *Termios) *Termios {
 	t := *term
 	/* Clear all except baud, stop bit and parity settings */

--- a/pkg/termios/termios_linux.go
+++ b/pkg/termios/termios_linux.go
@@ -139,12 +139,12 @@ func MakeSerialBaud(term *Termios, baud int) (*Termios, error) {
 }
 
 // MakeSerialDefault updates the Termios to typical serial configuration:
-// - Ignore all flow control (modem, hardware, software...)
-// - Translate carriage return to newline on input
-// - Enable canonical mode: Input is available line by line, with line editing
-//   enabled (ERASE, KILL are supported)
-// - Local ECHO is added (and handled by line editing)
-// - Map newline to carriage return newline on output
+//   - Ignore all flow control (modem, hardware, software...)
+//   - Translate carriage return to newline on input
+//   - Enable canonical mode: Input is available line by line, with line editing
+//     enabled (ERASE, KILL are supported)
+//   - Local ECHO is added (and handled by line editing)
+//   - Map newline to carriage return newline on output
 func MakeSerialDefault(term *Termios) *Termios {
 	t := *term
 	/* Clear all except baud, stop bit and parity settings */

--- a/pkg/termios/termios_plan9.go
+++ b/pkg/termios/termios_plan9.go
@@ -106,12 +106,12 @@ func MakeSerialBaud(term *Termios, baud int) (*Termios, error) {
 }
 
 // MakeSerialDefault updates the Termios to typical serial configuration:
-// - Ignore all flow control (modem, hardware, software...)
-// - Translate carriage return to newline on input
-// - Enable canonical mode: Input is available line by line, with line editing
-//   enabled (ERASE, KILL are supported)
-// - Local ECHO is added (and handled by line editing)
-// - Map newline to carriage return newline on output
+//   - Ignore all flow control (modem, hardware, software...)
+//   - Translate carriage return to newline on input
+//   - Enable canonical mode: Input is available line by line, with line editing
+//     enabled (ERASE, KILL are supported)
+//   - Local ECHO is added (and handled by line editing)
+//   - Map newline to carriage return newline on output
 func MakeSerialDefault(term *Termios) *Termios {
 	t := *term
 

--- a/pkg/ts/ts_test.go
+++ b/pkg/ts/ts_test.go
@@ -59,9 +59,9 @@ func TestPrependTimestamp(t *testing.T) {
 
 // TestPrependTimestampBuffering ensures two important properties with regards
 // to buffering which would be easy to miss with just a readline implementation:
-//     1. Data is printed before the whole line is available.
-//     2. Timestamp is generated at the beginning of the line, not at the end
-//        of the previous line.
+//  1. Data is printed before the whole line is available.
+//  2. Timestamp is generated at the beginning of the line, not at the end
+//     of the previous line.
 func TestPrependTimestampBuffering(t *testing.T) {
 	// Mock out the format function.
 	i := 0

--- a/pkg/uefivars/boot/efiDevicePathProtocol.go
+++ b/pkg/uefivars/boot/efiDevicePathProtocol.go
@@ -196,11 +196,11 @@ func (list EfiDevicePathProtocolList) String() string {
 // EfiDevicePathProtocolHdr is three one-byte fields that all DevicePathProtocol
 // entries begin with.
 //
-//    typedef struct _EFI_DEVICE_PATH_PROTOCOL {
-//        UINT8 Type;
-//        UINT8 SubType;
-//        UINT8 Length[2];
-//    } EFI_DEVICE_PATH_PROTOCOL;
+//	typedef struct _EFI_DEVICE_PATH_PROTOCOL {
+//	    UINT8 Type;
+//	    UINT8 SubType;
+//	    UINT8 Length[2];
+//	} EFI_DEVICE_PATH_PROTOCOL;
 //
 // It seems that the only relevant Type (for booting) is media.
 //

--- a/pkg/uio/buffer.go
+++ b/pkg/uio/buffer.go
@@ -130,12 +130,12 @@ func (b *Buffer) Cap() int {
 //
 // Use:
 //
-//   func (s *something) Unmarshal(l *Lexer) {
-//     s.Foo = l.Read8()
-//     s.Bar = l.Read8()
-//     s.Baz = l.Read16()
-//     return l.Error()
-//   }
+//	func (s *something) Unmarshal(l *Lexer) {
+//	  s.Foo = l.Read8()
+//	  s.Bar = l.Read8()
+//	  s.Baz = l.Read16()
+//	  return l.Error()
+//	}
 type Lexer struct {
 	*Buffer
 

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -340,10 +340,10 @@ func (o *Opts) addSymlinkTo(logger ulog.Logger, archive *initramfs.Opts, command
 //
 // Possible options are:
 //
-//   ./foobar
-//   ./foobar/glob*
-//   cmds/core/ip with UROOT_SOURCE=/directory/to/u-root
-//   cmds/core/g*lob with UROOT_SOURCE=/directory/to/u-root
+//	./foobar
+//	./foobar/glob*
+//	cmds/core/ip with UROOT_SOURCE=/directory/to/u-root
+//	cmds/core/g*lob with UROOT_SOURCE=/directory/to/u-root
 func resolvePackagePath(logger ulog.Logger, env golang.Environ, urootSource string, input string) ([]string, error) {
 	// In case the input is a u-root import path we strip the prefix here
 	// so that it can get re-added with a proper filepath.

--- a/pkg/watchdog/watchdog.go
+++ b/pkg/watchdog/watchdog.go
@@ -5,11 +5,12 @@
 // Package watchdog provides functions for interacting with the Linux watchdog.
 //
 // The basic usage is:
-//     wd, err := watchdog.Open(watchdog.Dev)
-//     while running {
-//         wd.KeepAlive()
-//     }
-//     wd.MagicClose()
+//
+//	wd, err := watchdog.Open(watchdog.Dev)
+//	while running {
+//	    wd.KeepAlive()
+//	}
+//	wd.MagicClose()
 //
 // Open() arms the watchdog. MagicClose() disarms the watchdog.
 //

--- a/tools/checklicenses/checklicenses.go
+++ b/tools/checklicenses/checklicenses.go
@@ -3,8 +3,8 @@
 // license that can be found in the LICENSE file.
 
 // Run with `go run checklicenses.go`. This script has one drawback:
-// - It does not correct the licenses; it simply outputs a list of files which
-//   do not conform and returns 1 if the list is non-empty.
+//   - It does not correct the licenses; it simply outputs a list of files which
+//     do not conform and returns 1 if the list is non-empty.
 package main
 
 import (

--- a/u-root.go
+++ b/u-root.go
@@ -193,7 +193,7 @@ func main() {
 }
 
 var recommendedVersions = []string{
-	"go1.17",
+	"go1.19",
 }
 
 func isRecommendedVersion(v string) bool {


### PR DESCRIPTION
To include native golang fuzzing tests in u-root, a version bump to golang version 1.18 is necessary.
The testimage-amd64 Dockerfile uses the latest commit of [multiboot-test-kernel](https://github.com/u-root/multiboot-test-kernel/commit/1c7e4f4722077dcab308cd1df9818eab011e58c4) with updated build flags.

Signed-off-by: Fabian Wienand <fabian.wienand@9elements.com>