### PR TITLE
cmds/core/time: add -p flag to time command

### DIFF
--- a/cmds/core/time/time.go
+++ b/cmds/core/time/time.go
@@ -6,7 +6,7 @@
 //
 // Synopsis:
 //
-//	time CMD [ARG]...
+//	time [-p] CMD [ARG]...
 //
 // Description:
 //
@@ -40,6 +40,8 @@ import (
 	"strings"
 	"time"
 )
+
+var _ = flag.Bool("p", true, "makes time output POSIX.2 compliant")
 
 func printTime(stderr io.Writer, l string, t time.Duration) {
 	fmt.Fprintf(stderr, "%s\n", label(l, t))


### PR DESCRIPTION
in general time output is not specified by POSIX, but with -p flag it does, u-root time command already output in POSIX format, so -p flag does nothing, but time -p will not fail