### PR TITLE
[maintenance] Remove deprecated `// +build CONSTRAINT` lines

### DIFF
--- a/cmds/core/backoff/main.go
+++ b/cmds/core/backoff/main.go
@@ -26,7 +26,6 @@
 //	  2022/03/31 14:29:39 Error: exit status 1
 
 //go:build !test
-// +build !test
 
 package main
 

--- a/cmds/core/brctl/brctl.go
+++ b/cmds/core/brctl/brctl.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 package main
 

--- a/cmds/core/cp/cp_others.go
+++ b/cmds/core/cp/cp_others.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package main
 

--- a/cmds/core/cpio/cpio_posix_test.go
+++ b/cmds/core/cpio/cpio_posix_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 package main
 

--- a/cmds/core/date/date_unix.go
+++ b/cmds/core/date/date_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package main
 

--- a/cmds/core/dhclient/dhclient.go
+++ b/cmds/core/dhclient/dhclient.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // dhclient sets up network config using DHCP.
 //

--- a/cmds/core/free/free.go
+++ b/cmds/core/free/free.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // free reports usage information for physical memory and swap space.
 //

--- a/cmds/core/fusermount/fusermount.go
+++ b/cmds/core/fusermount/fusermount.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && linux
-// +build !tinygo,linux
 
 // fusermount is a very limited replacement for the C fusermount.  It
 // is invoked by other programs, or interactively only to unmount.

--- a/cmds/core/fusermount/fusermount_linux_test.go
+++ b/cmds/core/fusermount/fusermount_linux_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && linux
-// +build !tinygo,linux
 
 package main
 

--- a/cmds/core/gosh/completer.go
+++ b/cmds/core/gosh/completer.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9 && !goshsmall && !goshliner
-// +build !tinygo,!plan9,!goshsmall,!goshliner
 
 package main
 

--- a/cmds/core/gosh/completer_common.go
+++ b/cmds/core/gosh/completer_common.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9 && !goshsmall
-// +build !tinygo,!plan9,!goshsmall
 
 package main
 

--- a/cmds/core/gosh/completer_liner.go
+++ b/cmds/core/gosh/completer_liner.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9 && !goshsmall && goshliner
-// +build !tinygo,!plan9,!goshsmall,goshliner
 
 package main
 

--- a/cmds/core/gosh/completer_nobuild.go
+++ b/cmds/core/gosh/completer_nobuild.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9 && goshsmall && !goshliner
-// +build !tinygo,!plan9,goshsmall,!goshliner
 
 package main
 

--- a/cmds/core/gosh/gosh.go
+++ b/cmds/core/gosh/gosh.go
@@ -5,7 +5,6 @@
 // Derived work from Daniel Martí <mvdan@mvdan.cc>
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 package main
 

--- a/cmds/core/hostname/hostname_linux.go
+++ b/cmds/core/hostname/hostname_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 package main
 

--- a/cmds/core/hostname/hostname_plan9.go
+++ b/cmds/core/hostname/hostname_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && plan9
-// +build !tinygo,plan9
 
 package main
 

--- a/cmds/core/id/groups.go
+++ b/cmds/core/id/groups.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package main
 

--- a/cmds/core/id/id.go
+++ b/cmds/core/id/id.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // id displays the user id, group id, and groups of the calling process.
 //

--- a/cmds/core/id/id_plan9.go
+++ b/cmds/core/id/id_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build plan9
-// +build plan9
 
 package main
 

--- a/cmds/core/id/id_test.go
+++ b/cmds/core/id/id_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package main
 

--- a/cmds/core/id/users.go
+++ b/cmds/core/id/users.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package main
 

--- a/cmds/core/init/fns_other.go
+++ b/cmds/core/init/fns_other.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !(darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris)
-// +build !tinygo,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package main
 

--- a/cmds/core/init/fns_unix.go
+++ b/cmds/core/init/fns_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package main
 

--- a/cmds/core/init/init_plan9.go
+++ b/cmds/core/init/init_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && plan9
-// +build !tinygo,plan9
 
 package main
 

--- a/cmds/core/io/asmports.go
+++ b/cmds/core/io/asmports.go
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && ((linux && amd64) || (linux && 386))
-// +build !tinygo
-// +build linux,amd64 linux,386
 
 package main
 

