### PR TITLE
Revamp ldd API

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -4,6 +4,8 @@ on:
 
 jobs:
   assign_reviewer:
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - uses: shufo/auto-assign-reviewer-by-files@v1.1.2

--- a/cmds/core/lddfiles/lddfiles_linux.go
+++ b/cmds/core/lddfiles/lddfiles_linux.go
@@ -28,12 +28,12 @@ import (
 )
 
 func main() {
-	l, err := ldd.Ldd(os.Args[1:]...)
+	l, err := ldd.FList(os.Args[1:]...)
 	if err != nil {
 		log.Fatalf("ldd: %v", err)
 	}
 
 	for _, dep := range l {
-		fmt.Printf("%s\n", dep.FullName)
+		fmt.Printf("%s\n", dep)
 	}
 }

--- a/cmds/core/lddfiles/lddfiles_linux.go
+++ b/cmds/core/lddfiles/lddfiles_linux.go
@@ -28,7 +28,7 @@ import (
 )
 
 func main() {
-	l, err := ldd.Ldd(os.Args[1:])
+	l, err := ldd.Ldd(os.Args[1:]...)
 	if err != nil {
 		log.Fatalf("ldd: %v", err)
 	}

--- a/cmds/core/lddfiles/lddfiles_linux.go
+++ b/cmds/core/lddfiles/lddfiles_linux.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/u-root/u-root/pkg/ldd"
 )
