### PR TITLE
tinygo: fix pkg/kmodule/compression{,_tinygo}.go build tags

### DIFF
--- a/pkg/kmodule/compression.go
+++ b/pkg/kmodule/compression.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !tinygo
+
 package kmodule
 
 import (

--- a/pkg/kmodule/compression_tinygo.go
+++ b/pkg/kmodule/compression_tinygo.go
@@ -3,7 +3,6 @@
 // license that can be found in the LICENSE file.
 
 //go:build tinygo
-// +build tinygo
 
 package kmodule
 


### PR DESCRIPTION
Add missing !tinygo line in pkg/kmodule/compression.go, without it, there are multiple definitions of the function:

    > tinygo build -tags tinygo.enable,noasm
    # github.com/u-root/u-root/pkg/kmodule
    ../../../pkg/kmodule/compression.go:20:6: 	other declaration of compressionReader
    ../../../pkg/kmodule/compression_tinygo.go:24:6: compressionReader redeclared in this block

