### PR TITLE
add a tamagoize tool

### DIFF
--- a/tools/tamagoize/main.go
+++ b/tools/tamagoize/main.go
@@ -1,0 +1,109 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This builds a tinygo image that does not need
+// fork/exec.
+
+package main
+
+import (
+	"flag"
+	"io/fs"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+var (
+	// this used to include rush, but tamago has their own shell
+	// should you want to bring rush back, you will need to grab the
+	// support from tinygobb.
+	list = flag.String("l", "", "comma-separated list of u-root commands to build")
+	debug = flag.Bool("d", false, "enable debug prints")
+	v = func(string, ...any) {}
+)
+
+func main() {
+	flag.Parse()
+
+	dir, err := os.MkdirTemp("", "tiny")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	c := exec.Command("./u-root", append([]string{"-tags", "tinygo", "-tmpdir", dir}, strings.Split(*list, ",")...)...)
+	c.Stdout, c.Stderr = os.Stdout, os.Stderr
+	if err := c.Run(); err != nil {
+		// An error is expected, for now.
+		v("Running u-root: %v", err)
+	}
+
+	build, err := filepath.Glob(filepath.Join(dir, "*"))
+	if err != nil {
+		log.Fatal(err)
+	}
+	if len(build) != 1 {
+		log.Fatalf("can not find unique builddir from %q, got %q", dir, build)
+	}
+
+	// Walk the tree, find all go files, in each file, replace os.Exit
+	// with //.Exit. Sleazy.
+	// This is the wrong way to do this, should use AST of course, as we do it with
+	// the busybox. I was in a hurry.
+	err = filepath.WalkDir(build[0], func(path string, d fs.DirEntry, err error) error {
+		if d.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+
+		b, errRead := os.ReadFile(path)
+		if errRead != nil {
+			return errRead
+		}
+		s := strings.ReplaceAll(string(b), "os.Exit", "//.Exit")
+		v("replaced os.Exit in %q, output %s", path, s)
+		if err := ioutil.WriteFile(path, []byte(s), 0644); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatalf("Walkdir %q: %v", build[0], err)
+	}
+
+	// The rewrite step may result in os no longer being needed in some
+	// source. run imports.
+	c = exec.Command("goimports", "-w", ".")
+	c.Dir = build[0]
+	c.Stdout, c.Stderr = os.Stdout, os.Stderr
+	log.Printf("Now run imports: %v in %q", c, c.Dir)
+	if err := c.Run(); err != nil {
+		log.Fatalf("Running go: %v, %v", c, err)
+	}
+
+	os.Exit(0)
+
+	// this is where we would build tamago and maybe it would work.
+	c = exec.Command("go", "build", "-tags", "tinygo")
+	c.Dir = filepath.Join(build[0], "src/bb.u-root.com/bb")
+	c.Stdout, c.Stderr = os.Stdout, os.Stderr
+	log.Printf("Now compile it: %v", c)
+	if err := c.Run(); err != nil {
+		log.Fatalf("Running go: %v, %v", c, err)
+	}
+
+	bin := filepath.Join(c.Dir, "bb")
+	fi, err := os.Stat(bin)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	log.Printf("The binary is: %q, info %v", bin, fi)
+
+}


### PR DESCRIPTION
the intent is that you can create a u-root source tree with makebb and build it into tamago, then you can have u-root commands in tamago.

as expected, I still can't get very far with Go modules. No surprise there.

rminnich@pop-os:~/go/src/github.com/u-root/u-root$ echo $te /home/rminnich/tamago/tamago-example

rminnich@pop-os:~/go/src/github.com/u-root/u-root$ makebb -g -gen-dir $te/u-root cmds/core/date 08:31:53 Disabling CGO for u-root...
08:31:53 Build environment: GOARCH=amd64 GOOS=linux GOPATH=/home/rminnich/go CGO_ENABLED=0 GO111MODULE= GOROOT=/home/rminnich/golang PATH=/home/rminnich/golang/bin:$PATH 08:31:53 directory supplied for busybox generated source is not an empty directory 08:31:53 Preserving bb generated source directory at /home/rminnich/tamago/tamago-example/u-root due to error.

rminnich@pop-os:~/go/src/github.com/u-root/u-root$ cd $te rminnich@pop-os:~/tamago/tamago-example$

rminnich@pop-os:~/tamago/tamago-example$ git diff main.go diff --git a/main.go b/main.go
index 0ae2dbe..e71de69 100644
--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ import (
        "github.com/usbarmory/tamago-example/cmd"
        "github.com/usbarmory/tamago-example/internal/semihosting"
        "github.com/usbarmory/tamago-example/network"
+
+       _ "github.com/usbarmory/tamago-example/bb"
 )

 var Build string

rminnich@pop-os:~/tamago/tamago-example$ git diff go.mod diff --git a/go.mod b/go.mod
index c5d550b..02a221d 100644
--- a/go.mod
+++ b/go.mod
@@ -37,3 +37,9 @@ require (
        golang.org/x/tools v0.3.0 // indirect
        gopkg.in/yaml.v2 v2.4.0 // indirect
 )
+
+replace github.com/usbarmory/tamago-example/bb => ./u-root/src/bb.u-root.com/bb

rminnich@pop-os:~/tamago/tamago-example$ go build . main.go:25:2: module github.com/usbarmory/tamago-example/bb provides package github.com/usbarmory/tamago-example/bb and is replaced but not required; to add it:
	go get github.com/usbarmory/tamago-example/bb

now what?