### PR TITLE
cmds/core/msr: fix bug, comments, tips

### DIFF
--- a/cmds/core/msr/doc_linux.go
+++ b/cmds/core/msr/doc_linux.go
@@ -17,7 +17,7 @@
 //
 //	To read the msrs for 0 (sorry, the command is msr and the forth command
 //	is msr, making this a bit confusing):
-//	sudo msr 0 msr 0x3a reg rd
+//	sudo msr 0 cpu 0x3a reg rd
 //	Breaking that down:
 //	0 - for cpu 0
 //	msr - for take the glob, in this case 0, and push all matching filenames on the stack
@@ -26,7 +26,7 @@
 //	rd - pop a 32-bit int and a []string and use them to read 1 or more MSRs
 //
 //	for all:
-//	sudo msr "'*" msr 0x3a reg rd
+//	sudo msr "'*" cpu 0x3a reg rd
 //
 //	The "'" is needed to quote the * so forth does not think we're multiplying.
 //

--- a/pkg/forth/forth.go
+++ b/pkg/forth/forth.go
@@ -82,6 +82,7 @@ func init() {
 		"*":        times,
 		"/":        div,
 		"%":        mod,
+		"printf":   fmtprintf,
 		"swap":     swap,
 		"ifelse":   ifelse,
 		"hostname": hostname,
@@ -360,6 +361,13 @@ func roundup(f Forth) {
 	v := toInt(f)
 	v = ((v + rnd - 1) / rnd) * rnd
 	f.Push(v)
+}
+
+func fmtprintf(f Forth) {
+	x := f.Pop()
+	s := x.(string)
+	y := f.Pop()
+	f.Push(fmt.Sprintf(s, y))
 }
 
 func swap(f Forth) {

--- a/pkg/forth/forth_test.go
+++ b/pkg/forth/forth_test.go
@@ -43,6 +43,8 @@ var forthTests = []forthTest{
 	{val: "5 5 + hostbase", res: "", err: strconv.ErrSyntax, empty: true},
 	{val: "1 1 '+ newword 1 1 '+ newword", res: "", err: ErrWordExist, empty: true},
 	{val: "1 4 bad newword", res: "", err: ErrNotEnoughElements, empty: false},
+	{val: "1 %d printf", res: "1\n", empty: true},
+	{val: "%d printf", res: "", err: ErrEmptyStack, empty: true},
 }
 
 func TestForth(t *testing.T) {


### PR DESCRIPTION
The first version of the forth package []string for the stack, not []any; this is because that's how forth was always implemented. But a stack of []any made much more sense. So it changed.

The msr command was written for this earlier version of forth, and in one place in particular, the rd function, it was not updated. This led to un-needed panics.
While panic can be used with a recover for this case, it is much better to just return the error in the slice of results.

Fix the rd function to add error to the slice of results from the rd command, not panic.

The comments were wrong in places, as to usage; further, they did mention some of the handy debugging one can do, e.g., to see what a glob would expand to for the cpus forth word, one can do this msr '[0-4] cpu
0-4

Since any of available forth words will do:
./msr \'[0-4] cpu 0x3a reg
[0-4 0x3a]
This shows the stack that would be ready to execute with the rd command
./msr \'[0-4] cpu 0x3a reg rd

[open /dev/cpu/0/msr: permission denied open /dev/cpu/1/msr: permission denied open /dev/cpu/2/msr: permission denied open /dev/cpu/3/msr: permission denied open
/dev/cpu/4/msr: permission denied]

is the result in this case.

sudo ./msr \'[0-4] cpu 0x10 reg rd
[4275528058551283 4275528058689478 4275528058808390 4275528058901765 4275528058972078] is the output for a real command

bugs: need to be able to format as hex :-(