### PR TITLE
Sfdp rules

### DIFF
--- a/cmds/fwtools/spidev/spidev_linux.go
+++ b/cmds/fwtools/spidev/spidev_linux.go
@@ -33,6 +33,7 @@ import (
 	flag "github.com/spf13/pflag"
 	"github.com/u-root/u-root/pkg/flash"
 	"github.com/u-root/u-root/pkg/flash/chips"
+	"github.com/u-root/u-root/pkg/flash/op"
 	"github.com/u-root/u-root/pkg/flash/sfdp"
 	"github.com/u-root/u-root/pkg/spidev"
 )
@@ -40,6 +41,7 @@ import (
 type spi interface {
 	Transfer([]spidev.Transfer) error
 	ID() (chips.ID, error)
+	Status() (op.Status, error)
 	SetSpeedHz(uint32) error
 	Close() error
 }

--- a/pkg/flash/chips/chips.go
+++ b/pkg/flash/chips/chips.go
@@ -38,9 +38,10 @@ type Chip struct {
 	Is4BA       bool
 	EraseBlocks []EraseBlock
 
-	Unlock op.OpCode
-	Write  op.OpCode
-	Read   op.OpCode
+	WriteEnableInstructionRequired bool
+	WriteEnableOpcodeSelect        op.OpCode
+	Write                          op.OpCode
+	Read                           op.OpCode
 }
 
 // String implements string for Chip.
@@ -97,8 +98,9 @@ var Chips = []Chip{
 			},
 		},
 
-		Unlock: op.WriteEnable,
-		Write:  op.AAI,
-		Read:   op.Read,
+		WriteEnableInstructionRequired: true,
+		WriteEnableOpcodeSelect:        op.WriteEnable,
+		Write:                          op.AAI,
+		Read:                           op.Read,
 	},
 }

--- a/pkg/flash/flash_linux.go
+++ b/pkg/flash/flash_linux.go
@@ -301,7 +301,7 @@ func (f *Flash) EraseAt(n int64, off int64) (int64, error) {
 			}
 		}
 
-		if spin > 101 {
+		if spin > 100 {
 			return i, fmt.Errorf("spi busy after erasing %d bytes", i)
 		}
 

--- a/pkg/flash/op/op.go
+++ b/pkg/flash/op/op.go
@@ -6,7 +6,10 @@
 // the beginning of a SPI transaction.
 package op
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type OpCode byte
 
@@ -74,4 +77,44 @@ func (o OpCode) String() string {
 
 func (o OpCode) Bytes() []byte {
 	return []byte{byte(o)}
+}
+
+type Status byte
+
+// Status is not universally defined, but a few bits are common.
+const (
+	WriteBusy Status = 1 << iota
+	WriteEnabled
+	ByteProtect0
+	ByteProtect1
+	ByteProtect2
+	ByteProtectP3
+	AutoAddressIncrement
+	ByteProtectLocked
+)
+
+var names = []string{
+	"WriteBusy",
+	"WriteEnabled",
+	"ByteProtect0",
+	"ByteProtect1",
+	"ByteProtect2",
+	"ByteProtectP3",
+	"AutoAddressIncrement",
+	"ByteProtectLocked",
+}
+
+func (status Status) String() string {
+	var s string
+	for i := 0; i < 8; i++ {
+		if byte(status)&(1<<i) != 0 {
+			s = s + names[i] + "|"
+		}
+	}
+	s = strings.TrimRight(s, "|")
+	return s
+}
+
+func (status Status) Busy() bool {
+	return (status & WriteBusy) != 0
 }

--- a/pkg/flash/op/op_test.go
+++ b/pkg/flash/op/op_test.go
@@ -56,3 +56,38 @@ func TestBytes(t *testing.T) {
 		}
 	}
 }
+
+func TestStatus(t *testing.T) {
+	for i, tt := range []struct {
+		name string
+		val  op.Status
+		out  string
+	}{
+		{name: "nothing", out: ""},
+		{name: "write enabled", val: op.WriteEnabled, out: "WriteEnabled"},
+		{name: "busy, write enabled", val: op.WriteBusy | op.WriteEnabled, out: "WriteBusy|WriteEnabled"},
+	} {
+		s := tt.val.String()
+		if s != tt.out {
+			t.Errorf("%d:%#x: got %s, want %s", i, tt.name, s, tt.out)
+		}
+	}
+}
+
+func TestStatusBus(t *testing.T) {
+	for i, tt := range []struct {
+		name string
+		val  op.Status
+		out  bool
+	}{
+		{name: "idle"},
+		{name: "busy", val: op.WriteBusy, out: true},
+		{name: "other than busy", val: op.WriteEnabled, out: false},
+	} {
+		busy := tt.val.Busy()
+		if busy != tt.out {
+			t.Errorf("%d:%#x: got %v, want %v", i, tt.name, busy, tt.out)
+		}
+	}
+
+}

--- a/pkg/flash/spimock/spimock_linux.go
+++ b/pkg/flash/spimock/spimock_linux.go
@@ -285,3 +285,10 @@ func (s *MockSPI) ID() (chips.ID, error) {
 	}
 	return 0xbf2541, nil
 }
+
+func (s *MockSPI) Status() (op.Status, error) {
+	if s.ForceTransferErr != nil {
+		return op.Status(0xff), s.ForceTransferErr
+	}
+	return 0, nil
+}


### PR DESCRIPTION
We now have fast SPI writing, using a block size of 256 bytes. 

No erasing yet.

This also fixes a messy bug in WriteAt where odd sized write blocks would cause it to reference past the
end of the slice.

Erasing tested, works fine.