### PR TITLE
pkg/dt: look-up direct children and prune sub-trees

### DIFF
--- a/pkg/dt/node.go
+++ b/pkg/dt/node.go
@@ -49,6 +49,7 @@ var StandardPropertyTypes = map[string]PropertyType{
 }
 
 var (
+	errInvalidChildIndex     = errors.New("invalid child index")
 	errPropertyRegionInvalid = errors.New("property value is not <u64x2>")
 )
 
@@ -57,6 +58,27 @@ type Node struct {
 	Name       string
 	Properties []Property `json:",omitempty"`
 	Children   []*Node    `json:",omitempty"`
+}
+
+// FindFirstMatchingChildIndex returns the index of the first immediate child node satisfying the
+// given predicate.
+func (n *Node) FindFirstMatchingChildIndex(predicate func(*Node) bool) (int, bool) {
+	for idx, child := range n.Children {
+		if predicate(child) {
+			return idx, true
+		}
+	}
+	return -1, false
+}
+
+// LookupChildByName returns the immediate child node with the given name.
+func (n *Node) LookupChildByName(name string) (*Node, bool) {
+	if idx, ok := n.FindFirstMatchingChildIndex(func(child *Node) bool {
+		return child.Name == name
+	}); ok {
+		return n.Children[idx], ok
+	}
+	return nil, false
 }
 
 // Walk calls f on a Node and alls its descendents.
@@ -72,7 +94,7 @@ func (n *Node) Walk(f func(*Node) error) error {
 	return nil
 }
 
