### PR TITLE
pkg/cpio: regarding hard link when link count greater than one

### DIFF
--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -215,7 +215,7 @@ func (r *Recorder) inode(i Info) (Info, bool) {
 
 	if d, ok := r.inodeMap[d]; ok {
 		i.Ino = d.Ino
-		return i, d.Name != i.Name
+		return i, i.NLink > 1 && d.Name != i.Name
 	}
 
 	i.Ino = r.inumber


### PR DESCRIPTION
I found this issue in my environment where a hard link with link count == 1