### PR TITLE
pkg/termios: fix darwin regression from previous commit, add tests

### DIFF
--- a/pkg/termios/termios_bsd.go
+++ b/pkg/termios/termios_bsd.go
@@ -129,7 +129,7 @@ func MakeSerialBaud(term *Termios, baud int) (*Termios, error) {
 	}
 
 	//	t.Cflag &^= unix.CBAUD
-	t.Cflag |= uint32(rate)
+	t.Cflag |= toTermiosCflag(rate)
 	t.Ispeed = rate
 	t.Ospeed = rate
 

--- a/pkg/termios/var_darwin.go
+++ b/pkg/termios/var_darwin.go
@@ -44,3 +44,5 @@ func init() {
 		boolFields[k] = v
 	}
 }
+
+func toTermiosCflag(r uint64) uint64 { return r }

--- a/pkg/termios/var_freebsd.go
+++ b/pkg/termios/var_freebsd.go
@@ -29,3 +29,5 @@ var baud2unixB = map[int]uint32{
 	115200: unix.B115200,
 	230400: unix.B230400,
 }
+
+func toTermiosCflag(r uint32) uint32 { return r }

--- a/pkg/termios/var_openbsd.go
+++ b/pkg/termios/var_openbsd.go
@@ -29,3 +29,5 @@ var baud2unixB = map[int]int32{
 	115200: unix.B115200,
 	230400: unix.B230400,
 }
+
+func toTermiosCflag(r int32) uint32 { return uint32(r) }


### PR DESCRIPTION
I broke darwin support in the just-merged #2593.

To atone for my sins, this PR adds some more test coverage (in addition to fixing darwin).