-// Find finds a Node starting at a node, given a matching function.
+// Find returns the first matching Node (recursively) starting at a node, and given a matching function.
 func (n *Node) Find(f func(*Node) bool) (*Node, bool) {
 	if ok := f(n); ok {
 		return n, ok
@@ -85,7 +107,7 @@ func (n *Node) Find(f func(*Node) bool) (*Node, bool) {
 	return nil, false
 }
 
-// FindAll returns all Node starting at a node, given a matching function.
+// FindAll returns all Nodes (recursively) starting at a node, and given a matching function.
 func (n *Node) FindAll(f func(*Node) bool) ([]*Node, bool) {
 	var nodes []*Node
 	if ok := f(n); ok {
@@ -103,7 +125,7 @@ func (n *Node) FindAll(f func(*Node) bool) ([]*Node, bool) {
 	return nodes, true
 }
 
-// NodeByName uses Find to find a node by name.
+// NodeByName uses Find to find a node by name recursively.
 func (n *Node) NodeByName(name string) (*Node, bool) {
 	return n.Find(func(n *Node) bool {
 		return n.Name == name

--- a/pkg/dt/node.go
+++ b/pkg/dt/node.go
@@ -142,6 +142,18 @@ func (n *Node) LookProperty(name string) (*Property, bool) {
 	return nil, false
 }
 
+// RemoveSubTreeAtIndex deletes the child at the given index (and all
+// its children).
+func (n *Node) RemoveSubTreeAtIndex(idx int) error {
+	if idx < 0 || idx >= len(n.Children) {
+		return fmt.Errorf("idx %d is not in range 0..%d: %w", idx, len(n.Children), errInvalidChildIndex)
+	}
+
+	// Compress the list of children nodes, keep the order
+	n.Children = append(n.Children[:idx], n.Children[idx+1:]...)
+	return nil
+}
+
 // RemoveProperty deletes a property by name.
 func (n *Node) RemoveProperty(name string) bool {
 	for idx := range n.Properties {

--- a/pkg/dt/node_test.go
+++ b/pkg/dt/node_test.go
@@ -69,6 +69,103 @@ func TestLookupImmediateChild(t *testing.T) {
 	}
 }
 
+func TestPruneSubtree(t *testing.T) {
+	subtree1 := &Node{
+		Name: "child1",
+		Children: []*Node{
+			{
+				Name: "child1_1",
+			},
+			{
+				Name: "child1_2",
+			},
+		},
+	}
+	subtree2 := &Node{
+		Name: "child2",
+		Children: []*Node{
+			{
+				Name: "child2_1",
+			},
+			{
+				Name: "child2_2",
+			},
+		},
+	}
+	subtree3 := &Node{
+		Name: "child3",
+		Children: []*Node{
+			{
+				Name: "child3_1",
+			},
+			{
+				Name: "child3_2",
+			},
+		},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		idx     int
+		want    *Node
+		wantErr error
+	}{
+		{
+			name: "remove at head",
+			idx:  0,
+			want: &Node{
+				Name:     "parent",
+				Children: []*Node{subtree2, subtree3},
+			},
+		},
+		{
+			name: "remove in the middle",
+			idx:  1,
+			want: &Node{
+				Name:     "parent",
+				Children: []*Node{subtree1, subtree3},
+			},
+		},
+		{
+			name: "remove at tail",
+			idx:  2,
+			want: &Node{
+				Name:     "parent",
+				Children: []*Node{subtree1, subtree2},
+			},
+		},
+		{
+			name:    "remove invalid index",
+			idx:     -1,
+			wantErr: errInvalidChildIndex,
+		},
+		{
+			name:    "remove another invalid index",
+			idx:     3,
+			wantErr: errInvalidChildIndex,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := &Node{
+				Name: "parent",
+				Children: []*Node{
+					subtree1,
+					subtree2,
+					subtree3,
+				},
+			}
+			err := tree.RemoveSubTreeAtIndex(tc.idx)
+			if !errors.Is(err, tc.wantErr) {
+				t.Errorf("t.RemoveSubTreeAtIndex(%d) returned error %v, want error %v",
+					tc.idx, err, tc.wantErr)
+			}
+			if err == nil && tc.wantErr == nil && !reflect.DeepEqual(tree, tc.want) {
+				t.Errorf("after removing %d got %+v, want %+v", tc.idx, tree, tc.want)
+			}
+		})
+	}
+}
+
 func TestRemoveProperty(t *testing.T) {
 	for _, tc := range []struct {
 		name     string

--- a/pkg/dt/node_test.go
+++ b/pkg/dt/node_test.go
@@ -10,6 +10,65 @@ import (
 	"testing"
 )
 
+func TestLookupImmediateChild(t *testing.T) {
+	subtree0 := &Node{
+		Name: "child0",
+		Children: []*Node{
+			{
+				Name: "child0_1",
+			},
+		},
+	}
+	subtree1 := &Node{
+		Name: "child1",
+		Children: []*Node{
+			{
+				Name: "child1_1",
+			},
+		},
+	}
+	subtree2 := &Node{
+		Name: "child2",
+		Children: []*Node{
+			{
+				Name: "child2_1",
+			},
+		},
+	}
+	tree := &Node{
+		Name: "parent",
+		Children: []*Node{
+			subtree0,
+			subtree1,
+			subtree2,
+		},
+	}
+	for _, tc := range []struct {
+		name      string
+		needle    string
+		wantNode  *Node
+		wantFound bool
+	}{
+		{name: "2nd child", needle: "child1", wantNode: subtree1, wantFound: true},
+		{name: "3rd child", needle: "child2", wantNode: subtree2, wantFound: true},
+		{name: "1st child", needle: "child0", wantNode: subtree0, wantFound: true},
+		{name: "exists but not immediate", needle: "child1_1", wantFound: false},
+		{name: "missing", needle: "not found", wantFound: false},
+		{name: "prefix", needle: "child", wantFound: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			n, found := tree.LookupChildByName(tc.needle)
+			if found != tc.wantFound {
+				t.Errorf("tree.LookupChildByName(%s) returns found %v, want %v",
+					tc.needle, found, tc.wantFound)
+			}
+			if found && tc.wantFound && !reflect.DeepEqual(n, tc.wantNode) {
+				t.Errorf("when looking up %s, got %+v, want %+v", tc.needle, n, tc.wantNode)
+			}
+		})
+	}
+}
+
 func TestRemoveProperty(t *testing.T) {
 	for _, tc := range []struct {
 		name     string


### PR DESCRIPTION
A few minor extensions to the existing pkg/dt API to look-up direct children and prune sub-trees,

It is sometimes useful to look up a specific direct child of a given node, instead of recursively looking up _a_ child at any depth in the tree. A 2nd patch adds the ability to edit the FDT to remove a node and its subtree.