### PR TITLE
flash/op: add String() and Bytes() for OpCode

### DIFF
--- a/cmds/fwtools/spidev/spidev_linux.go
+++ b/cmds/fwtools/spidev/spidev_linux.go
@@ -90,12 +90,12 @@ func run(args []string, spiOpen spiOpenFunc, input io.Reader, output io.Writer) 
 		// transfers to ensure that happens.
 		transfers := []spidev.Transfer{
 			{
-				Tx:       []byte{op.PRDRES},
+				Tx:       op.PRDRES.Bytes(),
 				Rx:       make([]byte, 1),
 				CSChange: true,
 			},
 			{
-				Tx: []byte{op.ReadJEDECID, 0, 0, 0},
+				Tx: append(op.ReadJEDECID.Bytes(), 0, 0, 0),
 				Rx: make([]byte, 4),
 			},
 		}

--- a/pkg/flash/op/op.go
+++ b/pkg/flash/op/op.go
@@ -6,29 +6,72 @@
 // the beginning of a SPI transaction.
 package op
 
+import "fmt"
+
+type OpCode byte
+
 const (
 	// PageProgram programs a page on the flash chip.
-	PageProgram byte = 0x02
+	PageProgram OpCode = 0x02
 	// Read reads from the flash chip.
-	Read byte = 0x03
+	Read OpCode = 0x03
 	// WriteDisable disables writing.
-	WriteDisable byte = 0x04
+	WriteDisable OpCode = 0x04
 	// ReadStatus reads the status register.
-	ReadStatus byte = 0x05
+	ReadStatus OpCode = 0x05
 	// WriteEnable enables writing.
-	WriteEnable byte = 0x06
+	WriteEnable OpCode = 0x06
 	// SectorErase erases a sector to the value 0xff.
-	SectorErase byte = 0x20
+	SectorErase OpCode = 0x20
 	// ReadSFDP reads from the SFDP.
-	ReadSFDP byte = 0x5a
+	ReadSFDP OpCode = 0x5a
 	// ReadID reads the JEDEC ID.
-	ReadJEDECID byte = 0x9f
+	ReadJEDECID OpCode = 0x9f
 	// PRD/RES
-	PRDRES = 0xab
-	// Enter4BA enters 4-byte addressing mode.
-	Enter4BA byte = 0xb7
+	PRDRES OpCode = 0xab
+	// AAI is auto address increment
+	AAI OpCode = 0xad
+	// Enter4BA enters 4-OpCode addressing mode.
+	Enter4BA OpCode = 0xb7
 	// BlockErase erases a block to the value 0xff.
-	BlockErase byte = 0xd8
-	// Exit4BA exits 4-byte addressing mode.
-	Exit4BA byte = 0xe9
+	BlockErase OpCode = 0xd8
+	// Exit4BA exits 4-OpCode addressing mode.
+	Exit4BA OpCode = 0xe9
 )
+
+func (o OpCode) String() string {
+	switch o {
+	case PageProgram:
+		return "PageProgram"
+	case Read:
+		return "Read"
+	case WriteDisable:
+		return "WriteDisable"
+	case ReadStatus:
+		return "ReadStatus"
+	case WriteEnable:
+		return "WriteEnable"
+	case SectorErase:
+		return "SectorErase"
+	case ReadSFDP:
+		return "ReadSFDP"
+	case ReadJEDECID:
+		return "ReadJEDECID"
+	case PRDRES:
+		return "PRDRES"
+	case AAI:
+		return "AAI"
+	case Enter4BA:
+		return "Enter4BA"
+	case BlockErase:
+		return "BlockErase"
+	case Exit4BA:
+		return "Exit4BA"
+	default:
+		return fmt.Sprintf("Unknown(%02x)", byte(o))
+	}
+}
+
+func (o OpCode) Bytes() []byte {
+	return []byte{byte(o)}
+}

--- a/pkg/flash/op/op_test.go
+++ b/pkg/flash/op/op_test.go
@@ -1,0 +1,58 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package op_test
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/flash/op"
+)
+
+func TestString(t *testing.T) {
+	bad := op.OpCode(0xff)
+	tests := []struct {
+		opcode   op.OpCode
+		expected string
+	}{
+		{op.PageProgram, "PageProgram"},
+		{op.Read, "Read"},
+		{op.WriteDisable, "WriteDisable"},
+		{op.ReadStatus, "ReadStatus"},
+		{op.WriteEnable, "WriteEnable"},
+		{op.SectorErase, "SectorErase"},
+		{op.ReadSFDP, "ReadSFDP"},
+		{op.ReadJEDECID, "ReadJEDECID"},
+		{op.PRDRES, "PRDRES"},
+		{op.Enter4BA, "Enter4BA"},
+		{op.BlockErase, "BlockErase"},
+		{op.Exit4BA, "Exit4BA"},
+		{bad, fmt.Sprintf("Unknown(%02x)", byte(bad))},
+	}
+
+	for _, tt := range tests {
+		actual := tt.opcode.String()
+		if actual != tt.expected {
+			t.Errorf("String() for %v: expected %s, got %s", tt.opcode, tt.expected, actual)
+		}
+	}
+}
+
+func TestBytes(t *testing.T) {
+	tests := []struct {
+		opcode   op.OpCode
+		expected []byte
+	}{
+		{op.PageProgram, []byte{byte(op.PageProgram)}},
+	}
+
+	for _, tt := range tests {
+		actual := tt.opcode.Bytes()
+		if !bytes.Equal(actual, tt.expected) {
+			t.Errorf("Bytes() for %v: expected %v, got %v", tt.opcode, tt.expected, actual)
+		}
+	}
+}

--- a/pkg/flash/spimock/spimock_linux.go
+++ b/pkg/flash/spimock/spimock_linux.go
@@ -197,7 +197,7 @@ func (s *MockSPI) Transfer(transfers []spidev.Transfer) error {
 	if err != nil {
 		return err
 	}
-	switch o {
+	switch op.OpCode(o) {
 	case op.PageProgram:
 		if !s.IsWriteEnabled {
 			break


### PR DESCRIPTION
I decided not to use a map. 

Using a switch lets the compiler optimize at it sees fit, where a map wires in a decision as to best implementation, a map sitting around we almost never need, and so on. I'm sensitive to this in a world of little devices.