### PR TITLE
cmds/core/ip: fix arg parsing

### DIFF
--- a/cmds/core/ip/ip_linux.go
+++ b/cmds/core/ip/ip_linux.go
@@ -395,7 +395,7 @@ func run(out io.Writer) error {
 
 func main() {
 	flag.Parse()
-	arg = os.Args[1:]
+	arg = flag.Args()
 	if err := run(os.Stdout); err != nil {
 		log.Fatalf("ip: %v", err)
 	}


### PR DESCRIPTION
`os.Args[1:]` may include "-6", which should be excluded.

Fixes: c2762deff650 ("cmds/core/ip: remove cmd logic from main")
Signed-off-by: Changyuan Lyu <changyuanl@google.com>