### PR TITLE
cmds/core/date: set test error output to bytes.Buffer

### DIFF
--- a/cmds/core/date/date_test.go
+++ b/cmds/core/date/date_test.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"os"
 	"regexp"
 	"strings"
@@ -237,6 +238,11 @@ func TestRun(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var buf bytes.Buffer
 			rc := RealClock{}
+			// Avoid spamming our CI with errors -- we don't
+			// look at error output (yet), but when we do, this
+			// bytes.Buffer will make it more convenient.
+			var stderr bytes.Buffer
+			flag.CommandLine.SetOutput(&stderr)
 			if err := run(tt.arg, tt.univ, tt.fileref, rc, &buf); err != nil {
 				if !strings.Contains(err.Error(), tt.wantErr) {
 					t.Errorf("%q failed: %q", tt.name, err)


### PR DESCRIPTION
There is some error text printed by date tests, and it makes looking at CI errors very difficult. Direct it into a bytes.Buffer instead.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>