### PR TITLE
uroot/util: add unixflag processing

### DIFF
--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -10,14 +10,14 @@
 //
 // Options:
 //
-//	-a[ll]: show hidden files
-//	-h[uman-readable]: show human-readable sizes
-//	-d[irectory]: show directories but not their contents
-//	-F|classify: append indicator (, one of */=>@|) to entries
-//	-l[ong]: long form
-//	-Q|quote-name: quoted
-//	-R|recursive: equivalent to findutil's find
-//	-s[ize]: sort by size
+//	-a: show hidden files
+//	-h: show human-readable sizes
+//	-d: show directories but not their contents
+//	-F: append indicator (, one of */=>@|) to entries
+//	-l: long form
+//	-Q: quoted
+//	-R: equivalent to findutil's find
+//	-s: sort by size
 //
 // Bugs:
 //
@@ -26,6 +26,7 @@ package main
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log"
@@ -34,8 +35,8 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	flag "github.com/spf13/pflag"
 	"github.com/u-root/u-root/pkg/ls"
+	"github.com/u-root/u-root/pkg/uroot/unixflag"
 )
 
 type cmd struct {
@@ -204,19 +205,25 @@ func (c cmd) list(names []string) error {
 	return nil
 }
 
-func main() {
+// run runs a command. args are as from os.Args, i.e., args[0] is the command name.
+func run(w io.Writer, args []string) error {
 	var c cmd
-	flag.BoolVarP(&c.all, "all", "a", false, "show hidden files")
-	flag.BoolVarP(&c.human, "human-readable", "h", false, "human readable sizes")
-	flag.BoolVarP(&c.directory, "directory", "d", false, "list directories but not their contents")
-	flag.BoolVarP(&c.long, "long", "l", false, "long form")
-	flag.BoolVarP(&c.quoted, "quote-name", "Q", false, "quoted")
-	flag.BoolVarP(&c.recurse, "recursive", "R", false, "equivalent to findutil's find")
-	flag.BoolVarP(&c.classify, "classify", "F", false, "append indicator (, one of */=>@|) to entries")
-	flag.BoolVarP(&c.size, "size", "S", false, "sort by size")
-	c.w = os.Stdout
-	flag.Parse()
-	if err := c.list(flag.Args()); err != nil {
+	f := flag.NewFlagSet(args[0], flag.ExitOnError)
+	f.BoolVar(&c.all, "a", false, "show hidden files")
+	f.BoolVar(&c.human, "h", false, "human readable sizes")
+	f.BoolVar(&c.directory, "d", false, "list directories but not their contents")
+	f.BoolVar(&c.long, "l", false, "long form")
+	f.BoolVar(&c.quoted, "Q", false, "quoted")
+	f.BoolVar(&c.recurse, "R", false, "equivalent to findutil's find")
+	f.BoolVar(&c.classify, "F", false, "append indicator (, one of */=>@|) to entries")
+	f.BoolVar(&c.size, "S", false, "sort by size")
+	c.w = w
+	f.Parse(unixflag.ArgsToGoArgs(args[1:]))
+	return c.list(flag.Args())
+}
+
+func main() {
+	if err := run(os.Stdout, os.Args); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/cmds/core/ls/ls_plan9.go
+++ b/cmds/core/ls/ls_plan9.go
@@ -8,14 +8,14 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"strings"
 
-	flag "github.com/spf13/pflag"
 	"github.com/u-root/u-root/pkg/ls"
 )
 
-var final = flag.BoolP("print-last", "p", false, "Print only the final path element of each file name")
+var final = flag.Bool("p", false, "Print only the final path element of each file name")
 
 func (c cmd) printFile(stringer ls.Stringer, f file) {
 	if f.err != nil {

--- a/cmds/core/ls/ls_test.go
+++ b/cmds/core/ls/ls_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -123,34 +124,27 @@ func TestListName(t *testing.T) {
 }
 
 // Test list func
-func TestList(t *testing.T) {
+func TestRun(t *testing.T) {
 	// Creating test table
 	for _, tt := range []struct {
 		name   string
-		input  []string
+		args   []string
 		err    error
-		flag   cmd
 		prefix bool
 	}{
 		{
-			name:  "input empty, quoted = true, long = true",
-			input: []string{},
-			err:   nil,
-			flag: cmd{
-				quoted: true,
-				long:   true,
-			},
+			name: "input empty, quoted = true, long = true",
+			args: []string{"ls", "-Ql"},
+			err:  nil,
 		},
 		{
-			name:  "input empty, quoted = true, long = true",
-			input: []string{"dir"},
-			err:   os.ErrNotExist,
+			name: "input empty, quoted = true, long = true",
+			args: []string{"ls", "-Ql", "dir"},
+			err:  os.ErrNotExist,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			tt.flag.w = &buf
-			if err := tt.flag.list(tt.input); err != nil {
+			if err := run(io.Discard, tt.args); err != nil {
 				if !errors.Is(err, tt.err) {
 					t.Errorf("list() = '%v', want: '%v'", err, tt.err)
 				}

--- a/pkg/uroot/unixflag/unixflag.go
+++ b/pkg/uroot/unixflag/unixflag.go
@@ -1,0 +1,43 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package unixflag
+
+import (
+	"os"
+	"strings"
+)
+
+// ArgsToGoArgs converts a Unix-style argument list such that:
+// all -- switches before the first non-switch argument are converted to - switches
+// all - switches are split into a set of single switches with a -
+// first non- args stops the process.
+// so, e.g., ps -aux turns into ps -a -u -x
+// ls -al --somelongthing becomes ls -a -l -somelongthing
+func ArgsToGoArgs(args []string) []string {
+	var out []string
+	for i, f := range args {
+		if strings.HasPrefix(f, "--") {
+			out = append(out, f[1:])
+			continue
+		}
+		if strings.HasPrefix(f, "-") {
+			fs := strings.Split(f[1:], "")
+			for _, ff := range fs {
+				out = append(out, "-"+ff)
+			}
+			continue
+		}
+		out = append(out, args[i:]...)
+		break
+	}
+	return out
+}
+
+// OSArgsToGoArgs converts os.Args to Unix-style args.
+// The first argument, i.e. the executable name, is removed.
+// ArgsToGoArgs is called with the rest of the args
+func OSArgsToGoArgs() []string {
+	return ArgsToGoArgs(os.Args[1:])
+}

--- a/pkg/uroot/unixflag/unixflag_test.go
+++ b/pkg/uroot/unixflag/unixflag_test.go
@@ -1,0 +1,48 @@
+// Copyright 2014-2017 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package unixflag_test
+
+import (
+	"os"
+	"slices"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/uroot/unixflag"
+)
+
+func TestArgsToGoArgs(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		args []string
+		out  []string
+	}{
+		{name: "no args", args: []string{}, out: []string{}},
+		{name: "-l", args: []string{"-l"}, out: []string{"-l"}},
+		{name: "-l etc", args: []string{"-l", "etc"}, out: []string{"-l", "etc"}},
+		{name: "-long etc", args: []string{"-long", "etc"}, out: []string{"-l", "-o", "-n", "-g", "etc"}},
+		{name: "-long --short etc", args: []string{"-long", "--short", "etc"}, out: []string{"-l", "-o", "-n", "-g", "-short", "etc"}},
+		{name: "-long --short etc -long ", args: []string{"-long", "--short", "etc", "-long"}, out: []string{"-l", "-o", "-n", "-g", "-short", "etc", "-long"}},
+		{name: "-aux", args: []string{"-aux"}, out: []string{"-a", "-u", "-x"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			out := unixflag.ArgsToGoArgs(tt.args)
+			if !slices.Equal(out, tt.out) {
+				t.Fatalf("%v: got %v, want %v", tt.args, out, tt.out)
+			}
+		})
+	}
+
+}
+
+func TestOSArgsToGoArgs(t *testing.T) {
+	// because this test has to set os.Args, it is racy, so either only
+	// do one case or don't run the tests concurrently.
+	os.Args = []string{"sh", "-xe", "--baz", "ls", "-l", "--foo"}
+	out := unixflag.OSArgsToGoArgs()
+	xargs := []string{"-x", "-e", "-baz", "ls", "-l", "--foo"}
+	if !slices.Equal(out, xargs) {
+		t.Fatalf("%v:got %v, want %v", os.Args, out, xargs)
+	}
+}


### PR DESCRIPTION
    Go flag processing has followed the Plan 9 model from the beginning,
    where -name is a switch for name, whereas in Unix, it means
    -n -a -m -e.

    This is fine for new programs, but a problem for old programs, like ls, where people
    expect Unix rules to apply.

    Since 2013 or so, u-root dealt with this by importing a variety of flag packages.
    They all come with their own problems, including binary size.

    We must have a way to optionally use Unix rules where they are expected. This is
    essential, due to the large number of scripts in existence.

    Add a function to uroot/util, ArgsToGoArgs, which will take a []string, and change:
    --arg is translated to -arg
    -arg is tranlated to -a -r -g
    The first non-dash argument ends processing.

    Add a function, OSArgsToGoArgs, which call ArgsToGoArgs with os.Args[1:]

    To use it with the flag CommandLine (discouraged)
    go.Commandline.Parse(OSArgsToGoArgs())

    To use it with your own flagset, (recommended)
    f := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
    f.IntVar(...)
    etc.

    f.Parse(OSArgsToGoArgs())

    This PR includes a modification to ls, in which spf13 is removed, NewFlagSet is used to avoid the
    globals in the flag package, and commands like
    ls -al
    now work.