### PR TITLE
Dd for tinygo

### DIFF
--- a/cmds/core/dd/dd.go
+++ b/cmds/core/dd/dd.go
@@ -458,7 +458,8 @@ func run(stdin io.Reader, stdout io.WriteSeeker, stderr io.Writer, name string, 
 	if *status != "none" && *status != "xfer" && *status != "progress" {
 		usage()
 	}
-	progress := progress.Begin(*status, &bytesWritten)
+	progress := progress.New(stderr, *status, &bytesWritten)
+	progress.Begin()
 
 	// bs = both 'ibs' and 'obs' (IEEE Std 1003.1 - 2013)
 	if bs.IsSet {

--- a/cmds/core/dd/dd_test.go
+++ b/cmds/core/dd/dd_test.go
@@ -196,7 +196,8 @@ func TestParallelChunkedCopy(t *testing.T) {
 			// Now we need a readbuffer
 			readBuf := bytes.NewReader(tt.inputBuffer)
 
-			err := parallelChunkedCopy(readBuf, writeBuf, int64(len(tt.inputBuffer)), 8, 0)
+			var bytesWritten int64
+			err := parallelChunkedCopy(readBuf, writeBuf, int64(len(tt.inputBuffer)), 8, &bytesWritten, 0)
 
 			if err != nil && !tt.wantError {
 				t.Errorf("parallelChunkedCopy failed with %v", err)

--- a/pkg/progress/progress_test.go
+++ b/pkg/progress/progress_test.go
@@ -5,6 +5,7 @@
 package progress
 
 import (
+	"bytes"
 	"testing"
 	"time"
 )
@@ -33,12 +34,9 @@ func TestProgressBegin(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			someVariable := int64(1)
-			p := Begin(tt.mode, &someVariable)
-
-			if p == nil {
-				t.Errorf(`Begin(%q, %v) = %v, want not nil`, tt.mode, &someVariable, p)
-			}
-
+			b := &bytes.Buffer{}
+			p := New(b, tt.mode, &someVariable)
+			p.Begin()
 			time.Sleep(tt.wait * time.Second)
 
 			if tt.sendQuit {
@@ -74,12 +72,9 @@ func TestProgressEnd(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			someVariable := int64(1)
-			p := Begin(tt.mode, &someVariable)
-
-			if p == nil {
-				t.Fatal("Progress Structure is nil")
-			}
-
+			b := &bytes.Buffer{}
+			p := New(b, tt.mode, &someVariable)
+			p.Begin()
 			time.Sleep(tt.wait * time.Second)
 
 			p.End()


### PR DESCRIPTION
dd fixes for tinygo. These are pretty minimal to get it to go at all, but they have the nice side effect of removing testutil and allowing concurrency in tests. 

The unit package adds a good 11K to the binary when built with tinygo. It's not entirely clear that we need what it does, but for now, it remains. 

Due to some odd limitations in tinygo, the final test memory footprint had to be reduce from 1G to 1/4 G, but I doubt this changes the validity of the test.

This change will also allow dd to be built into the 'forkless' environment.