### PR TITLE
pkg/flash: update flash to use chips package

### DIFF
--- a/cmds/fwtools/spidev/spidev_linux.go
+++ b/cmds/fwtools/spidev/spidev_linux.go
@@ -32,6 +32,7 @@ import (
 
 	flag "github.com/spf13/pflag"
 	"github.com/u-root/u-root/pkg/flash"
+	"github.com/u-root/u-root/pkg/flash/chips"
 	"github.com/u-root/u-root/pkg/flash/op"
 	"github.com/u-root/u-root/pkg/flash/sfdp"
 	"github.com/u-root/u-root/pkg/spidev"
@@ -41,6 +42,7 @@ type spi interface {
 	Transfer([]spidev.Transfer) error
 	SetSpeedHz(uint32) error
 	Close() error
+	ID() (chips.ID, error)
 }
 
 var (

--- a/pkg/flash/flash_linux.go
+++ b/pkg/flash/flash_linux.go
@@ -49,7 +49,7 @@ func New(spi SPI) (*Flash, error) {
 	var id chips.ID
 	id, err = f.spi.ID()
 	if err != nil {
-		return nil, fmt.Errorf("Can not ID chip: %w", err)
+		return nil, fmt.Errorf("can not ID chip: %w", err)
 	}
 	c, err := chips.Lookup(id)
 	if err == nil {

--- a/pkg/flash/flash_linux.go
+++ b/pkg/flash/flash_linux.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/u-root/u-root/pkg/flash/chips"
 	"github.com/u-root/u-root/pkg/flash/op"
 	"github.com/u-root/u-root/pkg/flash/sfdp"
 	"github.com/u-root/u-root/pkg/spidev"
@@ -22,6 +23,7 @@ const sfdpMaxAddress = (1 << 24) - 1
 // SPI interface for the underlying calls to the SPI driver.
 type SPI interface {
 	Transfer(transfers []spidev.Transfer) error
+	ID() (chips.ID, error)
 }
 
 // Flash provides operations for SPI flash chips.
@@ -29,21 +31,12 @@ type Flash struct {
 	// spi is the underlying SPI device.
 	spi SPI
 
-	// is4ba is true if 4-byte addressing mode is enabled.
-	is4ba bool
-
-	// size is the size of the flash chip in bytes.
-	size int64
+	// Chip is derived from SFDP or looking up
+	// the chip via the ID.
+	chips.Chip
 
 	// sfdp is cached.
 	sfdp *sfdp.SFDP
-
-	// JEDEC ID is cached.
-	id uint32
-
-	pageSize   int64
-	sectorSize int64
-	blockSize  int64
 }
 
 // New creates a new flash device from a SPI interface.
@@ -53,36 +46,60 @@ func New(spi SPI) (*Flash, error) {
 	}
 
 	var err error
+	var id chips.ID
+	id, err = f.spi.ID()
+	if err != nil {
+		return nil, fmt.Errorf("Can not ID chip: %w", err)
+	}
+	c, err := chips.Lookup(id)
+	if err == nil {
+		f.Chip = *c
+		// Even when we have a chip, there is still
+		// benefit to trying to get an SFDP.
+		// Further, the package as written wants
+		// some sort of empty sfdp to exist, and this
+		// is the easiest way to do it.
+		f.sfdp, _ = sfdp.Read(f.SFDPReader())
+		return f, nil
+	}
+
 	f.sfdp, err = sfdp.Read(f.SFDPReader())
 	if err != nil {
-		return nil, fmt.Errorf("could not read sfdp: %v", err)
+		return nil, fmt.Errorf("chip %#x: chip not known, and no SFDP: %w", id, err)
 	}
-
-	density, err := f.SFDP().Param(sfdp.ParamFlashMemoryDensity)
-	if err != nil {
-		return nil, fmt.Errorf("flash chip SFDP does not have density param")
+	if err = f.FillFromSFDP(); err != nil {
+		return nil, fmt.Errorf("chip %#x: chip not known, and no SFDP: %w", id, err)
 	}
-	if density >= 0x80000000 {
-		return nil, fmt.Errorf("unsupported flash density: %#x", density)
-	}
-	f.size = (density + 1) / 8
-
-	// Assume 4ba if address if size requires 4 bytes.
-	if f.size >= 0x1000000 {
-		f.is4ba = true
-	}
-
-	// TODO
-	f.pageSize = 256
-	f.sectorSize = 4096
-	f.blockSize = 65536
 
 	return f, nil
 }
 
+func (f *Flash) FillFromSFDP() error {
+	density, err := f.SFDP().Param(sfdp.ParamFlashMemoryDensity)
+	if err != nil {
+		return fmt.Errorf("flash chip SFDP does not have density param")
+	}
+	if density >= 0x80000000 {
+		return fmt.Errorf("unsupported flash density: %#x", density)
+	}
+	f.ArraySize = (density + 1) / 8
+
+	// Assume 4ba if address if size requires 4 bytes.
+	if f.ArraySize >= 0x1000000 {
+		f.Is4BA = true
+	}
+
+	// TODO
+	f.PageSize = 256
+	f.SectorSize = 4096
+	f.BlockSize = 65536
+
+	return nil
+}
+
 // Size returns the size of the flash chip in bytes.
 func (f *Flash) Size() int64 {
-	return f.size
+	return f.ArraySize
 }
 
 const maxTransferSize = 4096
@@ -98,7 +115,7 @@ func min(x, y int64) int64 {
 func (f *Flash) prepareAddress(addr int64) []byte {
 	data := make([]byte, 4)
 	binary.BigEndian.PutUint32(data, uint32(addr))
-	if f.is4ba {
+	if f.Is4BA {
 		return data
 	}
 	return data[1:]
@@ -107,10 +124,10 @@ func (f *Flash) prepareAddress(addr int64) []byte {
 // ReadAt reads from the flash chip.
 func (f *Flash) ReadAt(p []byte, off int64) (int, error) {
 	// This is a valid implementation of io.ReaderAt.
-	if off < 0 || off > f.size {
+	if off < 0 || off > f.ArraySize {
 		return 0, io.EOF
 	}
-	p = p[:min(int64(len(p)), f.size-off)]
+	p = p[:min(int64(len(p)), f.ArraySize-off)]
 
 	// Split the transfer into maxTransferSize chunks.
 	for i := 0; i < len(p); i += maxTransferSize {
@@ -129,11 +146,13 @@ func (f *Flash) ReadAt(p []byte, off int64) (int, error) {
 func (f *Flash) writeAt(p []byte, off int64) (int, error) {
 	if err := f.spi.Transfer([]spidev.Transfer{
 		// Enable writing.
+		{Tx: op.PRDRES.Bytes(), CSChange: true},
 		{Tx: op.WriteEnable.Bytes(), CSChange: true},
 		// Send the address.
 		{Tx: append(op.PageProgram.Bytes(), f.prepareAddress(off)...)},
 		// Send the data.
-		{Tx: p},
+		{Tx: p, CSChange: true},
+		{Tx: op.WriteDisable.Bytes(), CSChange: true},
 	}); err != nil {
 		return 0, err
 	}
@@ -148,13 +167,13 @@ func (f *Flash) writeAt(p []byte, off int64) (int, error) {
 // what you want instead!
 func (f *Flash) WriteAt(p []byte, off int64) (int, error) {
 	// This is a valid implementation of io.WriterAt.
-	if off < 0 || off > f.size {
+	if off < 0 || off > f.ArraySize {
 		return 0, io.EOF
 	}
-	p = p[:min(int64(len(p)), f.size-off)]
+	p = p[:min(int64(len(p)), f.ArraySize-off)]
 
 	// Special case where no page boundaries are crossed.
-	if off%f.pageSize+int64(len(p)) <= f.pageSize {
+	if off%f.PageSize+int64(len(p)) <= f.PageSize {
 		return f.writeAt(p, off)
 	}
 
@@ -162,16 +181,16 @@ func (f *Flash) WriteAt(p []byte, off int64) (int, error) {
 	// 1. A partial page before the first aligned offset. (optional)
 	// 2. All the aligned pages in the middle.
 	// 3. A partial page after the last aligned offset. (optional)
-	firstAlignedOff := (off + f.pageSize - 1) / f.pageSize * f.pageSize
-	lastAlignedOff := (off + int64(len(p))) / f.pageSize * f.pageSize
+	firstAlignedOff := (off + f.PageSize - 1) / f.PageSize * f.PageSize
+	lastAlignedOff := (off + int64(len(p))) / f.PageSize * f.PageSize
 
 	if off != firstAlignedOff {
 		if n, err := f.writeAt(p[:firstAlignedOff-off], off); err != nil {
 			return n, err
 		}
 	}
-	for i := firstAlignedOff; i < lastAlignedOff; i += f.pageSize {
-		if _, err := f.writeAt(p[i:i+f.pageSize], off+i); err != nil {
+	for i := firstAlignedOff; i < lastAlignedOff; i += f.PageSize {
+		if _, err := f.writeAt(p[i:i+f.PageSize], off+i); err != nil {
 			return int(i), err
 		}
 	}
@@ -191,22 +210,22 @@ func (f *Flash) ProgramAt(p []byte, off int64) (int, error) {
 // EraseAt erases n bytes from offset off. Both parameters must be aligned to
 // sectorSize.
 func (f *Flash) EraseAt(n int64, off int64) (int64, error) {
-	if off < 0 || off > f.size || off+n > f.size {
+	if off < 0 || off > f.ArraySize || off+n > f.ArraySize {
 		return 0, io.EOF
 	}
 
-	if (off%f.sectorSize != 0) || (n%f.sectorSize != 0) {
+	if (off%f.SectorSize != 0) || (n%f.SectorSize != 0) {
 		return 0, fmt.Errorf("len(p) and off must be multiple of the sector size")
 	}
 
 	for i := int64(0); i < n; {
 		opcode := op.SectorErase
-		eraseSize := f.sectorSize
+		eraseSize := f.SectorSize
 
 		// Optimization to erase faster.
-		if i%f.blockSize == 0 && n-i > f.blockSize {
+		if i%f.BlockSize == 0 && n-i > f.BlockSize {
 			opcode = op.BlockErase
-			eraseSize = f.blockSize
+			eraseSize = f.BlockSize
 		}
 
 		if err := f.spi.Transfer([]spidev.Transfer{
@@ -262,12 +281,13 @@ func (f *SFDPReader) ReadAt(p []byte, off int64) (int, error) {
 		return 0, io.EOF
 	}
 	p = p[:min(int64(len(p)), sfdpMaxAddress-off)]
-	tx := append(op.ReadSFDP.Bytes(),
+	tx := []byte{
+		byte(op.ReadSFDP),
 		// offset, 3-bytes, big-endian
-		byte((off>>16)&0xff), byte((off>>8)&0xff), byte(off&0xff),
+		byte((off >> 16) & 0xff), byte((off >> 8) & 0xff), byte(off & 0xff),
 		// dummy 0xff
 		0xff,
-	)
+	}
 	if err := f.spi.Transfer([]spidev.Transfer{
 		{Tx: tx},
 		{Rx: p},

--- a/pkg/flash/flash_linux_test.go
+++ b/pkg/flash/flash_linux_test.go
@@ -15,6 +15,7 @@ import (
 
 // TestSFDPReader tests reading arbitrary offsets from the SFDP.
 func TestSFDPReader(t *testing.T) {
+	fakeErr := errors.New("fake transfer error")
 	for _, tt := range []struct {
 		name             string
 		readOffset       int64
@@ -40,16 +41,16 @@ func TestSFDPReader(t *testing.T) {
 			name:             "transfer error",
 			readOffset:       0x10,
 			readSize:         4,
-			forceTransferErr: errors.New("fake transfer error"),
-			wantNewErr:       errors.New("could not read sfdp: fake transfer error"),
+			forceTransferErr: fakeErr,
+			wantNewErr:       fakeErr,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			s := spimock.New()
 			s.ForceTransferErr = tt.forceTransferErr
 			f, err := New(s)
-			if gotErrString, wantErrString := fmt.Sprint(err), fmt.Sprint(tt.wantNewErr); gotErrString != wantErrString {
-				t.Errorf("flash.New() err = %q; want %q", gotErrString, wantErrString)
+			if !errors.Is(err, tt.wantNewErr) {
+				t.Errorf("flash.New() err = %v; want %v", err, tt.forceTransferErr)
 			}
 			if err != nil {
 				return
@@ -80,6 +81,10 @@ func TestSFDPReadDWORD(t *testing.T) {
 	}
 
 	sfdp := f.SFDP()
+	if sfdp == nil {
+		t.Fatalf("f.SFDP: got nil, want value")
+	}
+
 	dword, err := sfdp.Dword(0, 0)
 	if err != nil {
 		t.Error(err)

--- a/pkg/flash/spimock/spimock_linux.go
+++ b/pkg/flash/spimock/spimock_linux.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/u-root/u-root/pkg/flash/chips"
 	"github.com/u-root/u-root/pkg/flash/op"
 	"github.com/u-root/u-root/pkg/spidev"
 	"golang.org/x/sys/unix"
@@ -276,4 +277,11 @@ func (s *MockSPI) SetSpeedHz(hz uint32) error {
 	}
 	s.SpeedHz = hz
 	return nil
+}
+
+func (s *MockSPI) ID() (chips.ID, error) {
+	if s.ForceTransferErr != nil {
+		return -1, s.ForceTransferErr
+	}
+	return 0xbf2541, nil
 }

--- a/pkg/spidev/spidev_linux.go
+++ b/pkg/spidev/spidev_linux.go
@@ -7,13 +7,17 @@
 package spidev
 
 import (
+	"bytes"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"math"
 	"os"
 	"runtime"
 	"unsafe"
 
+	"github.com/u-root/u-root/pkg/flash/chips"
+	"github.com/u-root/u-root/pkg/flash/op"
 	"golang.org/x/sys/unix"
 )
 
@@ -141,6 +145,12 @@ type Transfer struct {
 	WordDelayUSecs uint8
 }
 
+func (t *Transfer) String() string {
+	var x [8]byte
+	n, _ := io.ReadAtLeast(bytes.NewBuffer(t.Tx), x[:], len(x))
+	return fmt.Sprintf("%#02x...[:%d](%s)", x[:n], len(t.Tx), op.OpCode(x[0]).String())
+}
+
 // ErrTxOverflow is returned if the Transfer buffer is too large.
 type ErrTxOverflow struct {
 	TxLen, TxMax int
@@ -177,24 +187,46 @@ type SPI struct {
 	f *os.File
 	// Used for mocking.
 	syscall func(trap, a1, a2 uintptr, a3 unsafe.Pointer) (r1, r2 uintptr, err unix.Errno)
+	// logger allows logging
+	logger func(string, ...any)
+}
+
+type opt func(s *SPI) error
+
+// WithLogger returns an opt which can be used in Open to add
+// a logger. A common usage would be:
+// spidev.Open("/dev/spidev0.0", WithLogger(log.Printf))
+func WithLogger(l func(string, ...any)) opt {
+	return func(s *SPI) error {
+		s.logger = l
+		return nil
+	}
 }
 
 // Open opens a new SPI device. dev is a filename such as "/dev/spidev0.0".
 // Remember to call Close() once done.
-func Open(dev string) (*SPI, error) {
+func Open(dev string, opts ...opt) (*SPI, error) {
 	f, err := os.OpenFile(dev, os.O_RDWR, 0)
 	if err != nil {
 		return nil, err
 	}
-	return &SPI{
-		f: f,
+	s := &SPI{
+		f:      f,
+		logger: func(string, ...any) {}, // log.Printf,
+		//logger: log.Printf,
 		// a3 must be an unsafe.Pointer instead of a uintptr, otherwise
 		// we cannot mock out in the test without creating a race
 		// condition. See `go doc unsafe.Pointer`.
 		syscall: func(trap, a1, a2 uintptr, a3 unsafe.Pointer) (r1, r2 uintptr, err unix.Errno) {
 			return unix.Syscall(trap, a1, a2, uintptr(a3))
 		},
-	}, err
+	}
+	for _, o := range opts {
+		if err := o(s); err != nil {
+			return nil, err
+		}
+	}
+	return s, nil
 }
 
 // Close closes the SPI device.
@@ -208,6 +240,7 @@ func (s *SPI) Transfer(transfers []Transfer) error {
 	// Convert []Transfer to []iocTransfer.
 	it := make([]iocTransfer, len(transfers))
 	for i, t := range transfers {
+		s.logger("%d:%s", i, t.String())
 		it[i] = iocTransfer{
 			speedHz:        t.SpeedHz,
 			delayUSecs:     t.DelayUSecs,
@@ -300,4 +333,31 @@ func (s *SPI) SetSpeedHz(hz uint32) error {
 		return os.NewSyscallError("ioctl(SPI_IOC_WR_MAX_SPEED_HZ)", err)
 	}
 	return nil
+}
+
+// ID gets the 24-bit id as an int
+func (s *SPI) ID() (chips.ID, error) {
+	// Wake it up, then get the id.
+	// PRDRES is not universally handled on all devices, but that's ok.
+	// but CE MUST drop, so we structure this as two separate
+	// transfers to ensure that happens.
+	var id [4]byte
+	transfers := []Transfer{
+		{
+			Tx:       []byte{byte(op.PRDRES)},
+			Rx:       make([]byte, 1),
+			CSChange: true,
+		},
+		{
+			Tx: []byte{byte(op.ReadJEDECID), 0, 0, 0},
+			Rx: id[:],
+		},
+	}
+
+	if err := s.Transfer(transfers); err != nil {
+		return -1, err
+	}
+
+	id[0] = 0
+	return chips.ID(binary.BigEndian.Uint32(id[:])), nil
 }


### PR DESCRIPTION
Check for the chip ID first, before trying to read the SFDP. If it is found, use those values for density and so on.

In any case, always try to read the sfdp. As time goes by, more and more chips will implement it, and it will go from mostly failing to mostly working.