### PR TITLE
cmds/exp/rush: make it build with tinygo

### DIFF
--- a/cmds/exp/rush/attr_tinygo.go
+++ b/cmds/exp/rush/attr_tinygo.go
@@ -1,0 +1,13 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build tinygo
+
+package main
+
+func builtinAttr(c *Command) {
+}
+
+func forkAttr(c *Command) {
+}

--- a/cmds/exp/rush/cd.go
+++ b/cmds/exp/rush/cd.go
@@ -13,7 +13,7 @@ import (
 var errCdUsage = errors.New("usage: cd one-path")
 
 func init() {
-	addBuiltIn("cd", cd)
+	_ = addBuiltIn("cd", cd)
 }
 
 func cd(c *Command) error {

--- a/cmds/exp/rush/info.go
+++ b/cmds/exp/rush/info.go
@@ -29,7 +29,7 @@ import (
 )
 
 func init() {
-	addBuiltIn("rushinfo", infocmd)
+	_ = addBuiltIn("rushinfo", infocmd)
 }
 
 func infocmd(c *Command) error {

--- a/cmds/exp/rush/rush.go
+++ b/cmds/exp/rush/rush.go
@@ -72,7 +72,7 @@ func wire(cmds []*Command) error {
 		// There seems to be no way to do the classic
 		// inherited pipes thing in Go. Hard to believe.
 		go func() {
-			io.Copy(w, r)
+			_, _ = io.Copy(w, r)
 			w.Close()
 		}()
 	}

--- a/cmds/exp/rush/tty_linux.go
+++ b/cmds/exp/rush/tty_linux.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !tinygo
+// +build !tinygo
+
 package main
 
 import (

--- a/cmds/exp/rush/tty_tinygo.go
+++ b/cmds/exp/rush/tty_tinygo.go
@@ -1,0 +1,16 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build tinygo
+// +build tinygo
+
+package main
+
+// tty does whatever needs to be done to set up a tty for GOOS.
+func tty() {
+}
+
+func foreground() {
+	// Place process group in foreground.
+}


### PR DESCRIPTION
It does not work, yet: there are missing functions in the tinygo environment. But, once they are there, we have a (crude) shell.

Signed-off-by: Ronald G. Minnich <rminnich@google.com>