### PR TITLE
tinygo: enable cmd/core/init

### DIFF
--- a/cmds/core/init/fns_unix.go
+++ b/cmds/core/init/fns_unix.go
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo && (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
-// +build !tinygo
+//go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main

--- a/pkg/libinit/net_linux.go
+++ b/pkg/libinit/net_linux.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build linux && !tinygo
+// +build linux,!tinygo
+
 package libinit
 
 import (

--- a/pkg/libinit/net_linux_tinygo.go
+++ b/pkg/libinit/net_linux_tinygo.go
@@ -1,0 +1,21 @@
+// Copyright 2014-2019 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && tinygo
+// +build linux,tinygo
+
+package libinit
+
+import (
+	"github.com/u-root/u-root/pkg/ulog"
+)
+
+// Stub for notifying the user that network functionality is not supported on linux platforms
+func linuxNetInit() {
+	ulog.KernelLog.Printf("tinygo builds currently do not support network functionality on linux platforms\n")
+}
+
+func init() {
+	osNetInit = linuxNetInit
+}


### PR DESCRIPTION
Add conditional compilation to exclude any use of network packages for now. Further, `klauspost/zstd` is used, so to build this cmdlet with tinygo requires to set the build tag `noasm` as well. Since this package uses `unix.Sync` the latest `tinygo` release cannot yet be used but instead, a dev build is required.

```
tinygo build -tags noasm .
```

@rminnich