### PR TITLE
pkg/termios: add openbsd support

### DIFF
--- a/pkg/termios/sgtty_openbsd.go
+++ b/pkg/termios/sgtty_openbsd.go
@@ -2,20 +2,17 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !plan9 && !windows && !darwin && !freebsd && !openbsd
-// +build !plan9,!windows,!darwin,!freebsd,!openbsd
-
 package termios
 
 import "golang.org/x/sys/unix"
 
 const (
-	gets       = unix.TCGETS
-	sets       = unix.TCSETS
+	gets       = unix.TIOCGETA
+	sets       = unix.TIOCSETA
 	getWinSize = unix.TIOCGWINSZ
 	setWinSize = unix.TIOCSWINSZ
 )
 
-func speed(speed int) uint32 {
-	return uint32(speed)
+func speed(speed int) int32 {
+	return int32(speed)
 }

--- a/pkg/termios/termios_bsd.go
+++ b/pkg/termios/termios_bsd.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build darwin || freebsd
-// +build darwin freebsd
+//go:build darwin || freebsd || openbsd
+// +build darwin freebsd openbsd
 
 package termios
 
@@ -129,7 +129,7 @@ func MakeSerialBaud(term *Termios, baud int) (*Termios, error) {
 	}
 
 	//	t.Cflag &^= unix.CBAUD
-	t.Cflag |= rate
+	t.Cflag |= uint32(rate)
 	t.Ispeed = rate
 	t.Ospeed = rate
 

--- a/pkg/termios/var_openbsd.go
+++ b/pkg/termios/var_openbsd.go
@@ -1,0 +1,31 @@
+// Copyright 2021 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package termios
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// baud2unixB convert a baudrate to the corresponding unix const.
+var baud2unixB = map[int]int32{
+	50:     unix.B50,
+	75:     unix.B75,
+	110:    unix.B110,
+	134:    unix.B134,
+	150:    unix.B150,
+	200:    unix.B200,
+	300:    unix.B300,
+	600:    unix.B600,
+	1200:   unix.B1200,
+	1800:   unix.B1800,
+	2400:   unix.B2400,
+	4800:   unix.B4800,
+	9600:   unix.B9600,
+	19200:  unix.B19200,
+	38400:  unix.B38400,
+	57600:  unix.B57600,
+	115200: unix.B115200,
+	230400: unix.B230400,
+}


### PR DESCRIPTION
I verified that this permits Tailscale SSH (Tailscale's SSH server) to run on OpenBSD.
