### PR TITLE
cmds/core/cat: don't pass cmdline args as a [FILE]

### DIFF
--- a/cmds/core/cat/cat.go
+++ b/cmds/core/cat/cat.go
@@ -55,7 +55,7 @@ func run(args []string, stdin io.Reader, stdout io.Writer) error {
 
 func main() {
 	flag.Parse()
-	if err := run(os.Args[1:], os.Stdin, os.Stdout); err != nil {
+	if err := run(flag.Args(), os.Stdin, os.Stdout); err != nil {
 		log.Fatalf("cat failed with: %v", err)
 	}
 }


### PR DESCRIPTION
currenlty cat -u file.txt will try to open file -u

Signed-off-by: Siarhiej Siemianczuk <pdp.eleven11@gmail.com>