### PR TITLE
kexec: switch segments to use []byte

### DIFF
--- a/pkg/boot/kexec/memory_linux_test.go
+++ b/pkg/boot/kexec/memory_linux_test.go
@@ -79,7 +79,7 @@ func TestAlignAndMerge(t *testing.T) {
 				NewSegment(nil, Range{Start: 0, Size: 0x1000}),
 			},
 			want: Segments{
-				NewSegment(nil, Range{Start: 0, Size: 0x1000}),
+				NewSegment([]byte{}, Range{Start: 0, Size: 0x1000}),
 			},
 		},
 		{
@@ -181,8 +181,7 @@ func TestAlignAndMerge(t *testing.T) {
 				t.Errorf("AlignAndMerge physical ranges = (-want, +got):\n%s", diff)
 			}
 			for i, s := range got {
-				b := s.Buf.toSlice()
-				if diff := cmp.Diff(tt.want[i].Buf.toSlice(), b); diff != "" {
+				if diff := cmp.Diff(tt.want[i].Buf, s.Buf); diff != "" {
 					t.Errorf("segment %s bytes differ (-want, +got):\n%s", got[i].Phys, diff)
 				}
 			}


### PR DESCRIPTION
This makes segment management much easier. It removes the "pool" hack we were using to keep pieces of memory alive. Convert them to kexec format only when actual kexec syscall is called.