### PR TITLE
Actually compile Go VM tests; halve CircleCI test time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,15 +161,6 @@ jobs:
           command: go run tools/checklicenses/checklicenses.go -c
             tools/checklicenses/config.json
 
-  check_symlinks:
-    <<: *golang-template
-    steps:
-      - checkout
-      - run:
-          name: Symbol tests to ensure we do not break symlink handling
-          command: mkdir /tmp/usr && ln -s /tmp/usr/x /tmp/usr/y && go run u-root.go
-            -files /tmp/usr minimal
-
   check_templates:
     <<: *golang-template
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ templates:
   golang-template:
     &golang-template
     docker:
-      - image: uroottest/test-image-amd64:v5.1.0
+      - image: uroottest/test-image-amd64:v5.2.0
     working_directory: /home/circleci/go/src/github.com/u-root/u-root
     environment:
       - UROOT_SOURCE: /home/circleci/go/src/github.com/u-root/u-root
@@ -189,7 +189,7 @@ jobs:
   test-integration-amd64:
     <<: *integration-template
     docker:
-      - image: uroottest/test-image-amd64:v5.1.0
+      - image: uroottest/test-image-amd64:v5.2.0
     # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
     resource_class: large
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,8 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - test
+      - test-pkgs
+      - test-cmds
       - test-build
       - test-build-tamago-riscv64
       - test-build-tamago-arm
@@ -54,25 +55,32 @@ workflows:
       - check_licenses
 
 jobs:
-  test:
+  test-pkgs:
     <<: *beefy-template
     environment:
       - GOMAXPROCS: 1
     steps:
       - checkout
       - run:
-          name: Test Packages
-          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root go test -v -a
+          name: Test packages
+          command: UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -v -a
             -timeout=20m -ldflags='-s' -failfast -coverprofile=coverage_pkg.txt
             -covermode=atomic -coverpkg=./pkg/... ./pkg/...
           no_output_timeout: 15m
 
       - run:
