### PR TITLE
cmds/core/gosh: make autocomplete disable-able

### DIFF
--- a/cmds/core/gosh/gosh.go
+++ b/cmds/core/gosh/gosh.go
@@ -30,9 +30,14 @@ import (
 const HISTFILE = "/tmp/bubble-sh.history" //TODO: make configurable
 
 func main() {
+	completion := true
+	if disable, ok := os.LookupEnv("GOSH_COMPLETION_DISABLE"); ok && disable == "1" {
+		completion = false
+	}
+
 	flag.Parse()
 
-	err := run(flag.NArg(), flag.Args())
+	err := run(completion, flag.Args()...)
 
 	if status, ok := interp.IsExitStatus(err); ok {
 		os.Exit(int(status))
@@ -44,7 +49,7 @@ func main() {
 	}
 }
 
-func run(narg int, args []string) error {
+func run(completion bool, args ...string) error {
 	runner, err := interp.New(interp.StdIO(os.Stdin, os.Stdout, os.Stderr))
 	if err != nil {
 		return err
@@ -52,17 +57,17 @@ func run(narg int, args []string) error {
 
 	parser := syntax.NewParser()
 
-	if narg > 0 {
+	if len(args) > 0 {
 		if strings.HasSuffix(args[0], "sh") {
-			return runScript(runner, parser, args, args[0])
+			return runScript(runner, parser, args[0], args...)
 		}
 
 		return runCmd(runner, parser, strings.NewReader(strings.Join(args, " ")), args[0])
 	}
 
-	if narg == 0 {
+	if len(args) == 0 {
 		if term.IsTerminal(int(os.Stdin.Fd())) {
-			return runInteractive(runner, parser, os.Stdout, os.Stderr)
+			return runInteractive(runner, parser, os.Stdout, os.Stderr, completion)
 		}
 
 		return runCmd(runner, parser, os.Stdin, "")
@@ -71,7 +76,7 @@ func run(narg int, args []string) error {
 	return nil
 }
 
-func runScript(runner *interp.Runner, parser *syntax.Parser, args []string, name string) error {
+func runScript(runner *interp.Runner, parser *syntax.Parser, name string, args ...string) error {
 	if len(args) > 1 {
 		return fmt.Errorf("no support for trailing arguments to script: %v", args[1:])
 	}
@@ -103,7 +108,7 @@ func runCmd(runner *interp.Runner, parser *syntax.Parser, command io.Reader, nam
 	return runner.Run(context.Background(), prog)
 }
 
-func runInteractive(runner *interp.Runner, parser *syntax.Parser, stdout, stderr io.Writer) error {
+func runInteractive(runner *interp.Runner, parser *syntax.Parser, stdout, stderr io.Writer, completion bool) error {
 	input := bubbline.New()
 
 	if err := input.LoadHistory(HISTFILE); err != nil {
@@ -112,7 +117,9 @@ func runInteractive(runner *interp.Runner, parser *syntax.Parser, stdout, stderr
 
 	input.SetAutoSaveHistory(HISTFILE, true)
 
-	input.AutoComplete = autocomplete
+	if completion {
+		input.AutoComplete = autocomplete
+	}
 
 	var runErr error
 
@@ -155,7 +162,7 @@ func runInteractive(runner *interp.Runner, parser *syntax.Parser, stdout, stderr
 		// check if we want to execute a shell script
 		fields := strings.Fields(line)
 		if len(fields) > 0 && strings.HasSuffix(fields[0], "sh") {
-			if err := runScript(runner, parser, fields, fields[0]); err != nil {
+			if err := runScript(runner, parser, fields[0], fields...); err != nil {
 				fmt.Fprintf(stderr, "error: %s\n", err.Error())
 			}
 

--- a/cmds/core/gosh/gosh.go
+++ b/cmds/core/gosh/gosh.go
@@ -31,12 +31,17 @@ const HISTFILE = "/tmp/bubble-sh.history" //TODO: make configurable
 
 func main() {
 	completion := true
-	// If UROOT_SHELL_TABCOMPLETE
+	// If UROOT_SHELL_TABCOMPLETE_DISABLE
 	//   is not set, completion is enabled.
-	//   is set, and it has value 1, completion is enabled.
-	//   is set, and it has value !=1, completion is DISABLED.
-	if c, ok := os.LookupEnv("UROOT_SHELL_TABCOMPLETE"); ok && c != "1" {
-		completion = false
+	//   is set, and it has value "0", "false", or "no": completion is enabled.
+	//   otherwise, completion is DISABLED.
+	if c, ok := os.LookupEnv("UROOT_SHELL_TABCOMPLETE_DISABLE"); ok {
+		switch c {
+		// enabled.
+		case "0", "false", "no":
+		default:
+			completion = false
+		}
 	}
 
 	flag.Parse()

--- a/cmds/core/gosh/gosh.go
+++ b/cmds/core/gosh/gosh.go
@@ -168,6 +168,11 @@ func runInteractive(runner *interp.Runner, parser *syntax.Parser, stdout, stderr
 			break
 		}
 
+		if line == "nocomplete" {
+			input.AutoComplete = nil
+			continue
+		}
+
 		// check if we want to execute a shell script
 		fields := strings.Fields(line)
 		if len(fields) > 0 && strings.HasSuffix(fields[0], "sh") {

--- a/cmds/core/gosh/gosh.go
+++ b/cmds/core/gosh/gosh.go
@@ -31,7 +31,11 @@ const HISTFILE = "/tmp/bubble-sh.history" //TODO: make configurable
 
 func main() {
 	completion := true
-	if disable, ok := os.LookupEnv("GOSH_COMPLETION_DISABLE"); ok && disable == "1" {
+	// If UROOT_SHELL_TABCOMPLETE
+	//   is not set, completion is enabled.
+	//   is set, and it has value 1, completion is enabled.
+	//   is set, and it has value !=1, completion is DISABLED.
+	if c, ok := os.LookupEnv("UROOT_SHELL_TABCOMPLETE"); ok && c != "1" {
 		completion = false
 	}
 

--- a/cmds/core/gosh/gosh_test.go
+++ b/cmds/core/gosh/gosh_test.go
@@ -25,25 +25,18 @@ import (
 func TestRun(t *testing.T) {
 	for _, tt := range []struct {
 		name string
-		narg int
 		args []string
 	}{
 		{
 			name: "no args",
-			narg: 0,
 		},
 		{
 			name: "args",
-			narg: 1,
 			args: []string{"echo"},
-		},
-		{
-			name: "negative args",
-			narg: -1,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := run(tt.narg, tt.args); err != nil {
+			if err := run(false, tt.args...); err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
 		})
@@ -134,7 +127,7 @@ func TestRunInteractive(t *testing.T) {
 
 			parser := syntax.NewParser()
 
-			if err := runInteractive(runner, parser, outWriter, outWriter); err != nil && tt.wantErr == nil {
+			if err := runInteractive(runner, parser, outWriter, outWriter, false); err != nil && tt.wantErr == nil {
 				t.Errorf("Unexpected error: %v", err)
 			} else if tt.wantErr != nil && fmt.Sprint(err) != tt.wantErr.Error() {
 				t.Errorf("Want error %q, got: %v", tt.wantErr, err)

--- a/uroot_test.go
+++ b/uroot_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	gbbgolang "github.com/u-root/gobusybox/src/pkg/golang"
@@ -30,8 +31,7 @@ var twocmds = []string{
 
 func xTestDCE(t *testing.T) {
 	delFiles := false
-	f, _ := buildIt(
-		t,
+	f, _, err := buildIt(t,
 		[]string{
 			"-build=bb", "-no-strip",
 			"world",
@@ -41,6 +41,10 @@ func xTestDCE(t *testing.T) {
 		},
 		nil,
 		nil)
+
+	if err != nil {
+		t.Fatal(err)
+	}
 	defer func() {
 		if delFiles {
 			os.RemoveAll(f.Name())
@@ -282,60 +286,83 @@ func TestUrootCmdline(t *testing.T) {
 	}
 	var bbTests []testCase
 	for _, test := range bareTests {
-		bbTest := test
-		bbTest.name = bbTest.name + " gbb-gopath"
-		bbTest.args = append([]string{"-build=gbb"}, bbTest.args...)
-		bbTest.env = append(bbTest.env, "GO111MODULE=off")
-
 		gbbTest := test
 		gbbTest.name = gbbTest.name + " gbb-gomodule"
 		gbbTest.args = append([]string{"-build=gbb"}, gbbTest.args...)
 		gbbTest.env = append(gbbTest.env, "GO111MODULE=on")
 
-		bbTests = append(bbTests, gbbTest, bbTest)
+		bbTests = append(bbTests, gbbTest)
 	}
 
 	for _, tt := range append(noCmdTests, bbTests...) {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			delFiles := true
-			f, sum1 := buildIt(t, tt.args, tt.env, tt.err)
-			defer func() {
-				if delFiles {
-					os.RemoveAll(f.Name())
+			var (
+				f1, f2     *os.File
+				sum1, sum2 []byte
+				errs       error
+				wg         = &sync.WaitGroup{}
+			)
+
+			wg.Add(2)
+			go func() {
+				f1, sum1, err = buildIt(t, tt.args, tt.env, tt.err)
+				if err != nil {
+					errs = errors.Join(errs, err)
+					return
 				}
+
+				a, err := itest.ReadArchive(f1.Name())
+				if err != nil {
+					errs = errors.Join(errs, err)
+					return
+				}
+
+				for _, v := range tt.validators {
+					if err := v.Validate(a); err != nil {
+						t.Errorf("validator failed: %v / archive:\n%s", err, a)
+					}
+				}
+				wg.Done()
 			}()
 
-			a, err := itest.ReadArchive(f.Name())
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			for _, v := range tt.validators {
-				if err := v.Validate(a); err != nil {
-					t.Errorf("validator failed: %v / archive:\n%s", err, a)
+			defer func() {
+				if delFiles {
+					os.RemoveAll(f1.Name())
 				}
-			}
+			}()
+			go func() {
+				var err error
+				f2, sum2, err = buildIt(t, tt.args, tt.env, tt.err)
+				errs = errors.Join(errs, err)
+				wg.Done()
+			}()
 
-			f2, sum2 := buildIt(t, tt.args, tt.env, tt.err)
 			defer func() {
 				if delFiles {
 					os.RemoveAll(f2.Name())
 				}
 			}()
+			wg.Wait()
+			if errs != nil {
+				t.Error(err)
+				return
+			}
 			if !bytes.Equal(sum1, sum2) {
 				delFiles = false
 				t.Errorf("not reproducible, hashes don't match")
 				t.Errorf("env: %v args: %v", tt.env, tt.args)
-				t.Errorf("file1: %v file2: %v", f.Name(), f2.Name())
+				t.Errorf("file1: %v file2: %v", f1.Name(), f2.Name())
 			}
 		})
 	}
 }
 
-func buildIt(t *testing.T, args, env []string, want error) (*os.File, []byte) {
+func buildIt(t *testing.T, args, env []string, want error) (*os.File, []byte, error) {
 	f, err := os.CreateTemp("", "u-root-")
 	if err != nil {
-		t.Fatal(err)
+		return nil, nil, err
 	}
 	// Use the u-root command outside of the $GOPATH tree to make sure it
 	// still works.
@@ -344,15 +371,15 @@ func buildIt(t *testing.T, args, env []string, want error) (*os.File, []byte) {
 	t.Logf("Commandline: %v u-root %v", strings.Join(env, " "), strings.Join(arg, " "))
 	c.Env = append(c.Env, env...)
 	if out, err := c.CombinedOutput(); err != want {
-		t.Fatalf("Error: %v\nOutput:\n%s", err, out)
+		return nil, nil, fmt.Errorf("Error: %v\nOutput:\n%s", err, out)
 	} else if err != nil {
 		h1 := sha256.New()
 		if _, err := io.Copy(h1, f); err != nil {
-			t.Fatal()
+			return nil, nil, err
 		}
-		return f, h1.Sum(nil)
+		return f, h1.Sum(nil), nil
 	}
-	return f, nil
+	return f, nil, nil
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
new environment variable controls tab completion.
It could be added to any new shell if we change again

	// If UROOT_SHELL_TABCOMPLETE
	//   is not set, completion is enabled.
	//   is set, and it has value 1, completion is enabled.
	//   is set, and it has value !=1, completion is DISABLED.

I also took the opportunity to tidy things up a bit, using variadics where it made sense, and removing the use of nargs arguments: this is Go.