### PR TITLE
gosh: add a -interactive switch to disable terminal noise

### DIFF
--- a/cmds/core/gosh/gosh.go
+++ b/cmds/core/gosh/gosh.go
@@ -80,8 +80,10 @@ func run(completion bool, interactive bool, stdin io.Reader, args ...string) err
 	}
 
 	if len(args) == 0 {
-		if interactive && term.IsTerminal(int(os.Stdin.Fd())) {
-			return runInteractive(runner, parser, os.Stdout, os.Stderr, completion)
+		if interactive {
+			if r, ok := stdin.(*os.File); ok && term.IsTerminal(int(r.Fd())) {
+				return runInteractive(runner, parser, os.Stdout, os.Stderr, completion)
+			}
 		}
 
 		return runCmd(runner, parser, stdin, "")

--- a/cmds/core/gosh/gosh.go
+++ b/cmds/core/gosh/gosh.go
@@ -17,6 +17,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/signal"
 	"strings"
@@ -42,8 +43,7 @@ func main() {
 	}
 
 	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
+		log.Fatal(err)
 	}
 }
 

--- a/cmds/core/gosh/gosh_test.go
+++ b/cmds/core/gosh/gosh_test.go
@@ -36,7 +36,7 @@ func TestRun(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			if err := run(false, false, &bytes.Buffer{}, tt.args...); err != nil {
+			if err := run(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}, false, tt.args...); err != nil {
 				t.Errorf("Unexpected error: %v", err)
 			}
 		})
@@ -128,7 +128,7 @@ func TestRunInteractive(t *testing.T) {
 
 			parser := syntax.NewParser()
 
-			if err := runInteractive(runner, parser, outWriter, outWriter, false); err != nil && tt.wantErr == nil {
+			if err := runInteractive(runner, parser, outWriter, outWriter); err != nil && tt.wantErr == nil {
 				t.Errorf("Unexpected error: %v", err)
 			} else if tt.wantErr != nil && fmt.Sprint(err) != tt.wantErr.Error() {
 				t.Errorf("Want error %q, got: %v", tt.wantErr, err)

--- a/cmds/core/gosh/gosh_test.go
+++ b/cmds/core/gosh/gosh_test.go
@@ -62,15 +62,38 @@ func TestRunFail(t *testing.T) {
 }
 
 func TestRunScript(t *testing.T) {
+	d := t.TempDir()
+	script := filepath.Join(d, "a.sh")
+	if err := os.WriteFile(script, []byte("echo hi\n"), 0666); err != nil {
+		t.Fatalf("Writing %q: got %v, want nil", script, err)
+	}
+
 	for _, tt := range []struct {
 		name  string
 		pairs []string
 		err   error
 	}{
+
 		{
 			name: "bad file",
 			pairs: []string{
 				"/",
+				"",
+			},
+			err: errors.New("read /: is a directory"),
+		},
+		{
+			name: "bad file",
+			pairs: []string{
+				"bad file",
+				"",
+			},
+			err: errors.New("open bad file: no such file or directory"),
+		},
+		{
+			name: "echo script",
+			pairs: []string{
+				script,
 				"",
 			},
 			err: errors.New("open bad file: no such file or directory"),
@@ -85,7 +108,7 @@ func TestRunScript(t *testing.T) {
 
 			parser := syntax.NewParser()
 
-			if err := runScript(runner, parser, tt.name); err != nil {
+			if err := runScript(runner, parser, tt.pairs[0]); err != nil {
 				// can't use errors.Is: please ask mvdan to fix that.
 				if fmt.Sprintf("%v", err) != fmt.Sprintf("%v", tt.err) {
 					t.Errorf("got '%v', want '%v'", err, tt.err)


### PR DESCRIPTION
gosh is a very active shell. On each command, it spews all kinds of ANSI control sequences and so on.

This noise comes from bubbline, which seems to have no way to easily minimize all the activity. The noise causes trouble for test environments.

Add a switch, -interactive, default true, which if set false makes gosh act like a simple, noninteractive, line-at-a-time shell.