### PR TITLE
gotest: run benchmarks in VMs

### DIFF
--- a/integration/testcmd/gotest/uinit/gotest.go
+++ b/integration/testcmd/gotest/uinit/gotest.go
@@ -89,7 +89,7 @@ func runTest() error {
 			return
 		}
 
-		args := []string{"-test.v"}
+		args := []string{"-test.v", "-test.bench=.", "-test.run=."}
 		coverFile := filepath.Join(filepath.Dir(path), "coverage.txt")
 		if len(*coverProfile) > 0 {
 			args = append(args, "-test.coverprofile", coverFile)


### PR DESCRIPTION
By default, running a test binary only runs tests, not benchmarks or fuzz tests. this left VM tests out of that ability. Adding just benchmark tests here, because fuzz tests need some more flags that I didn't want to figure out.

Also fixing some test that started failing in the VM presumably because the VM is slower and the test is flaky.