--- a/cmds/core/io/cmos.go
+++ b/cmds/core/io/cmos.go
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && (amd64 || 386)
-// +build !tinygo
-// +build amd64 386
 
 package main
 

--- a/cmds/core/io/smn.go
+++ b/cmds/core/io/smn.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && amd64 && linux
-// +build !tinygo,amd64,linux
 
 // The System Management Network (SMN, try to say it fast)
 // is a parallel universe address space on newer AMD64 cpus.

--- a/cmds/core/kill/kill.go
+++ b/cmds/core/kill/kill.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // Kill kills processes.
 //

--- a/cmds/core/kill/siglist.go
+++ b/cmds/core/kill/siglist.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package main
 

--- a/cmds/core/kill/signaler_unix.go
+++ b/cmds/core/kill/signaler_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package main
 

--- a/cmds/core/ls/ls_plan9.go
+++ b/cmds/core/ls/ls_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build plan9
-// +build plan9
 
 package main
 

--- a/cmds/core/ls/ls_unix.go
+++ b/cmds/core/ls/ls_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9 && !windows
-// +build !plan9,!windows
 
 package main
 

--- a/cmds/core/mkfifo/mkfifo.go
+++ b/cmds/core/mkfifo/mkfifo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // mkfifo creates a named pipe.
 //

--- a/cmds/core/mknod/mknod.go
+++ b/cmds/core/mknod/mknod.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // Unmount a filesystem at the specified path.
 //

--- a/cmds/core/mount/mount.go
+++ b/cmds/core/mount/mount.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // mount mounts a filesystem at the specified path.
 //

--- a/cmds/core/mount/mount_plan9.go
+++ b/cmds/core/mount/mount_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && plan9
-// +build !tinygo,plan9
 
 // Mount mounts servename on old, with an optional keypattern spec
 //

--- a/cmds/core/mount/mount_test.go
+++ b/cmds/core/mount/mount_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 package main
 

--- a/cmds/core/mount/opts.go
+++ b/cmds/core/mount/opts.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !linux
-// +build !tinygo,!linux
 
 package main
 

--- a/cmds/core/msr/msr_linux.go
+++ b/cmds/core/msr/msr_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // msr reads and writes msrs using a Forth interpreter on argv
 //

--- a/cmds/core/ntpdate/ntpdate.go
+++ b/cmds/core/ntpdate/ntpdate.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // ntpdate uses NTP to adjust the system clock.
 //

--- a/cmds/core/pci/pci.go
+++ b/cmds/core/pci/pci.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // pci: show pci bus vendor ids and other info
 //

--- a/cmds/core/ps/ps.go
+++ b/cmds/core/ps/ps.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // Print process information.
 //

--- a/cmds/core/rsdp/rsdp.go
+++ b/cmds/core/rsdp/rsdp.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // rsdp allows to determine the ACPI RSDP structure address which could
 // be passed to the boot command later on

--- a/cmds/core/sshd/const_unix.go
+++ b/cmds/core/sshd/const_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 package main
 

--- a/cmds/core/strace/strace_linux.go
+++ b/cmds/core/strace/strace_linux.go
@@ -3,9 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && linux && (amd64 || riscv64 || arm64)
-// +build !tinygo
-// +build linux
-// +build amd64 riscv64 arm64
 
 // strace is a simple multi-process syscall & signal tracer.
 //

--- a/cmds/core/strace/strace_linux_test.go
+++ b/cmds/core/strace/strace_linux_test.go
@@ -3,9 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && linux && (amd64 || riscv64 || arm64)
-// +build !tinygo
-// +build linux
-// +build amd64 riscv64 arm64
 
 package main
 

--- a/cmds/core/stty/stty.go
+++ b/cmds/core/stty/stty.go
@@ -6,7 +6,6 @@
 // u-root does with the packages it uses.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // stty is an stty command in Go.
 // It follows many of the conventions of standard stty.

--- a/cmds/core/switch_root/switch_root_linux.go
+++ b/cmds/core/switch_root/switch_root_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && linux
-// +build !tinygo,linux
 
 package main
 

--- a/cmds/core/sync/sync.go
+++ b/cmds/core/sync/sync.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // sync command in Go.
 //

--- a/cmds/core/sync/sync_unix.go
+++ b/cmds/core/sync/sync_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux && !plan9
-// +build !linux,!plan9
 
 package main
 

--- a/cmds/core/time/time_all.go
+++ b/cmds/core/time/time_all.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo
-// +build !tinygo
 
 package main
 

