### PR TITLE
pkg/dt,pkg/boot/bls: remove unused variables

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,7 +13,7 @@ linters:
 
 linters-settings:
   staticcheck:
-    checks: ["all", "-SA1019", "-SA4006"]
+    checks: ["all", "-SA1019"]
   stylecheck:
     checks: ["all", "-ST1003", "-ST1023"]
 

--- a/pkg/boot/bls/bls.go
+++ b/pkg/boot/bls/bls.go
@@ -214,7 +214,7 @@ func parseLinuxImage(vals map[string]string, fsRoot string, variables map[string
 					if value == "" {
 						// If it's not found, fallback to look for default_kernelopts
 						log.Printf("kernelopts is empty, look for default_kernelopts\n")
-						if value, err = getGrubvalue(variables, "default_kernelopts"); value == "" {
+						if value, _ = getGrubvalue(variables, "default_kernelopts"); value == "" {
 							return nil, fmt.Errorf("no valid kernelopts is found")
 						}
 					}

--- a/pkg/dt/fdt_test.go
+++ b/pkg/dt/fdt_test.go
@@ -210,8 +210,7 @@ func TestFindProperty(t *testing.T) {
 		t.Fatalf("Checking value of %s: got %q, want %q", p.Name, p.Value, v)
 	}
 	l = "bogosity"
-	p, ok = n.LookProperty(l)
-	if ok {
+	if _, ok = n.LookProperty(l); ok {
 		t.Fatalf("Find property %q in %s: got true, want false", l, n)
 	}
 }


### PR DESCRIPTION
first invocation of getGrubvalue can return an error, second only empty string