### PR TITLE
cmds/core/touch: command with RFC3339 datetime

### DIFF
--- a/cmds/core/touch/touch.go
+++ b/cmds/core/touch/touch.go
@@ -1,0 +1,108 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+type params struct {
+	time         time.Time
+	access       bool
+	modification bool
+	create       bool
+}
+
+type cmd struct {
+	stderr io.Writer
+	params
+	args []string
+}
+
+func command(stderr io.Writer, p params, args ...string) *cmd {
+	return &cmd{
+		args:   args,
+		params: p,
+		stderr: stderr,
+	}
+}
+
+func parseParams(dateTime string, access, modification, create bool) (params, error) {
+	flag.Parse()
+	t := time.Now()
+	if dateTime != "" {
+		var err error
+		t, err = time.Parse(time.RFC3339, dateTime)
+		if err != nil {
+			return params{}, err
+		}
+	}
+	return params{
+		access:       access || (!access && !modification),
+		modification: modification || (!access && !modification),
+		create:       create,
+		time:         t,
+	}, nil
+}
+
+func (c *cmd) run() error {
+	// TODO: move to errors.Join in future
+	// right now log error in stderr and return last error
+	// to indicate a non zero exit code
+	var lastError error
+	for _, arg := range c.args {
+		_, existsErr := os.Stat(arg)
+		notExist := os.IsNotExist(existsErr)
+		if notExist {
+			if c.create {
+				continue
+			}
+
+			f, err := os.Create(arg)
+			if err != nil {
+				lastError = err
+				fmt.Fprintf(c.stderr, "touch: %v\n", err)
+				continue
+			}
+			f.Close()
+		}
+
+		accessTime := time.Time{}
+		if c.access || notExist {
+			accessTime = c.time
+		}
+		modificationTime := time.Time{}
+		if c.modification || notExist {
+			modificationTime = c.time
+		}
+
+		err := os.Chtimes(arg, accessTime, modificationTime)
+		if err != nil {
+			lastError = err
+			fmt.Fprintf(c.stderr, "touch: %v\n", err)
+		}
+	}
+
+	return lastError
+}
+
+func main() {
+	access := flag.Bool("a", false, "change only the access time")
+	modification := flag.Bool("m", false, "change only the modification time")
+	create := flag.Bool("c", false, "do not create any file if it does not exist")
+	dateTime := flag.String("d", "", "use specified time instead of current time RFC3339")
+	flag.Parse()
+	p, err := parseParams(*dateTime, *access, *modification, *create)
+	if err != nil || len(flag.Args()) == 0 {
+		flag.Usage()
+		os.Exit(1)
+	}
+	if err := command(os.Stderr, p, flag.Args()...).run(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmds/core/touch/touch_test.go
+++ b/cmds/core/touch/touch_test.go
@@ -1,0 +1,172 @@
+// Copyright 2023 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+package main
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestParseParamsDate(t *testing.T) {
+	date := "2021-01-01T00:00:00Z"
+	expected, err := time.Parse(time.RFC3339, date)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	p, err := parseParams(date, false, false, false)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if !expected.Equal(p.time) {
+		t.Errorf("expected %v, got %v", expected, p.time)
+	}
+
+	date = "invalid"
+	_, err = parseParams(date, false, false, false)
+	if err == nil {
+		t.Errorf("expected error, got nil")
+	}
+}
+
+func TestParseParams(t *testing.T) {
+	var tests = []struct {
+		expected     params
+		access       bool
+		modification bool
+		create       bool
+	}{
+		{
+			access:       false,
+			modification: false,
+			create:       false,
+			expected: params{
+				access:       true,
+				modification: true,
+				create:       false,
+			},
+		},
+		{
+			access:       true,
+			modification: false,
+			create:       false,
+			expected: params{
+				access:       true,
+				modification: false,
+				create:       false,
+			},
+		},
+		{
+			access:       false,
+			modification: true,
+			create:       true,
+			expected: params{
+				access:       false,
+				modification: true,
+				create:       true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		p, err := parseParams("", test.access, test.modification, test.create)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if p.access != test.expected.access {
+			t.Errorf("expected %v, got %v", test.expected.access, p.access)
+		}
+		if p.modification != test.expected.modification {
+			t.Errorf("expected %v, got %v", test.expected.modification, p.modification)
+		}
+		if p.create != test.expected.create {
+			t.Errorf("expected %v, got %v", test.expected.create, p.create)
+		}
+	}
+}
+
+var tests = []struct {
+	err  error
+	p    params
+	name string
+	args []string
+}{
+	{
+		name: "create is true, no new files created",
+		args: []string{"a1", "a2"},
+		p: params{
+			access:       true,
+			modification: true,
+			create:       true,
+			time:         time.Now(),
+		},
+	},
+	{
+		name: "create is false, files should be created",
+		args: []string{"a1", "a2"},
+		p: params{
+			access:       true,
+			modification: true,
+			create:       false,
+			time:         time.Now(),
+		},
+	},
+	{
+		name: "no such file or directory",
+		args: []string{"no/such/file/or/direcotry"},
+		p: params{
+			create: false,
+			time:   time.Now(),
+		},
+		err: os.ErrNotExist,
+	},
+}
+
+func TestTouchEmptyDir(t *testing.T) {
+	for _, test := range tests {
+		temp := t.TempDir()
+		var args []string
+		for _, arg := range test.args {
+			args = append(args, temp+arg)
+		}
+		stderr := &bytes.Buffer{}
+		err := command(stderr, test.p, args...).run()
+		if !errors.Is(err, test.err) {
+			t.Fatalf("command() expected %v, got %v", test.err, err)
+		}
+		if test.err != nil {
+			continue
+		}
+
+		for _, arg := range args {
+			_, err := os.Stat(arg)
+			if test.p.create {
+				if !os.IsNotExist(err) {
+					t.Errorf("expected %s to not exist", arg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("expected %s to exist, got %v", arg, err)
+				}
+
+				stat, err := os.Stat(arg)
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+
+				if test.p.modification {
+					if stat.ModTime().Unix() != test.p.time.Unix() {
+						t.Errorf("expected %s to have mod time %v, got %v", arg, test.p.time, stat.ModTime())
+					}
+				}
+			}
+
+		}
+	}
+}


### PR DESCRIPTION
-d datetime use RFC3339 as date format
-m modification time of file
-a access time of file
-c do not create a specified file if it does not exist