--- a/cmds/core/time/time_tinygo.go
+++ b/cmds/core/time/time_tinygo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build tinygo
-// +build tinygo
 
 package main
 

--- a/cmds/core/timeout/timeout.go
+++ b/cmds/core/timeout/timeout.go
@@ -24,7 +24,6 @@
 //	$
 
 //go:build !test
-// +build !test
 
 package main
 

--- a/cmds/core/touch/access_linux_test.go
+++ b/cmds/core/touch/access_linux_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package main
 

--- a/cmds/core/tty/tty.go
+++ b/cmds/core/tty/tty.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package main
 

--- a/cmds/core/umount/umount.go
+++ b/cmds/core/umount/umount.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // Unmount a filesystem at the specified path.
 //

--- a/cmds/core/uname/uname.go
+++ b/cmds/core/uname/uname.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 // Print build information about the kernel and machine.
 //

--- a/cmds/core/uname/uname_test.go
+++ b/cmds/core/uname/uname_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !plan9
-// +build !tinygo,!plan9
 
 package main
 

--- a/cmds/core/which/which_other.go
+++ b/cmds/core/which/which_other.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !darwin && !dragonfly && !freebsd && !linux && !nacl && !netbsd && !openbsd && !solaris
-// +build !tinygo,!darwin,!dragonfly,!freebsd,!linux,!nacl,!netbsd,!openbsd,!solaris
 
 package main
 

--- a/cmds/core/which/which_unix.go
+++ b/cmds/core/which/which_unix.go
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && (darwin || dragonfly || freebsd || linux || nacl || netbsd || openbsd || solaris)
-// +build !tinygo
-// +build darwin dragonfly freebsd linux nacl netbsd openbsd solaris
 
 package main
 

--- a/cmds/exp/cbmem/const.go
+++ b/cmds/exp/cbmem/const.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package main
 

--- a/cmds/exp/cbmem/io.go
+++ b/cmds/exp/cbmem/io.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package main
 

--- a/cmds/exp/cbmem/types.go
+++ b/cmds/exp/cbmem/types.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package main
 

--- a/cmds/exp/lsfabric/lsfabric.go
+++ b/cmds/exp/lsfabric/lsfabric.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64 && linux
-// +build amd64,linux
 
 package main
 

--- a/cmds/exp/pox/pox_vm_test.go
+++ b/cmds/exp/pox/pox_vm_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !race
-// +build !tinygo,!race
 
 package main
 

--- a/cmds/exp/rush/attr.go
+++ b/cmds/exp/rush/attr.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !linux
-// +build !tinygo,!linux
 
 package main
 

--- a/cmds/exp/rush/attr_linux.go
+++ b/cmds/exp/rush/attr_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && linux
-// +build !tinygo,linux
 
 package main
 

--- a/cmds/exp/rush/runone_unix.go
+++ b/cmds/exp/rush/runone_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo
-// +build !tinygo
 
 package main
 

--- a/cmds/exp/rush/rush_tinygo.go
+++ b/cmds/exp/rush/rush_tinygo.go
@@ -6,7 +6,6 @@
 // It is replaced by the tinygobb tool.
 
 //go:build tinygo
-// +build tinygo
 
 package main
 

--- a/cmds/exp/rush/tty.go
+++ b/cmds/exp/rush/tty.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && !linux
-// +build !tinygo,!linux
 
 package main
 

--- a/cmds/exp/rush/tty_linux.go
+++ b/cmds/exp/rush/tty_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo
-// +build !tinygo
 
 package main
 

--- a/cmds/exp/rush/tty_tinygo.go
+++ b/cmds/exp/rush/tty_tinygo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build tinygo
-// +build tinygo
 
 package main
 

--- a/cmds/exp/ssh/utils_plan9.go
+++ b/cmds/exp/ssh/utils_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && plan9
-// +build !tinygo,plan9
 
 package main
 

--- a/cmds/exp/ssh/utils_unix.go
+++ b/cmds/exp/ssh/utils_unix.go
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && (!plan9 || !windows)
-// +build !tinygo
-// +build !plan9 !windows
 
 package main
 

--- a/cmds/exp/syscallfilter/main_linux.go
+++ b/cmds/exp/syscallfilter/main_linux.go
@@ -3,8 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !tinygo && ((linux && arm64) || (linux && amd64) || (linux && riscv64))
-// +build !tinygo
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 // syscallfilter runs a command with a possibly empty set of filters:
 //

