### PR TITLE
update go-tpm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/gliderlabs/ssh v0.1.2-0.20181113160402-cbabf5414432
 	github.com/gojuno/minimock/v3 v3.0.8
 	github.com/google/go-cmp v0.5.9
-	github.com/google/go-tpm v0.9.0
+	github.com/google/go-tpm v0.9.1-0.20230914180155-ee6cbcd136f8
 	github.com/google/goexpect v0.0.0-20191001010744-5b6988669ffa
 	github.com/google/uuid v1.3.0
 	github.com/insomniacslk/dhcp v0.0.0-20230220063916-5369909a5de7

--- a/go.sum
+++ b/go.sum
@@ -77,8 +77,8 @@ github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-tpm v0.9.0 h1:sQF6YqWMi+SCXpsmS3fd21oPy/vSddwZry4JnmltHVk=
-github.com/google/go-tpm v0.9.0/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
+github.com/google/go-tpm v0.9.1-0.20230914180155-ee6cbcd136f8 h1:g9RVRZdQrNEK2E94RcFescvXFC9afWsFar4IIdejP34=
+github.com/google/go-tpm v0.9.1-0.20230914180155-ee6cbcd136f8/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
 github.com/google/goexpect v0.0.0-20191001010744-5b6988669ffa h1:PMkmJA8ju9DjqAJjIzrBdrmhuuPsoNnNLYgKQBopWL0=
 github.com/google/goexpect v0.0.0-20191001010744-5b6988669ffa/go.mod h1:qtE5aAEkt0vOSA84DBh8aJsz6riL8ONfqfULY7lBjqc=
 github.com/google/goterm v0.0.0-20200907032337-555d40f16ae2 h1:CVuJwN34x4xM2aT4sIKhmeib40NeBPhRihNjQmpJsA4=

--- a/vendor/github.com/google/go-tpm/tpm2/pcrs.go
+++ b/vendor/github.com/google/go-tpm/tpm2/pcrs.go
@@ -1,0 +1,55 @@
+package tpm2
+
+// pcrSelectionFormatter is a Platform TPM Profile-specific interface for
+// formatting TPM PCR selections.
+// This interface isn't (yet) part of the go-tpm public interface. After we
+// add a second implementation, we should consider making it public.
+type pcrSelectionFormatter interface {
+	// PCRs returns the TPM PCR selection bitmask associated with the given PCR indices.
+	PCRs(pcrs ...uint) []byte
+}
+
+// PCClientCompatible is a pcrSelectionFormatter that formats PCR selections
+// suitable for use in PC Client PTP-compatible TPMs (the vast majority):
+// https://trustedcomputinggroup.org/resource/pc-client-platform-tpm-profile-ptp-specification/
+// PC Client mandates at least 24 PCRs but does not provide an upper limit.
+var PCClientCompatible pcrSelectionFormatter = pcClient{}
+
+type pcClient struct{}
+
+// The TPM requires all PCR selections to be at least big enough to select all
+// the PCRs in the minimum PCR allocation.
+const pcClientMinimumPCRCount = 24
+
+func (pcClient) PCRs(pcrs ...uint) []byte {
+	// Find the biggest PCR we selected.
+	maxPCR := uint(0)
+	for _, pcr := range pcrs {
+		if pcr > maxPCR {
+			maxPCR = pcr
+		}
+	}
+	selectionSize := maxPCR/8 + 1
+
+	// Enforce the minimum PCR selection size.
+	if selectionSize < (pcClientMinimumPCRCount / 8) {
+		selectionSize = (pcClientMinimumPCRCount / 8)
+	}
+
+	// Allocate a byte array to store the bitfield, that has at least
+	// enough bits to store our selections.
+	selection := make([]byte, selectionSize)
+	for _, pcr := range pcrs {
+		// The PCR selection mask is byte-wise little-endian:
+		//   select[0] contains bits representing the selection of PCRs 0 through 7
+		//   select[1] contains PCRs 8 through 15, and so on.
+		byteIdx := pcr / 8
+		// Within the byte, the PCR selection is bit-wise big-endian:
+		//   bit 0 of select[0] contains the selection of PCR 0
+		//   bit 1 of select[0] contains the selection of PCR 1, and so on.
+		bitIdx := pcr % 8
+
+		selection[byteIdx] |= (1 << bitIdx)
+	}
+	return selection
+}

--- a/vendor/github.com/google/go-tpm/tpm2/structures.go
+++ b/vendor/github.com/google/go-tpm/tpm2/structures.go
@@ -343,6 +343,10 @@ type TPMIYesNo = bool
 // See definition in Part 2: Structures, section 9.3.
 type TPMIDHObject = TPMHandle
 
+// TPMIDHPersistent represents a TPMI_DH_PERSISTENT.
+// See definition in Part 2: Structures, section 9.5.
+type TPMIDHPersistent = TPMHandle
+
 // TPMIDHEntity represents a TPMI_DH_ENTITY.
 // See definition in Part 2: Structures, section 9.6.
 type TPMIDHEntity = TPMHandle

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -89,7 +89,7 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-tpm v0.9.0
+# github.com/google/go-tpm v0.9.1-0.20230914180155-ee6cbcd136f8
 ## explicit; go 1.20
 github.com/google/go-tpm/legacy/tpm2
 github.com/google/go-tpm/tpm


### PR DESCRIPTION
This change pulls the latest github.com/google/go-tpm to get the following features:

* 2 new TPM commands (`Import` and `EvictControl`)
* Helper for formatting PCR selections
* Better support for `TPM_RH_NULL` when not specified by the command