### PR TITLE
pkg/boot/grub: add support for grub devicetree command

### DIFF
--- a/pkg/boot/boottest/json.go
+++ b/pkg/boot/boottest/json.go
@@ -138,6 +138,9 @@ func LinuxImageToJSON(li *boot.LinuxImage) map[string]interface{} {
 	if li.Initrd != nil {
 		m["initrd"] = module(li.Initrd)
 	}
+	if li.DTB != nil {
+		m["dtb"] = module(li.DTB)
+	}
 	return m
 }
 

--- a/pkg/boot/grub/grub.go
+++ b/pkg/boot/grub/grub.go
@@ -522,6 +522,15 @@ func (c *parser) append(ctx context.Context, config string) error {
 				return err
 			}
 
+		case "devicetree":
+			if e, ok := c.linuxEntries[c.curEntry]; ok {
+				dtb, err := c.getFile(arg)
+				if err != nil {
+					return err
+				}
+				e.DTB = dtb
+			}
+
 		case "menuentry":
 			c.curEntry = strconv.Itoa(c.numEntry)
 			c.curLabel = arg

--- a/pkg/boot/grub/testdata_new/ubuntu_16_04_boot.json
+++ b/pkg/boot/grub/testdata_new/ubuntu_16_04_boot.json
@@ -8,6 +8,9 @@
     "kernel": {
       "url": "file:///testdata_new/ubuntu_16_04_boot/vmlinuz-4.10.0-42-generic.efi.signed"
     },
+    "dtb": {
+      "url": "file:///testdata_new/ubuntu_16_04_boot/dtb-4.10.0-42-generic"
+    },
     "name": "Ubuntu",
     "rank": "0"
   },

--- a/pkg/boot/grub/testdata_new/ubuntu_16_04_boot/grub/grub.cfg
+++ b/pkg/boot/grub/testdata_new/ubuntu_16_04_boot/grub/grub.cfg
@@ -145,6 +145,7 @@ menuentry 'Ubuntu' --class ubuntu --class gnu-linux --class gnu --class os $menu
 	fi
 	linux	/vmlinuz-4.10.0-42-generic.efi.signed root=/dev/mapper/ubuntu--vg-root ro  quiet splash $vt_handoff
 	initrd	/initrd.img-4.10.0-42-generic
+	devicetree	/dtb-4.10.0-42-generic
 }
 submenu 'Advanced options for Ubuntu' $menuentry_id_option 'gnulinux-advanced-UUID2' {
 	menuentry 'Ubuntu, with Linux 4.10.0-42-generic' --class ubuntu --class gnu-linux --class gnu --class os $menuentry_id_option 'gnulinux-4.10.0-42-generic-advanced-UUID2' {


### PR DESCRIPTION
I've been using u-root to boot linux on an arm64 chromebook and noticed that the grub "devicetree" command didn't work. This is widely used in Debian/Ubuntu for arm64 in combination with flash-kernel to keep kernel and DTBs in sync.