--- a/integration/generic-tests/dhclient_test.go
+++ b/integration/generic-tests/dhclient_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/integration/generic-tests/esxi_boot_test.go
+++ b/integration/generic-tests/esxi_boot_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/integration/generic-tests/fork_bomb_test.go
+++ b/integration/generic-tests/fork_bomb_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/integration/generic-tests/io_test.go
+++ b/integration/generic-tests/io_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64 && !race
-// +build amd64,!race
 
 package integration
 

--- a/integration/generic-tests/kexec_test.go
+++ b/integration/generic-tests/kexec_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/integration/generic-tests/multiboot_test.go
+++ b/integration/generic-tests/multiboot_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/integration/generic-tests/pxeboot_test.go
+++ b/integration/generic-tests/pxeboot_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/integration/generic-tests/tcz_test.go
+++ b/integration/generic-tests/tcz_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/integration/generic-tests/uefiboot_test.go
+++ b/integration/generic-tests/uefiboot_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64 && !race
-// +build amd64,!race
 
 package integration
 

--- a/integration/generic-tests/uinit_test.go
+++ b/integration/generic-tests/uinit_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/integration/gotests/gotest_test.go
+++ b/integration/gotests/gotest_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package integration
 

--- a/pkg/acpi/acpi_test.go
+++ b/pkg/acpi/acpi_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package acpi
 

--- a/pkg/acpi/fpdt/fbpt/fbpt_test.go
+++ b/pkg/acpi/fpdt/fbpt/fbpt_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package fbpt
 

--- a/pkg/acpi/fpdt/fpdt_test.go
+++ b/pkg/acpi/fpdt/fpdt_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package fpdt
 

--- a/pkg/acpi/linux_test.go
+++ b/pkg/acpi/linux_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package acpi
 

--- a/pkg/acpi/tables.go
+++ b/pkg/acpi/tables.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package acpi
 

--- a/pkg/acpi/tables_linux.go
+++ b/pkg/acpi/tables_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package acpi
 

--- a/pkg/boot/kexec/kexec_fileload_implemented_linux.go
+++ b/pkg/boot/kexec/kexec_fileload_implemented_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64 || arm64 || riscv64
-// +build amd64 arm64 riscv64
 
 package kexec
 

--- a/pkg/boot/kexec/kexec_fileload_other_linux.go
+++ b/pkg/boot/kexec/kexec_fileload_other_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !amd64 && !arm64 && !riscv64
-// +build !amd64,!arm64,!riscv64
 
 package kexec
 

--- a/pkg/boot/linux/load_other_linux.go
+++ b/pkg/boot/linux/load_other_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !amd64 && !arm64
-// +build !amd64,!arm64
 
 package linux
 

--- a/pkg/boot/multiboot/internal/trampoline/trampoline.go
+++ b/pkg/boot/multiboot/internal/trampoline/trampoline.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux || !amd64
-// +build !linux !amd64
 
 package trampoline
 

--- a/pkg/brctl/brctl_integration_test.go
+++ b/pkg/brctl/brctl_integration_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package brctl
 

--- a/pkg/brctl/util.go
+++ b/pkg/brctl/util.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package brctl
 

--- a/pkg/cmdline/cmdline_other.go
+++ b/pkg/cmdline/cmdline_other.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package cmdline
 

--- a/pkg/cmos/cmos.go
+++ b/pkg/cmos/cmos.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64 || 386
-// +build amd64 386
 
 package cmos
 

--- a/pkg/cmos/cmos_test.go
+++ b/pkg/cmos/cmos_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && amd64) || (linux && 386)
-// +build linux,amd64 linux,386
 
 package cmos
 

--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9 && !windows
-// +build !plan9,!windows
 
 package cpio
 

--- a/pkg/cpio/fs_unix_test.go
+++ b/pkg/cpio/fs_unix_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9 && !windows
-// +build !plan9,!windows
 
 package cpio
 

--- a/pkg/cpio/mknod_unix.go
+++ b/pkg/cpio/mknod_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !freebsd && !plan9 && !windows
-// +build !freebsd,!plan9,!windows
 
 package cpio
 

--- a/pkg/gpio/gpio_integration_test.go
+++ b/pkg/gpio/gpio_integration_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package gpio
 

