### PR TITLE
memmap: rename /sys/firmware/memmap parser

### DIFF
--- a/cmds/exp/dumpmemmap/main_linux.go
+++ b/cmds/exp/dumpmemmap/main_linux.go
@@ -8,7 +8,7 @@
 // Support for:
 //
 //   - /proc/iomem (exists on all systems)
-//   - /sys/firmware/memmap (exists on EFI systems)
+//   - /sys/firmware/memmap (exists on x86 systems)
 //   - /sys/kernel/debug/memblock (exists on systems with CONFIG_ARCH_KEEP_MEMBLOCK, in particular arm64)
 //   - /sys/firmware/fdt (exists on systems with device trees)
 package main
@@ -29,7 +29,7 @@ func printMM(mm kexec.MemoryMap) {
 }
 
 func main() {
-	memmap, err := kexec.MemoryMapFromEFI()
+	memmap, err := kexec.MemoryMapFromSysfsMemmap()
 	if err != nil {
 		log.Printf("/sys/firmware/memmap: %v", err)
 	} else {

--- a/pkg/boot/kexec/memory_map_linux.go
+++ b/pkg/boot/kexec/memory_map_linux.go
@@ -207,12 +207,14 @@ func MemoryMapFromFDT(fdt *dt.FDT) (MemoryMap, error) {
 
 var memoryMapRoot = "/sys/firmware/memmap/"
 
-// MemoryMapFromEFI reads a firmware-provided memory map from /sys/firmware/memmap.
-func MemoryMapFromEFI() (MemoryMap, error) {
-	return memoryMapFromEFI(memoryMapRoot)
+// MemoryMapFromSysfsMemmap reads a firmware-provided memory map from /sys/firmware/memmap.
+//
+// Linux support for this exists only on X86 at the time of this commit.
+func MemoryMapFromSysfsMemmap() (MemoryMap, error) {
+	return memoryMapFromSysfsMemmap(memoryMapRoot)
 }
 
-func memoryMapFromEFI(memoryMapDir string) (MemoryMap, error) {
+func memoryMapFromSysfsMemmap(memoryMapDir string) (MemoryMap, error) {
 	type memRange struct {
 		// start and end addresses are inclusive
 		start, end uintptr

--- a/pkg/boot/kexec/memory_map_linux_test.go
+++ b/pkg/boot/kexec/memory_map_linux_test.go
@@ -208,7 +208,7 @@ func TestMemoryMapFromFDT(t *testing.T) {
 	}
 }
 
-func TestMemoryMapFromEFI(t *testing.T) {
+func TestMemoryMapFromSysfsMemmap(t *testing.T) {
 	root := t.TempDir()
 
 	create := func(dir string, start, end uintptr, typ RangeType) error {
@@ -245,12 +245,12 @@ func TestMemoryMapFromEFI(t *testing.T) {
 		{Range: Range{Start: 300, Size: 50}, Type: RangeReserved},
 	}
 
-	phys, err := memoryMapFromEFI(root)
+	phys, err := memoryMapFromSysfsMemmap(root)
 	if err != nil {
-		t.Fatalf("MemoryMapFromEFI() error: %v", err)
+		t.Fatalf("MemoryMapFromSysfsMemmap() error: %v", err)
 	}
 	if !reflect.DeepEqual(phys, want) {
-		t.Errorf("MemoryMapFromEFI() got %v, want %v", phys, want)
+		t.Errorf("MemoryMapFromSysfsMemmap() got %v, want %v", phys, want)
 	}
 }
 

--- a/pkg/boot/linux/load_linux_amd64.go
+++ b/pkg/boot/linux/load_linux_amd64.go
@@ -75,7 +75,7 @@ func KexecLoad(kernel, ramfs *os.File, cmdline string, opts KexecOptions) error 
 	Debug("Try parsing memory map...")
 	// TODO(10000TB): refactor this call into initialization of
 	// kexec.Memory, as it does not depend on specific boot.
-	mm, err := kexec.MemoryMapFromEFI()
+	mm, err := kexec.MemoryMapFromSysfsMemmap()
 	if err != nil {
 		return fmt.Errorf("parse memory map: %v", err)
 	}

--- a/pkg/boot/multiboot/multiboot.go
+++ b/pkg/boot/multiboot/multiboot.go
@@ -290,7 +290,7 @@ func (m *multiboot) load(debug bool, ibft *ibft.IBFT) error {
 	}
 
 	log.Printf("Parsing memory map")
-	memmap, err := kexec.MemoryMapFromEFI()
+	memmap, err := kexec.MemoryMapFromSysfsMemmap()
 	if err != nil {
 		return fmt.Errorf("error parsing memory map: %v", err)
 	}

--- a/pkg/boot/uefi/uefi.go
+++ b/pkg/boot/uefi/uefi.go
@@ -20,10 +20,10 @@ import (
 )
 
 var (
-	kexecLoad             = kexec.Load
-	kexecMemoryMapFromEFI = kexec.MemoryMapFromEFI
-	getRSDP               = acpi.GetRSDP
-	getSMBIOSBase         = smbios.SMBIOSBase
+	kexecLoad                     = kexec.Load
+	kexecMemoryMapFromSysfsMemmap = kexec.MemoryMapFromSysfsMemmap
+	getRSDP                       = acpi.GetRSDP
+	getSMBIOSBase                 = smbios.SMBIOSBase
 )
 
 // SerialPortConfig defines debug port configuration
@@ -123,7 +123,7 @@ func (fv *FVImage) Load(verbose bool) error {
 	configAddr := fv.ImageBase - uintptr(uefiPayloadConfigSize)
 
 	// Get MemoryMap
-	mm, err := kexecMemoryMapFromEFI()
+	mm, err := kexecMemoryMapFromSysfsMemmap()
 	if err != nil {
 		return err
 	}

--- a/pkg/boot/uefi/uefi_test.go
+++ b/pkg/boot/uefi/uefi_test.go
@@ -32,7 +32,7 @@ func mockKexecLoad(entry uintptr, segments kexec.Segments, flags uint64) error {
 	return nil
 }
 
-func mockKexecMemoryMapFromEFI() (kexec.MemoryMap, error) {
+func mockKexecMemoryMapFromSysfsMemmap() (kexec.MemoryMap, error) {
 	return kexec.MemoryMap{}, nil
 }
 
@@ -50,8 +50,8 @@ func TestLoadFvImage(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromEFI = old }(kexecMemoryMapFromEFI)
-	kexecMemoryMapFromEFI = mockKexecMemoryMapFromEFI
+	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromSysfsMemmap = old }(kexecMemoryMapFromSysfsMemmap)
+	kexecMemoryMapFromSysfsMemmap = mockKexecMemoryMapFromSysfsMemmap
 
 	defer func(old func() (*acpi.RSDP, error)) { getRSDP = old }(getRSDP)
 	getRSDP = mockGetRSDP
@@ -97,14 +97,14 @@ func TestLoadFvImageNotFound(t *testing.T) {
 	}
 }
 
-func TestLoadFvImageFailAtMemoryMapFromEFI(t *testing.T) {
+func TestLoadFvImageFailAtMemoryMapFromSysfsMemmap(t *testing.T) {
 	fv, err := New("testdata/fv_with_sec.fd")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromEFI = old }(kexecMemoryMapFromEFI)
-	kexecMemoryMapFromEFI = func() (kexec.MemoryMap, error) {
+	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromSysfsMemmap = old }(kexecMemoryMapFromSysfsMemmap)
+	kexecMemoryMapFromSysfsMemmap = func() (kexec.MemoryMap, error) {
 		return nil, fmt.Errorf("PARSE_MEMORY_MAP_FAILED")
 	}
 
@@ -122,8 +122,8 @@ func TestLoadFvImageFailAtGetRSDP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromEFI = old }(kexecMemoryMapFromEFI)
-	kexecMemoryMapFromEFI = mockKexecMemoryMapFromEFI
+	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromSysfsMemmap = old }(kexecMemoryMapFromSysfsMemmap)
+	kexecMemoryMapFromSysfsMemmap = mockKexecMemoryMapFromSysfsMemmap
 
 	defer func(old func() (*acpi.RSDP, error)) { getRSDP = old }(getRSDP)
 	getRSDP = func() (*acpi.RSDP, error) {
@@ -144,8 +144,8 @@ func TestLoadFvImageFailAtGetSMBIOS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromEFI = old }(kexecMemoryMapFromEFI)
-	kexecMemoryMapFromEFI = mockKexecMemoryMapFromEFI
+	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromSysfsMemmap = old }(kexecMemoryMapFromSysfsMemmap)
+	kexecMemoryMapFromSysfsMemmap = mockKexecMemoryMapFromSysfsMemmap
 
 	defer func(old func() (*acpi.RSDP, error)) { getRSDP = old }(getRSDP)
 	getRSDP = mockGetRSDP
@@ -170,8 +170,8 @@ func TestLoadFvImageFailAtKexec(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromEFI = old }(kexecMemoryMapFromEFI)
-	kexecMemoryMapFromEFI = mockKexecMemoryMapFromEFI
+	defer func(old func() (kexec.MemoryMap, error)) { kexecMemoryMapFromSysfsMemmap = old }(kexecMemoryMapFromSysfsMemmap)
+	kexecMemoryMapFromSysfsMemmap = mockKexecMemoryMapFromSysfsMemmap
 
 	defer func(old func() (*acpi.RSDP, error)) { getRSDP = old }(getRSDP)
 	getRSDP = mockGetRSDP


### PR DESCRIPTION
I was wrong. It only exists on x86 systems, and works with e820 and EFI.