### PR TITLE
Introduce ipmi.OpenPath and make blobs.BlobStats public.

### DIFF
--- a/pkg/ipmi/ipmi_linux.go
+++ b/pkg/ipmi/ipmi_linux.go
@@ -9,14 +9,17 @@ import (
 	"os"
 )
 
-// Open a channel to an IPMI device /dev/ipmi{devnum}.
-func Open(devnum int) (*IPMI, error) {
-	d := fmt.Sprintf("/dev/ipmi%d", devnum)
-
-	f, err := os.OpenFile(d, os.O_RDWR, 0)
+// OpenPath opens a channel to an IPMI device by path (e.g., /dev/ipmi0).
+func OpenPath(path string) (*IPMI, error) {
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
 	}
 
 	return &IPMI{dev: newDev(f)}, nil
+}
+
+// Open opens a channel to an IPMI device by device number (e.g., 0 for /dev/ipmi{devnum}).
+func Open(devnum int) (*IPMI, error) {
+	return OpenPath(fmt.Sprintf("/dev/ipmi%d", devnum))
 }

--- a/pkg/ipmi/ipmi_vm_test.go
+++ b/pkg/ipmi/ipmi_vm_test.go
@@ -207,3 +207,30 @@ func TestLogSystemEventQemu(t *testing.T) {
 		t.Errorf("i.LogSystemEvent(e) = %v", err)
 	}
 }
+
+func TestOpenNonexistentDeviceQemu(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+	i, err := Open(42)
+	if err == nil {
+		i.Close()
+		t.Errorf("Open(42) succeeded unexpectedly")
+	}
+
+	i, err = OpenPath("/dev/ipmi42")
+	if err == nil {
+		i.Close()
+		t.Errorf("OpenPath(/dev/ipmi42) succeeded unexpectedly")
+	}
+}
+
+func TestOpenPathQemu(t *testing.T) {
+	testutil.SkipIfNotRoot(t)
+	i, err := OpenPath("/dev/ipmi0")
+	if err != nil {
+		t.Fatalf("Open(/dev/ipmi0) = %v", err)
+	}
+	err = i.Close()
+	if err != nil {
+		t.Errorf("i.Close() = %v", err)
+	}
+}


### PR DESCRIPTION
This change makes two minor feature updates to the ipmi and blobs packages:

1. Introduces OpenPath to open the ipmi device by full path instead of just device number.

2. Makes BlobStats's members public, so that BlobStat and BlobSessionStat can be used.

In testing this change, I noticed that BlobStat/BlobSessionStat had a bug. Fixed that as well. (You can't pass a struct with a slice member to binary.Read.)