### PR TITLE
pkg/pty/pty_test:Skip test if /dev/tty does not exist

### DIFF
--- a/pkg/pty/pty_test.go
+++ b/pkg/pty/pty_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	if _, err := New(); os.IsNotExist(err) {
+	if _, err := New(); os.IsNotExist(err) || errors.Is(err, syscall.ENXIO) {
 		t.Skipf("Failed allocate /dev/pts device")
 	} else if err != nil {
 		t.Errorf("New pty: want nil, got %v", err)


### PR DESCRIPTION
Similar to TestRunRestoreTTYMode() below, TestNew() should skip the case when there is no /dev/tty in the system.

Signed-off-by: Changyuan Lyu <changyuanl@google.com>