### PR TITLE
cmds/core/ip: fix flag parsing

### DIFF
--- a/cmds/core/ip/ip_linux.go
+++ b/cmds/core/ip/ip_linux.go
@@ -280,7 +280,7 @@ func (cmd *cmd) run() error {
 func (cmd *cmd) batchCmds() error {
 	file, err := os.Open(cmd.Opts.Batch)
 	if err != nil {
-		log.Fatalf("Failed to open batch file: %v", err)
+		return err
 	}
 	defer file.Close()
 

--- a/cmds/core/ip/ip_linux.go
+++ b/cmds/core/ip/ip_linux.go
@@ -151,8 +151,7 @@ func parseFlags(args []string, out io.Writer) (cmd, error) {
 		fs.PrintDefaults()
 	}
 
-	fs.Parse(unixflag.ArgsToGoArgs(args))
-
+	fs.Parse(unixflag.ArgsToGoArgs(args[1:]))
 	cmd.Args = fs.Args()
 
 	cmd.Family = netlink.FAMILY_ALL
@@ -312,7 +311,7 @@ func (cmd *cmd) batchCmds() error {
 }
 
 func (cmd *cmd) runSubCommand() error {
-	cmd.Cursor = 0
+	cmd.Cursor = -1
 
 	if !cmd.tokenRemains() {
 		fmt.Fprint(cmd.Out, ipHelp)

--- a/cmds/core/ip/ip_linux_test.go
+++ b/cmds/core/ip/ip_linux_test.go
@@ -552,6 +552,7 @@ func TestRun(t *testing.T) {
 		name     string
 		cmd      cmd
 		expected string
+		wantErr  bool
 	}{
 		{
 			name: "Normal execution",
@@ -560,6 +561,17 @@ func TestRun(t *testing.T) {
 				Cursor:         1,
 				ExpectedValues: []string{"arg1", "arg2"},
 			},
+			wantErr: true,
+		},
+		{
+			name: "Batch execution",
+			cmd: cmd{
+				Opts: flags{
+					Batch: "testdata/batch.txt",
+				},
+				Cursor: 0,
+			},
+			wantErr: true,
 		},
 	}
 
@@ -569,7 +581,11 @@ func TestRun(t *testing.T) {
 
 			test.cmd.Out = &out
 
-			_ = test.cmd.run()
+			err := test.cmd.run()
+
+			if test.wantErr && err == nil || !test.wantErr && err != nil {
+				t.Errorf("expected %v, got %v", test.wantErr, err)
+			}
 		})
 	}
 }

--- a/cmds/core/ip/ip_linux_test.go
+++ b/cmds/core/ip/ip_linux_test.go
@@ -25,7 +25,7 @@ func TestParseFlags(t *testing.T) {
 	}{
 		{
 			name: "no args",
-			args: []string{},
+			args: []string{"ip"},
 			out:  &bytes.Buffer{},
 			wantCmd: cmd{
 				Opts: flags{
@@ -35,7 +35,7 @@ func TestParseFlags(t *testing.T) {
 		},
 		{
 			name: "inet4",
-			args: []string{"-4"},
+			args: []string{"ip", "-4"},
 			out:  &bytes.Buffer{},
 			wantCmd: cmd{
 				Opts: flags{
@@ -47,7 +47,7 @@ func TestParseFlags(t *testing.T) {
 		},
 		{
 			name: "inet6",
-			args: []string{"-6"},
+			args: []string{"ip", "-6"},
 			wantCmd: cmd{
 				Opts: flags{
 					Loops: 1,
@@ -58,17 +58,17 @@ func TestParseFlags(t *testing.T) {
 		},
 		{
 			name:    "mpls",
-			args:    []string{"-M"},
+			args:    []string{"ip", "-M"},
 			wantErr: true,
 		},
 		{
 			name:    "bridge",
-			args:    []string{"-B"},
+			args:    []string{"ip", "-B"},
 			wantErr: true,
 		},
 		{
 			name: "link",
-			args: []string{"-0"},
+			args: []string{"ip", "-0"},
 			wantCmd: cmd{
 				Opts: flags{
 					Loops: 1,
@@ -79,7 +79,7 @@ func TestParseFlags(t *testing.T) {
 		},
 		{
 			name: "family",
-			args: []string{"--family=inet"},
+			args: []string{"ip", "--family=inet"},
 			wantCmd: cmd{
 				Opts: flags{
 					Loops:  1,
@@ -90,7 +90,7 @@ func TestParseFlags(t *testing.T) {
 		},
 		{
 			name: "family inet6",
-			args: []string{"--family=inet6"},
+			args: []string{"ip", "--family=inet6"},
 			wantCmd: cmd{
 				Opts: flags{
 					Loops:  1,
@@ -101,27 +101,27 @@ func TestParseFlags(t *testing.T) {
 		},
 		{
 			name:    "family err",
-			args:    []string{"--family=abc"},
+			args:    []string{"ip", "--family=abc"},
 			wantErr: true,
 		},
 		{
 			name:    "resolve",
-			args:    []string{"-r"},
+			args:    []string{"ip", "-r"},
 			wantErr: true,
 		},
 		{
 			name:    "color",
-			args:    []string{"--color=all"},
+			args:    []string{"ip", "--color=all"},
 			wantErr: true,
 		},
 		{
 			name:    "oneline",
-			args:    []string{"-o"},
+			args:    []string{"ip", "-o"},
 			wantErr: true,
 		},
 		{
 			name: "rcvBuf",
-			args: []string{"--rcvbuf=100"},
+			args: []string{"ip", "--rcvbuf=100"},
 			wantCmd: cmd{
 				Opts: flags{
 					Loops:  1,
@@ -163,7 +163,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "Addr",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "addr", "help"},
+				Args:   []string{"addr", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -171,7 +171,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "Addr invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "addr", "invalid"},
+				Args:   []string{"addr", "invalid"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -180,7 +180,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "link",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "link", "help"},
+				Args:   []string{"link", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -188,7 +188,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "link invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "link", "invalid"},
+				Args:   []string{"link", "invalid"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -197,7 +197,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "route",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "route", "help"},
+				Args:   []string{"route", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -205,7 +205,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "route invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "route", "invalid"},
+				Args:   []string{"route", "invalid"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -214,7 +214,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "neigh",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "neigh", "help"},
+				Args:   []string{"neigh", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -222,7 +222,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "neigh invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "neigh", "invalid"},
+				Args:   []string{"neigh", "invalid"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -231,7 +231,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "monitor",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "monitor", "help"},
+				Args:   []string{"monitor", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -239,7 +239,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "monitor invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "monitor", "abc"},
+				Args:   []string{"monitor", "abc"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -248,7 +248,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tunnel",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tunnel", "help"},
+				Args:   []string{"tunnel", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -256,7 +256,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tunnel invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tunnel", "invalid"},
+				Args:   []string{"tunnel", "invalid"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -265,7 +265,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tuntap",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tuntap", "help"},
+				Args:   []string{"tuntap", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -273,7 +273,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tuntap invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tuntap", "ac"},
+				Args:   []string{"tuntap", "ac"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -282,7 +282,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tcpmetrics",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tcpmetrics", "help"},
+				Args:   []string{"tcpmetrics", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -290,7 +290,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tcpmetrics invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tcpmetrics", "abv"},
+				Args:   []string{"tcpmetrics", "abv"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -299,7 +299,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "VRF",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "vrf", "help"},
+				Args:   []string{"vrf", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -307,7 +307,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "VRF invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "vrf", "abc"},
+				Args:   []string{"vrf", "abc"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -316,7 +316,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "help"},
+				Args:   []string{"xfrm", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -324,7 +324,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "a"},
+				Args:   []string{"xfrm", "a"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -333,7 +333,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm monitor",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "monitor", "help"},
+				Args:   []string{"xfrm", "monitor", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -341,7 +341,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm monitor invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "monitor", "a"},
+				Args:   []string{"xfrm", "monitor", "a"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -350,7 +350,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm state",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "state", "help"},
+				Args:   []string{"xfrm", "state", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -358,7 +358,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm state invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "state", "s"},
+				Args:   []string{"xfrm", "state", "s"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -367,7 +367,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm policy",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "policy", "help"},
+				Args:   []string{"xfrm", "policy", "help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -375,7 +375,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm policy invalid",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "policy", "aa"},
+				Args:   []string{"xfrm", "policy", "aa"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -384,7 +384,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "Help",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "help"},
+				Args:   []string{"help"},
 				Out:    new(bytes.Buffer),
 			},
 		},
@@ -392,7 +392,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "Fail",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "yz"},
+				Args:   []string{"yz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -401,7 +401,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "Addr wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "addr", "xyz"},
+				Args:   []string{"addr", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -410,7 +410,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "link wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "link", "xyz"},
+				Args:   []string{"link", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -419,7 +419,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "route wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "route", "xyz"},
+				Args:   []string{"route", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -428,7 +428,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "neigh wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "neigh", "xyz"},
+				Args:   []string{"neigh", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -437,7 +437,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "monitor wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "monitor", "xyz"},
+				Args:   []string{"monitor", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -446,7 +446,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tunnel wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tunnel", "xyz"},
+				Args:   []string{"tunnel", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -455,7 +455,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tuntap wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tuntap", "xyz"},
+				Args:   []string{"tuntap", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -464,7 +464,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "tcpmetrics wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "tcpmetrics", "xyz"},
+				Args:   []string{"tcpmetrics", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -473,7 +473,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "VRF wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "vrf", "xyz"},
+				Args:   []string{"vrf", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,
@@ -482,7 +482,7 @@ func TestRunSubCommand(t *testing.T) {
 			name: "xfrm wrong arg",
 			cmd: cmd{
 				Cursor: 0,
-				Args:   []string{"ip", "xfrm", "xyz"},
+				Args:   []string{"xfrm", "xyz"},
 				Out:    new(bytes.Buffer),
 			},
 			wantErr: true,

--- a/cmds/core/ip/neigh_linux.go
+++ b/cmds/core/ip/neigh_linux.go
@@ -51,12 +51,7 @@ func (cmd *cmd) neigh() error {
 	case "flush":
 		return cmd.neighFlush()
 	case "get":
-		ip, err := cmd.parseAddress()
-		if err != nil {
-			return err
-		}
-
-		iface, err := cmd.parseDeviceName(true)
+		ip, iface, err := cmd.parseNeighGet()
 		if err != nil {
 			return err
 		}
@@ -68,6 +63,20 @@ func (cmd *cmd) neigh() error {
 	}
 
 	return cmd.usage()
+}
+
+func (cmd cmd) parseNeighGet() (net.IP, netlink.Link, error) {
+	ip, err := cmd.parseAddress()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	iface, err := cmd.parseDeviceName(true)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return ip, iface, nil
 }
 
 func (cmd *cmd) parseNeighAddDelReplaceParams() (*netlink.Neigh, error) {

--- a/cmds/core/ip/neigh_linux_test.go
+++ b/cmds/core/ip/neigh_linux_test.go
@@ -445,3 +445,47 @@ func TestNeighFlagState(t *testing.T) {
 		})
 	}
 }
+
+func TestParseNeighGet(t *testing.T) {
+	tests := []struct {
+		name    string
+		token   []string
+		wantIP  net.IP
+		wantIF  netlink.Link
+		wantErr bool
+	}{
+		{
+			name:    "Valid IP and interface",
+			token:   []string{"address", "192.168.0.2", "dev", "lo"},
+			wantErr: false,
+		},
+		{
+			name:  "Error in parseAddress",
+			token: []string{"abc"},
+
+			wantIP:  nil,
+			wantIF:  nil,
+			wantErr: true,
+		},
+		{
+			name:    "Error in parseDeviceName",
+			token:   []string{"address", "192.168.0.2", "xyz"},
+			wantIF:  nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cmd{
+				Cursor: -1,
+				Args:   tt.token,
+			}
+			_, _, err := cmd.parseNeighGet()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseNeighGet() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}

--- a/cmds/core/ip/tuntap_linux.go
+++ b/cmds/core/ip/tuntap_linux.go
@@ -110,6 +110,16 @@ func (cmd *cmd) parseTunTap() (tuntapOptions, error) {
 }
 
 func (cmd *cmd) tuntapAdd(options tuntapOptions) error {
+	link := tunTapDevice(options)
+
+	if err := cmd.handle.LinkAdd(link); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func tunTapDevice(options tuntapOptions) *netlink.Tuntap {
 	link := &netlink.Tuntap{
 		LinkAttrs: netlink.LinkAttrs{
 			Name: options.Name,
@@ -127,11 +137,7 @@ func (cmd *cmd) tuntapAdd(options tuntapOptions) error {
 
 	link.Flags = options.Flags
 
-	if err := cmd.handle.LinkAdd(link); err != nil {
-		return err
-	}
-
-	return nil
+	return link
 }
 
 func (cmd *cmd) tuntapDel(options tuntapOptions) error {

--- a/cmds/core/ip/tuntap_linux_test.go
+++ b/cmds/core/ip/tuntap_linux_test.go
@@ -342,3 +342,80 @@ func TestPrintTunTaps(t *testing.T) {
 		})
 	}
 }
+
+func TestTunTapDevice(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  tuntapOptions
+		expected *netlink.Tuntap
+	}{
+		{
+			name: "Valid options",
+			options: tuntapOptions{
+				Name:  "test0",
+				Mode:  netlink.TUNTAP_MODE_TUN,
+				User:  1000,
+				Group: 1000,
+				Flags: netlink.TUNTAP_DEFAULTS,
+			},
+			expected: &netlink.Tuntap{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: "test0",
+				},
+				Mode:  netlink.TUNTAP_MODE_TUN,
+				Owner: 1000,
+				Group: 1000,
+				Flags: netlink.TUNTAP_DEFAULTS,
+			},
+		},
+		{
+			name: "User out of range",
+			options: tuntapOptions{
+				Name:  "test1",
+				Mode:  netlink.TUNTAP_MODE_TUN,
+				User:  -1,
+				Group: 1000,
+				Flags: netlink.TUNTAP_DEFAULTS,
+			},
+			expected: &netlink.Tuntap{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: "test1",
+				},
+				Mode:  netlink.TUNTAP_MODE_TUN,
+				Group: 1000,
+				Flags: netlink.TUNTAP_DEFAULTS,
+			},
+		},
+		{
+			name: "Group out of range",
+			options: tuntapOptions{
+				Name:  "test2",
+				Mode:  netlink.TUNTAP_MODE_TUN,
+				User:  1000,
+				Group: -1,
+				Flags: netlink.TUNTAP_DEFAULTS,
+			},
+			expected: &netlink.Tuntap{
+				LinkAttrs: netlink.LinkAttrs{
+					Name: "test2",
+				},
+				Mode:  netlink.TUNTAP_MODE_TUN,
+				Owner: 1000,
+				Flags: netlink.TUNTAP_DEFAULTS,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tunTapDevice(tt.options)
+			if result.LinkAttrs.Name != tt.expected.LinkAttrs.Name ||
+				result.Mode != tt.expected.Mode ||
+				result.Owner != tt.expected.Owner ||
+				result.Group != tt.expected.Group ||
+				result.Flags != tt.expected.Flags {
+				t.Errorf("tunTapDevice() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The refactoring of flag parsing broke  some of the flags of the IP cmd, this commit fixes the parsing for all flags