### PR TITLE
boot: serialize downloaded image info for reload

### DIFF
--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -27,6 +27,7 @@
 package main
 
 import (
+	"encoding/json"
 	"io"
 	"log"
 	"os"
@@ -44,19 +45,20 @@ import (
 )
 
 type options struct {
-	cmdline      string
-	debug        bool
-	dtb          string
-	exec         bool
-	extra        string
-	initramfs    string
-	load         bool
-	loadSyscall  bool
-	mmapInitrd   bool
-	mmapKernel   bool
-	modules      []string
-	purgatory    string
-	reuseCmdline bool
+	cmdline           string
+	debug             bool
+	dtb               string
+	exec              bool
+	extra             string
+	initramfs         string
+	load              bool
+	loadSyscall       bool
+	linuxImageCfgFile string
+	mmapInitrd        bool
+	mmapKernel        bool
+	modules           []string
+	purgatory         string
+	reuseCmdline      bool
 }
 
 func registerFlags() *options {
@@ -71,6 +73,7 @@ func registerFlags() *options {
 	flag.StringVar(&o.initramfs, "initramfs", "", "Use file as the kernel's initial ramdisk")
 	flag.BoolVarP(&o.load, "load", "l", false, "Load the new kernel into the current kernel")
 	flag.BoolVarP(&o.loadSyscall, "loadsyscall", "L", false, "Use the kexec_load syscall (not kexec_file_load)")
+	flag.StringVarP(&o.linuxImageCfgFile, "linux-image-cfg-file", "I", "", "Load Linux image from JSON info file given")
 	flag.BoolVar(&o.mmapInitrd, "mmap-initrd", true, "Mmap initrd file into virtual buffer, other than directly reading it (Only supported in Arm64 classic load mode for now)")
 	flag.BoolVar(&o.mmapKernel, "mmap-kernel", true, "Mmap kernel file into virtual buffer, other than directly reading it (Only supported in Arm64 classi load mode for now)")
 	flag.StringArrayVar(&o.modules, "module", nil, `Load multiboot module with command line args (e.g --module="mod arg1")`)
@@ -90,9 +93,37 @@ func main() {
 		purgatory.Debug = log.Printf
 	}
 
-	if (!opts.exec && flag.NArg() == 0) || flag.NArg() > 1 {
+	var kernelpath string
+	if flag.NArg() > 0 {
+		kernelpath = flag.Arg(0)
+	}
+	// Option values from linux image config takes precedence
+	// over from cmdline.
+	if len(opts.linuxImageCfgFile) > 0 {
+		log.Printf("Load image info from %s", opts.linuxImageCfgFile)
+		d, err := os.ReadFile(opts.linuxImageCfgFile)
+		if err != nil {
+			log.Fatalf("Failed to load image info: %v", err)
+		}
+		lli := boot.LoadedLinuxImage{}
+		if err := json.Unmarshal(d, &lli); err != nil {
+			log.Fatalf("Unmarshal image info: %v", err)
+		}
+		if lli.Kernel != nil {
+			kernelpath = lli.Kernel.Name()
+		}
+		opts.cmdline = lli.Cmdline
+		if lli.Initrd != nil {
+			opts.initramfs = lli.Initrd.Name()
+		}
+		opts.loadSyscall = lli.LoadSyscall
+		opts.mmapKernel = lli.KexecOpts.MmapKernel
+		opts.mmapInitrd = lli.KexecOpts.MmapRamfs
+	}
+
+	if (!opts.exec && len(kernelpath) == 0) || flag.NArg() > 1 {
 		flag.PrintDefaults()
-		log.Fatalf("usage: kexec [flags] kernelname OR kexec -e")
+		log.Fatalf("usage: kexec [flags] kernelname OR kexec [flags] -linux-image-cfg-file [file] OR kexec -e")
 	}
 
 	if opts.cmdline != "" && opts.reuseCmdline {
@@ -119,7 +150,6 @@ func main() {
 		log.Fatal(err)
 	}
 	if opts.load {
-		kernelpath := flag.Arg(0)
 		kernel, err := os.Open(kernelpath)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -8,10 +8,15 @@ package boot
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/u-root/u-root/pkg/boot/kexec"
 	"github.com/u-root/uio/ulog"
 )
+
+// DefaultLinuxImageCfgFile is the default file name in tmp directory to write loaded LinuxImage info to.
+const DefaultLinuxImageCfgFile = "linux_image_cfg.json"
 
 // LoadOption is an optional parameter to Load.
 type LoadOption func(*loadOptions)
@@ -20,13 +25,16 @@ type loadOptions struct {
 	logger        ulog.Logger
 	verbose       bool
 	callKexecLoad bool
+	// linuxImageCfgFile specifies where to writes loaded linuximage info to.
+	linuxImageCfgFile string
 }
 
 func defaultLoadOptions() *loadOptions {
 	return &loadOptions{
-		logger:        ulog.Null,
-		verbose:       false,
-		callKexecLoad: true,
+		logger:            ulog.Null,
+		verbose:           false,
+		callKexecLoad:     true,
+		linuxImageCfgFile: filepath.Join(os.TempDir(), DefaultLinuxImageCfgFile),
 	}
 }
 
@@ -60,6 +68,13 @@ func WithVerbose(verbose bool) LoadOption {
 func WithDryRun(dryRun bool) LoadOption {
 	return func(o *loadOptions) {
 		o.callKexecLoad = !dryRun
+	}
+}
+
+// WithLinuxImageCfgFile allows user to specify a different linux image config file path.
+func WithLinuxImageCfgFile(f string) LoadOption {
+	return func(o *loadOptions) {
+		o.linuxImageCfgFile = f
 	}
 }
 


### PR DESCRIPTION
This is only triggered when we specify to not load image. Downloaded image info, together with other
configs like cmdline will be saved to a file under tmpfs, which can be reloaded via kexec cmd