### PR TITLE
cmds/core/time: make it build with tinygo, tidy up

### DIFF
--- a/cmds/core/time/time.go
+++ b/cmds/core/time/time.go
@@ -64,13 +64,10 @@ func run(args []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) err
 	defer func(*exec.Cmd, time.Time) {
 		realTime := time.Since(start)
 		printTime(stderr, "real", realTime)
-		if c.ProcessState != nil {
-			printTime(stderr, "user", c.ProcessState.UserTime())
-			printTime(stderr, "sys", c.ProcessState.SystemTime())
-		}
+		printProcessState(stderr, c)
 	}(c, start)
 	if err := c.Run(); err != nil {
-		return err
+		return fmt.Errorf("%q:%w", args, err)
 	}
 	return nil
 }

--- a/cmds/core/time/time_all.go
+++ b/cmds/core/time/time_all.go
@@ -1,0 +1,21 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !tinygo
+// +build !tinygo
+
+package main
+
+import (
+	"io"
+	"os/exec"
+)
+
+func printProcessState(w io.Writer, c *exec.Cmd) {
+	if c.ProcessState == nil {
+		return
+	}
+	printTime(w, "user", c.ProcessState.UserTime())
+	printTime(w, "sys", c.ProcessState.SystemTime())
+}

--- a/cmds/core/time/time_test.go
+++ b/cmds/core/time/time_test.go
@@ -6,40 +6,36 @@ package main
 
 import (
 	"bytes"
+	"errors"
+	"os/exec"
 	"regexp"
 	"testing"
 )
 
-func TestTimeRewrite(t *testing.T) {
+func TestTime(t *testing.T) {
 	var tests = []struct {
-		args      []string
-		want      string
-		wantError bool
+		args []string
+		want string
+		err  error
 	}{
 		{
-			want:      "real 0.000.*\nuser 0.000.*\nsys 0.000",
-			wantError: false,
+			want: "real 0.000.*\nuser 0.000.*\nsys 0.000",
 		},
 		{
-			args:      []string{"date"},
-			want:      "real [0-9][0-9]*.*\nuser [0-9][0-9]*.*\nsys [0-9][0-9]*.*",
-			wantError: false,
+			args: []string{"date"},
+			want: "real [0-9][0-9]*.*\nuser [0-9][0-9]*.*\nsys [0-9][0-9]*.*",
 		},
 		{
-			args:      []string{"deadbeef"},
-			wantError: true,
+			args: []string{"deadbeef"},
+			err:  exec.ErrNotFound,
 		},
 	}
 
 	for _, test := range tests {
 		var stdin, stdout, stderr bytes.Buffer
 		err := run(test.args, &stdin, &stdout, &stderr)
-		if test.wantError && err == nil {
-			t.Error("want error but got nil")
-			continue
-		}
-		if !test.wantError && err != nil {
-			t.Errorf("want nil got: %v", err)
+		if !errors.Is(err, test.err) {
+			t.Errorf("got %v, want %v", err, test.err)
 			continue
 		}
 

--- a/cmds/core/time/time_tinygo.go
+++ b/cmds/core/time/time_tinygo.go
@@ -1,0 +1,21 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build tinygo
+// +build tinygo
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+func printProcessState(w io.Writer, c *exec.Cmd) {
+	if c.ProcessState == nil {
+		return
+	}
+	fmt.Fprintf(w, "%v", c.ProcessState)
+}


### PR DESCRIPTION
time now uses the errors package, simplifying tests.

It now builds with tinygo

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>