### PR TITLE
oss-fuzz: replace t.TempDir()

### DIFF
--- a/cmds/boot/localboot/grub_test.go
+++ b/cmds/boot/localboot/grub_test.go
@@ -16,6 +16,8 @@ import (
 
 func FuzzParseGrubCfg(f *testing.F) {
 
+	tmpDir := f.TempDir()
+
 	//no log output
 	log.SetOutput(io.Discard)
 	log.SetFlags(0)
@@ -40,12 +42,12 @@ func FuzzParseGrubCfg(f *testing.F) {
 
 		f.Add(string(seedBytes))
 	}
+
 	f.Fuzz(func(t *testing.T, data string) {
 		if len(data) > 256000 {
 			return
 		}
 
-		tmpDir := t.TempDir()
 		blockDevs := block.BlockDevices{&block.BlockDev{Name: tmpDir, FSType: "test", FsUUID: "07338180-4a96-4611-aa6a-a452600e4cfe"}}
 		ParseGrubCfg(grubV2, blockDevs, data, tmpDir)
 

--- a/cmds/exp/gosh/gosh_test.go
+++ b/cmds/exp/gosh/gosh_test.go
@@ -200,6 +200,7 @@ func FuzzRun(f *testing.F) {
 		"wait with args not handled yet"}
 	re := strings.NewReplacer("\x22", "", "\x24", "", "\x26", "", "\x27", "", "\x28", "", "\x29", "", "\x2A", "", "\x3C", "", "\x3E", "", "\x3F", "", "\x5C", "", "\x7C", "")
 
+	dirPath := f.TempDir()
 	sh := shell{}
 	var buf bytes.Buffer
 	runner, err := interp.New(interp.StdIO(nil, &buf, &buf))
@@ -265,7 +266,6 @@ func FuzzRun(f *testing.F) {
 			return
 		}
 
-		dirPath := t.TempDir()
 		buf.Reset()
 		runner.Reset()
 		runner.Dir = dirPath

--- a/pkg/boot/grub/config_test.go
+++ b/pkg/boot/grub/config_test.go
@@ -112,6 +112,27 @@ func TestConfigs(t *testing.T) {
 
 func FuzzParseGrubConfig(f *testing.F) {
 
+	baseDir := f.TempDir()
+
+	dirPath := filepath.Join(baseDir, "EFI", "uefi")
+	err := os.MkdirAll(dirPath, 0o777)
+	if err != nil {
+		f.Fatalf("failed %v: %v", dirPath, err)
+	}
+
+	path := filepath.Join(dirPath, "grub.cfg")
+	devices := block.BlockDevices{&block.BlockDev{
+		Name:   dirPath,
+		FSType: "test",
+		FsUUID: strings.TrimSpace("07338180-4a96-4611-aa6a-a452600e4cfe"),
+	}}
+	mountPool := &mount.Pool{}
+	mountPool.Add(&mount.MountPoint{
+		Path:   dirPath,
+		Device: filepath.Join("/dev", dirPath),
+		FSType: "test",
+	})
+
 	//no log output
 	log.SetOutput(io.Discard)
 	log.SetFlags(0)
@@ -147,27 +168,6 @@ func FuzzParseGrubConfig(f *testing.F) {
 		if bytes.Contains(data, []byte("include")) {
 			return
 		}
-
-		baseDir := t.TempDir()
-
-		dirPath := filepath.Join(baseDir, "EFI", "uefi")
-		err := os.MkdirAll(dirPath, 0o777)
-		if err != nil {
-			t.Fatalf("failed %v: %v", dirPath, err)
-		}
-
-		path := filepath.Join(dirPath, "grub.cfg")
-		devices := block.BlockDevices{&block.BlockDev{
-			Name:   dirPath,
-			FSType: "test",
-			FsUUID: strings.TrimSpace("07338180-4a96-4611-aa6a-a452600e4cfe"),
-		}}
-		mountPool := &mount.Pool{}
-		mountPool.Add(&mount.MountPoint{
-			Path:   dirPath,
-			Device: filepath.Join("/dev", dirPath),
-			FSType: "test",
-		})
 
 		err = os.WriteFile(path, data, 0o777)
 		if err != nil {

--- a/pkg/boot/syslinux/syslinux_test.go
+++ b/pkg/boot/syslinux/syslinux_test.go
@@ -710,6 +710,10 @@ func TestParseURL(t *testing.T) {
 
 func FuzzParseSyslinuxConfig(f *testing.F) {
 
+	dirPath := f.TempDir()
+
+	path := filepath.Join(dirPath, "isolinux.cfg")
+
 	log.SetOutput(io.Discard)
 	log.SetFlags(0)
 
@@ -741,9 +745,6 @@ func FuzzParseSyslinuxConfig(f *testing.F) {
 			return
 		}
 
-		dirPath := t.TempDir()
-
-		path := filepath.Join(dirPath, "isolinux.cfg")
 		err := os.WriteFile(path, data, 0o777)
 		if err != nil {
 			t.Fatalf("Failed to create configfile '%v':%v", path, err)


### PR DESCRIPTION
Need to roll back some fuzzing tests from calling f.TempDir() to t.TempDir(), as this is currently not supported by OSS-Fuzz. 
As each run in oss-fuzz is sandboxed anyway, this is only relevant when fuzzing locally. 
Signed-off-by: Fabian Wienand <fabian.wienand@9elements.com>