### PR TITLE
Update README.md for Go version 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ u-root embodies four different projects.
 
 # Usage
 
-Make sure your Go version is >=1.19.
+Make sure your Go version is >=1.21.
 
 Download and install u-root either via git:
 


### PR DESCRIPTION
Fixing build error:
vendor/github.com/u-root/uio/uio/buffer.go:179:18: undefined: binary.NativeEndian note: module requires Go 1.21