### PR TITLE
boot: improved Load API

### DIFF
--- a/cmds/boot/fitboot/main.go
+++ b/cmds/boot/fitboot/main.go
@@ -32,9 +32,7 @@ var v = func(string, ...interface{}) {}
 func main() {
 	flag.Parse()
 
-	var loadOptions []boot.LoadOption
 	if *debug {
-		loadOptions = append(loadOptions, boot.Verbose)
 		v = log.Printf
 	}
 
@@ -81,7 +79,7 @@ func main() {
 		f.KeyRing = ring
 	}
 
-	if err := f.Load(loadOptions...); err != nil {
+	if err := f.Load(boot.WithVerbose(*debug)); err != nil {
 		log.Fatal(err)
 	}
 

--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -85,9 +85,7 @@ func main() {
 	opts := registerFlags()
 	flag.Parse()
 
-	var loadOpts []boot.LoadOption
 	if opts.debug {
-		loadOpts = append(loadOpts, boot.Verbose)
 		linux.Debug = log.Printf
 		purgatory.Debug = log.Printf
 	}
@@ -172,7 +170,7 @@ func main() {
 				},
 			}
 		}
-		if err := image.Load(loadOpts...); err != nil {
+		if err := image.Load(boot.WithVerbose(opts.debug)); err != nil {
 			log.Fatal(err)
 		}
 	}

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -33,17 +33,34 @@ func defaultLoadOptions() *loadOptions {
 // WithLogger is a LoadOption that logs verbose debug output l.
 func WithLogger(l ulog.Logger) LoadOption {
 	return func(o *loadOptions) {
-		o.verbose = true
+		o.verbose = (l != nil)
+		if l == nil {
+			l = ulog.Null
+		}
 		o.logger = l
 	}
 }
 
-// Verbose is a LoadOption that logs to os.Stderr like the standard log package.
+// Verbose is a LoadOption that logs to log.Default().
 var Verbose = WithLogger(ulog.Log)
 
+// WithVerbose enables verbose logging if verbose is set to true.
+func WithVerbose(verbose bool) LoadOption {
+	return func(o *loadOptions) {
+		o.verbose = verbose
+		if verbose {
+			o.logger = ulog.Log
+		} else {
+			o.logger = ulog.Null
+		}
+	}
+}
+
 // WithDryRun is a LoadOption that makes sure no kexec_load syscall is called during Load.
-func WithDryRun(o *loadOptions) {
-	o.callKexecLoad = false
+func WithDryRun(dryRun bool) LoadOption {
+	return func(o *loadOptions) {
+		o.callKexecLoad = !dryRun
+	}
 }
 
 // OSImage represents a bootable OS package.

--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -272,11 +272,7 @@ type OSImageAction struct {
 
 // Load implements Entry.Load by loading the OS image into memory.
 func (oia OSImageAction) Load() error {
-	var lo []boot.LoadOption
-	if oia.Verbose {
-		lo = append(lo, boot.Verbose)
-	}
-	if err := oia.OSImage.Load(lo...); err != nil {
+	if err := oia.OSImage.Load(boot.WithVerbose(oia.Verbose)); err != nil {
 		return fmt.Errorf("could not load image %s: %v", oia.OSImage, err)
 	}
 	return nil


### PR DESCRIPTION
verbose and dryRun will for the most part be set through boolean flags, so a boolean WithVerbose(bool) and WithDryRun(bool) should be available for easy use.