### PR TITLE
cmds/core/hexdump: use constants and os.WriteFile

### DIFF
--- a/cmds/core/hexdump/hexdump.go
+++ b/cmds/core/hexdump/hexdump.go
@@ -47,6 +47,7 @@ func hexdump(filenames []string, reader io.Reader, writer io.Writer) error {
 	if _, err := io.Copy(w, r); err != nil {
 		return err
 	}
+
 	return nil
 }
 

--- a/cmds/core/hexdump/hexdump_test.go
+++ b/cmds/core/hexdump/hexdump_test.go
@@ -69,16 +69,14 @@ func TestHexdump(t *testing.T) {
 				// or os.ErrNotExist.
 				// Once that is fixed, we can use errors.Is
 				if tt.wantErr == nil {
-					t.Errorf("hexdump() = '%v', want: nil", got)
-					return
+					t.Fatalf("hexdump() = '%v', want: nil", got)
 				}
 				if !strings.HasPrefix(got.Error(), tt.wantErr.Error()[:10]) {
-					t.Errorf("hexdump() = '%v', want: '%v'", got, tt.wantErr)
-					return
+					t.Fatalf("hexdump() = '%v', want: '%v'", got, tt.wantErr)
 				}
 			}
 			if writeBuf.String() != tt.want {
-				t.Errorf("Console output: '%s', want: '%s'", writeBuf.String(), tt.want)
+				t.Errorf("Console output: %q, want: %q", writeBuf.String(), tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
The code was writing the file but not closing it, which could be trouble on some systems.

The string of all letters was used more than once; make it a const.

go test and tinygo test now both work, once #3646 WIP: fix else/defer bug goes in to tinygo.