### PR TITLE
FIX: cmds/exp/tftp: read buffer adaption and last read correction

### DIFF
--- a/pkg/tftp/tftp.go
+++ b/pkg/tftp/tftp.go
@@ -319,23 +319,7 @@ func executeGet(client ClientIf, host, port string, files []string) error {
 			}
 		}
 
-		nR := 0
-		data := make([]byte, 0)
-		for {
-			fmt.Println("loop")
-			readData := make([]byte, 10)
-			rD, err := resp.Read(data)
-			if err != nil && !errors.Is(err, io.EOF) {
-				return err
-			}
-			if errors.Is(err, io.EOF) {
-				break
-			}
-			nR += rD
-			data = append(data, readData...)
-		}
-
-		_, err = localfile.Write(data)
+		_, err = io.Copy(localfile, resp)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
fix tftp again:
* Buffer size for reading now has 512 bytes as RFC 1350 defines data size for transmission.
* If the read function indicates EOF, write only bytes which are not zero.
* remove debug statement which slipped through review.