### PR TITLE
Add tool for unlocking TCG Opal-secured NVMe drives

### DIFF
--- a/cmds/exp/disk_unlock/disk_unlock.go
+++ b/cmds/exp/disk_unlock/disk_unlock.go
@@ -1,42 +1,26 @@
-// Copyright 2020 the u-root Authors. All rights reserved
+// Copyright 2022 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// The disk_unlock command is used to unlock a disk drive as follows:
-//  1. Via BMC, read a 32-byte secret seed known as the Host Secret Seed (HSS)
-//     using the OpenBMC IPMI blob transfer protocol
-//  2. Compute a password as follows:
-//     We get the deterministically computed 32-byte HDKF-SHA256 using:
-//     - salt: "SKM PROD_V2 ACCESS"
-//     - hss: 32-byte HSS
-//     - device identity: strings formed by concatenating the assembly serial
-//     number, the _ character, and the assembly part number.
-//  3. Unlock the drive with the given password
-//  4. Update the partition table for the disk
+// The disk_unlock command is used to unlock a disk drive with a
+// HSS-derived password, and rescan the drive to enumerate the
+// unlocked partitions.
 package main
 
 import (
-	"crypto/sha256"
 	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
-	"github.com/u-root/u-root/pkg/ipmi"
-	"github.com/u-root/u-root/pkg/ipmi/blobs"
+	"github.com/u-root/u-root/pkg/hsskey"
 	"github.com/u-root/u-root/pkg/mount/block"
 	"github.com/u-root/u-root/pkg/mount/scuzz"
-	"golang.org/x/crypto/hkdf"
 )
 
 const (
-	hostSecretSeedLen = 32
-
-	passwordSalt = "SKM PROD_V2 ACCESS"
-
 	// Master Password ID for SKM-based unlock.
 	skmMPI = 0x0601
 )
@@ -53,97 +37,6 @@ func verboseLog(msg string) {
 	if *verbose {
 		log.Print(msg)
 	}
-}
-
-// readHssBlob reads a host secret seed from the given blob id.
-func readHssBlob(id string, h *blobs.BlobHandler) (data []uint8, rerr error) {
-	sessionID, err := h.BlobOpen(id, blobs.BMC_BLOB_OPEN_FLAG_READ)
-	if err != nil {
-		return nil, fmt.Errorf("IPMI BlobOpen for %s failed: %v", id, err)
-	}
-	defer func() {
-		// If the function returned successfully but failed to close the blob,
-		// return an error.
-		if err := h.BlobClose(sessionID); err != nil && rerr == nil {
-			rerr = fmt.Errorf("IPMI BlobClose %s failed: %v", id, err)
-		}
-	}()
-
-	data, err = h.BlobRead(sessionID, 0, hostSecretSeedLen)
-	if err != nil {
-		return nil, fmt.Errorf("IPMI BlobRead %s failed: %v", id, err)
-	}
-
-	if len(data) != hostSecretSeedLen {
-		return nil, fmt.Errorf("HSS size incorrect: got %d for %s", len(data), id)
-	}
-
-	return data, nil
-}
-
-// getAllHss reads all host secret seeds over IPMI.
-func getAllHss() ([][]uint8, error) {
-	i, err := ipmi.Open(0)
-	if err != nil {
-		return nil, err
-	}
-	h := blobs.NewBlobHandler(i)
-
-	blobCount, err := h.BlobGetCount()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get blob count: %v", err)
-	}
-
-	hssList := [][]uint8{}
-	seen := make(map[string]bool)
-	skmSubstr := "/skm/hss/"
-
-	// Read from all */skm/hss/* blobs.
-	for j := 0; j < blobCount; j++ {
-		id, err := h.BlobEnumerate(j)
-		if err != nil {
-			return nil, fmt.Errorf("failed to enumerate blob %d: %v", j, err)
-		}
-
-		if !strings.Contains(id, skmSubstr) {
-			continue
-		}
-
-		hss, err := readHssBlob(id, h)
-		if err != nil {
-			log.Printf("failed to read HSS of id %s: %v", id, err)
-			continue
-		}
-
-		msg := fmt.Sprintf("HSS Entry: Id=%s", id)
-		if *verboseNoSanitize {
-			msg = msg + fmt.Sprintf(",Seed=%x", hss)
-		}
-		verboseLog(msg)
-
-		hssStr := fmt.Sprint(hss)
-		if _, ok := seen[hssStr]; !ok {
-			seen[hssStr] = true
-			hssList = append(hssList, hss)
-		}
-	}
-
-	return hssList, nil
-}
-
-// Compute the password deterministically as the 32-byte HDKF-SHA256 of the
-// HSS plus the device identity.
-func genPassword(hss []byte, info *scuzz.Info) ([]byte, error) {
-	hash := sha256.New
-	devID := fmt.Sprintf("%s_%s", info.Serial, info.Model)
-
-	r := hkdf.New(hash, hss, ([]byte)(passwordSalt), ([]byte)(devID))
-	key := make([]byte, 32)
-
-	if _, err := io.ReadFull(r, key); err != nil {
-		return nil, err
-	}
-	return key, nil
 }
 
 // writeFile is ioutil.WriteFile but disallows creating new file
