### PR TITLE
exp/pox: add the binary in since ldd.List no longer does

### DIFF
--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -157,6 +157,9 @@ func poxCreate(bin ...string) error {
 		}
 		return fmt.Errorf("running ldd on %v: %v %s", bin, err, stderr)
 	}
+	// At some point the ldd API changed and it no longer includes the
+	// bins.
+	names = append(names, bin...)
 
 	sort.Strings(names)
 	// Now we need to make a template file hierarchy and put


### PR DESCRIPTION
At some point the API changed and it broke pox.

There was never a test for this b/c it's just about impossible to write a long-lived test for pox, it is incredibly system-dependent. Oh well.