### PR TITLE
Add stdin, stdout, stderr options to StartShell struct

### DIFF
--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -18,7 +18,7 @@ import (
 	"time"
 
 	"github.com/u-root/u-root/pkg/boot"
-	"github.com/u-root/u-root/pkg/sh"
+	"github.com/u-root/u-root/pkg/libinit"
 	"golang.org/x/sys/unix"
 )
 
@@ -290,7 +290,9 @@ func (oia OSImageAction) Exec() error {
 func (OSImageAction) IsDefault() bool { return true }
 
 // StartShell is a menu.Entry that starts a LinuxBoot shell.
-type StartShell struct{}
+type StartShell struct {
+	Mod []libinit.CommandModifier
+}
 
 // Label is the label to show to the user.
 func (StartShell) Label() string {
@@ -307,10 +309,10 @@ func (StartShell) Load() error {
 }
 
 // Exec implements Entry.Exec by running /bin/defaultsh.
-func (StartShell) Exec() error {
+func (s StartShell) Exec() error {
 	// Reset signal handler for SIGINT to enable user interrupts again
 	signal.Reset(syscall.SIGINT)
-	return sh.RunWithLogs("/bin/defaultsh")
+	return libinit.Command("/bin/defaultsh", s.Mod...).Run()
 }
 
 // IsDefault indicates that this should not be run as a default action.

--- a/pkg/libinit/proc.go
+++ b/pkg/libinit/proc.go
@@ -5,6 +5,7 @@
 package libinit
 
 import (
+	"io"
 	"os"
 	"os/exec"
 
@@ -22,6 +23,27 @@ func WithArguments(arg ...string) CommandModifier {
 		if len(arg) > 0 {
 			c.Args = append(c.Args, arg...)
 		}
+	}
+}
+
+// WithStdin changes the command's stdin to r.
+func WithStdin(r io.Reader) CommandModifier {
+	return func(c *exec.Cmd) {
+		c.Stdin = r
+	}
+}
+
+// WithStdout changes the command's stdout to w.
+func WithStdout(w io.Writer) CommandModifier {
+	return func(c *exec.Cmd) {
+		c.Stdout = w
+	}
+}
+
+// WithStderr changes the command's stderr to w.
+func WithStderr(w io.Writer) CommandModifier {
+	return func(c *exec.Cmd) {
+		c.Stderr = w
 	}
 }
 


### PR DESCRIPTION
Allow users to specify stdin, stdout, and stderr options when running the shell.