--- a/pkg/ipmi/ipmi_vm_test.go
+++ b/pkg/ipmi/ipmi_vm_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package ipmi
 

--- a/pkg/ldd/ldd.go
+++ b/pkg/ldd/ldd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build freebsd || linux || darwin
-// +build freebsd linux darwin
 
 // ldd returns library dependencies of an executable.
 //

--- a/pkg/ldd/ldd_darwin.go
+++ b/pkg/ldd/ldd_darwin.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin
-// +build darwin
 
 package ldd
 

--- a/pkg/ldd/ldd_test.go
+++ b/pkg/ldd/ldd_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build freebsd || linux
-// +build freebsd linux
 
 package ldd
 

--- a/pkg/ldd/ldd_unix.go
+++ b/pkg/ldd/ldd_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build freebsd || linux
-// +build freebsd linux
 
 package ldd
 

--- a/pkg/ldd/ldd_unix_test.go
+++ b/pkg/ldd/ldd_unix_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build freebsd || linux
-// +build freebsd linux
 
 package ldd
 

--- a/pkg/ls/fileinfo_plan9.go
+++ b/pkg/ls/fileinfo_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build plan9
-// +build plan9
 
 package ls
 

--- a/pkg/memio/archport_linux.go
+++ b/pkg/memio/archport_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && amd64) || (linux && 386)
-// +build linux,amd64 linux,386
 
 package memio
 

--- a/pkg/memio/ports_linux.go
+++ b/pkg/memio/ports_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && amd64) || (linux && 386)
-// +build linux,amd64 linux,386
 
 package memio
 

--- a/pkg/memio/ports_linux_test.go
+++ b/pkg/memio/ports_linux_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && amd64) || (linux && 386)
-// +build linux,amd64 linux,386
 
 package memio
 

--- a/pkg/memio/ports_plan9.go
+++ b/pkg/memio/ports_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build plan9
-// +build plan9
 
 package memio
 

--- a/pkg/mount/block/vm_test.go
+++ b/pkg/mount/block/vm_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package block
 

--- a/pkg/mount/gpt/gpt_test.go
+++ b/pkg/mount/gpt/gpt_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package gpt
 

--- a/pkg/mount/loop/losetup_integration_test.go
+++ b/pkg/mount/loop/losetup_integration_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package loop
 

--- a/pkg/mount/magic.go
+++ b/pkg/mount/magic.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build linux
-// +build linux
 
 package mount
 

--- a/pkg/mount/mount_integration_test.go
+++ b/pkg/mount/mount_integration_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package mount
 

--- a/pkg/mount/scuzz/const_amd64.go
+++ b/pkg/mount/scuzz/const_amd64.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64
-// +build amd64
 
 package scuzz
 

--- a/pkg/mount/scuzz/sg_linux_test.go
+++ b/pkg/mount/scuzz/sg_linux_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64
-// +build amd64
 
 package scuzz
 

--- a/pkg/mount/scuzz_mount_test.go
+++ b/pkg/mount/scuzz_mount_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build amd64
-// +build amd64
 
 package mount_test
 

--- a/pkg/namespace/namespace_unix.go
+++ b/pkg/namespace/namespace_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // This file is inserted here so the lack of these variables/implmenetations doesn't break
 // IDEs and tooling on other platforms.

--- a/pkg/pci/gen.go
+++ b/pkg/pci/gen.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/pkg/pty/pty_integration_test.go
+++ b/pkg/pty/pty_integration_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package pty
 

--- a/pkg/pty/pty_test.go
+++ b/pkg/pty/pty_test.go
@@ -5,7 +5,6 @@
 // This test is flaky AF under the race detector.
 
 //go:build !race
-// +build !race
 
 package pty
 

--- a/pkg/rand/random_std.go
+++ b/pkg/rand/random_std.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build plan9 || windows
-// +build plan9 windows
 
 package rand
 

--- a/pkg/rand/random_unix.go
+++ b/pkg/rand/random_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build aix || darwin || dragonfly || freebsd || nacl || netbsd || openbsd || solaris
-// +build aix darwin dragonfly freebsd nacl netbsd openbsd solaris
 
 package rand
 

--- a/pkg/rand/random_urandom.go
+++ b/pkg/rand/random_urandom.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build aix || darwin || dragonfly || freebsd || nacl || netbsd || openbsd || solaris || linux
-// +build aix darwin dragonfly freebsd nacl netbsd openbsd solaris linux
 
 package rand
 

