### PR TITLE
Use unix.ByteSliceToString to convert Utsname fields

### DIFF
--- a/cmds/core/uname/uname.go
+++ b/cmds/core/uname/uname.go
@@ -23,7 +23,6 @@
 package main
 
 import (
-	"bytes"
 	"flag"
 	"fmt"
 	"log"
@@ -43,14 +42,10 @@ var (
 	domain    = flag.Bool("d", false, "print your domain name")
 )
 
-func toString(d []byte) string {
-	return string(d[:bytes.IndexByte(d[:], 0)])
-}
-
 func handleFlags(u *unix.Utsname) string {
-	Sysname, Nodename := toString(u.Sysname[:]), toString(u.Nodename[:])
-	Release, Version := toString(u.Release[:]), toString(u.Version[:])
-	Machine, Domainname := toString(u.Machine[:]), toString(u.Domainname[:])
+	Sysname, Nodename := unix.ByteSliceToString(u.Sysname[:]), unix.ByteSliceToString(u.Nodename[:])
+	Release, Version := unix.ByteSliceToString(u.Release[:]), unix.ByteSliceToString(u.Version[:])
+	Machine, Domainname := unix.ByteSliceToString(u.Machine[:]), unix.ByteSliceToString(u.Domainname[:])
 	info := make([]string, 0, 6)
 
 	if *all || flag.NFlag() == 0 {

--- a/pkg/kmodule/kmodule_linux.go
+++ b/pkg/kmodule/kmodule_linux.go
@@ -10,7 +10,6 @@ package kmodule
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -177,7 +176,7 @@ func genDeps(opts ProbeOpts) (depMap, error) {
 		if err := unix.Uname(&u); err != nil {
 			return nil, fmt.Errorf("could not get release (uname -r): %v", err)
 		}
-		rel = string(u.Release[:bytes.IndexByte(u.Release[:], 0)])
+		rel = unix.ByteSliceToString(u.Release[:])
 	}
 
 	var moduleDir string


### PR DESCRIPTION
Use `ByteSliceToString` defined in the `golang.org/x/sys/unix` package to convert `Utsname` `[]byte` fields to strings.
