### PR TITLE
[oss-fuzz integration]: misc fixes in fuzzing tests

### DIFF
--- a/cmds/boot/localboot/grub_test.go
+++ b/cmds/boot/localboot/grub_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func FuzzParseGrubCfg(f *testing.F) {
-	tmpDir := f.TempDir()
 
 	//no log output
 	log.SetOutput(io.Discard)
@@ -46,6 +45,7 @@ func FuzzParseGrubCfg(f *testing.F) {
 			return
 		}
 
+		tmpDir := t.TempDir()
 		blockDevs := block.BlockDevices{&block.BlockDev{Name: tmpDir, FSType: "test", FsUUID: "07338180-4a96-4611-aa6a-a452600e4cfe"}}
 		ParseGrubCfg(grubV2, blockDevs, data, tmpDir)
 

--- a/pkg/boot/grub/config_test.go
+++ b/pkg/boot/grub/config_test.go
@@ -150,10 +150,10 @@ func FuzzParseGrubConfig(f *testing.F) {
 
 		baseDir := t.TempDir()
 
-		dirPath := baseDir + "/EFI/uefi"
+		dirPath := filepath.Join(baseDir, "EFI", "uefi")
 		err := os.MkdirAll(dirPath, 0o777)
 		if err != nil {
-			t.Errorf("failed %v: %v", dirPath, err)
+			t.Fatalf("failed %v: %v", dirPath, err)
 		}
 
 		path := filepath.Join(dirPath, "grub.cfg")
@@ -171,7 +171,7 @@ func FuzzParseGrubConfig(f *testing.F) {
 
 		err = os.WriteFile(path, data, 0o777)
 		if err != nil {
-			t.Errorf("Failed to create configfile '%v':%v", path, err)
+			t.Fatalf("Failed to create configfile '%v':%v", path, err)
 		}
 
 		ParseLocalConfig(context.Background(), baseDir, devices, mountPool)

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -5,6 +5,7 @@
 package syslinux
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -708,9 +709,6 @@ func TestParseURL(t *testing.T) {
 }
 
 func FuzzParseSyslinuxConfig(f *testing.F) {
-	dirPath := f.TempDir()
-
-	path := filepath.Join(dirPath, "isolinux.cfg")
 
 	log.SetOutput(io.Discard)
 	log.SetFlags(0)
@@ -733,10 +731,19 @@ func FuzzParseSyslinuxConfig(f *testing.F) {
 	f.Add([]byte("lABel 0\nAppend initrd"))
 	f.Add([]byte("lABel 0\nkernel mboot.c32\nAppend ---"))
 	f.Fuzz(func(t *testing.T, data []byte) {
-		if len(data) > 1000000 {
+
+		if len(data) > 4096 {
 			return
 		}
 
+		// do not allow arbitrary files reads
+		if bytes.Contains(data, []byte("include")) {
+			return
+		}
+
+		dirPath := t.TempDir()
+
+		path := filepath.Join(dirPath, "isolinux.cfg")
 		err := os.WriteFile(path, data, 0o777)
 		if err != nil {
 			t.Errorf("Failed to create configfile '%v':%v", path, err)

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -746,7 +746,7 @@ func FuzzParseSyslinuxConfig(f *testing.F) {
 		path := filepath.Join(dirPath, "isolinux.cfg")
 		err := os.WriteFile(path, data, 0o777)
 		if err != nil {
-			t.Errorf("Failed to create configfile '%v':%v", path, err)
+			t.Fatalf("Failed to create configfile '%v':%v", path, err)
 		}
 
 		ParseLocalConfig(context.Background(), dirPath)

--- a/pkg/cpio/newc_test.go
+++ b/pkg/cpio/newc_test.go
@@ -660,13 +660,13 @@ func FuzzReadWriteNewc(f *testing.F) {
 		}
 
 		if err := WriteTrailer(w); err != nil {
-			t.Errorf("WriteTrailer: %v", err)
+			t.Fatalf("WriteTrailer: %v", err)
 		}
 
 		r = Newc.Reader(bytes.NewReader(buf.Bytes()))
 		filesReadBack, err := ReadAllRecords(r)
 		if err != nil {
-			t.Errorf("TestReadWrite: reading generated data: %v", err)
+			t.Fatalf("TestReadWrite: reading generated data: %v", err)
 		}
 
 		// Now check a few things: arrays should be same length, Headers should match,

--- a/pkg/cpio/newc_test.go
+++ b/pkg/cpio/newc_test.go
@@ -7,6 +7,7 @@ package cpio
 import (
 	"bytes"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -634,10 +635,12 @@ func FuzzReadWriteNewc(f *testing.F) {
 
 	// Cannot log when fuzzing
 	Debug = func(s string, i ...interface{}) {}
+	log.SetOutput(io.Discard)
+	log.SetFlags(0)
 
 	f.Fuzz(func(t *testing.T, cpio []byte) {
 		// Unneccessary big inputs will only slow down the fuzzing
-		if len(cpio) > 256000 {
+		if len(cpio) > 64 {
 			return
 		}
 

--- a/pkg/cpio/testdata/fuzz/fuzz_read_write_newc.options
+++ b/pkg/cpio/testdata/fuzz/fuzz_read_write_newc.options
@@ -1,3 +1,3 @@
 [libfuzzer]
 dict = cpio.dict
-rss_limit_mb=10240
+max_len=64


### PR DESCRIPTION
These changes are intended as fixes to the fuzzing tests when running in the oss-fuzz environment.
1. Reduce input size of one test so libfuzzer does not run out of memory 
2. Use a temporary directory per fuzzing input run so no execution is influenced by previous runs
Signed-off-by: Fabian Wienand <fabian.wienand@9elements.com>