### PR TITLE
pkg/boot/linux.go: Decompress kernel before doing kexec

### DIFF
--- a/pkg/boot/jsonboot/bootconfig.go
+++ b/pkg/boot/jsonboot/bootconfig.go
@@ -14,8 +14,10 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/u-root/u-root/pkg/boot"
 	"github.com/u-root/u-root/pkg/boot/kexec"
 	"github.com/u-root/u-root/pkg/boot/multiboot"
+	"github.com/u-root/u-root/pkg/boot/util"
 	"github.com/u-root/u-root/pkg/crypto"
 )
 
@@ -168,7 +170,13 @@ func (bc *BootConfig) Boot() error {
 				}
 			}
 		}()
-		if err := kexec.FileLoad(kernel, initramfs, bc.KernelArgs); err != nil {
+		// Decompress Kernel (if compressed)
+		kernelRaw, err := boot.CopyToFileIfNotRegular(util.TryGzipFilter(kernel), true)
+		if err != nil {
+			return err
+		}
+
+		if err := kexec.FileLoad(kernelRaw, initramfs, bc.KernelArgs); err != nil {
 			return fmt.Errorf("kexec.FileLoad() failed: %v", err)
 		}
 	} else if bc.Multiboot != "" {

--- a/pkg/boot/linux.go
+++ b/pkg/boot/linux.go
@@ -198,7 +198,7 @@ func isTmpfsReadOnlyFile(f *os.File) bool {
 	return false
 }
 
-// copyToFileIfNotRegular copies given io.ReadAt to a tmpfs file when
+// CopyToFileIfNotRegular copies given io.ReadAt to a tmpfs file when
 // necessary. It skips copying when source file is a regular file under
 // tmpfs or ramfs, and it is not opened for writing.
 //
@@ -208,7 +208,7 @@ func isTmpfsReadOnlyFile(f *os.File) bool {
 // execve) if anything has the file opened for writing. That's unfortunately
 // something we can't guarantee here - unless we make a copy of the file
 // and dump it somewhere.
-func copyToFileIfNotRegular(r io.ReaderAt, verbose bool) (*os.File, error) {
+func CopyToFileIfNotRegular(r io.ReaderAt, verbose bool) (*os.File, error) {
 	// If source is a regular file in tmpfs, simply re-use that than copy.
 	//
 	// The assumption (bad?) is original local file was opened as a type
@@ -281,7 +281,7 @@ func loadLinuxImage(li *LinuxImage, logger ulog.Logger, verbose bool) (*LoadedLi
 		return nil, nil, errNilKernel
 	}
 
-	k, err := copyToFileIfNotRegular(util.TryGzipFilter(li.Kernel), verbose)
+	k, err := CopyToFileIfNotRegular(util.TryGzipFilter(li.Kernel), verbose)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -297,7 +297,7 @@ func loadLinuxImage(li *LinuxImage, logger ulog.Logger, verbose bool) (*LoadedLi
 
 	var i *os.File
 	if li.Initrd != nil {
-		i, err = copyToFileIfNotRegular(li.Initrd, verbose)
+		i, err = CopyToFileIfNotRegular(li.Initrd, verbose)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/boot/linux_test.go
+++ b/pkg/boot/linux_test.go
@@ -141,7 +141,7 @@ func TestCopyToFile(t *testing.T) {
 	want := "abcdefg hijklmnop"
 	buf := bytes.NewReader([]byte(want))
 
-	f, err := copyToFileIfNotRegular(buf, true)
+	f, err := CopyToFileIfNotRegular(buf, true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
It is possible/likely that the kernel is compressed. In order for kexec to actually find the magic value for aarch64 Linux kernels it needs to be decompressed before refering it to the kexec syscall.

Test: aarch64 Fedora 36 Server image can now be started via localboot.