### PR TITLE
pkg/syscallfilter: remove test obsoleted by go 1.19

### DIFF
--- a/pkg/syscallfilter/syscallfilter_linux_test.go
+++ b/pkg/syscallfilter/syscallfilter_linux_test.go
@@ -87,34 +87,6 @@ func TestNoActions(t *testing.T) {
 	}
 }
 
-func TestNoActionsDoubleWait(t *testing.T) {
-	if traced() {
-		t.Skipf("Skipping, we're being traced already")
-	}
-
-	c := Command("echo", "hi")
-	var stdout, stderr bytes.Buffer
-	c.Stdout, c.Stderr = &stdout, &stderr
-
-	if err := c.Run(); err != nil {
-		t.Fatalf(`%v.Run(), "echo", "hi"): %v != nil`, c, err)
-	}
-
-	// Through one path or another, c.Wait() should have been called.
-	// If we get no error here, that is a problem.
-	if err := c.Wait(); err == nil {
-		t.Errorf("c.Wait(): got nil, want an error")
-	}
-
-	t.Logf("stdout: %q, stderr: %q", stdout.String(), stderr.String())
-	if stdout.String() != "hi\n" {
-		t.Errorf("stdout: string is %q, not %q", stdout.String(), "hi\n")
-	}
-	if len(stderr.String()) != 0 {
-		t.Errorf("stderr.String: got %q, want %q", stderr.String(), "")
-	}
-}
-
 func TestNoErrorExit(t *testing.T) {
 	if traced() {
 		t.Skipf("Skipping, we're being traced already")


### PR DESCRIPTION
The test for a double wait is no longer needed
as of the fix called
os/exec: refactor goroutine communication in Wait
4e79f06

With go 1.19 and later, it just hangs. So remove it.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>