@@ -31,6 +32,14 @@ func main() {
 	l, err := ldd.FList(os.Args[1:]...)
 	if err != nil {
 		log.Fatalf("ldd: %v", err)
+	}
+
+	for _, p := range os.Args[1:] {
+		a, err := filepath.Abs(p)
+		if err != nil {
+			log.Fatalf("ldd: %v", err)
+		}
+		l = append(l, a)
 	}
 
 	for _, dep := range l {

--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -149,7 +149,7 @@ func poxCreate(bin ...string) error {
 	if len(bin) == 0 {
 		return fmt.Errorf(usage)
 	}
-	l, err := ldd.Ldd(bin)
+	l, err := ldd.Ldd(bin...)
 	if err != nil {
 		var stderr []byte
 		if eerr, ok := err.(*exec.ExitError); ok {

--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -149,7 +149,7 @@ func poxCreate(bin ...string) error {
 	if len(bin) == 0 {
 		return fmt.Errorf(usage)
 	}
-	l, err := ldd.Ldd(bin...)
+	names, err := ldd.List(bin...)
 	if err != nil {
 		var stderr []byte
 		if eerr, ok := err.(*exec.ExitError); ok {
@@ -158,10 +158,6 @@ func poxCreate(bin ...string) error {
 		return fmt.Errorf("running ldd on %v: %v %s", bin, err, stderr)
 	}
 
-	var names []string
-	for _, dep := range l {
-		names = append(names, dep.FullName)
-	}
 	sort.Strings(names)
 	// Now we need to make a template file hierarchy and put
 	// the stuff we want in there.
@@ -193,8 +189,7 @@ func poxCreate(bin ...string) error {
 			in.Close()
 			return err
 		}
-		out, err := os.OpenFile(dfile, os.O_WRONLY|os.O_CREATE,
-			fi.Mode().Perm())
+		out, err := os.OpenFile(dfile, os.O_WRONLY|os.O_CREATE, fi.Mode().Perm())
 		if err != nil {
 			in.Close()
 			return err

--- a/cmds/exp/pox/pox_vm_test.go
+++ b/cmds/exp/pox/pox_vm_test.go
@@ -113,7 +113,7 @@ func TestPoxCreate(t *testing.T) {
 		{
 			name:    "error in ldd.Ldd",
 			args:    []string{""},
-			wantErr: "running ldd on []: lstat : no such file or directory ",
+			wantErr: "running ldd on []: open : no such file or directory ",
 		},
 		{
 			name:    "self = false, zip = false, err in c.CombinedOutput()",

--- a/pkg/ldd/ldd.go
+++ b/pkg/ldd/ldd.go
@@ -5,43 +5,17 @@
 //go:build freebsd || linux || darwin
 // +build freebsd linux darwin
 
-// ldd returns all the library dependencies of an executable.
+// ldd returns library dependencies of an executable.
 //
 // The way this is done on GNU-based systems is interesting. For each ELF, one
-// finds the .interp section. If there is no interpreter
-// there's not much to do.
+// finds the .interp section. If there is no interpreter there's not much to
+// do.
 //
 // If there is an interpreter, we run it with the --list option and the file as
-// an argument. We need to parse the output.
-//
-// For all lines with =>  as the 2nd field, we take the 3rd field as a
-// dependency. The field may be a symlink.  Rather than stat the link and do
-// other such fooling around, we can do a readlink on it; if it fails, we just
-// need to add that file name; if it succeeds, we need to add that file name
-// and repeat with the next link in the chain. We can let the kernel do the
-// work of figuring what to do if and when we hit EMLINK.
+// an argument. We need to parse the output. For all lines with =>  as the 2nd
+// field, we take the 3rd field as a dependency.
 //
 // On many Unix kernels, the kernel ABI is stable. On OSX, the stability
 // is held in the library interface; the kernel ABI is explicitly not
 // stable. The ldd package on OSX will only return the files passed to it.
-// It will continue to resolve symbolic links.
 package ldd
-
-type FileInfo struct {
-	FullName string
-	os.FileInfo
-}
-
-// Paths returns the dependency file paths of files in names.
-func Paths(names ...string) ([]string, error) {
-	l, err := Ldd(names...)
-	if err != nil {
-		return nil, err
-	}
-
-	var list []string
-	for i := range l {
-		list = append(list, l[i].FullName)
-	}
-	return list, nil
-}

--- a/pkg/ldd/ldd.go
+++ b/pkg/ldd/ldd.go
@@ -1,0 +1,47 @@
+// Copyright 2009-2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build freebsd || linux || darwin
+// +build freebsd linux darwin
+
+// ldd returns all the library dependencies of an executable.
+//
+// The way this is done on GNU-based systems is interesting. For each ELF, one
+// finds the .interp section. If there is no interpreter
+// there's not much to do.
+//
+// If there is an interpreter, we run it with the --list option and the file as
+// an argument. We need to parse the output.
+//
+// For all lines with =>  as the 2nd field, we take the 3rd field as a
+// dependency. The field may be a symlink.  Rather than stat the link and do
+// other such fooling around, we can do a readlink on it; if it fails, we just
+// need to add that file name; if it succeeds, we need to add that file name
+// and repeat with the next link in the chain. We can let the kernel do the
+// work of figuring what to do if and when we hit EMLINK.
+//
+// On many Unix kernels, the kernel ABI is stable. On OSX, the stability
+// is held in the library interface; the kernel ABI is explicitly not
+// stable. The ldd package on OSX will only return the files passed to it.
+// It will continue to resolve symbolic links.
+package ldd
+
+type FileInfo struct {
+	FullName string
+	os.FileInfo
+}
+
+// Paths returns the dependency file paths of files in names.
+func Paths(names ...string) ([]string, error) {
+	l, err := Ldd(names...)
+	if err != nil {
+		return nil, err
+	}
+
+	var list []string
+	for i := range l {
+		list = append(list, l[i].FullName)
+	}
+	return list, nil
+}

--- a/pkg/ldd/ldd_darwin.go
+++ b/pkg/ldd/ldd_darwin.go
@@ -5,12 +5,6 @@
 //go:build darwin
 // +build darwin
 
-// ldd returns none of the library dependencies of an executable.
-//
-// On many Unix kernels, the kernel ABI is stable. On OSX, the stability
-// is held in the library interface; the kernel ABI is explicitly not
-// stable. The ldd package on OSX will only return the files passed to it.
-// It will continue to resolve symbolic links.
 package ldd
 
 import (
@@ -74,22 +68,4 @@ func Ldd(names ...string) ([]*FileInfo, error) {
 	}
 
 	return libs, nil
-}
-
-type FileInfo struct {
-	FullName string
-	os.FileInfo
-}
-
-// List returns the dependency file paths of files in names.
-func List(names ...string) ([]string, error) {
-	var list []string
-	l, err := Ldd(names...)
-	if err != nil {
-		return nil, err
-	}
-	for i := range l {
-		list = append(list, l[i].FullName)
-	}
-	return list, nil
 }

--- a/pkg/ldd/ldd_darwin.go
+++ b/pkg/ldd/ldd_darwin.go
@@ -59,7 +59,7 @@ func follow(l string, names map[string]*FileInfo) error {
 // links, returning them as well.
 //
 // It's not an error for a file to not be an ELF.
-func Ldd(names []string) ([]*FileInfo, error) {
+func Ldd(names ...string) ([]*FileInfo, error) {
 	var (
 		list = make(map[string]*FileInfo)
 		libs []*FileInfo
@@ -82,9 +82,9 @@ type FileInfo struct {
 }
 
 // List returns the dependency file paths of files in names.
-func List(names []string) ([]string, error) {
+func List(names ...string) ([]string, error) {
 	var list []string
-	l, err := Ldd(names)
+	l, err := Ldd(names...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ldd/ldd_darwin.go
+++ b/pkg/ldd/ldd_darwin.go
@@ -7,65 +7,16 @@
 
 package ldd
 
-import (
-	"fmt"
-	"os"
-	"path/filepath"
-)
-
-// Follow starts at a pathname and adds it
-// to a map if it is not there.
-// If the pathname is a symlink, indicated by the Readlink
-// succeeding, links repeats and continues
-// for as long as the name is not found in the map.
-func follow(l string, names map[string]*FileInfo) error {
-	for {
-		if names[l] != nil {
-			return nil
-		}
-		i, err := os.Lstat(l)
-		if err != nil {
-			return fmt.Errorf("%v", err)
-		}
-
-		names[l] = &FileInfo{FullName: l, FileInfo: i}
-		if i.Mode().IsRegular() {
-			return nil
-		}
-		// If it's a symlink, the read works; if not, it fails.
-		// we can skip testing the type, since we still have to
-		// handle any error if it's a link.
-		next, err := os.Readlink(l)
-		if err != nil {
-			return err
-		}
-		// It may be a relative link, so we need to
-		// make it abs.
-		if filepath.IsAbs(next) {
-			l = next
-			continue
-		}
-		l = filepath.Join(filepath.Dir(l), next)
-	}
-}
-
-// Ldd returns the list of files passed to it, and resolves all symbolic
-// links, returning them as well.
+// List returns nothing.
 //
 // It's not an error for a file to not be an ELF.
-func Ldd(names ...string) ([]*FileInfo, error) {
-	var (
-		list = make(map[string]*FileInfo)
-		libs []*FileInfo
-	)
-	for _, n := range names {
-		if err := follow(n, list); err != nil {
-			return nil, err
-		}
-	}
-	for i := range list {
-		libs = append(libs, list[i])
-	}
+func List(names ...string) ([]string, error) {
+	return nil, nil
+}
 
-	return libs, nil
+// FList returns nothing.
+//
+// It's not an error for a file to not be an ELF.
+func FList(names ...string) ([]string, error) {
+	return nil, nil
 }

--- a/pkg/ldd/ldd_darwin_test.go
+++ b/pkg/ldd/ldd_darwin_test.go
@@ -5,50 +5,20 @@
 package ldd
 
 import (
-	"fmt"
 	"testing"
 )
-
-// lddOne is a helper that runs Ldd on one file. It returns
-// the list so we can use elements from the list on another
-// test. We do it this way because, unlike /bin/date, there's
-// almost nothing else we can assume exists, e.g. /lib/libc.so
-// is a different name on almost every *ix* system.
-func lddOne(name string) ([]string, error) {
-	libMap := make(map[string]bool)
-	n, err := Ldd([]string{name})
-	if err != nil {
-		return nil, fmt.Errorf("Ldd on %v: want nil, got %v", name, err)
-	}
-	l, err := List([]string{name})
-	if err != nil {
-		return nil, fmt.Errorf("LddList on %v: want nil, got %v", name, err)
-	}
-	if len(n) != len(l) {
-		return nil, fmt.Errorf("%v: Len of Ldd(%v) and LddList(%v): want same, got different", name, len(n), len(l))
-	}
-	for i := range n {
-		libMap[n[i].FullName] = true
-	}
-	for i := range n {
-		if !libMap[l[i]] {
-			return nil, fmt.Errorf("%v: %v was in LddList but not in Ldd", name, l[i])
-		}
-	}
-	return l, nil
-}
 
 // TestLddList tests that the LddList is the
 // same as the info returned by Ldd
 func TestLddList(t *testing.T) {
-	n, err := lddOne("/etc/resolv.conf")
+	n, err := List("/etc/resolv.conf")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	for _, f := range n {
 		t.Logf("Test %v", f)
-		n, err := lddOne(f)
+		n, err := List(f)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/ldd/ldd_test.go
+++ b/pkg/ldd/ldd_test.go
@@ -8,7 +8,6 @@
 package ldd
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 )
@@ -17,7 +16,7 @@ import (
 // This is just about guaranteed to have
 // some output on most linux systems.
 func TestLdd(t *testing.T) {
-	n, err := Ldd([]string{"/bin/date"})
+	n, err := List("/bin/date")
 	if err != nil {
 		t.Fatalf("Ldd on /bin/date: want nil, got %v", err)
 	}
@@ -27,42 +26,14 @@ func TestLdd(t *testing.T) {
 	}
 }
 
-// lddOne is a helper that runs Ldd on one file. It returns
-// the list so we can use elements from the list on another
-// test. We do it this way because, unlike /bin/date, there's
-// almost nothing else we can assume exists, e.g. /lib/libc.so
-// is a different name on almost every *ix* system.
-func lddOne(name string) ([]string, error) {
-	libMap := make(map[string]bool)
-	n, err := Ldd([]string{name})
-	if err != nil {
-		return nil, fmt.Errorf("Ldd on %v: want nil, got %v", name, err)
-	}
-	l, err := List([]string{name})
-	if err != nil {
-		return nil, fmt.Errorf("LddList on %v: want nil, got %v", name, err)
-	}
-	if len(n) != len(l) {
-		return nil, fmt.Errorf("%v: Len of Ldd(%v) and LddList(%v): want same, got different", name, len(n), len(l))
-	}
-	for i := range n {
-		libMap[n[i].FullName] = true
-	}
-	for i := range n {
-		if !libMap[l[i]] {
-			return nil, fmt.Errorf("%v: %v was in LddList but not in Ldd", name, l[i])
-		}
-	}
-	return l, nil
-}
-
 // TestLddList tests that the LddList is the
 // same as the info returned by Ldd
 func TestLddList(t *testing.T) {
-	n, err := lddOne("/bin/date")
+	n, err := List("/bin/date")
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	// Find the first name in the array that contains "lib"
 	// Test 'em all
 	for _, f := range n {
@@ -70,7 +41,7 @@ func TestLddList(t *testing.T) {
 			continue
 		}
 		t.Logf("Test %v", f)
-		n, err := lddOne(f)
+		n, err := List(f)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -169,7 +169,7 @@ func GetInterp(file string) (string, error) {
 // read it, or we are not able to run its interpreter.
 //
 // It's not an error for a file to not be an ELF.
-func Ldd(names []string) ([]*FileInfo, error) {
+func Ldd(names ...string) ([]*FileInfo, error) {
 	var (
 		list    = make(map[string]*FileInfo)
 		interps = make(map[string]*FileInfo)
@@ -221,9 +221,9 @@ func Ldd(names []string) ([]*FileInfo, error) {
 }
 
 // List returns the dependency file paths of files in names.
-func List(names []string) ([]string, error) {
+func List(names ...string) ([]string, error) {
 	var list []string
-	l, err := Ldd(names)
+	l, err := Ldd(names...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -16,42 +16,6 @@ import (
 	"strings"
 )
 
-// Follow starts at a pathname and adds it
-// to a map if it is not there.
-// If the pathname is a symlink, indicated by the Readlink
-// succeeding, links repeats and continues
-// for as long as the name is not found in the map.
-func follow(l string, names map[string]*FileInfo) error {
-	for {
-		if names[l] != nil {
-			return nil
-		}
-		i, err := os.Lstat(l)
-		if err != nil {
-			return fmt.Errorf("%v", err)
-		}
-
-		names[l] = &FileInfo{FullName: l, FileInfo: i}
-		if i.Mode().IsRegular() {
-			return nil
-		}
-		// If it's a symlink, the read works; if not, it fails.
-		// we can skip testing the type, since we still have to
-		// handle any error if it's a link.
-		next, err := os.Readlink(l)
-		if err != nil {
-			return err
-		}
-		// It may be a relative link, so we need to
-		// make it abs.
-		if filepath.IsAbs(next) {
-			l = next
-			continue
-		}
-		l = filepath.Join(filepath.Dir(l), next)
-	}
-}
-
 func parseinterp(input string) ([]string, error) {
 	var names []string
 	for _, p := range strings.Split(input, "\n") {
@@ -146,24 +110,66 @@ func GetInterp(file string) (string, error) {
 	return interp, nil
 }
 
-// Ldd returns a list of all library dependencies for a set of files.
+// follow returns all paths and any files they recursively point to through
+// symlinks.
+func follow(paths ...string) ([]string, error) {
+	seen := make(map[string]struct{})
+
+	for _, path := range paths {
+		if err := followInternal(path, seen); err != nil {
+			return nil, err
+		}
+	}
+
+	deps := make([]string, 0, len(seen))
+	for s := range seen {
+		deps = append(deps, s)
+	}
+	return deps, nil
+}
+
+func followInternal(path string, seen map[string]struct{}) error {
+	for {
+		if _, ok := seen[path]; ok {
+			return nil
+		}
+		i, err := os.Lstat(path)
+		if err != nil {
+			return err
+		}
+
+		seen[path] = struct{}{}
+		if i.Mode().IsRegular() {
+			return nil
+		}
+
+		// If it's a symlink, read works; if not, it fails.
+		// We can skip testing the type, since we still have to
+		// handle any error if it's a link.
+		next, err := os.Readlink(path)
+		if err != nil {
+			return err
+		}
+
+		// A relative link has to be interpreted relative to the file's
+		// parent's path.
+		if !filepath.IsAbs(next) {
+			next = filepath.Join(filepath.Dir(path), next)
+		}
+		path = next
+	}
+}
+
+// List returns a list of all library dependencies for a set of files.
 //
 // If a file has no dependencies, that is not an error. The only possible error
 // is if a file does not exist, or it says it has an interpreter but we can't
 // read it, or we are not able to run its interpreter.
 //
 // It's not an error for a file to not be an ELF.
-func Ldd(names ...string) ([]*FileInfo, error) {
-	var (
-		list    = make(map[string]*FileInfo)
-		interps = make(map[string]*FileInfo)
-		libs    []*FileInfo
-	)
-	for _, n := range names {
-		if err := follow(n, list); err != nil {
-			return nil, err
-		}
-	}
+func List(names ...string) ([]string, error) {
+	list := make(map[string]struct{})
+	interps := make(map[string]struct{})
 	for _, n := range names {
 		interp, err := GetInterp(n)
 		if err != nil {
@@ -172,34 +178,42 @@ func Ldd(names ...string) ([]*FileInfo, error) {
 		if interp == "" {
 			continue
 		}
-		// We could just append the interp but people
-		// expect to see that first.
-		if interps[interp] == nil {
-			err := follow(interp, interps)
-			if err != nil {
-				return nil, err
-			}
-		}
+		interps[interp] = struct{}{}
 
-		// oh boy. Now to run the interp and get more names.
-		n, err := runinterp(interp, n)
+		// Run the interpreter to get dependencies.
+		sonames, err := runinterp(interp, n)
 		if err != nil {
 			return nil, err
 		}
-		for _, soname := range n {
-			if err := follow(soname, list); err != nil {
-				return nil, err
-			}
+		for _, name := range sonames {
+			list[name] = struct{}{}
 		}
 	}
 
-	for i := range interps {
-		libs = append(libs, interps[i])
-	}
+	libs := make([]string, 0, len(list)+len(interps))
 
-	for i := range list {
-		libs = append(libs, list[i])
+	// People expect to see the interps first.
+	for s := range interps {
+		libs = append(libs, s)
 	}
-
+	for s := range list {
+		libs = append(libs, s)
+	}
 	return libs, nil
+}
+
+// FList returns a list of all library dependencies for a set of files,
+// including following symlinks.
+//
+// If a file has no dependencies, that is not an error. The only possible error
+// is if a file does not exist, or it says it has an interpreter but we can't
+// read it, or we are not able to run its interpreter.
+//
+// It's not an error for a file to not be an ELF.
+func FList(names ...string) ([]string, error) {
+	deps, err := List(names...)
+	if err != nil {
+		return nil, err
+	}
+	return follow(deps...)
 }

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -5,21 +5,6 @@
 //go:build freebsd || linux
 // +build freebsd linux
 
-// ldd returns all the library dependencies of an executable.
-//
-// The way this is done on GNU-based systems is interesting. For each ELF, one
-// finds the .interp section. If there is no interpreter
-// there's not much to do.
-//
-// If there is an interpreter, we run it with the --list option and the file as
-// an argument. We need to parse the output.
-//
-// For all lines with =>  as the 2nd field, we take the 3rd field as a
-// dependency. The field may be a symlink.  Rather than stat the link and do
-// other such fooling around, we can do a readlink on it; if it fails, we just
-// need to add that file name; if it succeeds, we need to add that file name
-// and repeat with the next link in the chain. We can let the kernel do the
-// work of figuring what to do if and when we hit EMLINK.
 package ldd
 
 import (
@@ -105,11 +90,6 @@ func runinterp(interp, file string) ([]string, error) {
 		return nil, err
 	}
 	return parseinterp(string(o))
-}
-
-type FileInfo struct {
-	FullName string
-	os.FileInfo
 }
 
 func GetInterp(file string) (string, error) {
@@ -218,17 +198,4 @@ func Ldd(names ...string) ([]*FileInfo, error) {
 	}
 
 	return libs, nil
-}
-
-// List returns the dependency file paths of files in names.
-func List(names ...string) ([]string, error) {
-	var list []string
-	l, err := Ldd(names...)
-	if err != nil {
-		return nil, err
-	}
-	for i := range l {
-		list = append(list, l[i].FullName)
-	}
-	return list, nil
 }

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -102,6 +102,7 @@ func GetInterp(file string) (string, error) {
 	if err != nil {
 		return "", nil
 	}
+
 	s := f.Section(".interp")
 	var interp string
 	if s != nil {
@@ -111,14 +112,17 @@ func GetInterp(file string) (string, error) {
 		if err != nil {
 			return "fail", err
 		}
+
+		// .interp section is file name + \0 character.
+		interp := strings.TrimRight(string(i), "\000")
+
 		// Ignore #! interpreters
-		if len(i) > 1 && i[0] == '#' && i[1] == '!' {
+		if strings.HasPrefix(interp, "#!") {
 			return "", nil
 		}
-		// annoyingly, s.Data() seems to return the null at the end and,
-		// weirdly, that seems to confuse the kernel. Truncate it.
-		interp = string(i[:len(i)-1])
+		return interp, nil
 	}
+
 	if interp == "" {
 		if f.Type != elf.ET_DYN || f.Class == elf.ELFCLASSNONE {
 			return "", nil

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -430,7 +430,7 @@ func ParseExtraFiles(logger ulog.Logger, archive *initramfs.Files, extraFiles []
 				}
 				// Pull dependencies in the case of binaries. If `path` is not
 				// a binary, `libs` will just be empty.
-				libs, err := ldd.List([]string{name})
+				libs, err := ldd.List(name)
 				if err != nil {
 					return fmt.Errorf("WARNING: couldn't add ldd dependencies for %q: %v", name, err)
 				}

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -405,7 +405,7 @@ func ParseExtraFiles(logger ulog.Logger, archive *initramfs.Files, extraFiles []
 		if err != nil {
 			return fmt.Errorf("couldn't find absolute path for %q: %v", src, err)
 		}
-		if err := archive.AddFileNoFollow(src, dst); err != nil {
+		if err := archive.AddFile(src, dst); err != nil {
 			return fmt.Errorf("couldn't add %q to archive: %v", file, err)
 		}
 
@@ -430,17 +430,11 @@ func ParseExtraFiles(logger ulog.Logger, archive *initramfs.Files, extraFiles []
 				}
 				// Pull dependencies in the case of binaries. If `path` is not
 				// a binary, `libs` will just be empty.
-				libs, err := ldd.Paths(name)
+				libs, err := ldd.FList(name)
 				if err != nil {
 					return fmt.Errorf("WARNING: couldn't add ldd dependencies for %q: %v", name, err)
 				}
 				for _, lib := range libs {
-					// N.B.: we already added information about the src.
-					// Don't add it twice. We have to do this check here in
-					// case we're renaming the src to a different dest.
-					if lib == name {
-						continue
-					}
 					if err := archive.AddFileNoFollow(lib, lib[1:]); err != nil {
 						logger.Printf("WARNING: couldn't add ldd dependencies for %q: %v", lib, err)
 					}

--- a/pkg/uroot/uroot.go
+++ b/pkg/uroot/uroot.go
@@ -430,7 +430,7 @@ func ParseExtraFiles(logger ulog.Logger, archive *initramfs.Files, extraFiles []
 				}
 				// Pull dependencies in the case of binaries. If `path` is not
 				// a binary, `libs` will just be empty.
-				libs, err := ldd.List(name)
+				libs, err := ldd.Paths(name)
 				if err != nil {
 					return fmt.Errorf("WARNING: couldn't add ldd dependencies for %q: %v", name, err)
 				}


### PR DESCRIPTION
New:

* ldd.List(paths ..string) -> lists dependency files (interps and dynamic libraries), as named in the given binary.
* ldd.FList(paths ...string) -> like List, but also lists all files pointed to through symlinks in the dependency files.

Neither of them return the original file name in paths anymore.

Removing:

* ldd.List (equivalent is FList, but FList does not list the original file name anymore)
* ldd.Ldd (there is nothing returning FileInfo anymore, because nothing was using it)