### PR TITLE
Identify boot drive by SMBIOS slot information

### DIFF
--- a/cmds/exp/nvme_unlock/nvme_unlock.go
+++ b/cmds/exp/nvme_unlock/nvme_unlock.go
@@ -17,6 +17,7 @@ import (
 	"syscall"
 	"unsafe"
 
+	"github.com/u-root/u-root/pkg/finddrive"
 	"github.com/u-root/u-root/pkg/hsskey"
 	"github.com/u-root/u-root/pkg/mount/block"
 )
@@ -45,7 +46,7 @@ type opalLockUnlock struct {
 }
 
 var (
-	disk               = flag.String("disk", "/dev/nvme0n1", "The disk to be unlocked")
+	disk               = flag.String("disk", "", "The disk to be unlocked - will be discovered if left blank")
 	verbose            = flag.Bool("d", false, "print debug output")
 	verboseNoSanitize  = flag.Bool("dangerously-disable-sanitize", false, "Print sensitive information - this should only be used for testing!")
 	noRereadPartitions = flag.Bool("no-reread-partitions", false, "Only attempt to unlock the disk, don't re-read the partition table.")
@@ -69,6 +70,20 @@ func getSysfsInfo(index string, field string) (string, error) {
 }
 
 func run(disk string, verbose bool, verboseNoSanitize bool, noRereadPartitions bool, lock bool) error {
+	if disk == "" {
+		disks, err := finddrive.FindSlotType(finddrive.M2MKeySlotType)
+		if err != nil {
+			return fmt.Errorf("error finding boot disk: %v", err)
+		}
+		if len(disks) == 0 {
+			return fmt.Errorf("no boot disk found")
+		}
+		disk = disks[0]
+		if len(disks) > 1 {
+			log.Printf("Multiple boot disk candidates found, using the first from the list: %v", disks)
+		}
+	}
+
 	commandName := "unlock"
 	if lock {
 		commandName = "lock"

--- a/pkg/finddrive/finddrive.go
+++ b/pkg/finddrive/finddrive.go
@@ -1,0 +1,81 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package finddrive provides functionality to find an NVMe block device associated with
+// a particular physical slot on the machine, based on information in the SMBIOS table.
+package finddrive
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/u-root/u-root/pkg/smbios"
+)
+
+const (
+	// M2MKeySlotType is the SMBIOS slot type code for M.2 M-key
+	M2MKeySlotType = 0x17
+)
+
+// The path /sys/block/nvme0n1 will be a symlink to
+// /sys/devices/pci<domain:bus>/<slot BDF>/<drive BDF>/nvme/nvme0/nvme0n1
+func findBlockDevFromSmbios(sysPath string, s smbios.SystemSlots) ([]string, error) {
+	dev := (s.DeviceFunctionNumber & 0b11111000) >> 3
+	fn := s.DeviceFunctionNumber & 0b111
+	domainBusStr := fmt.Sprintf("%04x:%02x", s.SegmentGroupNumber, s.BusNumber)
+	slotBDFPrefix := fmt.Sprintf("%s/devices/pci%s/%s:%02x.%x/", sysPath, domainBusStr, domainBusStr, dev, fn)
+
+	blockPath := sysPath + "/block/"
+	dirEntries, err := os.ReadDir(blockPath)
+	if err != nil {
+		return nil, err
+	}
+	devPaths := make([]string, 0)
+	for _, dirEntry := range dirEntries {
+		path := blockPath + dirEntry.Name()
+		realPath, err := filepath.EvalSymlinks(path)
+		if err != nil {
+			return nil, err
+		}
+		if strings.HasPrefix(realPath, slotBDFPrefix) {
+			devPaths = append(devPaths, "/dev/"+dirEntry.Name())
+		}
+	}
+	return devPaths, nil
+}
+
+func findSlotType(sysPath string, slots []*smbios.SystemSlots, slotType uint8) ([]string, error) {
+	paths := make([]string, 0)
+	for _, s := range slots {
+		if s.SlotType == slotType {
+			newPaths, err := findBlockDevFromSmbios(sysPath, *s)
+			if err == nil {
+				paths = append(paths, newPaths...)
+			} else {
+				log.Printf("Error finding matching block device: %v", err)
+			}
+		}
+	}
+
+	return paths, nil
+}
+
+// FindSlotType searches the SMBIOS table for drives inserted in a slot with the specified type
+func FindSlotType(slotType uint8) ([]string, error) {
+	smbiosTables, err := smbios.FromSysfs()
+	if err != nil {
+		log.Printf("Could not read SMBIOS tables for version: %v", err)
+		return nil, err
+	}
+	slots, err := smbiosTables.GetSystemSlots()
+	if err != nil {
+		log.Printf("Could not read system slots from SMBIOS: %v", err)
+		return nil, err
+	}
+
+	return findSlotType("/sys", slots, slotType)
+}

--- a/pkg/finddrive/finddrive_test.go
+++ b/pkg/finddrive/finddrive_test.go
@@ -1,0 +1,103 @@
+// Copyright 2022 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package finddrive
+
+import (
+	"os"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/smbios"
+)
+
+const (
+	matchingSlotType    = 0xBB
+	nonMatchingSlotType = 0x66
+	missingSlotType     = 0x43
+	devName             = "nvme0n1"
+	matchedSlotPath     = "/dev/" + devName
+)
+
+var (
+	matchingSlot = smbios.SystemSlots{
+		SlotType:             matchingSlotType,
+		SegmentGroupNumber:   0x0A5A,
+		BusNumber:            0x44,
+		DeviceFunctionNumber: 0x96,
+	}
+	nonMatchingSlot = smbios.SystemSlots{
+		SlotType: nonMatchingSlotType,
+	}
+)
+
+func mockSysDir(t *testing.T) string {
+	sysDir := t.TempDir()
+
+	devicesPath := sysDir + "/devices/pci0a5a:44/0a5a:44:12.6/0a5a:00:00.0/nvme/nvme0/"
+	err := os.MkdirAll(devicesPath, 0o777)
+	if err != nil {
+		t.Errorf("Error creating path %s: %v", devicesPath, err)
+	}
+
+	err = os.MkdirAll(sysDir+"/block/", 0o777)
+	if err != nil {
+		t.Errorf("Error creating path %s: %v", sysDir+"/block/", err)
+	}
+
+	devicesFile := devicesPath + devName
+	f, err := os.Create(devicesFile)
+	if err != nil {
+		t.Errorf("Error creating file %s: %v", devicesFile, err)
+	}
+	f.Close()
+
+	err = os.Symlink(devicesFile, sysDir+"/block/nvme0n1")
+	if err != nil {
+		t.Errorf("Error creating symlink: %v", err)
+	}
+
+	return sysDir
+}
+
+func TestFindSlotType(t *testing.T) {
+	sysDir := mockSysDir(t)
+	slots := []*smbios.SystemSlots{&nonMatchingSlot, &matchingSlot, &nonMatchingSlot, &matchingSlot, &nonMatchingSlot}
+
+	paths, err := findSlotType(sysDir, slots, matchingSlotType)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(paths) != 2 || paths[0] != matchedSlotPath || paths[1] != matchedSlotPath {
+		t.Errorf("Wrong paths returned: %v", paths)
+	}
+}
+
+func TestFindSlotTypeMissing(t *testing.T) {
+	sysDir := mockSysDir(t)
+	slots := []*smbios.SystemSlots{&nonMatchingSlot, &matchingSlot, &nonMatchingSlot, &matchingSlot, &nonMatchingSlot}
+
+	paths, err := findSlotType(sysDir, slots, missingSlotType)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Errorf("Expected no paths returned: %v", paths)
+	}
+}
+
+func TestFindSlotTypeNoSlots(t *testing.T) {
+	sysDir := mockSysDir(t)
+	slots := []*smbios.SystemSlots{}
+
+	paths, err := findSlotType(sysDir, slots, matchingSlotType)
+
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Errorf("Expected no paths returned: %v", paths)
+	}
+}


### PR DESCRIPTION
This change adds a package under pkg/finddrive which provides functionality to identify the device path for a PCI-based block device, using slot type information provided by the SMBIOS table.  This is useful for systems with multiple NVMe drives, to disambiguate which should be attempted to boot from.  (The particular configuration motivating this change has a boot drive in the sole M.2 slot, with a number of other NVMe drives connected via PCIe slots.)

This change also modifies nvme_unlock to use this functionality by default, if no explicit device path is provided.

Signed-off-by: Albert Morgese <amorgese@google.com>