### PR TITLE
cmds/core/xargs: minimal xargs, just passing args

### DIFF
--- a/cmds/core/xargs/xargs.go
+++ b/cmds/core/xargs/xargs.go
@@ -14,12 +14,12 @@ import (
 )
 
 func main() {
-	if err := run(os.Stdin, os.Stdout, os.Stderr, os.Args[1:]); err != nil {
+	if err := run(os.Stdin, os.Stdout, os.Stderr, os.Args[1:]...); err != nil {
 		log.Fatal(err)
 	}
 }
 
-func run(stdin io.Reader, stdout, stderr io.Writer, args []string) error {
+func run(stdin io.Reader, stdout, stderr io.Writer, args ...string) error {
 	if len(args) == 0 {
 		args = append(args, "echo")
 	}

--- a/cmds/core/xargs/xargs.go
+++ b/cmds/core/xargs/xargs.go
@@ -1,0 +1,39 @@
+// Copyright 2013-2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bufio"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	if err := run(os.Stdin, os.Stdout, os.Stderr, os.Args[1:]); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(stdin io.Reader, stdout, stderr io.Writer, args []string) error {
+	if len(args) == 0 {
+		args = append(args, "echo")
+	}
+
+	scanner := bufio.NewScanner(stdin)
+	for scanner.Scan() {
+		sp := strings.Fields(scanner.Text())
+		args = append(args, sp...)
+	}
+
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = stdin
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+
+	return cmd.Run()
+}

--- a/cmds/core/xargs/xargs_test.go
+++ b/cmds/core/xargs/xargs_test.go
@@ -1,0 +1,34 @@
+// Copyright 2013-2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCommandNotFound(t *testing.T) {
+	stdin := strings.NewReader("hello world")
+	err := run(stdin, nil, nil, []string{"commandnotfound", "arg1"})
+	if !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("expected %v, got %v", exec.ErrNotFound, err)
+	}
+}
+
+func TestEcho(t *testing.T) {
+	stdin := strings.NewReader("hello world")
+	stdout := &bytes.Buffer{}
+	err := run(stdin, stdout, nil, nil)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+
+	if stdout.String() != "hello world\n" {
+		t.Fatalf("expected 'hello world', got %q", stdout.String())
+	}
+}

--- a/cmds/core/xargs/xargs_test.go
+++ b/cmds/core/xargs/xargs_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestCommandNotFound(t *testing.T) {
 	stdin := strings.NewReader("hello world")
-	err := run(stdin, nil, nil, []string{"commandnotfound", "arg1"})
+	err := run(stdin, nil, nil, "commandnotfound", "arg1")
 	if !errors.Is(err, exec.ErrNotFound) {
 		t.Fatalf("expected %v, got %v", exec.ErrNotFound, err)
 	}
@@ -23,7 +23,7 @@ func TestCommandNotFound(t *testing.T) {
 func TestEcho(t *testing.T) {
 	stdin := strings.NewReader("hello world")
 	stdout := &bytes.Buffer{}
-	err := run(stdin, stdout, nil, nil)
+	err := run(stdin, stdout, nil)
 	if err != nil {
 		t.Fatalf("expected nil, got %v", err)
 	}


### PR DESCRIPTION
Parsing is simplified by strings.Fields, so no quotes support.