### PR TITLE
pkg/ls:FromOSFileInfo: fix a panic if fi.Sys() returns the wrong type

### DIFF
--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -87,7 +87,7 @@ func listName(stringer ls.Stringer, d string, w io.Writer, prefix bool) error {
 		}
 
 		// error handling that matches standard ls is ... a real joy
-		if !errors.Is(err, os.ErrNotExist) {
+		if osfi != nil && !errors.Is(err, os.ErrNotExist) {
 			f.lsfi = ls.FromOSFileInfo(path, osfi)
 			if err != nil && path == d {
 				f.err = err


### PR DESCRIPTION
FromOSFileInfo had a blind cast of a FileInfo.Sys() to *syscall.Stat_t.

This could fail with a badly behaving file system, e.g. a 9p server that would fail a Stat in ways that the go runtime was not prepared for.  Ask me how I know :-) The fact that we have not seen this in 11 years of use testifies to its rarity, but ... it can happen.

In FromOSFileInfo, pick default values for UID, GID, and rdev

Check if fi.Sys() is a *syscall.Stat_t and, if so, use Uid, Gid, and Rdev from it.

Add a type to the linux test that implements os.FileInfo (yes, fs.FileInfo now ...) that can return a Sys() of the wrong type. I verified that this test
catches the failing case.

A bit of cleanup:
Rename the test file ls_linux_test.go to fileinfo_linux_test.go, to match everything else in this directory.

Remove a spurious fmt.Printf from the fileinfo_linux_test.go that added trash to the test output.