### PR TITLE
cmds/exp/readelf: use errors.Join

### DIFF
--- a/cmds/exp/readelf/readelf.go
+++ b/cmds/exp/readelf/readelf.go
@@ -16,6 +16,7 @@ package main
 import (
 	"debug/elf"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -44,11 +45,8 @@ func run(in io.ReaderAt, out io.Writer, args ...string) error {
 		for i, n := range args {
 			f, e := elf.Open(n)
 			if e != nil {
-				// Until CI gets to go1.21, just break
-				// on an error.
-				//err = errors.Join(err, e)
-				//continue
-				return e
+				err = errors.Join(err, e)
+				continue
 			}
 			files[i] = f
 			defer f.Close()

--- a/cmds/exp/readelf/readelf_test.go
+++ b/cmds/exp/readelf/readelf_test.go
@@ -45,6 +45,12 @@ func TestRead(t *testing.T) {
 		t.Fatalf("elf output: want %q, got %q", out.String(), goodOut)
 	}
 
+	// test errors.Join with one good file, one bad file
+	bogus := filepath.Join(d, "bogus")
+	if err := run(nil, &out, f, bogus); err == nil {
+		t.Errorf("reading good elfFile, then non-existent file: got nil, want err")
+	}
+
 	// short file
 	if err := os.WriteFile(f, elfFile[:64], 0666); err != nil {
 		t.Fatalf("Writing data: %v", err)


### PR DESCRIPTION
This lets us accumulate errors over several files.

e.g.:
rminnich@pop-os:~/go/src/github.com/u-root/u-root/cmds/exp/readelf$ ./readelf ./readelf x y z 2023/11/10 03:20:29 open x: no such file or directory open y: no such file or directory
open z: no such file or directory