### PR TITLE
cifuzz: do not report non-reproducible crashes

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -17,6 +17,7 @@ jobs:
         oss-fuzz-project-name: 'u-root'
         fuzz-seconds: 300
         dry-run: false
+        report-unreproducible-crashes: false
         language: go
     - name: Upload Crash
       uses: actions/upload-artifact@v3

--- a/cmds/core/gosh/testdata/fuzz/fuzz_gosh_run.options
+++ b/cmds/core/gosh/testdata/fuzz/fuzz_gosh_run.options
@@ -1,3 +1,3 @@
 [libfuzzer]
 dict = gosh.dict
-max_len = 32
+max_len = 16


### PR DESCRIPTION
Added the `report-unreproducible-crashes` flag to the cifuzz config (just a verbose change, this is false per default anyway).
Limited the input byte size for the gosh fuzzing to avoid any timeouts due to it. 