### PR TITLE
cmds/core/ls: Fix flag parsing

### DIFF
--- a/cmds/core/ls/ls.go
+++ b/cmds/core/ls/ls.go
@@ -219,7 +219,7 @@ func run(w io.Writer, args []string) error {
 	f.BoolVar(&c.size, "S", false, "sort by size")
 	c.w = w
 	f.Parse(unixflag.ArgsToGoArgs(args[1:]))
-	return c.list(flag.Args())
+	return c.list(f.Args())
 }
 
 func main() {


### PR DESCRIPTION
Currently the ls command does nothing except printing out the current directory, because it ignores all arguments.

Fix it by supplying the actual arguments.

Fixes #3019