### PR TITLE
Fix dmesg test so that testtool works in CI

### DIFF
--- a/cmds/core/dmesg/dmesg.go
+++ b/cmds/core/dmesg/dmesg.go
@@ -33,7 +33,7 @@ var (
 
 func dmesg(writer io.Writer, clear, readClear bool) error {
 	if clear && readClear {
-		return fmt.Errorf("cannot specify both -clear and -read-clear")
+		return fmt.Errorf("cannot specify both -clear and -read-clear:%w", os.ErrInvalid)
 	}
 
 	level := unix.SYSLOG_ACTION_READ_ALL
@@ -47,7 +47,7 @@ func dmesg(writer io.Writer, clear, readClear bool) error {
 	b := make([]byte, 256*1024)
 	amt, err := unix.Klogctl(level, b)
 	if err != nil {
-		return fmt.Errorf("syslog failed: %v", err)
+		return fmt.Errorf("syslog failed: %w", err)
 	}
 
 	_, err = writer.Write(b[:amt])


### PR DESCRIPTION
Container environments are not always truthful about the UID. Sometimes UID 0 in a container can not do root-level operations.

Also, use errors.Is instead of comparing strings;
embed returned errors with %w for testing.