### PR TITLE
pkg/cpio: add utility function WriteRecordsAndDirs

### DIFF
--- a/pkg/cpio/utils_test.go
+++ b/pkg/cpio/utils_test.go
@@ -5,6 +5,10 @@
 package cpio
 
 import (
+	"bytes"
+	"errors"
+	"io/fs"
+	"os"
 	"testing"
 )
 
@@ -50,4 +54,52 @@ func TestNormalize(t *testing.T) {
 			t.Errorf("Normalize(%q) = %q, want %q", tt.path, got, tt.want)
 		}
 	}
+}
+
+type bad struct {
+	err error
+}
+
+func (b *bad) WriteRecord(_ Record) error {
+	return b.err
+}
+
+var _ RecordWriter = &bad{}
+
+func TestWriteRecordsAndDirs(t *testing.T) {
+	// Make sure it fails for the non DedupWriters
+	if err := WriteRecordsAndDirs(&bad{}, nil); !errors.Is(err, os.ErrInvalid) {
+		t.Errorf("WriteRecordsAndDirs(&bad{}, nil): got %v, want %v", err, os.ErrInvalid)
+	}
+	var paths = []struct {
+		name string
+		err  error
+	}{
+		{name: "a/b/c/d", err: nil},
+		{name: "a/b/c/e", err: nil},
+		{name: "a/b", err: nil},
+	}
+
+	recs := make([]Record, 0)
+	for _, p := range paths {
+		recs = append(recs, Directory(p.name, 0777))
+	}
+	var b bytes.Buffer
+	w := Newc.Writer(&b)
+	if err := WriteRecordsAndDirs(w, recs[:2]); err != nil {
+		t.Fatalf("Writing %d records: got %v, want nil", len(recs), err)
+	}
+
+	out := "07070100000000000041FF0000000000000000000000000000000000000000000000000000000000000000000000000000000200000000a\x0007070100000000000041FF0000000000000000000000000000000000000000000000000000000000000000000000000000000400000000a/b\x00\x00\x0007070100000000000041FF0000000000000000000000000000000000000000000000000000000000000000000000000000000600000000a/b/c\x0007070100000000000041FF0000000000000000000000000000000000000000000000000000000000000000000000000000000800000000a/b/c/d\x00\x00\x0007070100000000000041FF0000000000000000000000000000000000000000000000000000000000000000000000000000000800000000a/b/c/e\x00\x00\x00"
+	if b.String() != out {
+		t.Fatalf("%q != %q", b.String(), out)
+	}
+	if err := WriteRecordsAndDirs(w, recs); !errors.Is(err, os.ErrExist) {
+		t.Fatalf("Writing %d records: got %v, want %v", len(recs), err, os.ErrExist)
+	}
+	// Test a bad write.
+	if err := WriteRecordsAndDirs(&bad{err: fs.ErrInvalid}, recs); !errors.Is(err, fs.ErrInvalid) {
+		t.Fatalf("Writing %d records: got %v, want %v", len(recs), err, fs.ErrInvalid)
+	}
+
 }


### PR DESCRIPTION
The need for this function is explained in detail in the code. Short form: it is easy to programatically
create cpio files that the Linux kernel does not
parse correctly.

If a file has a/b/c/d, but not Directory records
for a/b/c, the Linux kernel cpio parser will silently discard the record for a/b/c/d. This is not the same behavior as cpio programs.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>