### PR TITLE
tinygo: generic compressions

### DIFF
--- a/pkg/gzip/file.go
+++ b/pkg/gzip/file.go
@@ -6,6 +6,7 @@ package gzip
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -16,6 +17,21 @@ import (
 type File struct {
 	Options *Options
 	Path    string
+}
+
+// Compression and Decompression functions used by the File.Process method.
+// Bare metal support can be enabled, for example, witht the `tinygo` build tag.
+// Setting these build tags will result in the use of pure go libraries for compression/decompression.
+func Compress(r io.Reader, w io.Writer, level int, blocksize int, processes int) error {
+	return compress(r, w, level, blocksize, processes)
+}
+
+// Decompress takes gzip compressed input from io.Reader and expands it using
+// pgzip or gzip, depending on the build tags.
+// When the `tinygo` build tag is set, the `compress/gzip` package is used and the `processes`
+// argument is ignored.
+func Decompress(r io.Reader, w io.Writer, blocksize int, processes int) error {
+	return decompress(r, w, blocksize, processes)
 }
 
 // outputPath removes the path suffix on decompress and adds it on compress.

--- a/pkg/gzip/gunzip_tinygo.go
+++ b/pkg/gzip/gunzip_tinygo.go
@@ -1,22 +1,23 @@
-// Copyright 2017-2018 the u-root Authors. All rights reserved
+// Copyright 2024 the u-root Authors. All rights reserved
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo
+//go:build tinygo
+// +build tinygo
 
 package gzip
 
 import (
 	"io"
 
-	"github.com/klauspost/pgzip"
+	"compress/gzip"
 )
 
 // Decompress takes gzip compressed input from io.Reader and expands it using pgzip
-// to io.Writer. Data is read in block size (KB) chunks using up to the number of
+// to io.Writer. Data is read in blocksize (KB) chunks using upto the number of
 // CPU cores specified.
-func decompress(r io.Reader, w io.Writer, blocksize int, processes int) error {
-	zr, err := pgzip.NewReaderN(r, blocksize*1024, processes)
+func decompress(r io.Reader, w io.Writer, _, processes int) error {
+	zr, err := gzip.NewReader(r)
 	if err != nil {
 		return err
 	}

--- a/pkg/gzip/gunzip_tinygo.go
+++ b/pkg/gzip/gunzip_tinygo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build tinygo
-// +build tinygo
 
 package gzip
 

--- a/pkg/gzip/gzip.go
+++ b/pkg/gzip/gzip.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !tinygo
+// +build !tinygo
+
 package gzip
 
 import (
@@ -11,9 +14,9 @@ import (
 )
 
 // Compress takes input from io.Reader and deflates it using pgzip
-// to io.Writer. Data is compressed in blocksize (KB) chunks using
-// upto the number of CPU cores specified.
-func Compress(r io.Reader, w io.Writer, level int, blocksize int, processes int) error {
+// to io.Writer. Data is compressed in block size (KB) chunks using
+// up to the number of CPU cores specified.
+func compress(r io.Reader, w io.Writer, level int, blocksize int, processes int) error {
 	zw, err := pgzip.NewWriterLevel(w, level)
 	if err != nil {
 		return err

--- a/pkg/gzip/gzip.go
+++ b/pkg/gzip/gzip.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo
-// +build !tinygo
 
 package gzip
 

--- a/pkg/gzip/gzip_tinygo.go
+++ b/pkg/gzip/gzip_tinygo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build tinygo
-// +build tinygo
 
 package gzip
 

--- a/pkg/gzip/gzip_tinygo.go
+++ b/pkg/gzip/gzip_tinygo.go
@@ -1,0 +1,31 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build tinygo
+// +build tinygo
+
+package gzip
+
+import (
+	"io"
+
+	"compress/gzip"
+)
+
+// compress takes input from io.Reader and deflates it using pgzip.
+// to io.Writer. Data is compressed in blocksize (KB) chunks using
+// up to the number of CPU cores specified.
+func compress(r io.Reader, w io.Writer, level, _, _ int) error {
+	zw, err := gzip.NewWriterLevel(w, level)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(zw, r); err != nil {
+		zw.Close()
+		return err
+	}
+
+	return zw.Close()
+}

--- a/pkg/kmodule/compression.go
+++ b/pkg/kmodule/compression.go
@@ -1,0 +1,33 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kmodule
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/klauspost/pgzip"
+	"github.com/ulikunitz/xz"
+)
+
+// compressionReader returns a reader for the given file based on the file extension.
+// This implementation utilizes the optimized compression libraries for each format.
+func compressionReader(file *os.File) (reader io.Reader, err error) {
+	ext := filepath.Ext(file.Name())
+
+	switch ext {
+	case ".xz":
+		return xz.NewReader(file)
+	case ".gz":
+		return pgzip.NewReader(file)
+	case ".zst":
+		return zstd.NewReader(file)
+	default:
+		return nil, fmt.Errorf("compression not supported for %s:%w", ext, os.ErrNotExist)
+	}
+}

--- a/pkg/kmodule/compression_tinygo.go
+++ b/pkg/kmodule/compression_tinygo.go
@@ -1,0 +1,38 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build tinygo
+// +build tinygo
+
+package kmodule
+
+import (
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
+)
+
+// compressionReader returns a reader for the given file based on the file extension.
+// The current status of `tinygo` does not support the use of inline assembly, so for now we can only use pure go libraries.
+// Although klauspost/zstd is pure go, interanlly it executes inline assembly to get CPU features.
+func compressionReader(file *os.File) (reader io.Reader, err error) {
+	ext := filepath.Ext(file.Name())
+
+	switch ext {
+	case ".xz":
+		// xz is pure go so we can use that here
+		return xz.NewReader(file)
+	case ".gz":
+		return gzip.NewReader(file)
+	case ".zst":
+		return zstd.NewReader(file)
+	default:
+		return nil, fmt.Errorf("compression not supported for %s:%w", ext, os.ErrNotExist)
+	}
+}

--- a/pkg/kmodule/kmodule_linux.go
+++ b/pkg/kmodule/kmodule_linux.go
@@ -17,9 +17,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/klauspost/compress/zstd"
-	"github.com/klauspost/pgzip"
-	"github.com/ulikunitz/xz"
 	"golang.org/x/sys/unix"
 )
 
@@ -31,59 +28,6 @@ const (
 	// Ignore kernel version magic.
 	MODULE_INIT_IGNORE_VERMAGIC = 0x2
 )
-
-// Init loads the kernel module given by image with the given options.
-func Init(image []byte, opts string) error {
-	return unix.InitModule(image, opts)
-}
-
-// FileInit loads the kernel module contained by `f` with the given opts and
-// flags. Uncompresses modules with a .xz and .gz suffix before loading.
-//
-// FileInit falls back to init_module(2) via Init when the finit_module(2)
-// syscall is not available and when loading compressed modules.
-func FileInit(f *os.File, opts string, flags uintptr) error {
-	var r io.Reader
-	var err error
-	switch filepath.Ext(f.Name()) {
-	case ".xz":
-		if r, err = xz.NewReader(f); err != nil {
-			return err
-		}
-	case ".gz":
-		if r, err = pgzip.NewReader(f); err != nil {
-			return err
-		}
-	case ".zst":
-		if r, err = zstd.NewReader(f); err != nil {
-			return err
-		}
-	}
-
-	if r == nil {
-		err := unix.FinitModule(int(f.Fd()), opts, int(flags))
-		if err == unix.ENOSYS {
-			if flags != 0 {
-				return err
-			}
-			// Fall back to init_module(2).
-			r = f
-		} else {
-			return err
-		}
-	}
-
-	img, err := io.ReadAll(r)
-	if err != nil {
-		return err
-	}
-	return Init(img, opts)
-}
-
-// Delete removes a kernel module.
-func Delete(name string, flags uintptr) error {
-	return unix.DeleteModule(name, int(flags))
-}
 
 type modState uint8
 
@@ -109,6 +53,54 @@ type ProbeOpts struct {
 	RootDir        string
 	KVer           string
 	IgnoreProcMods bool
+}
+
+// Init loads the kernel module given by image with the given options.
+func Init(image []byte, opts string) error {
+	return unix.InitModule(image, opts)
+}
+
+// Wrapper for the compression readers
+func CompressionReader(file *os.File) (reader io.Reader, err error) {
+	return compressionReader(file)
+}
+
+// FileInit loads the kernel module contained by `f` with the given opts and
+// flags. Uncompresses modules with a .xz and .gz suffix before loading.
+//
+// FileInit falls back to init_module(2) via Init when the finit_module(2)
+// syscall is not available and when loading compressed modules.
+func FileInit(f *os.File, opts string, flags uintptr) error {
+	var r io.Reader
+	var err error
+
+	if r, err = CompressionReader(f); err != nil {
+		return err
+	}
+
+	if r == nil {
+		err := unix.FinitModule(int(f.Fd()), opts, int(flags))
+		if err == unix.ENOSYS {
+			if flags != 0 {
+				return err
+			}
+			// Fall back to init_module(2).
+			r = f
+		} else {
+			return err
+		}
+	}
+
+	img, err := io.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	return Init(img, opts)
+}
+
+// Delete removes a kernel module.
+func Delete(name string, flags uintptr) error {
+	return unix.DeleteModule(name, int(flags))
 }
 
 // Probe loads the given kernel module and its dependencies.

--- a/pkg/kmodule/kmodule_linux_test.go
+++ b/pkg/kmodule/kmodule_linux_test.go
@@ -6,8 +6,14 @@ package kmodule
 
 import (
 	"bytes"
+	"compress/gzip"
+	"errors"
+	"os"
 	"path"
 	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/ulikunitz/xz"
 )
 
 var procModsMock = `hid_generic 16384 0 - Live 0x0000000000000000
@@ -30,5 +36,164 @@ func TestGenLoadedMods(t *testing.T) {
 		if d.state != loaded {
 			t.Fatalf("mod %q should have been loaded", path.Base(mod))
 		}
+	}
+}
+
+// Helper function to generate compression test data for TestCompression.
+// Generates a map with the name of the file as key and the compressed data as value.
+// The data is compressed using xz, gzip, and zstd.
+// There is also one file with a bad extension to test the error handling.
+// Testing compression itself is out of scope.
+func generateCompressionTestData(data []byte) (map[string][]byte, error) {
+	var (
+		compressionBuffer bytes.Buffer
+		err               error
+	)
+
+	tData := make(map[string][]byte)
+
+	// 1. xz
+	wXZ, err := xz.NewWriter(&compressionBuffer)
+	if err != nil {
+		return nil, err
+	}
+	_, err = wXZ.Write(data)
+	if err != nil {
+		return nil, err
+	}
+	if err = wXZ.Close(); err != nil {
+		return nil, err
+	}
+
+	tData["test.xz"] = make([]byte, compressionBuffer.Len())
+	copy(tData["test.xz"], compressionBuffer.Bytes())
+	compressionBuffer.Reset()
+
+	// 2. gzip
+	wGZ := gzip.NewWriter(&compressionBuffer)
+	if _, err = wGZ.Write(data); err != nil {
+		return nil, err
+	}
+	if err = wGZ.Close(); err != nil {
+		return nil, err
+	}
+
+	tData["test.gz"] = make([]byte, compressionBuffer.Len())
+	copy(tData["test.gz"], compressionBuffer.Bytes())
+	compressionBuffer.Reset()
+
+	// 3. zstd
+	wZST, err := zstd.NewWriter(&compressionBuffer)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = wZST.Write(data); err != nil {
+		return nil, err
+	}
+
+	if err = wZST.Close(); err != nil {
+		return nil, err
+	}
+
+	tData["test.zst"] = make([]byte, compressionBuffer.Len())
+	copy(tData["test.zst"], compressionBuffer.Bytes())
+	compressionBuffer.Reset()
+
+	// 4. bad
+	tData["test.bad"] = []byte{'b', 'a', 'd'}
+	return tData, nil
+}
+
+// Since we don't need to test the compression function, we just check
+// for validity of file extension detection.
+func TestCompression(t *testing.T) {
+	var (
+		err error
+		i   = 0
+	)
+
+	const compressionTestString = "test\x00"
+
+	tDir := t.TempDir()
+	tFd := make([]*os.File, 4)
+	tFiles, err := generateCompressionTestData([]byte(compressionTestString))
+	if err != nil {
+		t.Fatalf("failed to generate test data: '%v'\n", err)
+	}
+
+	for name, data := range tFiles {
+		tFd[i], err = os.Create(path.Join(tDir, name))
+		if err != nil {
+			t.Fatalf("failed to create test file %q: '%v'\n", name, err)
+		}
+
+		n, err := tFd[i].Write(data)
+		if err != nil {
+			t.Fatalf("failed to write to test file %q: '%v'\n", name, err)
+		}
+
+		if err = tFd[i].Sync(); err != nil {
+			t.Fatalf("failed to sync test file %q: '%v'\n", name, err)
+		}
+
+		if n != len(data) {
+			t.Fatalf("failed to write all data to test file %q. Expected %d bytes, wrote %d\n", name, len(data), n)
+		}
+
+		i++
+	}
+
+	// defer func() {
+	// 	for _, f := range tFd {
+	// 		f.Close()
+	// 	}
+	// }()
+
+	testCases := map[string]struct {
+		file    *os.File
+		ext     string
+		isError bool
+		err     error
+	}{
+		"test.xz": {
+			file:    tFd[0],
+			ext:     ".xz",
+			isError: false,
+			err:     nil,
+		},
+		"test.gz": {
+			file:    tFd[1],
+			ext:     ".gz",
+			isError: false,
+			err:     nil,
+		},
+		"test.zst": {
+			file:    tFd[2],
+			ext:     ".zst",
+			isError: false,
+			err:     nil,
+		},
+		"test.bad": {
+			file:    tFd[3],
+			ext:     ".bad",
+			isError: true,
+			err:     os.ErrNotExist,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			_, err := compressionReader(tc.file)
+			if tc.isError {
+				if errors.Is(err, tc.err) {
+					return
+				}
+				t.Fatalf("expected error %v but got '%v'\n", tc.err, err)
+			}
+			if !tc.isError && err != nil {
+				t.Fatalf("expected no error but got '%v'\n", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Right now `tinygo` does not support the use of inline assembly files that are frequently used in compression algorithms to yield performance increases.
This PR removes these implementations from the dependencies and replaces them with generic `golang` implementations, so that `tinygo` can handle this.

EDIT: adding the [`noasm`](https://github.com/klauspost/compress/blob/d76f801616d1080ce0f747ded725a839e46d9331/internal/cpuinfo/cpuinfo_amd64.go#L1C1-L1C47) build tag resolved the inline assembly cpuid issues and zst is supported.

Buildable (with caveats):
 - [x] core/gzip
 - [x] core/insmod
 - [x] core/rmmod
 - [x] exp/modprobe