-          name: Test coverage
-          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root
-            UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -timeout=20m
-            -failfast -coverprofile=coverage.txt -covermode=atomic -cover
-            ./cmds/... ./pkg/...
+          name: Upload coverage
+          command: bash <(curl -s https://codecov.io/bash)
+
+  test-cmds:
+    <<: *beefy-template
+    steps:
+      - checkout
+      - run:
+          name: Test commands
+          command: UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -v
+            -timeout=20m -failfast -coverprofile=coverage.txt -covermode=atomic
+            -cover ./cmds/...
 
       - run:
           name: Upload coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,9 +213,9 @@ jobs:
       - run:
           name: Test integration
           command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root
-            UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=15m
+            UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=20m
             -ldflags='-s' -failfast ./integration/...
-          no_output_timeout: 15m
+          no_output_timeout: 20m
       - run:
           name: Upload integration coverage
           command: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ templates:
       - run:
           name: Test integration
           command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root
-            UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=15m
+            UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=20m
             -ldflags='-s' -failfast ./integration/...
           no_output_timeout: 15m
       - run:
@@ -190,7 +190,6 @@ jobs:
     <<: *integration-template
     docker:
       - image: uroottest/test-image-amd64:v5.2.0
-    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
     resource_class: large
 
   test-integration-arm:
@@ -198,24 +197,7 @@ jobs:
     docker:
       - image: uroottest/test-image-arm:v5.1.0
 
-  # This arch needs a different working dir, so don't use integration-template
   test-integration-arm64:
+    <<: *integration-template
     docker:
       - image: uroottest/test-image-arm64:v5.2.0
-    working_directory: /home/circleci/go/src/github.com/u-root/u-root
-    environment:
-      - UROOT_SOURCE: /home/circleci/go/src/github.com/u-root/u-root
-      - CGO_ENABLED: 0
-      # x7 all timeouts for QEMU VM tests since they run without KVM.
-      - UROOT_QEMU_TIMEOUT_X: 7
-    steps:
-      - checkout
-      - run:
-          name: Test integration
-          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root
-            UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=20m
-            -ldflags='-s' -failfast ./integration/...
-          no_output_timeout: 20m
-      - run:
-          name: Upload integration coverage
-          command: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ templates:
       - run:
           name: Test integration
           command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root
-            UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=20m
+            UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=20m -p=1
             -ldflags='-s' -failfast ./integration/...
           no_output_timeout: 15m
       - run:
@@ -57,13 +57,11 @@ workflows:
 jobs:
   test-pkgs:
     <<: *beefy-template
-    environment:
-      - GOMAXPROCS: 1
     steps:
       - checkout
       - run:
           name: Test packages
-          command: UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -v -a
+          command: UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -v -a -p=1
             -timeout=20m -ldflags='-s' -failfast -coverprofile=coverage_pkg.txt
             -covermode=atomic -coverpkg=./pkg/... ./pkg/...
           no_output_timeout: 15m
@@ -78,7 +76,7 @@ jobs:
       - checkout
       - run:
           name: Test commands
-          command: UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -v
+          command: UROOT_QEMU_COVERPROFILE=vmcoverage.txt go test -v -p=1
             -timeout=20m -failfast -coverprofile=coverage.txt -covermode=atomic
             -cover ./cmds/...
 
@@ -132,13 +130,12 @@ jobs:
     <<: *beefy-template
     environment:
       - CGO_ENABLED: 1
-      - GOMAXPROCS: 1
     steps:
       - checkout
       - run:
           name: Race detector
           command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root go test -race
-            -timeout=15m -failfast ./cmds/... ./pkg/...
+            -timeout=15m -p=1 -failfast ./cmds/... ./pkg/...
 
   compile_cmds:
     <<: *golang-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,8 @@ templates:
       - checkout
       - run:
           name: Test integration
-          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root
-            UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v -timeout=20m -p=1
-            -ldflags='-s' -failfast ./integration/...
+          command: UROOT_QEMU_COVERPROFILE=coverage.txt go test -a -v
+            -timeout=20m -p=1 -ldflags='-s' -failfast ./integration/...
           no_output_timeout: 15m
       - run:
           name: Upload integration coverage
@@ -129,13 +128,13 @@ jobs:
   race:
     <<: *beefy-template
     environment:
+      - UROOT_SOURCE: /home/circleci/go/src/github.com/u-root/u-root
       - CGO_ENABLED: 1
     steps:
       - checkout
       - run:
           name: Race detector
-          command: UROOT_SOURCE=/home/circleci/go/src/github.com/u-root/u-root go test -race
-            -timeout=15m -p=1 -failfast ./cmds/... ./pkg/...
+          command: go test -race -timeout=15m -p=1 -failfast ./cmds/... ./pkg/...
 
   compile_cmds:
     <<: *golang-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
   # This arch needs a different working dir, so don't use integration-template
   test-integration-arm64:
     docker:
-      - image: uroottest/test-image-arm64:v5.1.0
+      - image: uroottest/test-image-arm64:v5.2.0
     working_directory: /home/circleci/go/src/github.com/u-root/u-root
     environment:
       - UROOT_SOURCE: /home/circleci/go/src/github.com/u-root/u-root

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,3 +196,4 @@ jobs:
     <<: *integration-template
     docker:
       - image: uroottest/test-image-arm64:v5.2.0
+    resource_class: large

--- a/.circleci/images/test-image-amd64/Dockerfile
+++ b/.circleci/images/test-image-amd64/Dockerfile
@@ -23,7 +23,7 @@ RUN sudo apt-get update &&                          \
         libpixman-1-dev                             \
         meson                                       \
         ninja-build                                 \
-        python                                      \
+        python3                                     \
         zlib1g-dev                                  \
         `# Linux kernel build deps`                 \
         libelf-dev                                  \
@@ -39,11 +39,11 @@ RUN sudo apt-get update &&                          \
 
 # Create working directory
 WORKDIR /home/circleci
-COPY config_linux5.10_x86_64.txt .config
+COPY config_linux.txt .config
 
 # Build linux
 RUN set -eux;                                                             \
-    git clone --depth=1 --branch=v5.10 https://github.com/torvalds/linux; \
+    git clone --depth=1 --branch=v6.0 https://github.com/torvalds/linux;  \
     sudo chmod 0444 .config;                                              \
     mv .config linux/;                                                    \
     cd linux;                                                             \
@@ -84,7 +84,7 @@ RUN set -eux;                                                          \
 
 SHELL ["/bin/bash", "-c"]
 RUN set -ex;                                                           \
-    git clone --branch uefipayload --recursive                         \
+    git clone --branch uefipayload-2023 --recursive                    \
     https://github.com/linuxboot/edk2 uefipayload;                     \
     cd uefipayload;                                                    \
     source ./edksetup.sh;                                              \

--- a/.circleci/images/test-image-amd64/config_linux.txt
+++ b/.circleci/images/test-image-amd64/config_linux.txt
@@ -94,6 +94,8 @@ CONFIG_9P_FS=y
 # GPIO test - mock GPIO libraries
 CONFIG_GPIOLIB=y
 CONFIG_GPIO_MOCKUP=y
+# CONFIG_EXPERT is required for CONFIG_GPIO_SYSFS
+CONFIG_EXPERT=y
 CONFIG_GPIO_SYSFS=y
 
 # Compressed initramfs

--- a/.circleci/images/test-image-amd64/config_linux.txt
+++ b/.circleci/images/test-image-amd64/config_linux.txt
@@ -117,3 +117,6 @@ CONFIG_IPMI_SI=y
 
 # Add DMI/SMBIOS support
 CONFIG_DMI_SYSFS=y
+
+# pkg/efivarfs (and its test) require immutable bit on xattr
+CONFIG_TMPFS_XATTR=y

--- a/.circleci/images/test-image-arm64/Dockerfile
+++ b/.circleci/images/test-image-arm64/Dockerfile
@@ -24,7 +24,7 @@ RUN sudo apt-get update &&                          \
         libpixman-1-dev                             \
         meson                                       \
         ninja-build                                 \
-        python                                      \
+        python3                                     \
         qemu-efi-aarch64                            \
         zlib1g-dev                                  \
         `# Linux kernel build deps`                 \
@@ -33,11 +33,11 @@ RUN sudo apt-get update &&                          \
 
 # Create working directory
 WORKDIR /home/circleci
-COPY config_linux5.10.0_arm64.txt .config
+COPY config_linux.txt .config
 
 # Build linux
 RUN set -eux;                                                             \
-    git clone --depth=1 --branch=v5.15 https://github.com/torvalds/linux; \
+    git clone --depth=1 --branch=v6.0 https://github.com/torvalds/linux;  \
     sudo chmod 0444 .config;                                              \
     mv .config linux/;                                                    \
     cd linux;                                                             \

--- a/.circleci/images/test-image-arm64/config_linux.txt
+++ b/.circleci/images/test-image-arm64/config_linux.txt
@@ -113,3 +113,11 @@ CONFIG_RELOCATABLE=y
 
 # Enable ACPI
 CONFIG_ACPI=y
+
+# pkg/efivarfs (and its test) require immutable bit on xattr
+CONFIG_TMPFS_XATTR=y
+
+# v6.0 has a missing dependency, and PCIE_KIRIN is "y" in the defconfig.
+# Compilation fails if you use this and run `make olddefconfig` without setting
+# CONFIG_PCIE_KIRIN=n explicitly.
+CONFIG_PCIE_KIRIN=n

--- a/.circleci/images/test-image-arm64/config_linux.txt
+++ b/.circleci/images/test-image-arm64/config_linux.txt
@@ -121,3 +121,9 @@ CONFIG_TMPFS_XATTR=y
 # Compilation fails if you use this and run `make olddefconfig` without setting
 # CONFIG_PCIE_KIRIN=n explicitly.
 CONFIG_PCIE_KIRIN=n
+
+# Enable time in guest. QEMU uses PL031 to set RTC. pkg/boot/fit requires
+# current time signature checks.
+CONFIG_RTC_CLASS=y
+CONFIG_ARM_RZN1=y
+CONFIG_RTC_DRV_PL031=y

--- a/cmds/exp/pox/pox_vm_test.go
+++ b/cmds/exp/pox/pox_vm_test.go
@@ -1,6 +1,10 @@
 // Copyright 2012-2021 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
+
+//go:build !race
+// +build !race
+
 package main
 
 import (

--- a/integration/GET_KERNEL_QEMU
+++ b/integration/GET_KERNEL_QEMU
@@ -63,13 +63,16 @@ esac
 # Note the docker pull only hurts a lot the first time.
 # After you have run it once, further cp operations take a second or so.
 # By doing it this way, we always use the latest Docker files.
-DOCKER=uroottest/test-image-${UROOT_TESTARCH}
+CONTAINER=uroottest/test-image-${UROOT_TESTARCH}
 
-docker run -v $TMP:/out $DOCKER cp -a $UROOT_KERNEL  $UROOT_BIOS $UROOT_QEMU /out
+DIR=/home/circleci
+
+docker run $CONTAINER bash -c "echo \$UROOT_QEMU"
+docker run $CONTAINER tar Ccf $DIR - $UROOT_KERNEL $UROOT_QEMU $UROOT_BIOS | tar Cxf $TMP -
 
 ls -l $TMP
 
 # now adjust paths and such
-UROOT_KERNEL=$TMP/$UROOT_KERNEL
-UROOT_QEMU="$TMP/$UROOT_QEMU $UROOT_QEMU_OPTS"
-UROOT_BIOS=$TMP/$UROOT_BIOS
+export UROOT_KERNEL=$TMP/$UROOT_KERNEL
+export UROOT_QEMU="$TMP/$UROOT_QEMU $UROOT_QEMU_OPTS"
+export UROOT_BIOS=$TMP/$UROOT_BIOS

--- a/integration/gotests/gotest_test.go
+++ b/integration/gotests/gotest_test.go
@@ -107,6 +107,9 @@ func TestGoTest(t *testing.T) {
 				//
 				//     disk = make([]byte, 0x100000000)
 				qemu.ArbitraryArgs{"-m", "6G"},
+
+				// aarch64 VMs start at 1970-01-01 without RTC explicitly set.
+				qemu.ArbitraryArgs{"-rtc", "base=localtime,clock=vm"},
 			},
 		},
 		BuildOpts: uroot.Opts{

--- a/integration/gotests/gotest_test.go
+++ b/integration/gotests/gotest_test.go
@@ -78,6 +78,13 @@ func testPkgs(t *testing.T) []string {
 		blocklist = append(
 			blocklist,
 			"github.com/u-root/u-root/pkg/strace",
+
+			// These tests run in 1-2 seconds on x86, but run
+			// beyond their huge timeout under arm64 in the VM. Not
+			// sure why. Slow emulation?
+			"github.com/u-root/u-root/cmds/core/pci",
+			"github.com/u-root/u-root/cmds/exp/cbmem",
+			"github.com/u-root/u-root/pkg/vfile",
 		)
 	}
 	for i := 0; i < len(pkgs); i++ {

--- a/pkg/acpi/rsdp_linux_test.go
+++ b/pkg/acpi/rsdp_linux_test.go
@@ -5,6 +5,7 @@
 package acpi
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/u-root/u-root/pkg/testutil"
@@ -13,6 +14,11 @@ import (
 // TestRSDP tests whether any method for getting an RSDP works.
 func TestRSDP(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
+
+	// Our QEMU aarch64 does not boot via UEFI, so RSDP only works on x86.
+	if runtime.GOARCH != "amd64" {
+		t.Skip("RSDP in QEMU only available on amd64 for now")
+	}
 
 	_, err := GetRSDP()
 	if err != nil {

--- a/pkg/efivarfs/fs.go
+++ b/pkg/efivarfs/fs.go
@@ -12,6 +12,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// FS_IMMUTABLE_FL is an inode flag to make a file immutable.
+const FS_IMMUTABLE_FL = 0x10
+
 // getInodeFlags returns the extended attributes of a file.
 func getInodeFlags(f *os.File) (int, error) {
 	// If I knew how unix.Getxattr works I'd use that...
@@ -39,11 +42,11 @@ func makeMutable(f *os.File) (restore func(), err error) {
 	if err != nil {
 		return nil, err
 	}
-	if flags&unix.STATX_ATTR_IMMUTABLE == 0 {
+	if flags&FS_IMMUTABLE_FL == 0 {
 		return func() {}, nil
 	}
 
-	if err := setInodeFlags(f, flags&^unix.STATX_ATTR_IMMUTABLE); err != nil {
+	if err := setInodeFlags(f, flags&^FS_IMMUTABLE_FL); err != nil {
 		return nil, err
 	}
 	return func() {

--- a/pkg/efivarfs/fs.go
+++ b/pkg/efivarfs/fs.go
@@ -20,7 +20,7 @@ func getInodeFlags(f *os.File) (int, error) {
 	// If I knew how unix.Getxattr works I'd use that...
 	flags, err := unix.IoctlGetInt(int(f.Fd()), unix.FS_IOC_GETFLAGS)
 	if err != nil {
-		return 0, &os.PathError{Op: "ioctl", Path: f.Name(), Err: err}
+		return 0, &os.PathError{Op: "ioctl(FS_IOC_GETFLAGS)", Path: f.Name(), Err: err}
 	}
 	return flags, nil
 }
@@ -29,7 +29,7 @@ func getInodeFlags(f *os.File) (int, error) {
 func setInodeFlags(f *os.File, flags int) error {
 	// If I knew how unix.Setxattr works I'd use that...
 	if err := unix.IoctlSetPointerInt(int(f.Fd()), unix.FS_IOC_SETFLAGS, flags); err != nil {
-		return &os.PathError{Op: "ioctl", Path: f.Name(), Err: err}
+		return &os.PathError{Op: "ioctl(FS_IOC_SETFLAGS)", Path: f.Name(), Err: err}
 	}
 	return nil
 }

--- a/pkg/efivarfs/varfs_test.go
+++ b/pkg/efivarfs/varfs_test.go
@@ -10,12 +10,10 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
 	guid "github.com/google/uuid"
-	"github.com/u-root/u-root/pkg/testutil"
 )
 
 func TestProbeAndReturn(t *testing.T) {
@@ -147,12 +145,6 @@ func TestGet(t *testing.T) {
 			// This setup bypasses all the tests for this fake varfs.
 			e := &EFIVarFS{path: tmp}
 
-			if tt.name == "no permission" && runtime.GOARCH == "amd64" {
-				// For some reasons tests that run in the x86 Qemu
-				// VM ignore UNIX permission changes...
-				testutil.SkipIfInVMTest(t)
-			}
-
 			attr, data, err := e.Get(tt.vd)
 			if errors.Is(err, ErrNoFS) {
 				t.Logf("no EFIVarFS: %v; skipping this test", err)
@@ -272,12 +264,6 @@ func TestSet(t *testing.T) {
 			// This setup bypasses all the tests for this fake varfs.
 			e := &EFIVarFS{path: tmp}
 
-			if strings.Contains(tt.name, "permission") && runtime.GOARCH == "amd64" {
-				// For some reasons tests that run in the x86 Qemu
-				// VM ignore UNIX permission changes...
-				testutil.SkipIfInVMTest(t)
-			}
-
 			if err := e.Set(tt.vd, tt.attr, tt.data); err != nil {
 				if !errors.Is(err, tt.wantErr) {
 					// Needed as some errors include changing tmp directory names
@@ -353,12 +339,6 @@ func TestRemove(t *testing.T) {
 			tt.setup(tmp, t)
 			// This setup bypasses all the tests for this fake varfs.
 			e := &EFIVarFS{path: tmp}
-
-			if strings.Contains(tt.name, "permission") && runtime.GOARCH == "amd64" {
-				// For some reasons tests that run in the x86 Qemu
-				// VM ignore UNIX permission changes...
-				testutil.SkipIfInVMTest(t)
-			}
 
 			if err := e.Remove(tt.vd); err != nil {
 				if !errors.Is(err, tt.wantErr) {
@@ -503,12 +483,6 @@ func TestList(t *testing.T) {
 			tt.setup(tt.dir, t)
 			// This setup bypasses all the tests for this fake varfs.
 			e := &EFIVarFS{path: tmp}
-
-			if strings.Contains(tt.name, "permission") && runtime.GOARCH == "amd64" {
-				// For some reasons tests that run in the x86 Qemu
-				// VM ignore UNIX permission changes...
-				testutil.SkipIfInVMTest(t)
-			}
 
 			if _, err := e.List(); err != nil {
 				if !errors.Is(err, tt.wantErr) {

--- a/pkg/ipmi/ipmi_vm_test.go
+++ b/pkg/ipmi/ipmi_vm_test.go
@@ -35,41 +35,43 @@ func TestWatchdogRunningQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %v", err)
 	}
 	defer i.Close()
 
 	ret, err := i.WatchdogRunning()
 	if err != nil {
-		t.Errorf(`i.WatchdogRunning() = _, not %q`, err)
+		t.Errorf("i.WatchdogRunning() = %v", err)
 	}
 	if !ret {
-		t.Errorf(`i.WatchdogRunning() = true, not %v`, ret)
+		t.Errorf("i.WatchdogRunning() = %t, want true", ret)
 	}
 }
+
 func TestShutoffWatchdogQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %q", err)
 	}
 	defer i.Close()
 
 	if err := i.ShutoffWatchdog(); err != nil {
-		t.Errorf(`i.ShutoffWatchdog() = nil, not %q`, err)
+		t.Errorf("i.ShutoffWatchdog() = %q", err)
 	}
 }
+
 func TestGetDeviceIDQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %q", err)
 	}
 	defer i.Close()
 
 	id, err := i.GetDeviceID()
 	if err != nil {
-		t.Errorf(`i.GetDeviceID() = nil, not %q`, err)
+		t.Errorf("i.GetDeviceID() = %q", err)
 	}
 	if id.DeviceID != 0x20 {
 		t.Errorf("DeviceID: %q, want: %q", id.DeviceID, 0x1)
@@ -101,20 +103,21 @@ func TestGetDeviceIDQemu(t *testing.T) {
 	}
 
 }
+
 func TestEnableSELQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %q", err)
 	}
 	defer i.Close()
 
 	ret, err := i.EnableSEL()
 	if err != nil {
-		t.Errorf(`i.EnableSEL() = nil, not %q`, err)
+		t.Errorf("i.EnableSEL() = %v", err)
 	}
 	if !ret {
-		t.Errorf(`i.EnableSEL() = true, not %v`, ret)
+		t.Errorf("i.EnableSEL() = %v, want true", ret)
 	}
 }
 
@@ -122,78 +125,82 @@ func TestGetSELInfoQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %v", err)
 	}
 	defer i.Close()
 
 	info, err := i.GetSELInfo()
 	if err != nil {
-		t.Errorf(`i.GetSELInfo() = nil, not %q`, err)
+		t.Errorf("i.GetSELInfo() = %v", err)
 	}
 	if info.Version != 0x51 {
-		t.Errorf(`Version = %q, not %q`, info.Version, 0x51)
+		t.Errorf("Version = %q, want %q", info.Version, 0x51)
 	}
 	if info.Entries != 0x0 {
-		t.Errorf(`Version = %q, not %q`, info.Entries, 0x0)
+		t.Errorf("Version = %q, want %q", info.Entries, 0x0)
 	}
 	if info.FreeSpace != 0x800 {
-		t.Errorf(`Version = %q, not %q`, info.FreeSpace, 0x800)
+		t.Errorf("Version = %q, want %q", info.FreeSpace, 0x800)
 	}
 	if info.OpSupport != 0x2 {
-		t.Errorf(`Version = %q, not %q`, info.Version, 0x2)
+		t.Errorf("Version = %q, want %q", info.Version, 0x2)
 	}
 
 }
+
 func TestGetLanConfigQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	t.Skip("Not supported command")
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %v", err)
 	}
 	defer i.Close()
 
 	if _, err := i.GetLanConfig(1, 1); err != nil {
-		t.Errorf(`i.GetLanConfig(1, 1) = nil, not %q`, err)
+		t.Errorf("i.GetLanConfig(1, 1) = %v", err)
 	}
 }
+
 func TestRawCmdQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %v", err)
 	}
 	defer i.Close()
 
 	// WatchdogRunning configuration
 	data := []byte{0x6, 0x1}
 	if _, err := i.RawCmd(data); err != nil {
-		t.Errorf(`i.RawCmd(data) = nil, not %q`, err)
+		t.Errorf("i.RawCmd(data) = %v", err)
 	}
 }
+
 func TestSetSystemFWVersionQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	t.Skip("Not supported command")
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %v", err)
 	}
 	defer i.Close()
 
 	if err := i.SetSystemFWVersion("TestTest"); err == nil {
-		t.Errorf(`i.SetSystemFWVersion("TestTest") = nil, not %q`, err)
+		t.Errorf("i.SetSystemFWVersion(TestTest) = %v", err)
 	}
 }
+
 func TestLogSystemEventQemu(t *testing.T) {
 	testutil.SkipIfNotRoot(t)
 	i, err := Open(0)
 	if err != nil {
-		t.Fatalf("Open(0):= i,nil, not nil, %q", err)
+		t.Fatalf("Open(0) = %v", err)
 	}
 	defer i.Close()
 
 	e := &Event{}
 	if err := i.LogSystemEvent(e); err != nil {
-		t.Errorf(`i.LogSystemEvent(e) = nil, not %q`, err)
+		t.Errorf("i.LogSystemEvent(e) = %v", err)
 	}
 }

--- a/pkg/ipmi/ipmi_vm_test.go
+++ b/pkg/ipmi/ipmi_vm_test.go
@@ -43,8 +43,8 @@ func TestWatchdogRunningQemu(t *testing.T) {
 	if err != nil {
 		t.Errorf("i.WatchdogRunning() = %v", err)
 	}
-	if !ret {
-		t.Errorf("i.WatchdogRunning() = %t, want true", ret)
+	if ret {
+		t.Errorf("i.WatchdogRunning() = %t, want false", ret)
 	}
 }
 

--- a/pkg/ipmi/ipmi_vm_test.go
+++ b/pkg/ipmi/ipmi_vm_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !race
+// +build !race
+
 package ipmi
 
 import (

--- a/pkg/mount/block/vm_test.go
+++ b/pkg/mount/block/vm_test.go
@@ -55,6 +55,9 @@ func TestVM(t *testing.T) {
 				qemu.ArbitraryArgs{"-drive", "file=../testdata/gptdisk2,if=none,id=NVME1"},
 				// use-intel-id uses the vendor=0x8086 and device=0x5845 ids for NVME
 				qemu.ArbitraryArgs{"-device", "nvme,drive=NVME1,serial=nvme-1,use-intel-id"},
+
+				// With NVMe devices enabled, kernel crashes when not using q35 machine model.
+				qemu.ArbitraryArgs{"-machine", "q35"},
 			},
 		},
 	}

--- a/pkg/smbios/vm_test.go
+++ b/pkg/smbios/vm_test.go
@@ -19,10 +19,7 @@ func TestIntegration(t *testing.T) {
 	vmtest.GolangTest(t, []string{"github.com/u-root/u-root/pkg/smbios"}, &vmtest.Options{
 		QEMUOpts: qemu.Options{
 			Devices: []qemu.Device{
-				qemu.ArbitraryArgs{
-					"-smbios",
-					"type=2,manufacturer=u-root",
-				},
+				qemu.ArbitraryArgs{"-smbios", "type=2,manufacturer=u-root"},
 			},
 		},
 	})
@@ -95,23 +92,7 @@ func TestGetProcessorInfo(t *testing.T) {
 	}
 }
 
-func TestGetSystemSlots(t *testing.T) {
-
-	testutil.SkipIfNotRoot(t)
-
-	info, err := FromSysfs()
-	if err != nil {
-		t.Errorf("FromSysfs as a requirement failed.")
-	}
-
-	systemslots, err := info.GetSystemSlots()
-	if err != nil || systemslots == nil {
-		t.Errorf("GetSystemSlots() = %q, '%v'", systemslots, err)
-	}
-}
-
 func TestGetMemoryDevices(t *testing.T) {
-
 	testutil.SkipIfNotRoot(t)
 
 	info, err := FromSysfs()

--- a/pkg/smbios/vm_test.go
+++ b/pkg/smbios/vm_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !race
+// +build !race
+
 package smbios
 
 import (

--- a/pkg/vmtest/gotest.go
+++ b/pkg/vmtest/gotest.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"testing"
@@ -103,7 +102,7 @@ func GolangTest(t *testing.T, pkgs []string, o *Options) {
 			args = append(args, "-covermode=atomic")
 		}
 
-		cmd := exec.Command("go", args...)
+		cmd := env.GoCmd(args...)
 		if stderr, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("could not build %s: %v\n%s", pkg, err, string(stderr))
 		}


### PR DESCRIPTION
This initially worked, but almost all VM Go unit testing broken when Gobusybox was made the default by @MDr164 in May 2022, as [this comment indicates](https://github.com/u-root/u-root/pull/2404#issuecomment-1136008712). All arm64 tests and and most if not all x86 VM-based Go tests (like pkg/ipmi, pkg/mount, pkg/smbios) haven't been running.

Also, we don't seem to notice that the tests aren't running in the first place, but I'm dealing with that later.

End result of this PR:

* CircleCI presubmit now runs in ~15 minutes instead of 30 minutes
* Go unit VM tests work again (amd64 & arm64)
* 1.37% coverage increase
* [this list](https://github.com/u-root/u-root/pull/2589#issuecomment-1367591342) of broken tests fixed
* Couple of tests disabled, but not really relevant.

Before:

    ...
    integration.go:145: 2022/09/27 10:58:36 serial: 1970/01/01 00:01:26 Failed to start "/testdata/tests/github.com/u-root/u-root/pkg/boot/menu/menu.test": fork/exec /testdata/tests/github.com/u-root/u-root/pkg/boot/menu/menu.test: exec format error~
    ...

After:

    ...
    integration.go:145: 2022/12/28 19:07:22 serial: === RUN   TestDMIDecode~
    ...

This is a screenshot of `test-integration-arm64` of 3 months ago, **not running but passing**:

![Screenshot 2022-12-28 19 10 58](https://user-images.githubusercontent.com/1994130/209898525-714304e0-4a89-4d26-be77-058f41d3eea0.png)

This is a screenshot of `test` running `pkg/ulog` test, 3 months ago, **not running but passing**:

![image](https://user-images.githubusercontent.com/1994130/210005215-67bdaca4-49e1-4280-af9f-9e1337e4e84a.png)

