### PR TITLE
Deprecate UROOT_SOURCE and allow Go package paths again

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,9 +10,14 @@ jobs:
 
   linters:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go/src/github.com/u-root/u-root
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        path: go/src/github.com/u-root/u-root
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
@@ -53,9 +58,14 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go/src/github.com/u-root/u-root
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        path: go/src/github.com/u-root/u-root
 
     - name: Set up Go
       uses: actions/setup-go@v2
@@ -63,19 +73,24 @@ jobs:
         go-version: 1.19
 
     - name: Build
-      run: go build -mod=mod -v ./...
+      run: GOPATH=$GITHUB_WORKSPACE/go go build -mod=mod -v ./...
 
     - name: Vet Test
       run: go vet -composites=false -mod=mod ./...
 
     - name: Test
-      run: "CGO_ENABLED=0 go env && CGO_ENABLED=0 go test -mod=mod  ./pkg/uroot/..."
+      run: "CGO_ENABLED=0 go env && GOPATH=$GITHUB_WORKSPACE/go CGO_ENABLED=0 go test -mod=mod  ./pkg/uroot/..."
 
   badbuild:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go/src/github.com/u-root/u-root
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+      with:
+        path: go/src/github.com/u-root/u-root
 
     - name: Set up Go
       uses: actions/setup-go@v2

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-tpm v0.3.3
 	github.com/google/goexpect v0.0.0-20191001010744-5b6988669ffa
 	github.com/google/uuid v1.3.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/insomniacslk/dhcp v0.0.0-20211209223715-7d93572ebe8e
 	github.com/intel-go/cpuid v0.0.0-20200819041909-2aa72927c3e2
 	github.com/kevinburke/ssh_config v1.1.0
@@ -51,7 +52,6 @@ require (
 	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/google/goterm v0.0.0-20200907032337-555d40f16ae2 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/jsimonetti/rtnetlink v0.0.0-20201110080708-d2c240429e6c // indirect
 	github.com/kaey/framebuffer v0.0.0-20140402104929-7b385489a1ff // indirect
 	github.com/mattn/go-colorable v0.1.7 // indirect

--- a/pkg/uroot/builder/binary_test.go
+++ b/pkg/uroot/builder/binary_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
 )
 
