### PR TITLE
Fix /etc/ lossage in CreateRootfs

### DIFF
--- a/pkg/libinit/root_linux.go
+++ b/pkg/libinit/root_linux.go
@@ -92,7 +92,10 @@ type CpDir struct {
 }
 
 func (c CpDir) Create() error {
-	return cp.CopyTree(c.Source, c.Target)
+	copier := cp.Options{
+		NoFollowSymlinks: true,
+	}
+	return copier.CopyTree(c.Source, c.Target)
 }
 
 func (c CpDir) String() string {


### PR DESCRIPTION
With this PR, `CreateRootfs()` in `root_linux.go` uses the `NoFollowSymlinks` option to correctly handle broken symlinks found in `/etc` when setting up the filesystems.\n