### PR TITLE
dhcpv6: correct PreferredLifetime and ValidLifetime got from dhcpv6 l…

### DIFF
--- a/pkg/dhclient/dhcp6.go
+++ b/pkg/dhclient/dhcp6.go
@@ -68,14 +68,15 @@ func (p *Packet6) Configure() error {
 			// "Observed Incorrect Implementation Behavior".)
 			Mask: net.CIDRMask(128, 128),
 		},
-		PreferedLft: int(l.PreferredLifetime),
-		ValidLft:    int(l.ValidLifetime),
+		PreferedLft: int(l.PreferredLifetime.Seconds()),
+		ValidLft:    int(l.ValidLifetime.Seconds()),
 		// Optimistic DAD (Duplicate Address Detection) means we can
 		// use the address before DAD is complete. The DHCP server's
 		// job was to give us a unique IP so there is little risk of a
 		// collision.
 		Flags: unix.IFA_F_OPTIMISTIC,
 	}
+
 	if err := netlink.AddrReplace(p.iface, dst); err != nil {
 		if os.IsExist(err) {
 			return fmt.Errorf("add/replace %s to %v: %v", dst, p.iface, err)


### PR DESCRIPTION
…ease

The unit of PreferedLft and ValidLft is second. But the type of PreferredLifetime and ValidLifetime in dhcpv6 lease is time.Duration and its default unit is nanosecond.