### PR TITLE
FIX: cmds/exp/tftp: Read file from server until EOF

### DIFF
--- a/pkg/tftp/client.go
+++ b/pkg/tftp/client.go
@@ -24,32 +24,6 @@ type ClientIf interface {
 	Get(string) (Response, error)
 }
 
-// ClientMock serves as the Mock structure of Client for testing.
-type ClientMock struct{}
-
-// DummyResp serves as the mock structure of Response for testing.
-type DummyResp struct{}
-
-// Size mocks the Size function of tftp.Response for testing.
-func (d *DummyResp) Size() (int64, error) {
-	return 0, nil
-}
-
-// Read mocks the Read function of tftp.Response for testing.
-func (d *DummyResp) Read(b []byte) (int, error) {
-	return 0, io.EOF
-}
-
-// Get mocks the Get method of tftp.Client.
-func (c *ClientMock) Get(url string) (Response, error) {
-	return &DummyResp{}, nil
-}
-
-// Put mocks the Put method of tftp.Client.
-func (c *ClientMock) Put(url string, r io.Reader, size int64) error {
-	return nil
-}
-
 // Client implements the ClientIf and uses the tftp.Client as member to interact with the real library.
 type Client struct {
 	*tftp.Client

--- a/pkg/tftp/client.go
+++ b/pkg/tftp/client.go
@@ -37,7 +37,7 @@ func (d *DummyResp) Size() (int64, error) {
 
 // Read mocks the Read function of tftp.Response for testing.
 func (d *DummyResp) Read(b []byte) (int, error) {
-	return 0, nil
+	return 0, io.EOF
 }
 
 // Get mocks the Get method of tftp.Client.
@@ -72,7 +72,7 @@ func (r *RealResponse) Size() (int64, error) {
 
 // NewClient sets up a new tftp.Client according to the given ClientCfg struct.
 func NewClient(ccfg *ClientCfg) (*Client, error) {
-	c, err := tftp.NewClient(tftp.ClientMode(ccfg.Mode), ccfg.Rexmt, ccfg.Timeout)
+	c, err := tftp.NewClient(tftp.ClientMode(ccfg.Mode), ccfg.Rexmt, tftp.ClientTransferSize(false), ccfg.Timeout)
 	return &Client{
 		Client: c,
 	}, err

--- a/pkg/tftp/tftp.go
+++ b/pkg/tftp/tftp.go
@@ -63,8 +63,8 @@ func RunInteractive(f Flags, ipPort []string, stdin io.Reader, stdout io.Writer)
 		Host:    ipHost,
 		Port:    port,
 		Mode:    tftp.ModeNetASCII,
-		Rexmt:   tftp.ClientRetransmit(10),
-		Timeout: tftp.ClientTimeout(1),
+		Rexmt:   tftp.ClientRetransmit(4),
+		Timeout: tftp.ClientTimeout(10),
 		Trace:   false,
 		Literal: f.Literal,
 	}
@@ -160,7 +160,7 @@ func ExecuteOp(input []string, clientcfg *ClientCfg, stdout io.Writer) (bool, er
 
 func constructURL(host, port, dir string, file string) string {
 	var s strings.Builder
-	fmt.Fprintf(&s, "tftp://%s:%s/", host, port)
+	fmt.Fprintf(&s, "%s:%s/", host, port)
 	if dir != "" {
 		fmt.Fprintf(&s, "%s/", dir)
 	}
@@ -284,8 +284,6 @@ type getCmd struct {
 	localfile   string
 }
 
-var errSizeNoMatch = errors.New("data size of read and write mismatch")
-
 func executeGet(client ClientIf, host, port string, files []string) error {
 	ret := &getCmd{}
 	switch len(files) {
@@ -321,25 +319,27 @@ func executeGet(client ClientIf, host, port string, files []string) error {
 			}
 		}
 
-		datalen, err := resp.Size()
+		nR := 0
+		data := make([]byte, 0)
+		for {
+			fmt.Println("loop")
+			readData := make([]byte, 10)
+			rD, err := resp.Read(data)
+			if err != nil && !errors.Is(err, io.EOF) {
+				return err
+			}
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			nR += rD
+			data = append(data, readData...)
+		}
+
+		_, err = localfile.Write(data)
 		if err != nil {
 			return err
 		}
 
-		data := make([]byte, datalen)
-		nR, err := resp.Read(data)
-		if err != nil {
-			return err
-		}
-
-		nW, err := localfile.Write(data)
-		if err != nil {
-			return err
-		}
-
-		if nR != nW {
-			return errSizeNoMatch
-		}
 	}
 
 	return nil

--- a/pkg/tftp/tftp_test.go
+++ b/pkg/tftp/tftp_test.go
@@ -9,10 +9,37 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"testing"
 )
+
+// ClientMock serves as the Mock structure of Client for testing.
+type ClientMock struct{}
+
+// DummyResp serves as the mock structure of Response for testing.
+type DummyResp struct{}
+
+// Size mocks the Size function of tftp.Response for testing.
+func (d *DummyResp) Size() (int64, error) {
+	return 0, nil
+}
+
+// Read mocks the Read function of tftp.Response for testing.
+func (d *DummyResp) Read(b []byte) (int, error) {
+	return 0, io.EOF
+}
+
+// Get mocks the Get method of tftp.Client.
+func (c *ClientMock) Get(url string) (Response, error) {
+	return &DummyResp{}, nil
+}
+
+// Put mocks the Put method of tftp.Client.
+func (c *ClientMock) Put(url string, r io.Reader, size int64) error {
+	return nil
+}
 
 func TestReadInteractiveInput(t *testing.T) {
 	for _, tt := range []struct {

--- a/pkg/tftp/tftp_test.go
+++ b/pkg/tftp/tftp_test.go
@@ -85,7 +85,7 @@ func TestConstructURL(t *testing.T) {
 			port: "69",
 			dir:  "",
 			file: "abc.file",
-			exp:  "tftp://localhost:69/abc.file",
+			exp:  "localhost:69/abc.file",
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
fix executeGet:
Some tftp-servers do not support file size transmission. 
Adapted function for infinite read until EOF, then write file to disc.