### PR TITLE
HSS: Support reading HSS from EEPROM

### DIFF
--- a/cmds/exp/disk_unlock/disk_unlock.go
+++ b/cmds/exp/disk_unlock/disk_unlock.go
@@ -74,7 +74,7 @@ func main() {
 	verboseLog(fmt.Sprintf("Disk info for %s: %s", *disk, info.String()))
 
 	// Obtain 32 byte Host Secret Seed (HSS) from IPMI.
-	hssList, err := hsskey.GetAllHss(*verbose, *verboseNoSanitize)
+	hssList, err := hsskey.GetAllHss(*verbose, *verboseNoSanitize, "")
 	if err != nil {
 		log.Fatalf("error getting HSS: %v", err)
 	}

--- a/cmds/exp/nvme_unlock/nvme_unlock.go
+++ b/cmds/exp/nvme_unlock/nvme_unlock.go
@@ -52,6 +52,7 @@ var (
 	noRereadPartitions = flag.Bool("no-reread-partitions", false, "Only attempt to unlock the disk, don't re-read the partition table.")
 	lock               = flag.Bool("lock", false, "Lock instead of unlocking")
 	salt               = flag.String("salt", hsskey.DefaultPasswordSalt, "Salt for password generation")
+	eepromPattern      = flag.String("eeprom-pattern", "", "The pattern used to match EEPROM sysfs paths where the Host Secret Seeds are located")
 )
 
 func verboseLog(msg string) {
@@ -118,7 +119,7 @@ func run(disk string, verbose bool, verboseNoSanitize bool, noRereadPartitions b
 	}
 	defer diskFd.Close()
 
-	hssList, err := hsskey.GetAllHss(verbose, verboseNoSanitize)
+	hssList, err := hsskey.GetAllHss(verbose, verboseNoSanitize, *eepromPattern)
 	if err != nil {
 		return fmt.Errorf("error getting HSS: %v", err)
 	}

--- a/pkg/hsskey/filereader.go
+++ b/pkg/hsskey/filereader.go
@@ -1,0 +1,158 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package hsskey
+
+import (
+	"encoding/binary"
+	"fmt"
+	"hash/crc32"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+const (
+	baseSysfsPattern = "/sys/bus/i2c/devices/%s/eeprom"
+)
+
+// toOctalEscapeSequence converts a byte slice into similar format as C++ protobuf DebugString()
+// If the byte represents a printable ASCII character, add it as is to the output string
+// If it is non-printable or non-ASCII, add it as octal notation
+// This is used for comparing output from C++ tool for debugging purpose.
+func toOctalEscapeSequence(b []byte) string {
+	var shortHandNotions = map[string]string{
+		"\011": "\\t",
+		"\015": "\\r",
+	}
+	octalEscape := ""
+	for _, v := range b {
+		octalChar := fmt.Sprintf("\\%03o", v)
+		if v >= 32 && v <= 126 {
+			octalEscape += string(v)
+		} else if notion, ok := shortHandNotions[string(v)]; ok {
+			// DebugString prints these characters as shorthand notations
+			octalEscape += notion
+		} else {
+			octalEscape += octalChar
+		}
+	}
+	return octalEscape
+}
+
+// validateChecksum check if HSS data is valid based on the checksum value stored in the last 4
+// bytes.
+func validateChecksum(data []byte) bool {
+	size := len(data)
+	if size != hostSecretSeedStructSize {
+		return false
+	}
+	// Split the data into the main part and the checksum. Last 4 bytes is used for storing
+	// checksum value.
+	mainPart := data[:size-hostSecretSeedChecksumBytes]
+	checksumBytes := data[size-hostSecretSeedChecksumBytes:]
+
+	// Convert the checksum bytes from big-endian.
+	checksum := binary.BigEndian.Uint32(checksumBytes)
+
+	// Compute the checksum of the main part.
+	table := crc32.MakeTable(crc32.Castagnoli)
+	computedChecksum := crc32.Checksum(mainPart, table)
+
+	if computedChecksum != checksum {
+		return false
+	}
+	return true
+}
+
+// deduplicate removes duplicate entries from a slice of byte slices.
+func deduplicate(data [][]byte) [][]byte {
+	seen := make(map[string]bool)
+	result := [][]byte{}
+
+	for _, entry := range data {
+		strEntry := string(entry)
+		if !seen[strEntry] {
+			seen[strEntry] = true
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
+// getHssEepromPaths takes a glob pattern for EEPROM sysfs paths and return all the matching paths.
+// This function will return error if the provided glob pattern doesn't match any existing path.
+//
+// For example, if busDevicePattern is "0-007[01]", this function will look for all the paths
+// matching "/sys/bus/i2c/devices/0-007[01]/eeprom"
+func getHssEepromPaths(basePattern string, busDevicePattern string) ([]string, error) {
+	fullPathGlob := fmt.Sprintf(basePattern, busDevicePattern)
+	matches, err := filepath.Glob(fullPathGlob)
+	if err != nil {
+		return nil, fmt.Errorf("failed to search the file path %v", err)
+	}
+	if len(matches) == 0 {
+		return nil, fmt.Errorf("no matching path found for glob pattern %s", fullPathGlob)
+	}
+	return matches, nil
+}
+
+// readFromFile reads HSS keys from the specified file. Expecting the file containing 4 consecutive
+// HSS keys. Each HSS key is 64 bytes long and has a checksum for validation.
+func readHssFromFile(filePath string) ([][]byte, error) {
+	validLen := hostSecretSeedStructSize * hostSecretSeedCount
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file %v", err)
+	}
+	if len(data) < validLen {
+		return nil, fmt.Errorf("file size %d is less than expected", len(data))
+	}
+	if len(data) > validLen {
+		log.Printf("Expecting %d bytes but got more %d bytes", validLen, len(data))
+	}
+
+	var hssList [][]byte
+	for i := 0; i < hostSecretSeedCount; i++ {
+		start := i * hostSecretSeedStructSize
+		end := start + hostSecretSeedStructSize
+		hssKey := data[start:end]
+
+		// Verify the checksums.
+		if !validateChecksum(hssKey) {
+			log.Printf("Checksum validation failed for HSS key at offset %d", start)
+			continue
+		}
+		hssList = append(hssList, hssKey[:hostSecretSeedLen])
+	}
+	return hssList, nil
+}
+
+func getHssFromFile(verbose bool, verboseDangerous bool, filePaths []string) ([][]byte, error) {
+	allHss := [][]byte{}
+	for _, f := range filePaths {
+		hssKeys, err := readHssFromFile(f)
+		if err != nil {
+			log.Printf("Failed to read HSS keys from file %s. err: %v", f, err)
+			continue
+		}
+
+		if verbose {
+			msg := fmt.Sprintf("Reading HSS keys from file=%s", f)
+			if verboseDangerous {
+				for _, hss := range hssKeys {
+					msg = msg + fmt.Sprintf("\nseed=%x, seed(octal escape sequence)=%s", hss,
+						toOctalEscapeSequence(hss))
+				}
+			}
+			log.Print(msg)
+		}
+		allHss = append(allHss, hssKeys...)
+	}
+
+	// Remove duplicate HSS key.
+	allHss = deduplicate(allHss)
+
+	return allHss, nil
+}

--- a/pkg/hsskey/filereader_test.go
+++ b/pkg/hsskey/filereader_test.go
@@ -1,0 +1,413 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package hsskey
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+var castagnoliTable = crc32.MakeTable(crc32.Castagnoli)
+
+func TestToOctalEscapeSequence(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []byte
+		expected string
+	}{
+		{
+			name:     "case 1: printable ASCII characters",
+			input:    []byte("hello world!"),
+			expected: "hello world!",
+		},
+		{
+			name:     "case 2: non-printable ASCII characters",
+			input:    []byte{0, 12, 200, 255},
+			expected: "\\000\\014\\310\\377",
+		},
+		{
+			name:     "case 3: mix printable and non-printable ASCII characters",
+			input:    []byte{53, 193, 224, 43, 147, 134, 239, 118, 50, 115},
+			expected: "5\\301\\340+\\223\\206\\357v2s",
+		},
+		{
+			name:     "case 4: multiple characters with shorthand notations",
+			input:    []byte{251, 5, 232, 226, 13, 9},
+			expected: "\\373\\005\\350\\342\\r\\t",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toOctalEscapeSequence(tt.input)
+			if result != tt.expected {
+				t.Fatalf("toOctalEscapeSequence(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+// Create dummy hss data, last 4 bytes are reserved for checksum
+func createDummyHssData() []byte {
+	data := make([]byte, hostSecretSeedStructSize-hostSecretSeedChecksumBytes)
+	rand.Read(data)
+	checksum := crc32.Checksum(data, castagnoliTable)
+
+	checksumBytes := make([]byte, hostSecretSeedChecksumBytes)
+	binary.BigEndian.PutUint32(checksumBytes, checksum)
+	data = append(data, checksumBytes...)
+
+	return data
+}
+
+func TestValidateChecksum(t *testing.T) {
+	tests := []struct {
+		name   string
+		data   []byte
+		expect bool
+	}{
+		{
+			name:   "valid checksum",
+			expect: true,
+			data:   createDummyHssData(),
+		},
+		{
+			name:   "invalid checksum",
+			expect: false,
+			data: func() []byte {
+				data := createDummyHssData()
+				// Change the last byte of checksum to make it invalid
+				data[len(data)-1]++
+				return data
+			}(),
+		},
+		{
+			name:   "invalid size",
+			expect: false,
+			data:   []byte{1, 2, 3},
+		},
+		{
+			name:   "zero bytes",
+			expect: false,
+			data:   make([]byte, 64),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := validateChecksum(tt.data)
+			if result != tt.expect {
+				t.Fatalf("validateChecksum(%v) = %v, want %v", tt.data, result, tt.expect)
+			}
+		})
+	}
+}
+
+func TestDeduplicate(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    [][]uint8
+		expected [][]uint8
+	}{
+		{
+			name: "No duplicates",
+			input: [][]uint8{
+				{1, 2, 3},
+				{4, 5, 6},
+				{7, 8, 9},
+			},
+			expected: [][]uint8{
+				{1, 2, 3},
+				{4, 5, 6},
+				{7, 8, 9},
+			},
+		},
+		{
+			name: "With duplicates",
+			input: [][]uint8{
+				{1, 2, 3},
+				{1, 2, 3},
+				{4, 5, 6},
+			},
+			expected: [][]uint8{
+				{1, 2, 3},
+				{4, 5, 6},
+			},
+		},
+		{
+			name: "All duplicates",
+			input: [][]uint8{
+				{1, 2, 3},
+				{1, 2, 3},
+				{1, 2, 3},
+			},
+			expected: [][]uint8{
+				{1, 2, 3},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := deduplicate(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("deduplicate(%v) = %v, want %v", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetHssEepromPaths(t *testing.T) {
+	tests := []struct {
+		name          string
+		pattern       string
+		allFiles      []string
+		expectedFiles []string
+		isErr         bool
+	}{
+		{
+			name:    "Matching all EEPROMs",
+			pattern: "*",
+			allFiles: []string{
+				"/sys/bus/i2c/devices/0-0050/eeprom",
+				"/sys/bus/i2c/devices/1-0050/eeprom",
+				"/sys/bus/i2c/devices/1-0050/device",
+			},
+			expectedFiles: []string{
+				"/sys/bus/i2c/devices/0-0050/eeprom",
+				"/sys/bus/i2c/devices/1-0050/eeprom",
+			},
+			isErr: false,
+		},
+		{
+			name:    "Matching multiple EEPROMs",
+			pattern: "0-007[01]",
+			allFiles: []string{
+				"/sys/bus/i2c/devices/0-0070/eeprom",
+				"/sys/bus/i2c/devices/0-0071/eeprom",
+				"/sys/bus/i2c/devices/1-0070/device",
+			},
+			expectedFiles: []string{
+				"/sys/bus/i2c/devices/0-0070/eeprom",
+				"/sys/bus/i2c/devices/0-0071/eeprom",
+			},
+			isErr: false,
+		},
+		{
+			name:    "Matching multiple EEPROMs behind mux",
+			pattern: "0-0050/channel-[01]/*",
+			allFiles: []string{
+				"/sys/bus/i2c/devices/0-0050/channel-0/0-0070/eeprom",
+				"/sys/bus/i2c/devices/0-0050/channel-1/0-0075/eeprom",
+				"/sys/bus/i2c/devices/0-0055/eeprom",
+			},
+			expectedFiles: []string{
+				"/sys/bus/i2c/devices/0-0050/channel-0/0-0070/eeprom",
+				"/sys/bus/i2c/devices/0-0050/channel-1/0-0075/eeprom",
+			},
+			isErr: false,
+		},
+		{
+			name:    "No matching found",
+			pattern: "0-0050",
+			allFiles: []string{
+				"/sys/bus/i2c/devices/0-0070/eeprom",
+			},
+			expectedFiles: []string{},
+			isErr:         true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp dir
+			tempDir := t.TempDir()
+			// Create all files
+			for _, path := range tt.allFiles {
+				fullPath := filepath.Join(tempDir, path)
+				err := os.MkdirAll(filepath.Dir(fullPath), 0755)
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, err = os.Create(fullPath)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Use temp dir to create base sysfs pattern
+			testBaseSysfsPattern := filepath.Join(tempDir, baseSysfsPattern)
+			result, err := getHssEepromPaths(testBaseSysfsPattern, tt.pattern)
+
+			// Check if error matches expectation
+			if err != nil && !tt.isErr {
+				t.Fatalf("Unexpected error: %v", err)
+			}
+			if err == nil && tt.isErr {
+				t.Fatalf("Expected error but got none")
+			}
+
+			// Check if result matches expectation
+			expectedPaths := make(map[string]struct{})
+			for _, path := range tt.expectedFiles {
+				expectedPaths[filepath.Join(tempDir, path)] = struct{}{}
+			}
+
+			for _, path := range result {
+				if _, ok := expectedPaths[path]; !ok {
+					t.Fatalf("Unexpected path: %v", path)
+				}
+				delete(expectedPaths, path)
+			}
+			if len(expectedPaths) > 0 {
+				t.Fatalf("Missing path: %v", expectedPaths)
+			}
+		})
+	}
+}
+
+func TestReadHssFromFile(t *testing.T) {
+	validHssBlock1 := createDummyHssData()
+	validHssBlock2 := createDummyHssData()
+	invalidChecksumHssBlock1 := createDummyHssData()
+	invalidChecksumHssBlock2 := createDummyHssData()
+	// make checksum invalid
+	invalidChecksumHssBlock1[len(invalidChecksumHssBlock1)-1]++
+	invalidChecksumHssBlock2[len(invalidChecksumHssBlock2)-1]++
+
+	tests := []struct {
+		name         string
+		fileData     [][]byte
+		expectedData [][]byte
+		expectErr    bool
+	}{
+		{
+			name:     "Four valid hss blocks",
+			fileData: [][]byte{validHssBlock1, validHssBlock1, validHssBlock2, validHssBlock2},
+			expectedData: [][]byte{validHssBlock1[:32], validHssBlock1[:32], validHssBlock2[:32],
+				validHssBlock2[:32]},
+			expectErr: false,
+		},
+		{
+			name: "Two valid and two invalid",
+			fileData: [][]byte{validHssBlock1, invalidChecksumHssBlock1, validHssBlock2,
+				invalidChecksumHssBlock2},
+			expectedData: [][]byte{validHssBlock1[:32], validHssBlock2[:32]},
+			expectErr:    false,
+		},
+		{
+			name: "Mix invalid block",
+			fileData: [][]byte{make([]byte, 5), validHssBlock1, validHssBlock1, validHssBlock1,
+				validHssBlock1},
+			expectedData: nil,
+			expectErr:    true,
+		},
+		{
+			name: "File length is longer than 4 blocks",
+			fileData: [][]byte{validHssBlock1, invalidChecksumHssBlock1, validHssBlock2, validHssBlock2,
+				validHssBlock2},
+			expectedData: [][]byte{validHssBlock1[:32], validHssBlock2[:32], validHssBlock2[:32]},
+			expectErr:    false,
+		},
+		{
+			name:         "File too short",
+			fileData:     [][]byte{validHssBlock1},
+			expectedData: nil,
+			expectErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a temp file with the test HSS data.
+			tempFile, err := os.CreateTemp("", "testData")
+			if err != nil {
+				t.Fatalf("Failed to create temporary file: %v", err)
+			}
+			defer os.Remove(tempFile.Name())
+
+			var fileContent []byte
+			for _, bytes := range tt.fileData {
+				fileContent = append(fileContent, bytes...)
+			}
+			if err := os.WriteFile(tempFile.Name(), fileContent, 0644); err != nil {
+				t.Fatalf("Failed to write test file: %v", err)
+			}
+
+			hssList, err := readHssFromFile(tempFile.Name())
+			if err != nil {
+				if !tt.expectErr {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+			} else if !reflect.DeepEqual(hssList, tt.expectedData) {
+				t.Fatalf("readHssFromFile(%v) = %v, want %v", tempFile.Name(), hssList, tt.expectedData)
+			}
+		})
+	}
+}
+
+func TestGetHssFromFile(t *testing.T) {
+	// Create temp files.
+	tempFile1, err := os.CreateTemp("", "testData")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile1.Name())
+
+	tempFile2, err := os.CreateTemp("", "testData")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempFile2.Name())
+
+	tempConfigFile, err := os.CreateTemp("", "testConfig")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tempConfigFile.Name())
+
+	// Write test data into temp file 1
+	// 2 same key + another 2 same key
+	var fileContent1 []byte
+	f1td1 := createDummyHssData()
+	fileContent1 = append(fileContent1, f1td1...)
+	fileContent1 = append(fileContent1, f1td1...)
+	f1td2 := createDummyHssData()
+	fileContent1 = append(fileContent1, f1td2...)
+	fileContent1 = append(fileContent1, f1td2...)
+	if err := os.WriteFile(tempFile1.Name(), fileContent1, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write test data into temp file 2
+	// 2 same key + 1 invalid key + 1 another key
+	var fileContent2 []byte
+	f2td1 := createDummyHssData()
+	fileContent2 = append(fileContent2, f2td1...)
+	fileContent2 = append(fileContent2, f2td1...)
+	f2td2 := createDummyHssData()
+	f2td2[len(f2td2)-1]++
+	fileContent2 = append(fileContent2, f2td2...)
+	f2td3 := createDummyHssData()
+	fileContent2 = append(fileContent2, f2td3...)
+	if err := os.WriteFile(tempFile2.Name(), fileContent2, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	hssList, err := getHssFromFile(true, true, []string{tempFile1.Name(), tempFile2.Name()})
+	// Expected to read two unique HSS key from td1 and td4
+	expectedResult := [][]byte{f1td1[:32], f1td2[:32], f2td1[:32], f2td3[:32]}
+	if err != nil {
+		t.Fatalf("getHssFromFile() error = %v", err)
+	}
+	if !reflect.DeepEqual(hssList, expectedResult) {
+		t.Fatalf("getHssFromFile() = %v, want %v", hssList, expectedResult)
+	}
+}


### PR DESCRIPTION
This change adds an option for nvme_unlock to read HSS keys from EEPROM. We assume the EEPROMs will be enumerated in sysfs and can be accessed like a regular file.