### PR TITLE
Modify hss-file param in hss gathering to accept directory path

### DIFF
--- a/cmds/exp/disk_unlock/disk_unlock.go
+++ b/cmds/exp/disk_unlock/disk_unlock.go
@@ -33,7 +33,7 @@ var (
 	retries            = flag.Int("num_retries", 1, "Number of times to retry password if unlocking fails for any reason other than the password being wrong.")
 	salt               = flag.String("salt", hsskey.DefaultPasswordSalt, "Salt for password generation")
 	eepromPattern      = flag.String("eeprom-pattern", "", "The pattern used to match EEPROM sysfs paths where the Host Secret Seeds are located")
-	hssFiles           = flag.String("hss-files", "", "Comma deliminated paths to files containing a Host Secret Seed (HSS) to use")
+	hssFiles           = flag.String("hss-files", "", "Comma deliminated list of files or directories containing additional Host Secret Seed (HSS)")
 )
 
 func verboseLog(msg string) {

--- a/cmds/exp/nvme_unlock/nvme_unlock.go
+++ b/cmds/exp/nvme_unlock/nvme_unlock.go
@@ -53,7 +53,7 @@ var (
 	lock               = flag.Bool("lock", false, "Lock instead of unlocking")
 	salt               = flag.String("salt", hsskey.DefaultPasswordSalt, "Salt for password generation")
 	eepromPattern      = flag.String("eeprom-pattern", "", "The pattern used to match EEPROM sysfs paths where the Host Secret Seeds are located")
-	hssFiles           = flag.String("hss-files", "", "Comma deliminated paths to files containing a Host Secret Seed (HSS) to use")
+	hssFiles           = flag.String("hss-files", "", "Comma deliminated list of files or directories containing additional Host Secret Seed (HSS)")
 )
 
 func verboseLog(msg string) {


### PR DESCRIPTION
Previous arg accepted comma-deliminated list. This makes argument passing easier for platform abstracted content. Non uniform HSS gathering can be dumped into a standard directory, eg. /hss

The comma list has not been utilized yet, so easy swap.