### PR TITLE
ls: remove all globals

### DIFF
--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -126,7 +126,7 @@ func (c cmd) listName(stringer ls.Stringer, d string, prefix bool) error {
 
 	for _, f := range files {
 		if f.err != nil {
-			c.printFile(c.w, stringer, f)
+			c.printFile(stringer, f)
 			continue
 		}
 		if c.recurse {
@@ -151,7 +151,7 @@ func (c cmd) listName(stringer ls.Stringer, d string, prefix bool) error {
 			}
 		}
 
-		c.printFile(c.w, stringer, f)
+		c.printFile(stringer, f)
 	}
 
 	return nil

--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -10,10 +10,14 @@
 //
 // Options:
 //
-//	-l: long form
-//	-Q: quoted
-//	-R: equivalent to findutil's find
-//	-F: append indicator (one of */=>@|) to entries
+//	-a[ll]: show hidden files
+//	-h[uman-readable]: show human-readable sizes
+//	-d[irectory]: show directories but not their contents
+//	-F|classify: append indicator (, one of */=>@|) to entries
+//	-l[ong]: long form
+//	-Q|quote-name: quoted
+//	-R|recursive: equivalent to findutil's find
+//	-s[ize]: sort by size
 //
 // Bugs:
 //

--- a/cmds/core/ls/ls_linux_test.go
+++ b/cmds/core/ls/ls_linux_test.go
@@ -34,19 +34,21 @@ func TestListNameLinux(t *testing.T) {
 		t.Fatalf("err in unix.Mknod: %v", err)
 	}
 
+	var c cmd
 	// Setting the flags
-	*long = true
+	c.long = true
 	// Running the tests
 	// Write output in buffer.
 	var buf bytes.Buffer
 	var s ls.Stringer = ls.NameStringer{}
-	if *quoted {
+	if c.quoted {
 		s = ls.QuotedStringer{}
 	}
-	if *long {
-		s = ls.LongStringer{Human: *human, Name: s}
+	if c.long {
+		s = ls.LongStringer{Human: c.human, Name: s}
 	}
-	_ = listName(s, d, &buf, false)
+	c.w = &buf
+	_ = c.listName(s, d, false)
 	if !strings.Contains(buf.String(), "1110, 74616") {
 		t.Errorf("Expected value: %s, got: %s", "1110, 74616", buf.String())
 	}

--- a/cmds/core/ls/ls_plan9.go
+++ b/cmds/core/ls/ls_plan9.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	flag "github.com/spf13/pflag"
@@ -18,9 +17,9 @@ import (
 
 var final = flag.BoolP("print-last", "p", false, "Print only the final path element of each file name")
 
-func (c cmd) printFile(w io.Writer, stringer ls.Stringer, f file) {
+func (c cmd) printFile(stringer ls.Stringer, f file) {
 	if f.err != nil {
-		fmt.Fprintln(w, f.err)
+		fmt.Fprintln(c.w, f.err)
 		return
 	}
 	// Hide .files unless -a was given
@@ -32,6 +31,6 @@ func (c cmd) printFile(w io.Writer, stringer ls.Stringer, f file) {
 		if c.classify {
 			f.lsfi.Name = f.lsfi.Name + indicator(f.lsfi)
 		}
-		fmt.Fprintln(w, stringer.FileString(f.lsfi))
+		fmt.Fprintln(c.w, stringer.FileString(f.lsfi))
 	}
 }

--- a/cmds/core/ls/ls_plan9.go
+++ b/cmds/core/ls/ls_plan9.go
@@ -18,18 +18,18 @@ import (
 
 var final = flag.BoolP("print-last", "p", false, "Print only the final path element of each file name")
 
-func printFile(w io.Writer, stringer ls.Stringer, f file) {
+func (c cmd) printFile(w io.Writer, stringer ls.Stringer, f file) {
 	if f.err != nil {
 		fmt.Fprintln(w, f.err)
 		return
 	}
 	// Hide .files unless -a was given
-	if *all || !strings.HasPrefix(f.lsfi.Name, ".") {
+	if c.all || !strings.HasPrefix(f.lsfi.Name, ".") {
 		// Unless they said -p, we always print the full path
 		if !*final {
 			f.lsfi.Name = f.path
 		}
-		if *classify {
+		if c.classify {
 			f.lsfi.Name = f.lsfi.Name + indicator(f.lsfi)
 		}
 		fmt.Fprintln(w, stringer.FileString(f.lsfi))

--- a/cmds/core/ls/ls_unix.go
+++ b/cmds/core/ls/ls_unix.go
@@ -15,15 +15,15 @@ import (
 	"github.com/u-root/u-root/pkg/ls"
 )
 
-func printFile(w io.Writer, stringer ls.Stringer, f file) {
+func (c cmd) printFile(w io.Writer, stringer ls.Stringer, f file) {
 	if f.err != nil {
 		fmt.Fprintln(w, f.err)
 		return
 	}
 	// Hide .files unless -a was given
-	if *all || !strings.HasPrefix(f.lsfi.Name, ".") {
+	if c.all || !strings.HasPrefix(f.lsfi.Name, ".") {
 		// Print the file in the proper format.
-		if *classify {
+		if c.classify {
 			f.lsfi.Name = f.lsfi.Name + indicator(f.lsfi)
 		}
 		fmt.Fprintln(w, stringer.FileString(f.lsfi))

--- a/cmds/core/ls/ls_unix.go
+++ b/cmds/core/ls/ls_unix.go
@@ -9,15 +9,14 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"strings"
 
 	"github.com/u-root/u-root/pkg/ls"
 )
 
-func (c cmd) printFile(w io.Writer, stringer ls.Stringer, f file) {
+func (c cmd) printFile(stringer ls.Stringer, f file) {
 	if f.err != nil {
-		fmt.Fprintln(w, f.err)
+		fmt.Fprintln(c.w, f.err)
 		return
 	}
 	// Hide .files unless -a was given
@@ -26,6 +25,6 @@ func (c cmd) printFile(w io.Writer, stringer ls.Stringer, f file) {
 		if c.classify {
 			f.lsfi.Name = f.lsfi.Name + indicator(f.lsfi)
 		}
-		fmt.Fprintln(w, stringer.FileString(f.lsfi))
+		fmt.Fprintln(c.w, stringer.FileString(f.lsfi))
 	}
 }


### PR DESCRIPTION
This makes it usable in tamago and other bare-metal environments.