@@ -166,18 +59,6 @@ func writeFile(filename string, contents string) error {
 func main() {
 	flag.Parse()
 
-	// Obtain 32 byte Host Secret Seed (HSS) from IPMI.
-	hssList, err := getAllHss()
-	if err != nil {
-		log.Fatalf("error getting HSS: %v", err)
-	}
-
-	if len(hssList) == 0 {
-		log.Fatalf("no HSS found - can't unlock disk.")
-	}
-
-	verboseLog(fmt.Sprintf("Found %d Host Secret Seeds.", len(hssList)))
-
 	// Open the disk. Read its identity, and use it to unlock the disk.
 	sgdisk, err := scuzz.NewSGDisk(*disk)
 	if err != nil {
@@ -190,6 +71,18 @@ func main() {
 	}
 
 	verboseLog(fmt.Sprintf("Disk info for %s: %s", *disk, info.String()))
+
+	// Obtain 32 byte Host Secret Seed (HSS) from IPMI.
+	hssList, err := hsskey.GetAllHss(*verbose, *verboseNoSanitize)
+	if err != nil {
+		log.Fatalf("error getting HSS: %v", err)
+	}
+
+	if len(hssList) == 0 {
+		log.Fatalf("no HSS found - can't unlock disk.")
+	}
+
+	verboseLog(fmt.Sprintf("Found %d Host Secret Seeds.", len(hssList)))
 
 	switch {
 	case !info.SecurityStatus.SecurityEnabled():
@@ -219,7 +112,7 @@ func main() {
 
 TryAllHSS:
 	for i, hss := range hssList {
-		key, err := genPassword(hss, info)
+		key, err := hsskey.GenPassword(hss, ([]byte)(info.Serial), ([]byte)(info.Model))
 		if err != nil {
 			log.Printf("Couldn't generate password with HSS %d: %v", i, err)
 			continue

--- a/cmds/exp/disk_unlock/disk_unlock.go
+++ b/cmds/exp/disk_unlock/disk_unlock.go
@@ -31,6 +31,7 @@ var (
 	verboseNoSanitize  = flag.Bool("dangerously-disable-sanitize", false, "Print sensitive information - this should only be used for testing!")
 	noRereadPartitions = flag.Bool("no-reread-partitions", false, "Only attempt to unlock the disk, don't re-read the partition table.")
 	retries            = flag.Int("num_retries", 1, "Number of times to retry password if unlocking fails for any reason other than the password being wrong.")
+	salt               = flag.String("salt", hsskey.DefaultPasswordSalt, "Salt for password generation")
 )
 
 func verboseLog(msg string) {
@@ -112,7 +113,7 @@ func main() {
 
 TryAllHSS:
 	for i, hss := range hssList {
-		key, err := hsskey.GenPassword(hss, ([]byte)(info.Serial), ([]byte)(info.Model))
+		key, err := hsskey.GenPassword(hss, *salt, info.Serial, info.Model)
 		if err != nil {
 			log.Printf("Couldn't generate password with HSS %d: %v", i, err)
 			continue

--- a/cmds/exp/nvme_unlock/nvme_unlock.go
+++ b/cmds/exp/nvme_unlock/nvme_unlock.go
@@ -1,0 +1,184 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// The nvme_unlock command is used to unlock a NVMe drive with a
+// HSS-derived password, and rescan the drive to enumerate the
+// unlocked partitions.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/u-root/u-root/pkg/hsskey"
+	"github.com/u-root/u-root/pkg/mount/block"
+)
+
+const (
+	opalLockUnlockIoctl = 1092120797
+)
+
+type opalKey struct {
+	lr     byte
+	keyLen byte
+	align  [6]byte
+	key    [256]byte
+}
+
+type opalSessionInfo struct {
+	sum     uint32
+	who     uint32
+	opalKey opalKey
+}
+
+type opalLockUnlock struct {
+	session opalSessionInfo
+	lState  uint32
+	align   [4]byte
+}
+
+var (
+	disk               = flag.String("disk", "/dev/nvme0n1", "The disk to be unlocked")
+	verbose            = flag.Bool("d", false, "print debug output")
+	verboseNoSanitize  = flag.Bool("dangerously-disable-sanitize", false, "Print sensitive information - this should only be used for testing!")
+	noRereadPartitions = flag.Bool("no-reread-partitions", false, "Only attempt to unlock the disk, don't re-read the partition table.")
+	lock               = flag.Bool("lock", false, "Lock instead of unlocking")
+	salt               = flag.String("salt", hsskey.DefaultPasswordSalt, "Salt for password generation")
+)
+
+func verboseLog(msg string) {
+	if *verbose {
+		log.Print(msg)
+	}
+}
+
+func getSysfsInfo(index string, field string) (string, error) {
+	path := fmt.Sprintf("/sys/class/nvme/nvme%s/%s", index, field)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("error reading sysfs info at path %s: %v", path, err)
+	}
+	return strings.TrimSpace(string(data)), nil
+}
+
+func run(disk string, verbose bool, verboseNoSanitize bool, noRereadPartitions bool, lock bool) error {
+	commandName := "unlock"
+	if lock {
+		commandName = "lock"
+	}
+
+	diskIDRegexp := regexp.MustCompile(`/dev/nvme(\d+)n.*`)
+	diskIDMatches := diskIDRegexp.FindStringSubmatch(disk)
+	if diskIDMatches == nil {
+		return fmt.Errorf("unable to parse device path %s", disk)
+	}
+	diskID := diskIDMatches[1]
+
+	serial, err := getSysfsInfo(diskID, "serial")
+	if err != nil {
+		return err
+	}
+	model, err := getSysfsInfo(diskID, "model")
+	if err != nil {
+		return err
+	}
+
+	if verbose {
+		log.Printf("Serial %s", serial)
+		log.Printf("Model %s", model)
+	}
+
+	diskFd, err := os.Open(disk)
+	if err != nil {
+		return fmt.Errorf("error opening disk: %v", err)
+	}
+	defer diskFd.Close()
+
+	hssList, err := hsskey.GetAllHss(verbose, verboseNoSanitize)
+	if err != nil {
+		return fmt.Errorf("error getting HSS: %v", err)
+	}
+
+	if len(hssList) == 0 {
+		return fmt.Errorf("no HSS found - can't unlock disk")
+	}
+
+	if verbose {
+		log.Printf("Found %d Host Secret Seeds.", len(hssList))
+	}
+
+	succeeded := false
+	for i, hss := range hssList {
+		password, err := hsskey.GenPassword(hss, *salt, serial, model)
+		if err != nil {
+			log.Printf("Couldn't generate password with HSS %d: %v", i, err)
+			continue
+		}
+
+		var state uint32 = 0x02 // OPAL_RW
+		if lock {
+			state = 0x04 // OPAL_LK
+		}
+		arg := opalLockUnlock{
+			session: opalSessionInfo{
+				sum: 0,
+				who: 0,
+				opalKey: opalKey{
+					keyLen: 32,
+				},
+			},
+			lState: state,
+		}
+		copy(arg.session.opalKey.key[0:32], password)
+
+		r1, _, errNo := syscall.Syscall(syscall.SYS_IOCTL, diskFd.Fd(),
+			uintptr(opalLockUnlockIoctl), uintptr(unsafe.Pointer(&arg)))
+		if errNo != 0 {
+			log.Printf("%s failed with errno: %v", commandName, errNo)
+		} else if r1 != 0 {
+			log.Printf("%s returned nonzero value %v, password may be incorrect", commandName, r1)
+		} else {
+			succeeded = true
+			break
+		}
+	}
+
+	if succeeded {
+		log.Printf("Successfully %sed disk %s.", commandName, disk)
+	} else {
+		log.Printf("Failed to %s disk %s with any HSS.", commandName, disk)
+		return fmt.Errorf("all HSS failed")
+	}
+
+	if noRereadPartitions {
+		return nil
+	}
+
+	// Update partitions on the on the disk.
+	if verbose {
+		log.Print("Reloading disk partitions...")
+	}
+	diskdev, err := block.Device(disk)
+	if err != nil {
+		return fmt.Errorf("Could not find %s: %v", disk, err)
+	}
+
+	if err := diskdev.ReadPartitionTable(); err != nil && !lock {
+		return fmt.Errorf("Could not re-read partition table: %v", err)
+	}
+	return nil
+}
+
+func main() {
+	flag.Parse()
+	if err := run(*disk, *verbose, *verboseNoSanitize, *noRereadPartitions, *lock); err != nil {
+		log.Fatalf("nvme_unlock: %v", err)
+	}
+}

--- a/pkg/hsskey/hsskey.go
+++ b/pkg/hsskey/hsskey.go
@@ -1,0 +1,126 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package hsskey provides functionality for generating a key for unlocking
+// drives based on the following procedure:
+//  1. Via BMC, read a 32-byte secret seed known as the Host Secret Seed (HSS)
+//     using the OpenBMC IPMI blob transfer protocol
+//  2. Compute a password as follows:
+//     We get the deterministically computed 32-byte HDKF-SHA256 using:
+//     - salt: "SKM PROD_V2 ACCESS"
+//     - hss: 32-byte HSS
+//     - device identity: strings formed by concatenating the assembly serial
+//     number, the _ character, and the assembly part number.
+package hsskey
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+
+	"github.com/u-root/u-root/pkg/ipmi"
+	"github.com/u-root/u-root/pkg/ipmi/blobs"
+	"golang.org/x/crypto/hkdf"
+)
+
+const (
+	hostSecretSeedLen = 32
+
+	passwordSalt = "SKM PROD_V2 ACCESS"
+)
+
+// readHssBlob reads a host secret seed from the given blob id.
+func readHssBlob(id string, h *blobs.BlobHandler) (data []uint8, rerr error) {
+	sessionID, err := h.BlobOpen(id, blobs.BMC_BLOB_OPEN_FLAG_READ)
+	if err != nil {
+		return nil, fmt.Errorf("IPMI BlobOpen for %s failed: %v", id, err)
+	}
+	defer func() {
+		// If the function returned successfully but failed to close the blob,
+		// return an error.
+		if err := h.BlobClose(sessionID); err != nil && rerr == nil {
+			rerr = fmt.Errorf("IPMI BlobClose %s failed: %v", id, err)
+		}
+	}()
+
+	data, err = h.BlobRead(sessionID, 0, hostSecretSeedLen)
+	if err != nil {
+		return nil, fmt.Errorf("IPMI BlobRead %s failed: %v", id, err)
+	}
+
+	if len(data) != hostSecretSeedLen {
+		return nil, fmt.Errorf("HSS size incorrect: got %d for %s", len(data), id)
+	}
+
+	return data, nil
+}
+
+// GetAllHss reads all host secret seeds over IPMI.
+func GetAllHss(verbose bool, verboseDangerous bool) ([][]uint8, error) {
+	i, err := ipmi.Open(0)
+	if err != nil {
+		return nil, err
+	}
+	h := blobs.NewBlobHandler(i)
+
+	blobCount, err := h.BlobGetCount()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get blob count: %v", err)
+	}
+
+	hssList := [][]uint8{}
+	seen := make(map[string]bool)
+	skmSubstr := "/skm/hss/"
+
+	// Read from all */skm/hss/* blobs.
+	for j := 0; j < blobCount; j++ {
+		id, err := h.BlobEnumerate(j)
+		if err != nil {
+			return nil, fmt.Errorf("failed to enumerate blob %d: %v", j, err)
+		}
+
+		if !strings.Contains(id, skmSubstr) {
+			continue
+		}
+
+		hss, err := readHssBlob(id, h)
+		if err != nil {
+			log.Printf("failed to read HSS of id %s: %v", id, err)
+			continue
+		}
+
+		if verbose {
+			msg := fmt.Sprintf("HSS Entry: Id=%s", id)
+			if verboseDangerous {
+				msg = msg + fmt.Sprintf(",Seed=%x", hss)
+			}
+			log.Print(msg)
+		}
+
+		hssStr := fmt.Sprint(hss)
+		if _, ok := seen[hssStr]; !ok {
+			seen[hssStr] = true
+			hssList = append(hssList, hss)
+		}
+	}
+
+	return hssList, nil
+}
+
+// GenPassword computes the password deterministically as the 32-byte HDKF-SHA256 of the
+// HSS plus the device identity.
+func GenPassword(hss []byte, serial []uint8, model []uint8) ([]byte, error) {
+	hash := sha256.New
+	devID := fmt.Sprintf("%s_%s", serial, model)
+
+	r := hkdf.New(hash, hss, ([]byte)(passwordSalt), ([]byte)(devID))
+	key := make([]byte, 32)
+
+	if _, err := io.ReadFull(r, key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}

--- a/pkg/hsskey/hsskey_test.go
+++ b/pkg/hsskey/hsskey_test.go
@@ -1,0 +1,64 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package hsskey
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/ipmi/blobs"
+)
+
+type mockBlobReader struct {
+	data []uint8
+}
+
+func (h *mockBlobReader) BlobOpen(id string, flags int16) (blobs.SessionID, error) {
+	return 0, nil
+}
+
+func (h *mockBlobReader) BlobRead(sid blobs.SessionID, offset, size uint32) ([]uint8, error) {
+	return h.data, nil
+}
+
+func (h *mockBlobReader) BlobClose(sid blobs.SessionID) error {
+	return nil
+}
+
+func TestGenPassword(t *testing.T) {
+	mockHss := []byte{0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55,
+		0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55,
+		0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55,
+		0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55, 0xaa, 0x55}
+
+	expected := []byte{175, 97, 131, 232, 89, 61, 152, 29, 245,
+		45, 164, 141, 98, 78, 7, 243, 120, 96, 179, 166, 18,
+		59, 22, 172, 16, 151, 191, 99, 141, 25, 35, 246}
+
+	key, err := GenPassword(mockHss, DefaultPasswordSalt, "a", "b")
+
+	if err != nil || !bytes.Equal(key, expected) {
+		t.Fatalf("GenPassword generated a wrong key, expected:\n%v\nbut returned:\n%v", expected, key)
+	}
+}
+
+func TestReadHssBlobEmpty(t *testing.T) {
+	h := mockBlobReader{[]uint8{}}
+	_, err := readHssBlob("", &h)
+
+	if err == nil {
+		t.Fatalf("Expected invalid length failure")
+	}
+}
+
+func TestReadHssBlob(t *testing.T) {
+	data := [hostSecretSeedLen]uint8{}
+	h := mockBlobReader{data: data[:]}
+	_, err := readHssBlob("", &h)
+
+	if err != nil {
+		t.Fatalf("Expected success, got err: %v", err)
+	}
+}


### PR DESCRIPTION
Add a new nvme_unlock command to unlock NVMe drives secured according to the TCG Opal specification, using the kernel's sed-opal driver.  This uses the same key generation algorithm as the disk_unlock command, so that functionality is refactored into a separate package hsskey.

Signed-off-by: Albert Morgese <amorgese@google.com>