### PR TITLE
Flag refactoring

### DIFF
--- a/cmds/core/basename/basename.go
+++ b/cmds/core/basename/basename.go
@@ -15,8 +15,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
-	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -27,7 +25,7 @@ func usage(w io.Writer) {
 	fmt.Fprintf(w, "%s", usageString)
 }
 
-func runBasename(w io.Writer, args []string) {
+func run(w io.Writer, args []string) {
 	switch len(args) {
 	case 2:
 		fileName := filepath.Base(args[0])
@@ -44,6 +42,5 @@ func runBasename(w io.Writer, args []string) {
 }
 
 func main() {
-	flag.Parse()
-	runBasename(os.Stdout, flag.Args())
+	run(os.Stdout, os.Args[1:])
 }

--- a/cmds/core/basename/basename_test.go
+++ b/cmds/core/basename/basename_test.go
@@ -15,7 +15,7 @@ type test struct {
 	out   string
 }
 
-func TestBasename(t *testing.T) {
+func TestRun(t *testing.T) {
 	tests := []test{
 		{
 			flags: []string{"foo.h", ".h"},
@@ -47,7 +47,7 @@ func TestBasename(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("Using flags %s", tt.flags), func(t *testing.T) {
 			var out bytes.Buffer
-			runBasename(&out, tt.flags)
+			run(&out, tt.flags)
 
 			if out.String() != tt.out {
 				t.Errorf("stdout got:\n%s\nwant:\n%s", out.String(), tt.out)

--- a/cmds/core/fusermount/fusermount.go
+++ b/cmds/core/fusermount/fusermount.go
@@ -26,14 +26,14 @@
 package main
 
 import (
+	"flag"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"strconv"
 	"syscall"
-
-	flag "github.com/spf13/pflag"
 
 	"golang.org/x/sys/unix"
 )
@@ -45,25 +45,18 @@ const (
 )
 
 var (
-	unmount = flag.BoolP("unmount", "u", false, "unmount")
-	lazy    = flag.BoolP("lazy", "z", false, "lazy unmount")
-	verbose = flag.BoolP("verbose", "v", false, "verbose")
-	debug   = func(string, ...interface{}) {}
-	mpt     string
+	debug = func(string, ...interface{}) {}
+	mpt   string
 )
 
-const help = "usage: fusermount [-u|--unmount] [-z|--lazy] [-v|--verbose] <mountpoint>"
+const usage = "usage: fusermount [-u|--unmount] [-z|--lazy] [-v|--verbose] <mountpoint>"
 
-func usage() {
-	log.Fatalf(help)
-}
-
-func umount(n string) error {
+func umount(n string, lazy bool) error {
 	// we're not doing all the folderol of standard
 	// fusermount for euid() == 0.
 	// Let's see how that works out.
 	flags := 0
-	if *lazy {
+	if lazy {
 		flags |= unix.MNT_DETACH
 	}
 
@@ -156,17 +149,34 @@ func returnResult(cfd, ffd int, e error) error {
 	return nil
 }
 
-func main() {
-	flag.Parse()
+func run(out io.Writer, args []string) error {
+	var unmount, lazy, verbose bool
 
-	if *verbose {
+	f := flag.NewFlagSet(args[0], flag.ContinueOnError)
+	f.BoolVar(&unmount, "unmount", false, "unmount")
+	f.BoolVar(&unmount, "u", false, "unmount (shorthand)")
+
+	f.BoolVar(&lazy, "lazy", false, "lazy unmount")
+	f.BoolVar(&lazy, "z", false, "lazy unmount (shorthand)")
+
+	f.BoolVar(&verbose, "verbose", false, "verbose")
+	f.BoolVar(&verbose, "v", false, "verbose (shorthand)")
+
+	f.Usage = func() {
+		fmt.Fprintf(f.Output(), usage+"\n")
+		f.PrintDefaults()
+	}
+
+	f.Parse(args[1:])
+
+	if verbose {
 		debug = log.Printf
 	}
 
-	if len(flag.Args()) != 1 {
-		usage()
+	if len(f.Args()) != 1 {
+		f.Usage()
 	}
-	mpt = flag.Arg(0)
+	mpt = f.Arg(0)
 	debug("mountpoint: %v", mpt)
 
 	// We let "ability to open /dev/fuse" stand in as an indicator or
@@ -180,37 +190,44 @@ func main() {
 
 	// Bad design. All they had to do was make a -z and -u and have
 	// them both mean unmount. Oh well.
-	if *lazy && !*unmount {
+	if lazy && !unmount {
 		log.Fatalf("-z can only be used with -u")
 	}
 
 	// Fuse has to be seen to be believed.
 	// The only interactive use of fusermount is to unmount
-	if *unmount {
-		if err := umount(mpt); err != nil {
-			log.Fatal(err)
+	if unmount {
+		if err := umount(mpt, lazy); err != nil {
+			return err
 		}
-		return
 	}
 
 	if err := MountPointOK(mpt); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	if err := preMount(); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	cfd, err := getCommFD()
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	if err := doMount(FuseFD); err != nil {
-		log.Fatal(err)
+		return err
 	}
 
 	if err := returnResult(cfd, FuseFD, err); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func main() {
+	if err := run(os.Stdout, os.Args); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmds/core/fusermount/fusermount_linux_test.go
+++ b/cmds/core/fusermount/fusermount_linux_test.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -43,7 +44,7 @@ func TestArgs(t *testing.T) {
 		env          []string
 		requiresRoot bool
 	}{
-		{n: "badargs", o: help + "\n", e: 1, a: []string{"-zu"}, env: []string{CommFD + "=Nan"}},
+		{n: "badargs", o: usage + "\n", e: 1, a: []string{"-zu"}, env: []string{CommFD + "=Nan"}},
 		{n: "badpath", o: fmt.Sprintf("resolved path \"%s\" and mountpoint \"%s\" are not the same\n", tdir, ldir), e: 1, a: []string{ldir}, env: []string{CommFD + "=Nan"}},
 		{n: "badcfd", o: "_FUSE_COMMFD: strconv.Atoi: parsing \"Nan\": invalid syntax\n", e: 1, a: []string{tdir}, env: []string{CommFD + "=Nan"}},
 		{n: "badsock", o: "_FUSE_COMMFD: 5: bad file descriptor\n", e: 1, a: []string{tdir}, env: []string{CommFD + "=5"}, requiresRoot: true},
@@ -75,8 +76,9 @@ func TestArgs(t *testing.T) {
 				t.Fatalf("Fusermount %v %v: want '%v', got '%v'", v.n, v.a, v.o, o)
 			}
 			out := string(o[len("2018/12/20 16:54:31 "):])
-			if out != v.o {
-				t.Fatalf("Fusermount %v %v: want '%v', got '%v'", v.n, v.a, v.o, out)
+			//if out != v.o {
+			if !strings.Contains(out, v.o) {
+				t.Fatalf("Fusermount %v %v: want at least'%v', got '%v'", v.n, v.a, v.o, out)
 			}
 		})
 	}

--- a/cmds/core/ip/ip_linux.go
+++ b/cmds/core/ip/ip_linux.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -14,12 +15,10 @@ import (
 	"os"
 	"strings"
 
-	flag "github.com/spf13/pflag"
-
 	"github.com/vishvananda/netlink"
 )
 
-var inet6 = flag.BoolP("6", "6", false, "use ipv6")
+var inet6 bool
 
 // The language implemented by the standard 'ip' is not super consistent
 // and has lots of convenience shortcuts.
@@ -247,7 +246,7 @@ func link(w io.Writer) error {
 }
 
 func routeshow(w io.Writer) error {
-	return showRoutes(w, *inet6)
+	return showRoutes(w, inet6)
 }
 
 func nodespec() string {
@@ -394,6 +393,7 @@ func run(out io.Writer) error {
 }
 
 func main() {
+	flag.BoolVar(&inet6, "6", false, "use inet6")
 	flag.Parse()
 	arg = flag.Args()
 	if err := run(os.Stdout); err != nil {

--- a/cmds/core/kexec/kexec_test.go
+++ b/cmds/core/kexec/kexec_test.go
@@ -1,0 +1,242 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"flag"
+	"reflect"
+	"testing"
+)
+
+func TestParseCmdline(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		expected options
+	}{
+		{
+			name: "Test with exec flag only",
+			args: []string{"kexec", "-e"},
+			expected: options{
+				exec: true,
+			},
+		},
+		{
+			name: "Test with short load flag",
+			args: []string{"kexec", "-l", "/path/to/kernel"},
+			expected: options{
+				load:       true,
+				kernelpath: "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test with long load flag",
+			args: []string{"kexec", "--load", "/path/to/kernel"},
+			expected: options{
+				load:       true,
+				kernelpath: "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test with multiple flags 1",
+			args: []string{"kexec", "-l", "-d", "/path/to/kernel"},
+			expected: options{
+				load:       true,
+				debug:      true,
+				kernelpath: "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test with multiple flags 2",
+			args: []string{"kexec", "-l", "-d", "-L", "/path/to/kernel"},
+			expected: options{
+				load:        true,
+				debug:       true,
+				loadSyscall: true,
+				kernelpath:  "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test unix style flags 1",
+			args: []string{"kexec", "-ld", "/path/to/kernel"},
+			expected: options{
+				load:       true,
+				debug:      true,
+				kernelpath: "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test unix style flags 2",
+			args: []string{"kexec", "-ldL", "/path/to/kernel"},
+			expected: options{
+				load:        true,
+				debug:       true,
+				loadSyscall: true,
+				kernelpath:  "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test kernel arg special case 1",
+			args: []string{"kexec", "-l", "/path/to/kernel", "-d"},
+			expected: options{
+				load:       true,
+				debug:      true,
+				kernelpath: "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test kernel arg special case 2",
+			args: []string{"kexec", "-l", "/path/to/kernel", "-d", "-L"},
+			expected: options{
+				load:        true,
+				debug:       true,
+				loadSyscall: true,
+				kernelpath:  "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test kernel arg special case 3",
+			args: []string{"kexec", "-l", "/path/to/kernel", "-d", "-c", "${CMDLINE}"},
+			expected: options{
+				load:       true,
+				debug:      true,
+				cmdline:    "${CMDLINE}",
+				kernelpath: "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test command line",
+			args: []string{"kexec", "-l", "-c", "${CMDLINE}", "/path/to/kernel"},
+			expected: options{
+				load:       true,
+				cmdline:    "${CMDLINE}",
+				kernelpath: "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test all set",
+			args: []string{"kexec", "-c", "${CMDLINE}", "-d", "--dtb", "foo", "-e", "-x", "/some/file", "-i", "/path/to/initrd", "-l", "-L", "--module", "/mod1", "--reuse-cmdline", "/path/to/kernel"},
+			expected: options{
+				cmdline:      "${CMDLINE}",
+				debug:        true,
+				dtb:          "foo",
+				exec:         true,
+				extra:        "/some/file",
+				initramfs:    "/path/to/initrd",
+				load:         true,
+				loadSyscall:  true,
+				modules:      []string{"/mod1"},
+				reuseCmdline: true,
+				kernelpath:   "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test all set special case",
+			args: []string{"kexec", "-c", "${CMDLINE}", "-d", "--dtb", "foo", "-e", "-x", "/some/file", "-i", "/path/to/initrd", "-l", "/path/to/kernel", "-L", "--module", "/mod1", "--reuse-cmdline"},
+			expected: options{
+				cmdline:      "${CMDLINE}",
+				debug:        true,
+				dtb:          "foo",
+				exec:         true,
+				extra:        "/some/file",
+				initramfs:    "/path/to/initrd",
+				load:         true,
+				loadSyscall:  true,
+				modules:      []string{"/mod1"},
+				reuseCmdline: true,
+				kernelpath:   "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test all set, multiple modules 1",
+			args: []string{"kexec", "-c", "${CMDLINE}", "-d", "--dtb", "foo", "-e", "-x", "/some/file", "-i", "/path/to/initrd", "-l", "-L", "--module", "/mod1", "--module", "/mod2", "--reuse-cmdline", "/path/to/kernel"},
+			expected: options{
+				cmdline:      "${CMDLINE}",
+				debug:        true,
+				dtb:          "foo",
+				exec:         true,
+				extra:        "/some/file",
+				initramfs:    "/path/to/initrd",
+				load:         true,
+				loadSyscall:  true,
+				modules:      []string{"/mod1", "/mod2"},
+				reuseCmdline: true,
+				kernelpath:   "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test all set, multiple modules 2",
+			args: []string{"kexec", "-c", "${CMDLINE}", "-d", "--dtb", "foo", "-e", "-x", "/some/file", "-i", "/path/to/initrd", "-l", "-L", "--module", "/mod1", "--reuse-cmdline", "--module", "/mod2", "/path/to/kernel"},
+			expected: options{
+				cmdline:      "${CMDLINE}",
+				debug:        true,
+				dtb:          "foo",
+				exec:         true,
+				extra:        "/some/file",
+				initramfs:    "/path/to/initrd",
+				load:         true,
+				loadSyscall:  true,
+				modules:      []string{"/mod1", "/mod2"},
+				reuseCmdline: true,
+				kernelpath:   "/path/to/kernel",
+			},
+		},
+		{
+			name: "Test all set unix style flags",
+			args: []string{"kexec", "-delL", "/path/to/kernel"},
+			expected: options{
+				debug:       true,
+				exec:        true,
+				load:        true,
+				loadSyscall: true,
+				kernelpath:  "/path/to/kernel",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			o := &options{}
+			f := flag.NewFlagSet("test", flag.ExitOnError)
+			o.parseCmdline(tc.args, f)
+
+			tc.expected.purgatory = "default"
+			if !reflect.DeepEqual(o, &tc.expected) {
+				t.Errorf("\nexpected: %+v\ngot:     %+v", tc.expected, o)
+			}
+		})
+	}
+}
+
+func TestHackLoadFlagValue(t *testing.T) {
+	tests := []struct {
+		input  []string
+		output []string
+	}{
+		{
+			input:  []string{"kexec", "-l", "/kernel", "-i", "/initramfs.cpio", "-c", "${CMDLINE}"},
+			output: []string{"kexec", "-l", "/kernel", "-i", "/initramfs.cpio", "-c", "${CMDLINE}"},
+		},
+		{
+			input:  []string{"kexec", "--load", "/kernel", "-i", "/initramfs.cpio", "-c", "${CMDLINE}"},
+			output: []string{"kexec", "--load", "/kernel", "-i", "/initramfs.cpio", "-c", "${CMDLINE}"},
+		},
+		{
+			input:  []string{"kexec", "-l", "-i", "/initramfs.cpio", "-c", "${CMDLINE}", "/kernel"},
+			output: []string{"kexec", "-l", setButEmpty, "-i", "/initramfs.cpio", "-c", "${CMDLINE}", "/kernel"},
+		},
+		{
+			input:  []string{"kexec", "--load", "-i", "/initramfs.cpio", "-c", "${CMDLINE}", "/kernel"},
+			output: []string{"kexec", "--load", setButEmpty, "-i", "/initramfs.cpio", "-c", "${CMDLINE}", "/kernel"},
+		},
+	}
+
+	for _, test := range tests {
+		result := hackLoadFlagValue(test.input)
+		if !reflect.DeepEqual(result, test.output) {
+			t.Errorf("\nInput:    %v\nExpected: %v\nGot:      %v", test.input, test.output, result)
+		}
+	}
+}

--- a/cmds/core/mktemp/mktemp_test.go
+++ b/cmds/core/mktemp/mktemp_test.go
@@ -6,57 +6,53 @@ package main
 
 import (
 	"bytes"
+	"flag"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	flag "github.com/spf13/pflag"
 )
 
 type test struct {
-	flags flags
-	args  []string
-	out   string
-	err   error
+	cmdline []string
+	out     string
+	err     error
 }
 
 func TestMkTemp(t *testing.T) {
 	tmpDir := os.TempDir()
 	tests := []test{
 		{
-			flags: flags{},
-			out:   tmpDir,
-			err:   nil,
+			cmdline: []string{"mktemp"},
+			out:     tmpDir,
+			err:     nil,
 		},
 		{
-			flags: flags{d: true},
-			out:   tmpDir,
-			err:   nil,
+			cmdline: []string{"mktemp", "-d"},
+			out:     tmpDir,
+			err:     nil,
 		},
 		{
-			flags: flags{},
-			args:  []string{"foofoo.XXXX"},
-			out:   filepath.Join(tmpDir, "foofoo"),
-			err:   nil,
+			cmdline: []string{"mktemp", "foofoo.XXXX"},
+			out:     filepath.Join(tmpDir, "foofoo"),
+			err:     nil,
 		},
 		{
-			flags: flags{suffix: "baz"},
-			args:  []string{"foo.XXXX"},
-			out:   filepath.Join(tmpDir, "foo.baz"),
-			err:   nil,
+			cmdline: []string{"mktemp", "--suffix", "baz", "foo.XXXX"},
+			out:     filepath.Join(tmpDir, "foo.baz"),
+			err:     nil,
 		},
 		{
-			flags: flags{u: true, q: true},
-			out:   "",
-			err:   nil,
+			cmdline: []string{"mktemp", "-u"},
+			out:     "",
+			err:     nil,
 		},
 	}
 
 	// Table-driven testing
 	for _, tt := range tests {
 		var stdout bytes.Buffer
-		cmd := command(&stdout, tt.flags, tt.args)
+		cmd := command(&stdout, tt.cmdline)
 		err := cmd.run()
 		if err != tt.err {
 			t.Errorf("expected %v, got %v", tt.err, err)

--- a/cmds/core/more/more.go
+++ b/cmds/core/more/more.go
@@ -22,12 +22,11 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
-
-	flag "github.com/spf13/pflag"
 )
 
 var lines = flag.Int("lines", 40, "screen size in number of lines")

--- a/cmds/core/ps/ps_linux.go
+++ b/cmds/core/ps/ps_linux.go
@@ -110,7 +110,7 @@ func (p *Process) readStat(s string) error {
 	p.Time = p.getTime()
 	p.Ctty = p.getCtty()
 	p.Cmd = strings.TrimSuffix(strings.TrimPrefix(p.Cmd, "("), ")")
-	if *x && p.cmdline != "" {
+	if x && p.cmdline != "" {
 		p.Cmd = p.cmdline
 	}
 
@@ -246,7 +246,7 @@ func (pT *ProcessTable) doTable(statFileNames []string) error {
 		if err != nil {
 			continue
 		}
-		if *x {
+		if x {
 			p.cmdline, err = file(filepath.Join(d, "cmdline"))
 			if err != nil {
 				continue

--- a/cmds/core/ps/ps_test.go
+++ b/cmds/core/ps/ps_test.go
@@ -52,10 +52,10 @@ func TestPs(t *testing.T) {
 			want:    []string{"PID", "TTY", "TIME", "CMD"},
 		},
 	} {
-		*all = tt.all
-		*every = tt.every
-		*x = tt.x
-		*nSidTty = tt.nSidTty
+		all = tt.all
+		every = tt.every
+		x = tt.x
+		nSidTty = tt.nSidTty
 		aux = tt.aux
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}

--- a/cmds/core/rsdp/rsdp.go
+++ b/cmds/core/rsdp/rsdp.go
@@ -25,10 +25,10 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 
-	flag "github.com/spf13/pflag"
 	"github.com/u-root/u-root/pkg/acpi"
 )
 

--- a/cmds/core/shasum/shasum.go
+++ b/cmds/core/shasum/shasum.go
@@ -8,25 +8,17 @@ import (
 	"bufio"
 	"crypto/sha1"
 	"crypto/sha256"
+	"flag"
 	"fmt"
 	"hash"
 	"io"
 	"log"
 	"os"
-
-	"github.com/spf13/pflag"
 )
 
-var (
-	algorithm = pflag.IntP("algorithm", "a", 1, "SHA algorithm, valid args are 1 and 256")
-	help      = pflag.BoolP("help", "h", false, "Show this help and exit")
-)
+var algorithm int
+
 var usage = "Usage:\nshasum -a <algorithm> <File Name>"
-
-func helpPrinter() {
-	fmt.Println(usage)
-	pflag.PrintDefaults()
-}
 
 // shaPrinter prints sha1/sha256 of given data. The
 // value of algorithm is expected to be 1 for SHA1
@@ -48,15 +40,11 @@ func shaGenerator(w io.Writer, r io.Reader, algo int) ([]byte, error) {
 }
 
 func shasum(w io.Writer, r io.Reader, args ...string) error {
-	if *help {
-		helpPrinter()
-		return nil
-	}
 	var hashbytes []byte
 	var err error
 	if len(args) == 0 {
 		buf := bufio.NewReader(r)
-		if hashbytes, err = shaGenerator(w, buf, *algorithm); err != nil {
+		if hashbytes, err = shaGenerator(w, buf, algorithm); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "%x -\n", hashbytes)
@@ -68,7 +56,7 @@ func shasum(w io.Writer, r io.Reader, args ...string) error {
 			return err
 		}
 		defer file.Close()
-		if hashbytes, err = shaGenerator(w, file, *algorithm); err != nil {
+		if hashbytes, err = shaGenerator(w, file, algorithm); err != nil {
 			return err
 		}
 		fmt.Fprintf(w, "%x %s\n", hashbytes, arg)
@@ -77,8 +65,16 @@ func shasum(w io.Writer, r io.Reader, args ...string) error {
 }
 
 func main() {
-	pflag.Parse()
-	if err := shasum(os.Stdout, os.Stdin, pflag.Args()...); err != nil {
+	flag.IntVar(&algorithm, "algorithm", 1, "SHA algorithm, valid args are 1 and 256")
+	flag.IntVar(&algorithm, "a", 1, "SHA algorithm, valid args are 1 and 256 (shorthand)")
+
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), usage+"\n")
+		flag.PrintDefaults()
+	}
+
+	flag.Parse()
+	if err := shasum(os.Stdout, os.Stdin, flag.Args()...); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmds/core/shasum/shasum_test.go
+++ b/cmds/core/shasum/shasum_test.go
@@ -36,13 +36,8 @@ func TestSHASum(t *testing.T) {
 		name      string
 		args      []string
 		algorithm int
-		help      bool
 		want      string
 	}{
-		{
-			name: "help true",
-			help: true,
-		},
 		{
 			name:      "bufIn as input with sha1 sum",
 			args:      []string{},
@@ -104,8 +99,7 @@ func TestSHASum(t *testing.T) {
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setting flags
-			*algorithm = tt.algorithm
-			*help = tt.help
+			algorithm = tt.algorithm
 			bufIn := &bytes.Buffer{}
 			if _, err := bufIn.WriteString("abcdef\n"); err != nil {
 				t.Errorf("failed to write string to bufIn: %v", err)

--- a/cmds/core/strings/strings.go
+++ b/cmds/core/strings/strings.go
@@ -23,19 +23,17 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 
-	flag "github.com/spf13/pflag"
+	"github.com/u-root/u-root/pkg/uroot/unixflag"
 )
 
 var errInvalidFormatArgument = fmt.Errorf("invalid argument to option -t")
 var errInvalidMinLength = fmt.Errorf("invalid minimum string length -n")
-
-var n = flag.Int("n", 4, "the minimum string length")
-var t = flag.String("t", "", "offset format (d/o/x)")
 
 type cmd struct {
 	stdin  io.Reader
@@ -151,8 +149,13 @@ func (c *cmd) stringsFile(file string, w io.Writer) error {
 }
 
 func main() {
-	flag.Parse()
-	if err := command(os.Stdin, os.Stdout, params{n: *n, t: *t}, flag.Args()).run(); err != nil {
+	var n int
+	var t string
+	f := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	f.IntVar(&n, "n", 4, "the minimum string length")
+	f.StringVar(&t, "t", "", "write each string preceded by its byte offset from the start of the file (d decimal, o octal, x hexadecimal)")
+	f.Parse(unixflag.OSArgsToGoArgs())
+	if err := command(os.Stdin, os.Stdout, params{n: n, t: t}, flag.Args()).run(); err != nil {
 		log.Fatalf("strings: %v", err)
 	}
 }

--- a/cmds/core/tar/tar.go
+++ b/cmds/core/tar/tar.go
@@ -28,12 +28,13 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"log"
 	"os"
 
-	flag "github.com/spf13/pflag"
 	"github.com/u-root/u-root/pkg/tarutil"
+	"github.com/u-root/u-root/pkg/uroot/unixflag"
 )
 
 type cmd struct {
@@ -130,17 +131,37 @@ func (c *cmd) run() error {
 }
 
 func main() {
-	create := flag.BoolP("create", "c", false, "create a new tar archive from the given directory")
-	extract := flag.BoolP("extract", "x", false, "extract a tar archive from the given directory")
-	file := flag.StringP("file", "f", "", "tar file")
-	list := flag.BoolP("list", "t", false, "list the contents of an archive")
-	noRecursion := flag.Bool("no-recursion", false, "do not automatically recurse into directories")
-	verbose := flag.BoolP("verbose", "v", false, "print each filename")
+	var (
+		create      bool
+		extract     bool
+		file        string
+		list        bool
+		noRecursion bool
+		verbose     bool
+	)
+	f := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 
-	flag.Parse()
-	cmd, err := command(params{file: *file, create: *create, extract: *extract, list: *list, noRecursion: *noRecursion, verbose: *verbose}, flag.Args())
+	f.BoolVar(&create, "create", false, "create a new tar archive from the given directory")
+	f.BoolVar(&create, "c", false, "create a new tar archive from the given directory (shorthand)")
+
+	f.BoolVar(&extract, "extract", false, "extract a tar archive from the given directory")
+	f.BoolVar(&extract, "x", false, "extract a tar archive from the given directory (shorthand)")
+
+	f.StringVar(&file, "file", "", "tar file")
+	f.StringVar(&file, "f", "", "tar file (shorthand)")
+
+	f.BoolVar(&list, "list", false, "list the contents of an archive")
+	f.BoolVar(&list, "t", false, "list the contents of an archive (shorthand)")
+
+	f.BoolVar(&noRecursion, "no-recursion", false, "do not automatically recurse into directories")
+
+	f.BoolVar(&verbose, "verbose", false, "print each filename")
+	f.BoolVar(&verbose, "v", false, "print each filename (shorthand)")
+
+	f.Parse(unixflag.OSArgsToGoArgs())
+	cmd, err := command(params{file: file, create: create, extract: extract, list: list, noRecursion: noRecursion, verbose: verbose}, flag.Args())
 	if err != nil {
-		flag.Usage()
+		f.Usage()
 		log.Fatal(err)
 	}
 	if err := cmd.run(); err != nil {

--- a/cmds/core/tr/tr.go
+++ b/cmds/core/tr/tr.go
@@ -36,16 +36,15 @@ package main
 
 import (
 	"bufio"
+	"flag"
 	"fmt"
 	"io"
 	"log"
 	"os"
 	"unicode"
-
-	flag "github.com/spf13/pflag"
 )
 
-var del = flag.BoolP("delete", "d", false, "delete characters in SET1, do not translate")
+var del bool
 
 type cmd struct {
 	stdin  io.Reader
@@ -279,8 +278,12 @@ func unescape(s Set) ([]rune, error) {
 }
 
 func main() {
+	flag.BoolVar(&del, "delete", false, "delete characters in SET1, do not translate")
+	flag.BoolVar(&del, "d", false, "delete characters in SET1, do not translate (shorthand)")
+
 	flag.Parse()
-	cmd, err := command(os.Stdin, os.Stdout, flag.Args(), *del)
+
+	cmd, err := command(os.Stdin, os.Stdout, flag.Args(), del)
 	if err != nil {
 		log.Fatalf("%s: %v\n", name, err)
 	}

--- a/cmds/core/ts/ts.go
+++ b/cmds/core/ts/ts.go
@@ -10,20 +10,33 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"io"
 	"log"
 	"os"
 
-	flag "github.com/spf13/pflag"
 	"github.com/u-root/u-root/pkg/ts"
+	"github.com/u-root/u-root/pkg/uroot/unixflag"
 )
 
-var (
-	first    = flag.Bool("f", false, "All timestamps are relative to the first character")
-	relative = flag.Bool("R", false, "Timestamps are relative to the previous timestamp")
-)
+func run(stdin io.Reader, stdout io.Writer, args []string) error {
+	var first, relative bool
+	f := flag.NewFlagSet(args[0], flag.ExitOnError)
+	f.BoolVar(&first, "f", false, "All timestamps are relative to the first character")
+	f.BoolVar(&relative, "R", false, "Timestamps are relative to the previous timestamp")
 
-func run(stdin io.Reader, stdout io.Writer, first, relative bool) error {
+	f.Usage = func() {
+		fmt.Printf("Usage: ts [options]\n")
+		f.PrintDefaults()
+	}
+
+	f.Parse(unixflag.ArgsToGoArgs(args[1:]))
+	if f.NArg() != 0 {
+		f.Usage()
+		return fmt.Errorf("invalid use")
+	}
+
 	t := ts.New(stdin)
 	t.ResetTimeOnNextRead = first
 	if relative {
@@ -35,12 +48,7 @@ func run(stdin io.Reader, stdout io.Writer, first, relative bool) error {
 }
 
 func main() {
-	flag.Parse()
-	if flag.NArg() != 0 {
-		log.Fatal("Usage: ts")
-	}
-
-	if err := run(os.Stdin, os.Stdout, *first, *relative); err != nil {
+	if err := run(os.Stdin, os.Stdout, os.Args); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmds/core/ts/ts_test.go
+++ b/cmds/core/ts/ts_test.go
@@ -15,7 +15,7 @@ func TestTS(t *testing.T) {
 	stdin := strings.NewReader("hello\nworld\n")
 	stdout := &bytes.Buffer{}
 
-	err := run(stdin, stdout, true, true)
+	err := run(stdin, stdout, []string{"ts", "-R", "-f"})
 	if err != nil {
 		t.Error(err)
 	}
@@ -33,5 +33,15 @@ func TestTS(t *testing.T) {
 	m, err = regexp.MatchString(ts+" world$", l2)
 	if !m || err != nil {
 		t.Errorf("expected timestamped line, got %q", l2)
+	}
+}
+
+func TestInvalidUse(t *testing.T) {
+	stdin := strings.NewReader("")
+	stdout := &bytes.Buffer{}
+
+	err := run(stdin, stdout, []string{"ts", "foo"})
+	if err == nil {
+		t.Error("expected error, got nil")
 	}
 }

--- a/cmds/core/watchdogd/watchdogd_linux.go
+++ b/cmds/core/watchdogd/watchdogd_linux.go
@@ -28,13 +28,13 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"os"
 	"strings"
 	"time"
 
-	flag "github.com/spf13/pflag"
 	"github.com/u-root/u-root/pkg/watchdog"
 	"github.com/u-root/u-root/pkg/watchdogd"
 )
@@ -63,7 +63,7 @@ func runCommand() error {
 
 	switch cmd {
 	case "run":
-		fs := flag.NewFlagSet("watchdogd run", flag.PanicOnError)
+		fs := flag.NewFlagSet("run", flag.PanicOnError)
 		var (
 			dev        = fs.String("dev", watchdog.Dev, "device")
 			timeout    = fs.Duration("timeout", -1, "duration before timing out")

--- a/cmds/exp/dmidecode/dmidecode.go
+++ b/cmds/exp/dmidecode/dmidecode.go
@@ -5,21 +5,21 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 
-	flag "github.com/spf13/pflag"
-
 	"github.com/u-root/u-root/pkg/smbios"
+	"github.com/u-root/u-root/pkg/uroot/unixflag"
 )
 
 var (
-	flagDumpBin  = flag.String("dump-bin", "", `Do not decode the entries, instead dump the DMI data to a file in binary form. The generated file is suitable to pass to --from-dump later.`)
-	flagFromDump = flag.String("from-dump", "", `Read the DMI data from a binary file previously generated using --dump-bin.`)
-	flagType     = flag.StringSliceP("type", "t", nil, `Only  display  the  entries of type TYPE. TYPE can be either a DMI type number, or a comma-separated list of type numbers, or a keyword from the following list: bios, system, baseboard, chassis, processor, memory, cache, connector, slot. If this option is used more than once, the set of displayed entries will be the union of all the given types. If TYPE is not provided or not valid, a list of all valid keywords is printed and dmidecode exits with an error.`)
+	flagDumpBin  string
+	flagFromDump string
+	flagType     []string
 	// NB: When adding flags, update resetFlags in dmidecode_test.
 )
 
@@ -96,17 +96,17 @@ func dumpBin(textOut io.Writer, entryData, tableData []byte, fileName string) *d
 }
 
 func dmiDecode(textOut io.Writer) *dmiDecodeError {
-	typeFilter, err := parseTypeFilter(*flagType)
+	typeFilter, err := parseTypeFilter(flagType)
 	if err != nil {
 		return &dmiDecodeError{code: 2, error: fmt.Errorf("invalid --type: %v", err)}
 	}
 	fmt.Fprintf(textOut, "# dmidecode-go\n") // TODO: version.
-	entryData, tableData, err := getData(textOut, *flagFromDump, "/sys/firmware/dmi/tables")
+	entryData, tableData, err := getData(textOut, flagFromDump, "/sys/firmware/dmi/tables")
 	if err != nil {
 		return &dmiDecodeError{code: 1, error: fmt.Errorf("error parsing loading data: %v", err)}
 	}
-	if *flagDumpBin != "" {
-		return dumpBin(textOut, entryData, tableData, *flagDumpBin)
+	if flagDumpBin != "" {
+		return dumpBin(textOut, entryData, tableData, flagDumpBin)
 	}
 	si, err := smbios.ParseInfo(entryData, tableData)
 	if err != nil {
@@ -136,6 +136,14 @@ func dmiDecode(textOut io.Writer) *dmiDecodeError {
 		fmt.Fprintf(textOut, "%s\n\n", pt)
 	}
 	return nil
+}
+
+func init() {
+	flag.StringVar(&flagDumpBin, "dump-bin", "", `Do not decode the entries, instead dump the DMI data to a file in binary form. The generated file is suitable to pass to --from-dump later.`)
+	flag.StringVar(&flagFromDump, "from-dump", "", `Read the DMI data from a binary file previously generated using --dump-bin.`)
+
+	flag.Var((*unixflag.StringSlice)(&flagType), "type", `Only  display  the  entries of type TYPE. TYPE can be either a DMI type number, or a comma-separated list of type numbers, or a keyword from the following list: bios, system, baseboard, chassis, processor, memory, cache, connector, slot. If this option is used more than once, the set of displayed entries will be the union of all the given types. If TYPE is not provided or not valid, a list of all valid keywords is printed and dmidecode exits with an error.`)
+	flag.Var((*unixflag.StringSlice)(&flagType), "t", `Only  display  the  entries of type TYPE. TYPE can be either a DMI type number, or a comma-separated list of type numbers, or a keyword from the following list: bios, system, baseboard, chassis, processor, memory, cache, connector, slot. If this option is used more than once, the set of displayed entries will be the union of all the given types. If TYPE is not provided or not valid, a list of all valid keywords is printed and dmidecode exits with an error (shorthand).`)
 }
 
 func main() {

--- a/cmds/exp/dmidecode/dmidecode_test.go
+++ b/cmds/exp/dmidecode/dmidecode_test.go
@@ -7,14 +7,13 @@ package main
 import (
 	"bytes"
 	"encoding/hex"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-
-	flag "github.com/spf13/pflag"
 )
 
 const (
@@ -22,8 +21,8 @@ const (
 )
 
 func resetFlags() {
-	*flagFromDump = ""
-	*flagType = nil
+	flagFromDump = ""
+	flagType = nil
 }
 
 func testOutput(t *testing.T, dumpFile string, args []string, expectedOutFile string) {

--- a/cmds/exp/esxiboot/esxiboot_test.go
+++ b/cmds/exp/esxiboot/esxiboot_test.go
@@ -1,0 +1,65 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommand(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantCmd *cmd
+	}{
+		{
+			name: "Test with config flag",
+			args: []string{"esxiboot", "--config", "/path/to/config"},
+			wantCmd: &cmd{
+				cfg: "/path/to/config",
+			},
+		},
+		{
+			name: "Test with cdrom flag",
+			args: []string{"esxiboot", "--cdrom", "/dev/cdrom"},
+			wantCmd: &cmd{
+				cdrom: "/dev/cdrom",
+			},
+		},
+		{
+			name: "Test with device flag",
+			args: []string{"esxiboot", "--device", "/dev/sda"},
+			wantCmd: &cmd{
+				diskDev: "/dev/sda",
+			},
+		},
+		{
+			name: "Test with append flag",
+			args: []string{"esxiboot", "--device", "/dev/sda", "--append", "quiet splash"},
+			wantCmd: &cmd{
+				diskDev:       "/dev/sda",
+				appendCmdline: []string{"quiet splash"},
+			},
+		},
+		{
+			name: "Test with dry-run flag",
+			args: []string{"esxiboot", "--device", "/dev/sda", "--dry-run"},
+			wantCmd: &cmd{
+				diskDev: "/dev/sda",
+				dryRun:  true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd := command(tt.args)
+			if !reflect.DeepEqual(gotCmd, tt.wantCmd) {
+				t.Errorf("got: %+v, want: %+v", gotCmd, tt.wantCmd)
+			}
+		})
+	}
+}

--- a/cmds/exp/newsshd/newsshd_test.go
+++ b/cmds/exp/newsshd/newsshd_test.go
@@ -1,0 +1,55 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommand(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		expectedCmd *cmd
+	}{
+		{
+			name: "Default values",
+			args: []string{"newsshd"},
+			expectedCmd: &cmd{
+				hostKeyFile: "/etc/ssh_host_rsa_key",
+				pubKeyFile:  "key.pub",
+				port:        "2222",
+			},
+		},
+		{
+			name: "Custom hostkeyfile and pubkeyfile",
+			args: []string{"newsshd", "--hostkeyfile", "/custom/host_key", "--pubkeyfile", "custom_key.pub"},
+			expectedCmd: &cmd{
+				hostKeyFile: "/custom/host_key",
+				pubKeyFile:  "custom_key.pub",
+				port:        "2222",
+			},
+		},
+		{
+			name: "Shorthand flags",
+			args: []string{"newsshd", "-h", "/shorthand/host_key", "-k", "shorthand_key.pub", "-p", "2022"},
+			expectedCmd: &cmd{
+				hostKeyFile: "/shorthand/host_key",
+				pubKeyFile:  "shorthand_key.pub",
+				port:        "2022",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotCmd := command(tt.args)
+			if !reflect.DeepEqual(gotCmd, tt.expectedCmd) {
+				t.Errorf("%s: command() = %+v, want %+v", tt.name, gotCmd, tt.expectedCmd)
+			}
+		})
+	}
+}

--- a/cmds/exp/pox/pox_test.go
+++ b/cmds/exp/pox/pox_test.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -32,11 +33,39 @@ func TestExtraMounts(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			*extra = tt.extra
-			if got := extraMounts(tt.extra); got != nil {
+			c := cmd{
+				debug: func(s string, i ...interface{}) {},
+				extra: tt.extra,
+			}
+			if got := c.extraMounts(tt.extra); got != nil {
 				if !strings.Contains(got.Error(), tt.wantErr) {
 					t.Errorf("extraMounts() = %q, want: %q", got.Error(), tt.wantErr)
 				}
+			}
+		})
+	}
+}
+
+func TestFlags(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		cmdline string
+		want    cmd
+	}{
+		{
+			name:    "Default flags",
+			cmdline: "pox",
+			want: cmd{
+				file: "/tmp/pox.tcz",
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := command(strings.Split(tt.cmdline, " "))
+			got.debug, tt.want.debug = nil, nil
+
+			if !reflect.DeepEqual(got, &tt.want) {
+				t.Errorf("\ngot: %+v\nwant: %+v", got, tt.want)
 			}
 		})
 	}

--- a/cmds/exp/pox/pox_vm_test.go
+++ b/cmds/exp/pox/pox_vm_test.go
@@ -76,17 +76,21 @@ func TestPox(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			*verbose = tt.verbose
-			*run = tt.run
-			*create = tt.create
-			*file = tt.file
-			*extra = tt.extra
+			c := cmd{
+				debug:   func(s string, i ...interface{}) {},
+				verbose: tt.verbose,
+				run:     tt.run,
+				create:  tt.create,
+				file:    tt.file,
+				extra:   tt.extra,
+				args:    tt.args,
+			}
 			if tt.name == "err in extraMounts(os.Getenv('POX_EXTRA'))" {
 				os.Setenv("POX_EXTRA", "::")
 			}
-			if got := pox(tt.args...); got != nil {
+			if got := c.start(); got != nil {
 				if !strings.Contains(got.Error(), tt.wantErr) {
-					t.Errorf("pox() = %q, want: %q", got.Error(), tt.wantErr)
+					t.Errorf("cmd.start() = %q, want: %q", got.Error(), tt.wantErr)
 				}
 			}
 		})
@@ -154,10 +158,14 @@ func TestPoxCreate(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			*zip = tt.zip
-			*self = tt.self
-			*file = tt.file
-			if got := poxCreate(tt.args...); got != nil {
+			c := cmd{
+				debug: func(s string, i ...interface{}) {},
+				zip:   tt.zip,
+				self:  tt.self,
+				file:  tt.file,
+				args:  tt.args,
+			}
+			if got := c.poxCreate(); got != nil {
 				if !strings.Contains(got.Error(), tt.wantErr) {
 					t.Errorf("poxCreate() = %q, want: %q", got.Error(), tt.wantErr)
 				}
@@ -200,9 +208,13 @@ func TestPoxRun(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			*zip = tt.zip
-			*file = tt.file
-			if got := poxRun(tt.args...); got != nil {
+			c := cmd{
+				debug: func(s string, i ...interface{}) {},
+				zip:   tt.zip,
+				file:  tt.file,
+				args:  tt.args,
+			}
+			if got := c.poxRun(); got != nil {
 				if !strings.Contains(got.Error(), tt.wantErr) {
 					t.Errorf("poxRun() = %q, want: %q", got.Error(), tt.wantErr)
 				}

--- a/pkg/uroot/unixflag/unixflag.go
+++ b/pkg/uroot/unixflag/unixflag.go
@@ -41,3 +41,39 @@ func ArgsToGoArgs(args []string) []string {
 func OSArgsToGoArgs() []string {
 	return ArgsToGoArgs(os.Args[1:])
 }
+
+// StringArray implements flag.Value that appends multiple invocations of the
+// flag to a slice of strings. The value of each argument will not try to be
+// separated by comma. Use a StringSlice for that.
+// For example: `--flag foo --flag bar` will result in `[]string{"foo", "bar"}`.
+type StringArray []string
+
+// Set implements flag.Value.Set.
+func (s *StringArray) Set(value string) error {
+	*s = append(*s, value)
+	return nil
+}
+
+// String implements flag.Value.String.
+func (s StringArray) String() string {
+	return strings.Join(s, ",")
+}
+
+// StringSlice implements flag.Value that appends multiple invocations of the
+// flag to a slice of strings. Compared to StringArray flags, StringSlice flags
+// take comma-separated value as arguments and split them accordingly.
+// For example: `--flag=foo,bar --flag=baz` will result in `[]string{"foo", "bar", "baz"}`.
+type StringSlice []string
+
+// Set implements flag.Value.Set.
+func (s *StringSlice) Set(value string) error {
+	for _, v := range strings.Split(value, ",") {
+		*s = append(*s, v)
+	}
+	return nil
+}
+
+// String implements flag.Value.String.
+func (s StringSlice) String() string {
+	return strings.Join(s, ",")
+}

--- a/pkg/uroot/unixflag/unixflag_test.go
+++ b/pkg/uroot/unixflag/unixflag_test.go
@@ -46,3 +46,35 @@ func TestOSArgsToGoArgs(t *testing.T) {
 		t.Fatalf("%v:got %v, want %v", os.Args, out, xargs)
 	}
 }
+
+func TestStringArray(t *testing.T) {
+	var s unixflag.StringArray
+	if err := s.Set("foo"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set("bar"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(s), 2; got != want {
+		t.Fatalf("got slice of length %d, want %d", got, want)
+	}
+	if got, want := s.String(), "foo,bar"; got != want {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}
+
+func TestStringSlice(t *testing.T) {
+	var s unixflag.StringSlice
+	if err := s.Set("foo,bar"); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.Set("baz"); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := len(s), 3; got != want {
+		t.Fatalf("got slice of length %d, want %d", got, want)
+	}
+	if got, want := s.String(), "foo,bar,baz"; got != want {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
This PR eliminates the use of the pflag package in favor of using the standard flag package. 
As of now, this is only changed for commands in `cmds/core` and `cmds/exp`. 

Checking sizes of dependencies [1] indicates that pflag is extraordinary huge compared to flag.
```
...
2.9 MB mvdan.cc/sh/v3/syntax
2.8 MB github.com/spf13/pflag
2.6 MB reflect
...
560 kB mvdan.cc/sh/v3/expand
559 kB flag
551 kB encoding/asn1
...
```

Most of the commands use flag anyway, and only a couple use pflag. And most of these only do very basic flag parsing. 
The major difference between flag and pflag is pflag ability to interpret multiple combined shorthand flags like `ls -la` for `ls -l -a`

This is at the same time the only shortcomming, but this appiles only to very few commands in my opinion (ls, cp, ...). 
One could think of achieving this functionality with a bit extra work on parsing. 

| File Path           | Removed pflag |  no global flag parsing | Comment |
|---------------------|----------|----------|---|
| ./cmds/core/basename  | [x]      | [x]      |   |
| ./cmds/core/cp        | [x]      | [x]      | uses #3009 for multiple combined shorthand flags |
| ./cmds/core/dmesg     | [x]      | [x]      |   |
| ./cmds/core/fusermount| [x]      | [x]      |   |
| ./cmds/core/grep      | [x]      | [x]      |  uses #3009 for multiple combined shorthand flags |
| ./cmds/core/ip        | [x]      | [ ]      |   |
| ./cmds/core/kexec     | [x]      | [x]      | got support for returning flag / uses #3009 for multiple combined shorthand flags / got special handling for kernel-path arg |
| ~./cmds/core/ls~        | -      | -     |  done in #3009  |
| ./cmds/core/mktemp    | [x]      | [ ]      | uses #3009 for multiple combined shorthand flags  |
| ./cmds/core/more      | [x]      | [ ]      |   |
| ./cmds/core/netstat   | [x]      | [x]      |  uses #3009 for multiple combined shorthand flags |
| ./cmds/core/ps        | [x]      | [ ]      | uses #3009 for multiple combined shorthand flags |
| ./cmds/core/rsdp      | [x]      | [ ]      |   |
| ./cmds/core/shasum    | [x]      | [ ]      |   |
| ./cmds/core/strings   | [x]      | [ ]      |  uses #3009 for multiple combined shorthand flags |
| ./cmds/core/tar       | [x]      | [ ]      | uses #3009 for multiple combined shorthand flags   |
| ./cmds/core/tee       | [x]      | [ ]      | uses #3009 for multiple combined shorthand flags  |
| ./cmds/core/tr        | [x]      | [ ]      |   |
| ./cmds/core/ts        | [x]      | [x]      | uses #3009 for multiple combined shorthand flags   |
| ./cmds/core/watchdog  | [x]      | [x]      |   |
| ./cmds/core/watchdogd | [x]      | [ ]      |   |
| ./cmds/exp/dmidecode  | [x]      | [ ]      | got support for returning flag  |
| ./cmds/exp/esxiboot   | [x]      | [ ]      |  got support for returning flag / uses #3009 for multiple combined shorthand flags |
| ./cmds/exp/newsshd    | [x]      | [ ]      |  uses #3009 for multiple combined shorthand flags  |
| ./cmds/exp/pox        | [x]      | [x]      |  uses #3009 for multiple combined shorthand flags |

[1] Size analysis:
go version go1.22.1 linux/amd64
goweight, commit 624b44a (https://github.com/jondot/goweight)
makebb (gobusybox), commit d8fbaca

1) Run `makebb -k ./cmds/core/* ./cmds/exp/*`  with the cmds adapted to your needs
2) Note <temp dir> from output
4) Run `GOPATH=<temp dir> GO111MODULE=off goweight <temp dir>/src/bb.u-root.com/bb/main.goz`
// Setting of GOPATH and GO111MOD is due to the way gobusibox works and not related to how goweight works. goweight works when go build works.
