### PR TITLE
tinygobb: update and make it work again

### DIFF
--- a/cmds/exp/rush/rush_tinygo.go
+++ b/cmds/exp/rush/rush_tinygo.go
@@ -1,0 +1,15 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file exists to make gobusybox and u-root happy.
+// It is replaced by the tinygobb tool.
+
+//go:build tinygo
+// +build tinygo
+
+package main
+
+func runone(c *Command) error {
+	return nil
+}

--- a/tools/tinygobb/main.go
+++ b/tools/tinygobb/main.go
@@ -18,8 +18,11 @@ import (
 )
 
 var (
-	list = flag.String("l", "cmds/exp/rush", "comma-separated list of u-root commands to build")
-	code = `// Copyright 2023 the u-root Authors. All rights reserved
+	list   = flag.String("l", "cmds/exp/rush", "comma-separated list of u-root commands to build")
+	flash  = flag.Bool("flash", false, "whether to flash as well as build")
+	target = flag.String("target", "microbit-v2", "target name")
+	tinygo = flag.Bool("tinygo", false, "use tinygo, not go")
+	code   = `// Copyright 2023 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
@@ -37,20 +40,6 @@ func runone(c*Command) error {
    flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.PanicOnError)
    log.Printf("run %v", c)
    return bbmain.Run(c.cmd)
-}
-
-// tty does whatever needs to be done to set up a tty for GOOS.
-func tty() {
-}
-
-func foreground() {
-	// Place process group in foreground.
-}
-
-func builtinAttr(c *Command) {
-}
-
-func forkAttr(c *Command) {
 }
 
 `
@@ -124,6 +113,13 @@ func main() {
 	}
 
 	c = exec.Command("go", "build", "-tags", "tinygo")
+	if *tinygo {
+		action := "build"
+		if *flash {
+			action = "flash"
+		}
+		c = exec.Command("tinygo", action, "-target", *target)
+	}
 	c.Dir = filepath.Join(build[0], "src/bb.u-root.com/bb")
 	c.Stdout, c.Stderr = os.Stdout, os.Stderr
 	log.Printf("Now compile it: %v", c)


### PR DESCRIPTION
reduce the number of functions tinygobb updates
to just runone.

Add a placeholder cmds/exp/runone_tinygo.go,
so that gobusybox will not get confused.