### PR TITLE
Add file limit to cpio file creation

### DIFF
--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -243,7 +243,7 @@ func (r *Recorder) GetRecord(path string) (Record, error) {
 		if done {
 			return Record{Info: info}, nil
 		}
-		return Record{Info: info, ReaderAt: uio.NewLazyFile(path)}, nil
+		return Record{Info: info, ReaderAt: uio.NewLazyLimitFile(path, int64(info.FileSize))}, nil
 
 	case os.ModeSymlink:
 		linkname, err := os.Readlink(path)


### PR DESCRIPTION
There exists a race condition when attempting to add records to the cpio and when the underlying file is being written to at the same time. Introducing a limit writer in case more data gets written to the file.