--- a/pkg/securelaunch/vm_test.go
+++ b/pkg/securelaunch/vm_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package securelaunch
 

--- a/pkg/smbios/vm_test.go
+++ b/pkg/smbios/vm_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package smbios
 

--- a/pkg/strace/arch.go
+++ b/pkg/strace/arch.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/strace/epsocket.go
+++ b/pkg/strace/epsocket.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/strace/epsocket_test.go
+++ b/pkg/strace/epsocket_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/strace/print.go
+++ b/pkg/strace/print.go
@@ -15,7 +15,6 @@
 // Changes are Copyright 2018 the u-root Authors.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/strace/socket.go
+++ b/pkg/strace/socket.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/strace/syscall_linux.go
+++ b/pkg/strace/syscall_linux.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build arm64 || amd64 || riscv64
-// +build arm64 amd64 riscv64
 
 package strace
 

--- a/pkg/strace/syscalls.go
+++ b/pkg/strace/syscalls.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/strace/syscalls_test.go
+++ b/pkg/strace/syscalls_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/strace/tracer.go
+++ b/pkg/strace/tracer.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 // Package strace traces Linux process events.
 //

--- a/pkg/strace/tracer_test.go
+++ b/pkg/strace/tracer_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/strace/types.go
+++ b/pkg/strace/types.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package strace
 

--- a/pkg/syscallfilter/syscallfilter_linux.go
+++ b/pkg/syscallfilter/syscallfilter_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build (linux && arm64) || (linux && amd64) || (linux && riscv64)
-// +build linux,arm64 linux,amd64 linux,riscv64
 
 package syscallfilter
 

--- a/pkg/termios/sgtty.go
+++ b/pkg/termios/sgtty.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9 && !windows
-// +build !plan9,!windows
 
 package termios
 

--- a/pkg/termios/sgtty_unix.go
+++ b/pkg/termios/sgtty_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9 && !windows && !darwin && !freebsd && !openbsd && !netbsd
-// +build !plan9,!windows,!darwin,!freebsd,!openbsd,!netbsd
 
 package termios
 

--- a/pkg/termios/termios_bsd.go
+++ b/pkg/termios/termios_bsd.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build darwin || freebsd || openbsd || netbsd
-// +build darwin freebsd openbsd netbsd
 
 package termios
 

--- a/pkg/termios/termios_linux.go
+++ b/pkg/termios/termios_linux.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package termios
 

--- a/pkg/termios/termios_plan9.go
+++ b/pkg/termios/termios_plan9.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build plan9
-// +build plan9
 
 package termios
 

--- a/pkg/termios/termios_test.go
+++ b/pkg/termios/termios_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 // Package termios implements basic termios operations including getting
 // a termio struct, a winsize struct, and setting raw mode.

--- a/pkg/termios/var_unix.go
+++ b/pkg/termios/var_unix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package termios
 

--- a/pkg/testutil/testutil_posix.go
+++ b/pkg/testutil/testutil_posix.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !plan9
-// +build !plan9
 
 package testutil
 

--- a/pkg/uefivars/boot/fuzz.go
+++ b/pkg/uefivars/boot/fuzz.go
@@ -6,7 +6,6 @@
 //
 
 //go:build gofuzz
-// +build gofuzz
 
 package boot
 

--- a/pkg/ulog/klog_other.go
+++ b/pkg/ulog/klog_other.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package ulog
 

--- a/pkg/ulog/log_integration_test.go
+++ b/pkg/ulog/log_integration_test.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build !race
-// +build !race
 
 package ulog_test
 

--- a/tools/tinygobb/main.go
+++ b/tools/tinygobb/main.go
@@ -27,7 +27,6 @@ var (
 // license that can be found in the LICENSE file.
 
 //go:build tinygo
-// +build tinygo
 
 package bbrush
 


### PR DESCRIPTION
For the sake of managing build constraints and brevity, can we remove the (deprecated / ignored) `// +build CONSTRAINT` lines?

See: https://tip.golang.org/doc/go1.18#:~:text=Since%20the%20release%20of%20Go,or%20later%20in%20their%20go.

result of:

1. running gofmt on all sources to ensure //go:build lines were up-to-date with // +build lines

2.
```
find cmds integration pkg tools -name '*.go' -exec perl -n -i -e 'print unless m/^\/\/ *\+build/' {} \;
```