### PR TITLE
cmds/core/pwd: add test for follow links

### DIFF
--- a/cmds/core/pwd/pwd.go
+++ b/cmds/core/pwd/pwd.go
@@ -31,16 +31,7 @@ var (
 	_ = flag.Bool("L", true, "don't follow any symlinks")
 
 	physical = flag.Bool("P", false, "follow all symlinks (avoid all symlinks)")
-	cmd      = "pwd [-LP]"
 )
-
-func init() {
-	defUsage := flag.Usage
-	flag.Usage = func() {
-		os.Args[0] = cmd
-		defUsage()
-	}
-}
 
 func pwd(followSymlinks bool) (string, error) {
 	path, err := os.Getwd()

--- a/cmds/core/pwd/pwd_test.go
+++ b/cmds/core/pwd/pwd_test.go
@@ -1,0 +1,33 @@
+// Copyright 2012-2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestPWD(t *testing.T) {
+	dir := t.TempDir()
+	err := os.Chdir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rs, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := pwd(true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if r != rs {
+		t.Errorf("expected: %q, got %q", rs, r)
+	}
+}

--- a/cmds/core/pwd/pwd_test.go
+++ b/cmds/core/pwd/pwd_test.go
@@ -11,23 +11,50 @@ import (
 )
 
 func TestPWD(t *testing.T) {
-	dir := t.TempDir()
-	err := os.Chdir(dir)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name     string
+		physical bool
+	}{
+		{
+			name:     "follow-symlinks",
+			physical: true,
+		},
+		{
+			name:     "no-follow-symlinks",
+			physical: false,
+		},
 	}
 
-	rs, err := filepath.EvalSymlinks(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			err := os.Chdir(dir)
+			if err != nil {
+				t.Fatalf("os.Chdir(%q): got %v, want nil", dir, err)
+			}
 
-	r, err := pwd(true)
-	if err != nil {
-		t.Fatal(err)
-	}
+			// required on macOS, where tempDir returns path with symlink
+			// and PWD is defined on bash and zsh
+			err = os.Setenv("PWD", dir)
+			if err != nil {
+				t.Fatalf("os.Setenv(%q): got %v, want nil", dir, err)
+			}
 
-	if r != rs {
-		t.Errorf("expected: %q, got %q", rs, r)
+			expected := dir
+			if tt.physical {
+				expected, err = filepath.EvalSymlinks(dir)
+				if err != nil {
+					t.Fatalf("filepath.EvalSymlinks(%q): got %v, want nil", dir, err)
+				}
+			}
+
+			res, err := pwd(tt.physical)
+			if err != nil {
+				t.Fatalf("pwd(%t): error got %v, want nil", tt.physical, err)
+			}
+			if res != expected {
+				t.Errorf("pwd(%t): got %q, want %q", tt.physical, res, expected)
+			}
+		})
 	}
 }


### PR DESCRIPTION
removed usage because there are no way to run it as ./pwd -LP and flag package will print help when flags are incorrect.