### PR TITLE
fwtools/spidev: use the ID function from pkg spidev

### DIFF
--- a/cmds/fwtools/spidev/spidev_linux_test.go
+++ b/cmds/fwtools/spidev/spidev_linux_test.go
@@ -33,7 +33,7 @@ func TestRun(t *testing.T) {
 		{
 			name:            "id",
 			args:            []string{"id"},
-			wantOutputRegex: regexp.MustCompile("[0-9a-fA-F]{6}\n"),
+			wantOutputRegex: regexp.MustCompile("[0-9a-fA-F]*\n"),
 		},
 		{
 			name:             "id failing IO",
@@ -119,7 +119,7 @@ func TestRun(t *testing.T) {
 			got := run(tt.args, openFakeSpi, bytes.NewBuffer(tt.input), output)
 
 			if !errors.Is(got, tt.err) {
-				t.Errorf("run(): %v != %v", got, tt.err)
+				t.Fatalf("run(): %v != %v", got, tt.err)
 			}
 
 			gotOutputString := output.String()


### PR DESCRIPTION
Remove the code in the command, use ID from the package. tested today on rpi4