### PR TITLE
unshare: use /bin/sh instead of elvish

### DIFF
--- a/cmds/core/unshare/unshare_linux.go
+++ b/cmds/core/unshare/unshare_linux.go
@@ -57,7 +57,7 @@ func main() {
 
 	a := flag.Args()
 	if len(a) == 0 {
-		a = []string{"/ubin/elvish", "elvish"}
+		a = []string{"/bin/sh"}
 	}
 
 	c := exec.Command(a[0], a[1:]...)


### PR DESCRIPTION
Fix #962 for unshare.

console has had it fixed for years.

Closes #962.