### PR TITLE
pkg/strace/epsocket: fix handling of IP4/IP6

### DIFF
--- a/pkg/strace/epsocket.go
+++ b/pkg/strace/epsocket.go
@@ -83,7 +83,7 @@ func GetAddress(addr []byte) (*FullAddress, error) {
 		var a unix.RawSockaddrInet4
 		r = bytes.NewBuffer(addr)
 		if err := binary.Read(r, binary.BigEndian, &a); err != nil {
-			return &FullAddress{}, unix.EFAULT
+			return nil, unix.EFAULT
 		}
 		return &FullAddress{
 			Addr: Address(net.IP(a.Addr[:]).String()),

--- a/pkg/strace/epsocket.go
+++ b/pkg/strace/epsocket.go
@@ -17,7 +17,8 @@ package strace
 import (
 	"bytes"
 	"encoding/binary"
-	"strings"
+	"fmt"
+	"net"
 
 	"github.com/u-root/u-root/pkg/ubinary"
 	"golang.org/x/sys/unix"
@@ -38,31 +39,43 @@ type FullAddress struct {
 	Port uint16
 }
 
+// String implements String
+func (a *FullAddress) String() string {
+	if a == nil {
+		return ":"
+	}
+	return fmt.Sprintf("%s:%#x", []byte(a.Addr), a.Port)
+}
+
 // GetAddress reads an sockaddr struct from the given address and converts it
 // to the FullAddress format. It supports AF_UNIX, AF_INET and AF_INET6
 // addresses.
-func GetAddress(t Task, addr []byte) (FullAddress, error) {
-	r := bytes.NewBuffer(addr[:2])
+func GetAddress(addr []byte) (*FullAddress, error) {
+	r := bytes.NewBuffer(addr)
+
 	var fam uint16
 	if err := binary.Read(r, ubinary.NativeEndian, &fam); err != nil {
-		return FullAddress{}, unix.EFAULT
+		return nil, err
 	}
 
 	// Get the rest of the fields based on the address family.
 	switch fam {
 	case unix.AF_UNIX:
-		path := addr[2:]
+		path := r.Bytes()
+
 		if len(path) > unix.PathMax {
-			return FullAddress{}, unix.EINVAL
+			return nil, unix.ENAMETOOLONG
 		}
+
 		// Drop the terminating NUL (if one exists) and everything after
 		// it for filesystem (non-abstract) addresses.
-		if len(path) > 0 && path[0] != 0 {
-			if n := bytes.IndexByte(path[1:], 0); n >= 0 {
-				path = path[:n+1]
-			}
+		if n := bytes.IndexByte(path, 0); n > 0 {
+			path = path[:n]
+		} else {
+			return nil, unix.EINVAL
 		}
-		return FullAddress{
+
+		return &FullAddress{
 			Addr: Address(path),
 		}, nil
 
@@ -70,39 +83,26 @@ func GetAddress(t Task, addr []byte) (FullAddress, error) {
 		var a unix.RawSockaddrInet4
 		r = bytes.NewBuffer(addr)
 		if err := binary.Read(r, binary.BigEndian, &a); err != nil {
-			return FullAddress{}, unix.EFAULT
+			return &FullAddress{}, unix.EFAULT
 		}
-		out := FullAddress{
-			Addr: Address(a.Addr[:]),
+		return &FullAddress{
+			Addr: Address(net.IP(a.Addr[:]).String()),
 			Port: uint16(a.Port),
-		}
-		if out.Addr == "\x00\x00\x00\x00" {
-			out.Addr = ""
-		}
-		return out, nil
+		}, nil
 
 	case unix.AF_INET6:
 		var a unix.RawSockaddrInet6
 		r = bytes.NewBuffer(addr)
 		if err := binary.Read(r, binary.BigEndian, &a); err != nil {
-			return FullAddress{}, unix.EFAULT
+			return nil, unix.EFAULT
 		}
 
-		out := FullAddress{
-			Addr: Address(a.Addr[:]),
+		return &FullAddress{
+			Addr: Address(net.IP(a.Addr[:]).String()),
 			Port: uint16(a.Port),
-		}
-
-		//if isLinkLocal(out.Addr) {
-		//			out.NIC = NICID(a.Scope_id)
-		//}
-
-		if out.Addr == Address(strings.Repeat("\x00", 16)) {
-			out.Addr = ""
-		}
-		return out, nil
+		}, nil
 
 	default:
-		return FullAddress{}, unix.ENOTSUP
+		return nil, unix.ENOTSUP
 	}
 }

--- a/pkg/strace/epsocket_test.go
+++ b/pkg/strace/epsocket_test.go
@@ -1,0 +1,40 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package strace
+
+import (
+	"errors"
+	"io"
+	"reflect"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestGetAddress(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		addr []byte
+		f    *FullAddress
+		err  error
+	}{
+		{name: "empty", addr: []byte{}, f: nil, err: io.EOF},
+		{name: "too short", addr: []byte{unix.AF_UNIX, 0, 0}, f: nil, err: unix.EINVAL},
+		{name: "bad family", addr: []byte{0, 2, 'h', 'i', 0}, f: nil, err: unix.ENOTSUP},
+		{name: "unix", addr: []byte{unix.AF_UNIX, 0, 'h', 'i', 0}, f: &FullAddress{Addr: "hi"}, err: nil},
+		{name: "IP4", addr: []byte{unix.AF_INET, 0, 13, 14, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0}, f: &FullAddress{Addr: "1.2.3.4", Port: 3342}, err: nil},
+		{name: "IP6", addr: []byte{unix.AF_INET6, 0, 13, 14, 0xde, 0xad, 0xbe, 0xef, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0xa, 0xb, 0xc, 0xd}, f: &FullAddress{Addr: "1:203:405:607:809:a0b:c0d:e0f", Port: 3342}, err: nil},
+	} {
+		f, err := GetAddress(tt.addr)
+		if !errors.Is(err, tt.err) {
+			t.Errorf("%s:got err %v, want %v", tt.name, err, tt.err)
+			continue
+		}
+		if !reflect.DeepEqual(f, tt.f) {
+			t.Errorf("%s:got FullAddress %s, want %s", tt.name, f.String(), tt.f.String())
+		}
+	}
+
+}

--- a/pkg/strace/epsocket_test.go
+++ b/pkg/strace/epsocket_test.go
@@ -24,8 +24,11 @@ func TestGetAddress(t *testing.T) {
 		{name: "too short", addr: []byte{unix.AF_UNIX, 0, 0}, f: nil, err: unix.EINVAL},
 		{name: "bad family", addr: []byte{0, 2, 'h', 'i', 0}, f: nil, err: unix.ENOTSUP},
 		{name: "unix", addr: []byte{unix.AF_UNIX, 0, 'h', 'i', 0}, f: &FullAddress{Addr: "hi"}, err: nil},
+		{name: "unix ENAMETOOLONG", addr: (&[unix.PathMax * 2]byte{unix.AF_UNIX, 0, 'h', 'i', 0})[:], f: nil, err: unix.ENAMETOOLONG},
 		{name: "IP4", addr: []byte{unix.AF_INET, 0, 13, 14, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0}, f: &FullAddress{Addr: "1.2.3.4", Port: 3342}, err: nil},
+		{name: "IP4short", addr: []byte{unix.AF_INET, 0, 13}, f: nil, err: unix.EFAULT},
 		{name: "IP6", addr: []byte{unix.AF_INET6, 0, 13, 14, 0xde, 0xad, 0xbe, 0xef, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0xa, 0xb, 0xc, 0xd}, f: &FullAddress{Addr: "1:203:405:607:809:a0b:c0d:e0f", Port: 3342}, err: nil},
+		{name: "IP6short", addr: []byte{unix.AF_INET6, 0, 13, 14}, f: nil, err: unix.EFAULT},
 	} {
 		f, err := GetAddress(tt.addr)
 		if !errors.Is(err, tt.err) {
@@ -35,6 +38,20 @@ func TestGetAddress(t *testing.T) {
 		if !reflect.DeepEqual(f, tt.f) {
 			t.Errorf("%s:got FullAddress %s, want %s", tt.name, f.String(), tt.f.String())
 		}
+	}
+
+}
+
+func TestFullAddressStringer(t *testing.T) {
+	var a *FullAddress
+	s := a.String()
+	if s != ":" {
+		t.Errorf("nil String: got %q, want %q", s, ":")
+	}
+	a = &FullAddress{Addr: "unix", Port: 0xdead}
+	s = a.String()
+	if s != "unix:0xdead" {
+		t.Errorf("String: got %q, want %q", s, "unix:0xdead")
 	}
 
 }

--- a/pkg/strace/epsocket_test.go
+++ b/pkg/strace/epsocket_test.go
@@ -24,6 +24,7 @@ func TestGetAddress(t *testing.T) {
 		{name: "too short", addr: []byte{unix.AF_UNIX, 0, 0}, f: nil, err: unix.EINVAL},
 		{name: "bad family", addr: []byte{0, 2, 'h', 'i', 0}, f: nil, err: unix.ENOTSUP},
 		{name: "unix", addr: []byte{unix.AF_UNIX, 0, 'h', 'i', 0}, f: &FullAddress{Addr: "hi"}, err: nil},
+		{name: "unix no null", addr: []byte{unix.AF_UNIX, 0, 'h', 'i'}, f: nil, err: unix.EINVAL},
 		{name: "unix ENAMETOOLONG", addr: (&[unix.PathMax * 2]byte{unix.AF_UNIX, 0, 'h', 'i', 0})[:], f: nil, err: unix.ENAMETOOLONG},
 		{name: "IP4", addr: []byte{unix.AF_INET, 0, 13, 14, 1, 2, 3, 4, 0, 0, 0, 0, 0, 0, 0, 0}, f: &FullAddress{Addr: "1.2.3.4", Port: 3342}, err: nil},
 		{name: "IP4short", addr: []byte{unix.AF_INET, 0, 13}, f: nil, err: unix.EFAULT},

--- a/pkg/strace/socket.go
+++ b/pkg/strace/socket.go
@@ -198,7 +198,7 @@ func sockAddr(t Task, addr Addr, length uint32) string {
 
 	switch family {
 	case unix.AF_INET, unix.AF_INET6, unix.AF_UNIX:
-		fa, err := GetAddress(t, b)
+		fa, err := GetAddress(b)
 		if err != nil {
 			return fmt.Sprintf("%#x {Family: %s, error extracting address: %v}", addr, familyStr, err)
 		}


### PR DESCRIPTION
I am not sure why the original code does this but
it returns a binary string in FullAddress:Addr.

Change the code so that Addr is net.IP().String().

Add tests.

Fixes:#2609

Signed-off-by: Ronald G. Minnich <rminnich@google.com>