-func TestGBBBuild(t *testing.T) {
+func TestBinaryBuild(t *testing.T) {
 	dir := t.TempDir()
 
 	opts := Opts{
@@ -20,21 +20,23 @@ func TestGBBBuild(t *testing.T) {
 		Packages: []string{
 			"../test/foo",
 			"../../../cmds/core/elvish",
+			"github.com/u-root/u-root/cmds/core/init",
+			"cmd/test2json",
 		},
 		TempDir:   dir,
 		BinaryDir: "bbin",
 		BuildOpts: &gbbgolang.BuildOpts{},
 	}
 	af := initramfs.NewFiles()
-	var gbb GBBBuilder
-	if err := gbb.Build(ulogtest.Logger{TB: t}, af, opts); err != nil {
+	var b BinaryBuilder
+	if err := b.Build(ulogtest.Logger{TB: t}, af, opts); err != nil {
 		t.Fatalf("Build(%v, %v); %v != nil", af, opts, err)
 	}
 
 	mustContain := []string{
 		"bbin/elvish",
 		"bbin/foo",
-		"bbin/bb",
+		"bbin/init",
 	}
 	for _, name := range mustContain {
 		if !af.Contains(name) {

--- a/pkg/uroot/builder/builder.go
+++ b/pkg/uroot/builder/builder.go
@@ -6,7 +6,6 @@ package builder
 
 import (
 	gbbgolang "github.com/u-root/gobusybox/src/pkg/golang"
-	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/ulog"
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
 )
@@ -21,7 +20,7 @@ var (
 // Opts are options passed to the Builder.Build function.
 type Opts struct {
 	// Env is the Go compiler environment.
-	Env golang.Environ
+	Env gbbgolang.Environ
 
 	// Build options for building go binaries. Ultimate this holds all the
 	// args that end up being passed to `go build`.

--- a/pkg/uroot/builder/gbb.go
+++ b/pkg/uroot/builder/gbb.go
@@ -7,12 +7,10 @@ package builder
 import (
 	"errors"
 	"fmt"
-	"os"
 	"path"
 	"path/filepath"
 
 	"github.com/u-root/gobusybox/src/pkg/bb"
-	"github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/u-root/pkg/cpio"
 	"github.com/u-root/u-root/pkg/ulog"
 	"github.com/u-root/u-root/pkg/uroot/initramfs"
@@ -56,19 +54,12 @@ func (b GBBBuilder) Build(l ulog.Logger, af *initramfs.Files, opts Opts) error {
 	}
 	bbPath := filepath.Join(opts.TempDir, "bb")
 
-	// gobusybox has its own copy of the golang package, but Environ stayed
-	// (mostly) the same.
-	env := golang.Environ{
-		Context:     opts.Env.Context,
-		GO111MODULE: os.Getenv("GO111MODULE"),
-	}
-
 	if len(opts.BinaryDir) == 0 {
 		return fmt.Errorf("must specify binary directory")
 	}
 
 	bopts := &bb.Opts{
-		Env:          env,
+		Env:          opts.Env,
 		GenSrcDir:    opts.TempDir,
 		CommandPaths: opts.Packages,
 		BinaryPath:   bbPath,

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -415,7 +415,10 @@ func resolveGlobs(logger ulog.Logger, env gbbgolang.Environ, input string) ([]st
 			}
 			absPath, _ := filepath.Abs(match)
 
-			p, err := lookupPkgs(env, "", absPath)
+			// File paths have to be looked up *in* their
+			// directory, so that *their* go.mod is used to resolve
+			// them.
+			p, err := lookupPkgs(env, absPath, absPath)
 			if err != nil {
 				return nil, fmt.Errorf("failed to look up %q: %v", match, err)
 			} else if len(p) > 1 {

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -144,11 +144,6 @@ type Opts struct {
 	//   }
 	Commands []Commands
 
-	// UrootSource is the filesystem path to the locally checked out
-	// u-root source tree. This is needed to resolve templates or
-	// import paths of u-root commands.
-	UrootSource string
-
 	// TempDir is a temporary directory for builders to store files in.
 	TempDir string
 

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	gbbgolang "github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/u-root/pkg/cpio"
-	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/ldd"
 	"github.com/u-root/u-root/pkg/uflag"
 	"github.com/u-root/u-root/pkg/ulog"
@@ -43,7 +42,7 @@ const (
 // If an OS is not known it will return a reasonable u-root specific
 // default.
 func DefaultRamfs() *cpio.Archive {
-	switch golang.Default().GOOS {
+	switch gbbgolang.Default().GOOS {
 	case "linux":
 		return cpio.ArchiveFromRecords([]cpio.Record{
 			cpio.Directory("bin", 0o755),
@@ -119,7 +118,9 @@ func (c Commands) TargetDir() string {
 // build environment.
 type Opts struct {
 	// Env is the Golang build environment (GOOS, GOARCH, etc).
-	Env golang.Environ
+	//
+	// If nil, gbbgolang.Default is used.
+	Env *gbbgolang.Environ
 
 	// Commands specify packages to build using a specific builder.
 	//
@@ -232,13 +233,15 @@ func CreateInitramfs(logger ulog.Logger, opts Opts) error {
 		return fmt.Errorf("must give output file")
 	}
 
-	files := initramfs.NewFiles()
-
-	// Use the new busybox Environ.
-	env := gbbgolang.Environ{
-		Context:     opts.Env.Context,
-		GO111MODULE: os.Getenv("GO111MODULE"),
+	env := gbbgolang.Default()
+	if opts.Env != nil {
+		env = *opts.Env
 	}
+	if opts.BuildOpts == nil {
+		opts.BuildOpts = &gbbgolang.BuildOpts{}
+	}
+
+	files := initramfs.NewFiles()
 
 	// Expand commands.
 	for index, cmds := range opts.Commands {
@@ -247,11 +250,6 @@ func CreateInitramfs(logger ulog.Logger, opts Opts) error {
 			return err
 		}
 		opts.Commands[index].Packages = directoryPaths
-	}
-
-	// Make sure this isn't a nil pointer
-	if opts.BuildOpts == nil {
-		opts.BuildOpts = &gbbgolang.BuildOpts{}
 	}
 
 	// Add each build mode's commands to the archive.
@@ -263,7 +261,7 @@ func CreateInitramfs(logger ulog.Logger, opts Opts) error {
 
 		// Build packages.
 		bOpts := builder.Opts{
-			Env:       opts.Env,
+			Env:       env,
 			BuildOpts: opts.BuildOpts,
 			Packages:  cmds.Packages,
 			TempDir:   builderTmpDir,

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -13,8 +13,10 @@ import (
 	"syscall"
 	"testing"
 
+	gbbgolang "github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/u-root/pkg/cpio"
 	"github.com/u-root/u-root/pkg/golang"
+	"github.com/u-root/u-root/pkg/ulog/ulogtest"
 	"github.com/u-root/u-root/pkg/uroot/builder"
 	itest "github.com/u-root/u-root/pkg/uroot/initramfs/test"
 )
@@ -337,5 +339,182 @@ func TestCreateInitramfs(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestResolveGlobsSpecialCases(t *testing.T) {
+	gopath1, err := filepath.Abs("test/gopath1")
+	if err != nil {
+		t.Fatalf("failure to set up test: %v", err)
+	}
+	urootpath, err := filepath.Abs("../../")
+	if err != nil {
+		t.Fatalf("failure to set up test: %v", err)
+	}
+	gopath2, err := filepath.Abs("test/gopath2")
+	if err != nil {
+		t.Fatalf("failure to set up test: %v", err)
+	}
+
+	moduleOffEnv := gbbgolang.Default()
+	moduleOffEnv.GO111MODULE = "off"
+
+	gopath1Env := moduleOffEnv
+	gopath1Env.GOPATH = gopath1
+
+	gopath2Env := moduleOffEnv
+	gopath2Env.GOPATH = gopath2
+
+	l := &ulogtest.Logger{TB: t}
+
+	for _, tc := range []struct {
+		env      gbbgolang.Environ
+		in       string
+		expected []string
+		wantErr  bool
+	}{
+		// Single package directory relative to GOPATH
+		{
+			env:      gopath1Env,
+			in:       filepath.Join(gopath1, "src/foo"),
+			expected: []string{filepath.Join(urootpath, "pkg/uroot/test/gopath1/src/foo")},
+			wantErr:  false,
+		},
+		// Go import path glob
+		{
+			env: gopath2Env,
+			in:  "mypkg*",
+			expected: []string{
+				"mypkga",
+				"mypkgb",
+			},
+			wantErr: false,
+		},
+	} {
+		t.Run(fmt.Sprintf("%q", tc.in), func(t *testing.T) {
+			out, err := resolveGlobs(l, tc.env, tc.in)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("resolveGlobs(%v, %v) = (%v, %v), wantErr is %t", tc.env, tc.in, out, err, tc.wantErr)
+			}
+			if !reflect.DeepEqual(out, tc.expected) {
+				t.Errorf("resolveGlobs(%v, %v) = %#v; want %#v", tc.env, tc.in, out, tc.expected)
+			}
+		})
+	}
+}
+
+func TestResolveGlobsUrootGOPATH(t *testing.T) {
+	urootpath, err := filepath.Abs("../../")
+	if err != nil {
+		t.Fatalf("failure to set up test: %v", err)
+	}
+	foopath, err := filepath.Abs("test/gopath1/src/foo")
+	if err != nil {
+		t.Fatalf("failure to set up test: %v", err)
+	}
+
+	moduleOffEnv := gbbgolang.Default()
+	moduleOffEnv.GO111MODULE = "off"
+
+	moduleOnEnv := gbbgolang.Default()
+	moduleOnEnv.GO111MODULE = "on"
+
+	l := &ulogtest.Logger{TB: t}
+
+	for _, env := range []gbbgolang.Environ{moduleOffEnv, moduleOnEnv} {
+		for _, tc := range []struct {
+			in       string
+			expected []string
+			wantErr  bool
+		}{
+			// Nonexistent Package
+			{
+				in:       "fakepackagename",
+				expected: nil,
+				wantErr:  true,
+			},
+			// Single go package import
+			{
+				in:       "github.com/u-root/u-root/cmds/core/ls",
+				expected: []string{"github.com/u-root/u-root/cmds/core/ls"},
+				wantErr:  false,
+			},
+			// Single package directory relative to working dir
+			{
+				in:       "test/gopath1/src/foo",
+				expected: []string{filepath.Join(urootpath, "/pkg/uroot/test/gopath1/src/foo")},
+				wantErr:  false,
+			},
+			// Single package directory with absolute path
+			{
+				in:       foopath,
+				expected: []string{filepath.Join(urootpath, "pkg/uroot/test/gopath1/src/foo")},
+				wantErr:  false,
+			},
+			// Single package with Plan 9 only files.
+			{
+				in:      "github.com/u-root/u-root/cmds/core/bind",
+				wantErr: true,
+			},
+			// Package directory glob
+			{
+				in: "test/gopath2/src/mypkg*",
+				expected: []string{
+					filepath.Join(urootpath, "pkg/uroot/test/gopath2/src/mypkga"),
+					filepath.Join(urootpath, "pkg/uroot/test/gopath2/src/mypkgb"),
+				},
+				wantErr: false,
+			},
+			// Package directory glob does not match anything
+			{
+				in:      "test/gopath2/src/foo*",
+				wantErr: true,
+			},
+			// Go import path glob
+			{
+				in: "github.com/u-root/u-root/pkg/uroot/test/gopath2/src/my*",
+				expected: []string{
+					"github.com/u-root/u-root/pkg/uroot/test/gopath2/src/mypkga",
+					"github.com/u-root/u-root/pkg/uroot/test/gopath2/src/mypkgb",
+				},
+				wantErr: false,
+			},
+			// Glob does not match anything
+			{
+				in:      "github.com/u-root/u-root/pkg/uroot/test/gopath2/src/foo*",
+				wantErr: true,
+			},
+			// Go glob support
+			{
+				in: "github.com/u-root/u-root/pkg/uroot/test/gopath2/src/...",
+				expected: []string{
+					"github.com/u-root/u-root/pkg/uroot/test/gopath2/src/mypkga",
+					"github.com/u-root/u-root/pkg/uroot/test/gopath2/src/mypkgb",
+				},
+				wantErr: false,
+			},
+			// Go import path glob
+			{
+				in: "github.com/u-root/u-root/cmds/core/i*",
+				expected: []string{
+					"github.com/u-root/u-root/cmds/core/id",
+					"github.com/u-root/u-root/cmds/core/init",
+					"github.com/u-root/u-root/cmds/core/insmod",
+					"github.com/u-root/u-root/cmds/core/io",
+					"github.com/u-root/u-root/cmds/core/ip",
+				},
+				wantErr: false,
+			},
+		} {
+			t.Run(fmt.Sprintf("GO111MODULE=%s-%q", env.GO111MODULE, tc.in), func(t *testing.T) {
+				out, err := resolveGlobs(l, env, tc.in)
+				if (err != nil) != tc.wantErr {
+					t.Fatalf("resolveGlobs(%v, %v) = (%v, %v), wantErr is %t", env, tc.in, out, err, tc.wantErr)
+				}
+				if !reflect.DeepEqual(out, tc.expected) {
+					t.Errorf("resolveGlobs(%v, %v) = %#v; want %#v", env, tc.in, out, tc.expected)
+				}
+			})
+		}
 	}
 }

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -6,7 +6,6 @@ package uroot
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -88,7 +87,6 @@ func TestResolvePackagePathsUrootGOPATH(t *testing.T) {
 	moduleOnEnv := gbbgolang.Default()
 	moduleOnEnv.GO111MODULE = "on"
 
-	// Why doesn't the log package export this as a default?
 	l := &ulogtest.Logger{TB: t}
 
 	for _, env := range []gbbgolang.Environ{moduleOnEnv, moduleOffEnv} {
@@ -176,8 +174,7 @@ func TestCreateInitramfs(t *testing.T) {
 		t.Error(err)
 	}
 
-	// Why doesn't the log package export this as a default?
-	l := log.New(os.Stdout, "", log.LstdFlags)
+	l := &ulogtest.Logger{TB: t}
 
 	for i, tt := range []struct {
 		name       string

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -164,11 +164,6 @@ func TestCreateInitramfs(t *testing.T) {
 	dir := t.TempDir()
 	syscall.Umask(0)
 
-	urootpath, err := filepath.Abs("../../")
-	if err != nil {
-		t.Fatalf("failure to set up test: %v", err)
-	}
-
 	tmp777 := filepath.Join(dir, "tmp777")
 	if err := os.MkdirAll(tmp777, 0o777); err != nil {
 		t.Error(err)
@@ -191,7 +186,6 @@ func TestCreateInitramfs(t *testing.T) {
 				UseExistingInit: false,
 				InitCmd:         "init",
 				DefaultShell:    "ls",
-				UrootSource:     urootpath,
 				Commands: []Commands{
 					{
 						Builder: builder.BusyBox,
@@ -241,7 +235,6 @@ func TestCreateInitramfs(t *testing.T) {
 				TempDir:      dir,
 				DefaultShell: "zoocar",
 				InitCmd:      "foobar",
-				UrootSource:  urootpath,
 				Commands: []Commands{
 					{
 						Builder: builder.Binary,
@@ -277,7 +270,6 @@ func TestCreateInitramfs(t *testing.T) {
 				UseExistingInit: false,
 				InitCmd:         "init",
 				DefaultShell:    "ls",
-				UrootSource:     urootpath,
 				Commands: []Commands{
 					{
 						Builder: builder.BusyBox,
@@ -441,6 +433,11 @@ func TestResolveGlobsUrootGOPATH(t *testing.T) {
 			// Single package with Plan 9 only files.
 			{
 				in:      "github.com/u-root/u-root/cmds/core/bind",
+				wantErr: true,
+			},
+			// Single package with Plan 9 only files.
+			{
+				in:      filepath.Join(urootpath, "cmds/core/bind"),
 				wantErr: true,
 			},
 			// Package directory glob

--- a/pkg/uroot/uroot_test.go
+++ b/pkg/uroot/uroot_test.go
@@ -14,7 +14,6 @@ import (
 
 	gbbgolang "github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/u-root/pkg/cpio"
-	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/ulog/ulogtest"
 	"github.com/u-root/u-root/pkg/uroot/builder"
 	itest "github.com/u-root/u-root/pkg/uroot/initramfs/test"
@@ -180,7 +179,6 @@ func TestCreateInitramfs(t *testing.T) {
 		{
 			name: "BB archive with ls and init",
 			opts: Opts{
-				Env:             golang.Default(),
 				TempDir:         dir,
 				ExtraFiles:      nil,
 				UseExistingInit: false,
@@ -208,7 +206,6 @@ func TestCreateInitramfs(t *testing.T) {
 		{
 			name: "no temp dir",
 			opts: Opts{
-				Env:          golang.Default(),
 				InitCmd:      "init",
 				DefaultShell: "",
 			},
@@ -220,7 +217,6 @@ func TestCreateInitramfs(t *testing.T) {
 		{
 			name: "no commands",
 			opts: Opts{
-				Env:     golang.Default(),
 				TempDir: dir,
 			},
 			want: "",
@@ -231,7 +227,6 @@ func TestCreateInitramfs(t *testing.T) {
 		{
 			name: "init specified, but not in commands",
 			opts: Opts{
-				Env:          golang.Default(),
 				TempDir:      dir,
 				DefaultShell: "zoocar",
 				InitCmd:      "foobar",
@@ -252,7 +247,6 @@ func TestCreateInitramfs(t *testing.T) {
 		{
 			name: "init symlinked to absolute path",
 			opts: Opts{
-				Env:     golang.Default(),
 				TempDir: dir,
 				InitCmd: "/bin/systemd",
 			},
@@ -264,7 +258,6 @@ func TestCreateInitramfs(t *testing.T) {
 		{
 			name: "multi-mode archive",
 			opts: Opts{
-				Env:             golang.Default(),
 				TempDir:         dir,
 				ExtraFiles:      nil,
 				UseExistingInit: false,

--- a/pkg/vmtest/gotest.go
+++ b/pkg/vmtest/gotest.go
@@ -45,14 +45,6 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 		o.TmpDir = tmpDir
 	}
 
-	if o.BuildOpts.UrootSource == "" {
-		sourcePath, ok := os.LookupEnv("UROOT_SOURCE")
-		if !ok {
-			t.Fatal("This test needs UROOT_SOURCE set to the absolute path of the checked out u-root source")
-		}
-		o.BuildOpts.UrootSource = sourcePath
-	}
-
 	// Set up u-root build options.
 	env := golang.Default()
 	env.CgoEnabled = false

--- a/pkg/vmtest/gotest.go
+++ b/pkg/vmtest/gotest.go
@@ -13,11 +13,22 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/u-root/u-root/pkg/golang"
+	gbbgolang "github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/u-root/pkg/uio"
 	"github.com/u-root/u-root/pkg/uroot"
 	"github.com/u-root/u-root/pkg/vmtest/internal/json2test"
+	"golang.org/x/tools/go/packages"
 )
+
+func lookupPkgs(env gbbgolang.Environ, dir string, patterns ...string) ([]*packages.Package, error) {
+	cfg := &packages.Config{
+		Mode:  packages.NeedName | packages.NeedFiles,
+		Env:   append(os.Environ(), env.Env()...),
+		Dir:   dir,
+		Tests: true,
+	}
+	return packages.Load(cfg, patterns...)
+}
 
 // GolangTest compiles the unit tests found in pkgs and runs them in a QEMU VM.
 func GolangTest(t *testing.T, pkgs []string, o *Options) {
@@ -46,10 +57,10 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 	}
 
 	// Set up u-root build options.
-	env := golang.Default()
+	env := gbbgolang.Default()
 	env.CgoEnabled = false
 	env.GOARCH = TestArch()
-	o.BuildOpts.Env = env
+	o.BuildOpts.Env = &env
 
 	// Statically build tests and add them to the temporary directory.
 	var tests []string
@@ -95,13 +106,27 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 		if _, err := os.Stat(testFile); !os.IsNotExist(err) {
 			tests = append(tests, pkg)
 
-			p, err := o.BuildOpts.Env.Package(pkg)
+			pkgs, err := lookupPkgs(*o.BuildOpts.Env, "", pkg)
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("Failed to look up package %q: %v", pkg, err)
 			}
+
+			// One directory = one package in standard Go, so
+			// finding the first file's parent directory should
+			// find us the package directory.
+			var dir string
+			for _, p := range pkgs {
+				if len(p.GoFiles) > 0 {
+					dir = filepath.Dir(p.GoFiles[0])
+				}
+			}
+			if dir == "" {
+				t.Fatalf("Could not find package directory for %q", pkg)
+			}
+
 			// Optimistically copy any files in the pkg's
 			// directory, in case e.g. a testdata dir is there.
-			if err := copyRelativeFiles(p.Dir, filepath.Join(testDir, pkg)); err != nil {
+			if err := copyRelativeFiles(dir, filepath.Join(testDir, pkg)); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/vmtest/integration.go
+++ b/pkg/vmtest/integration.go
@@ -341,14 +341,6 @@ func CreateTestInitramfs(dontSetEnv bool, o uroot.Opts, uinit, outputFile string
 		o.Env = env
 	}
 
-	if o.UrootSource == "" {
-		sourcePath, ok := os.LookupEnv("UROOT_SOURCE")
-		if !ok {
-			return "", fmt.Errorf("failed to get u-root source directory, please set UROOT_SOURCE to the absolute path of the u-root source directory")
-		}
-		o.UrootSource = sourcePath
-	}
-
 	logger := log.New(os.Stderr, "", 0)
 
 	// If build opts don't specify any commands, include all commands. Else,

--- a/uroot_test.go
+++ b/uroot_test.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"testing"
 
+	gbbgolang "github.com/u-root/gobusybox/src/pkg/golang"
 	"github.com/u-root/u-root/pkg/cpio"
-	"github.com/u-root/u-root/pkg/golang"
 	"github.com/u-root/u-root/pkg/testutil"
 	"github.com/u-root/u-root/pkg/uio"
 	itest "github.com/u-root/u-root/pkg/uroot/initramfs/test"
@@ -47,7 +47,7 @@ func xTestDCE(t *testing.T) {
 	}()
 	st, _ := f.Stat()
 	t.Logf("Built %s, size %d", f.Name(), st.Size())
-	cmd := golang.Default().GoCmd("tool", "nm", f.Name())
+	cmd := gbbgolang.Default().GoCmd("tool", "nm", f.Name())
 	nmOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("failed to run nm: %s %s", err, nmOutput)
@@ -90,7 +90,7 @@ func (v noDeadCode) Validate(a *cpio.Archive) error {
 		}
 	}()
 	// 2. Run "go nm" on it and build symbol table.
-	cmd := golang.Default().GoCmd("tool", "nm", tf.Name())
+	cmd := gbbgolang.Default().GoCmd("tool", "nm", tf.Name())
 	nmOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to run nm: %s %s", err, nmOutput)
@@ -282,12 +282,12 @@ func TestUrootCmdline(t *testing.T) {
 	var bbTests []testCase
 	for _, test := range bareTests {
 		bbTest := test
-		bbTest.name = bbTest.name + " bb"
-		bbTest.args = append([]string{"-build=bb"}, bbTest.args...)
+		bbTest.name = bbTest.name + " gbb-gopath"
+		bbTest.args = append([]string{"-build=gbb"}, bbTest.args...)
 		bbTest.env = append(bbTest.env, "GO111MODULE=off")
 
 		gbbTest := test
-		gbbTest.name = gbbTest.name + " gbb"
+		gbbTest.name = gbbTest.name + " gbb-gomodule"
 		gbbTest.args = append([]string{"-build=gbb"}, gbbTest.args...)
 		gbbTest.env = append(gbbTest.env, "GO111MODULE=on")
 


### PR DESCRIPTION
* Implements globbing for Go package paths.
* Deprecates UROOT_SOURCE and -uroot-source, as you can now use Go package paths again.
* As globbing uses gbbgolang, move to use gbbgolang in the entire build process. `pkg/golang` in u-root is on its way to deletion.
* Removes makebb tool, as it is available in u-root/gobusybox (and migrating to using the gbbgolang package would have been annoying, it was still using the old pkg/bb).

Using package paths requires you be in a place where go.mod can resolve the path. This is the error you get when that isn't the case:

```
$ cd $HOME
$ u-root github.com/u-root/u-root/cmds/core/{init,ip}
$ 21:13:00 Build error: "github.com/u-root/u-root/cmds/core/init" matched as neither file system path/glob nor package path/glob: 1 error occurred:
        * -: no required module provides package github.com/u-root/u-root/cmds/core/init: go.mod file not found in current directory or any parent directory; see 'go help modules'
```

Thinking of moving this logic to gobusybox, too. TBD.