### PR TITLE
pox: get standalone mode working again

### DIFF
--- a/cmds/exp/pox/pox.go
+++ b/cmds/exp/pox/pox.go
@@ -288,6 +288,14 @@ func (c cmd) poxRun() error {
 	// So the args to exec.Command should just be c.args...
 	ec := exec.Command(c.pathInRoot, c.args[1:]...)
 	v("cmd q args %q", c.args)
+	// Go does the chroot first, then the chdir.
+	// So set dir to /
+	// If that is not done, pwd won't work at all, since
+	// Dir will not be set and the process cwd will be outside
+	// the chroot. We ran for years with this bug, but apptainer
+	// in a pox revealed. And, yes, sometimes you have to put
+	// apptainer in a pox; it's dynamically linked!
+	ec.Dir = "/"
 	ec.Stdin, ec.Stdout, ec.Stderr = os.Stdin, os.Stdout, os.Stderr
 	ec.SysProcAttr = &syscall.SysProcAttr{
 		Chroot: dir,

--- a/cmds/exp/pox/pox_test.go
+++ b/cmds/exp/pox/pox_test.go
@@ -57,6 +57,7 @@ func TestFlags(t *testing.T) {
 			cmdline: "pox",
 			want: cmd{
 				file: "/tmp/pox.tcz",
+				arg0: "pox",
 			},
 		},
 	} {
@@ -65,7 +66,7 @@ func TestFlags(t *testing.T) {
 			got.debug, tt.want.debug = nil, nil
 
 			if !reflect.DeepEqual(got, &tt.want) {
-				t.Errorf("\ngot: %+v\nwant: %+v", got, tt.want)
+				t.Errorf("\ngot: %+v\nwant: %+v", got, &tt.want)
 			}
 		})
 	}

--- a/cmds/exp/pox/pox_test.go
+++ b/cmds/exp/pox/pox_test.go
@@ -62,7 +62,7 @@ func TestFlags(t *testing.T) {
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			got := command(strings.Split(tt.cmdline, " "))
+			got := command(nil, nil, nil, strings.Split(tt.cmdline, " "))
 			got.debug, tt.want.debug = nil, nil
 
 			if !reflect.DeepEqual(got, &tt.want) {

--- a/cmds/exp/pox/pox_vm_test.go
+++ b/cmds/exp/pox/pox_vm_test.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -51,14 +52,14 @@ func TestPox(t *testing.T) {
 			name:    "err in usage",
 			args:    []string{"/bin/bash"},
 			file:    f,
-			wantErr: "pox [-[-verbose]|v] -[-run|r] | -[-create]|c  [-[-file]|f tcz-file] file [...file]",
+			wantErr: ErrUsage.Error(),
 		},
 		{
 			name:    "err in pox.Create",
 			args:    []string{},
 			create:  true,
 			file:    f,
-			wantErr: "pox [-[-verbose]|v] -[-run|r] | -[-create]|c  [-[-file]|f tcz-file] file [...file]",
+			wantErr: ErrUsage.Error(),
 		},
 		{
 			name:    "err in extraMounts(*extra)",
@@ -117,7 +118,7 @@ func TestPoxCreate(t *testing.T) {
 		{
 			name:    "len(bin) == 0",
 			args:    []string{},
-			wantErr: "pox [-[-verbose]|v] -[-run|r] | -[-create]|c  [-[-file]|f tcz-file] file [...file]",
+			wantErr: ErrUsage.Error(),
 		},
 		{
 			name:    "error in ldd.Ldd",
@@ -215,5 +216,33 @@ func TestPoxRun(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestSelfEmbedding(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skipf("skipping; must be root")
+	}
+	pwd, err := exec.LookPath("pwd")
+	if err != nil {
+		t.Skip("no pwd on this system")
+	}
+
+	// The above covers many code paths. The code below tests
+	// self-embedding.
+	if err := exec.Command("go", "build", "-o", "pox").Run(); err != nil {
+		t.Fatalf("building pox: got %v, want nil", err)
+	}
+
+	if err := exec.Command("./pox", "-cvsf", "pwd.pox", pwd).Run(); err != nil {
+		t.Fatalf("building pwd.pox: got %v, want nil", err)
+	}
+
+	out, err := exec.Command("./pwd.pox").CombinedOutput()
+	if err != nil {
+		t.Fatalf("running pwd.pox: got (%s,%v), want nil", out, err)
+	}
+	if string(out) != "/\n" {
+		t.Fatalf("running pwd.pox: got %s, want %s", string(out), "/")
 	}
 }

--- a/cmds/exp/pox/pox_vm_test.go
+++ b/cmds/exp/pox/pox_vm_test.go
@@ -189,11 +189,6 @@ func TestPoxRun(t *testing.T) {
 		wantErr string
 	}{
 		{
-			name:    "len(args) == 0",
-			args:    []string{},
-			wantErr: "pox [-[-verbose]|v] -[-run|r] | -[-create]|c  [-[-file]|f tcz-file] file [...file]",
-		},
-		{
 			name:    "zip = true with error",
 			args:    []string{"/bin/bash"},
 			zip:     true,


### PR DESCRIPTION
With the recent changes, pox standalone mode was totally broken.

You can now use it again
pox -cvsf date `which date`
sudo ./date

works fine.

While we are at it, we now print a useful message if you do not run a standalone pox as root. It comes complete with 38% snark.