### PR TITLE
cmds/core/grep: fix empty fixed-string

### DIFF
--- a/cmds/core/grep/grep.go
+++ b/cmds/core/grep/grep.go
@@ -201,6 +201,8 @@ func (c *cmd) run() error {
 	var re *regexp.Regexp
 	if !c.fixed {
 		re = regexp.MustCompile(r)
+	} else if c.expr == "" {
+		c.expr = c.args[0]
 	}
 	// very special case, just stdin
 	if len(c.args) < 2 {

--- a/cmds/core/grep/grep_test.go
+++ b/cmds/core/grep/grep_test.go
@@ -130,6 +130,19 @@ func TestStdinGrep(t *testing.T) {
 			p:      params{fixed: true, caseInsensitive: true},
 			args:   []string{"[A-z]"},
 		},
+		{
+			input:  "a\nb\nc\n",
+			output: "b\n",
+			err:    nil,
+			p:      params{fixed: true},
+			args:   []string{"b"},
+		},
+		{
+			input:  "a\nb\nc\n",
+			output: "b\n",
+			err:    nil,
+			p:      params{fixed: true, expr: "b"},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
initilise c.expr with args[0] if c.expr is empty