### PR TITLE
modules: udpdate go-tpm to incorporate tinygo issue fixes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,5 +24,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.59.1
+          version: v1.60.3
           args: --out-format=line-number

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,31 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.x', '1.22.x' ]
+        go-version: ['1.22.x' ]
         vmarch: [ 'amd64', 'arm', 'arm64' ]
         pattern: [ 'integration/generic-tests/...', 'integration/gotests/...' ]
         include:
           # Only run these with VM arch amd64 for now.
-          - go-version: '1.21.x'
-            vmarch: 'amd64'
-            pattern: 'cmds/...'
           - go-version: '1.22.x'
             vmarch: 'amd64'
             pattern: 'cmds/...'
 
-          - go-version: '1.21.x'
-            vmarch: 'amd64'
-            pattern: 'pkg/...'
-            extra-arg: '-coverpkg=./pkg/...'
           - go-version: '1.22.x'
             vmarch: 'amd64'
             pattern: 'pkg/...'
             extra-arg: '-coverpkg=./pkg/...'
 
           # Root dir tests
-          - go-version: '1.21.x'
-            vmarch: 'amd64'
-            pattern: '.'
           - go-version: '1.22.x'
             vmarch: 'amd64'
             pattern: '.'

--- a/cmds/core/shutdown/shutdown_linux.go
+++ b/cmds/core/shutdown/shutdown_linux.go
@@ -34,7 +34,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var errUsage = errors.New("shutdown [<-h|-r|-s|halt|reboot|suspend> [time [message...]]]")
+var (
+	errUsageMessage = errors.New("shutdown [<-h|-r|-s|halt|reboot|suspend> [time [message...]]]")
+)
 
 var (
 	opcodes = map[string]uint{
@@ -58,7 +60,7 @@ func shutdown(dryrun bool, args ...string) (uint, error) {
 	}
 	op, ok := opcodes[args[0]]
 	if !ok {
-		return 0, errUsage
+		return 0, errUsageMessage
 	}
 	if len(args) < 2 {
 		args = append(args, "now")

--- a/cmds/exp/fdtdump/fdtdump.go
+++ b/cmds/exp/fdtdump/fdtdump.go
@@ -50,6 +50,7 @@ func main() {
 		}
 		fmt.Println(string(out))
 	} else {
+		//nolint:staticcheck
 		if err := fdt.PrintDTS(os.Stdout); err != nil {
 			log.Fatalf("error printing dts: %v", err)
 		}

--- a/cmds/exp/pflask/pflask.go
+++ b/cmds/exp/pflask/pflask.go
@@ -18,7 +18,6 @@ import (
 	"time"
 	"unsafe"
 
-	// "github.com/u-root/u-root/pkg/termios"
 	"golang.org/x/sys/unix"
 )
 
@@ -277,10 +276,8 @@ func makeSymlinks(base string) {
 var (
 	cgpath  = flag.String("cgpath", "/sys/fs/cgroup", "set the cgroups")
 	cgroup  = flag.String("cgroup", "", "set the cgroups")
-	mnt     = flag.String("mount", "", "define mounts")
 	chroot  = flag.String("chroot", "", "where to chroot to")
 	chdir   = flag.String("chdir", "/", "where to chrdir to in the chroot")
-	console = flag.String("console", "/dev/console", "where the console is")
 	keepenv = flag.Bool("keepenv", false, "Keep the environment")
 	debug   = flag.Bool("d", false, "Enable debug logs")
 	env     = flag.String("env", "", "other environment variables")
@@ -355,10 +352,6 @@ func main() {
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
-		//t, err := termios.GetTermios(1)
-		//if err != nil {
-		//	log.Fatalf("Can't get termios on fd 1: %v", err)
-		//}
 		v("pflask: respawning...")
 		if err := c.Run(); err != nil {
 			log.Printf("Could not run:\n   %v\n    %v\n", c, err.Error())
@@ -382,7 +375,7 @@ func main() {
 	// If you make it /, strange things are bound to happen.
 	// if that is too limiting we'll have to change this.
 	if *chroot == "" {
-		log.Fatalf("you are required to set the chroot via -chroot")
+		log.Fatal("you are required to set the chroot via -chroot")
 	}
 	if *chroot == "/" {
 		log.Println("[WARN]: chroot set to /: strange things are bound to happen")
@@ -422,9 +415,7 @@ func main() {
 	makeConsole(*chroot, sname, unprivileged)
 
 	// umask(0022);
-
 	/* TODO: drop capabilities */
-
 	// do_user(user);
 
 	e := make(map[string]string)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/u-root/u-root
 
-go 1.21
+go 1.22
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
@@ -15,7 +15,7 @@ require (
 	github.com/gliderlabs/ssh v0.1.2-0.20181113160402-cbabf5414432
 	github.com/gojuno/minimock/v3 v3.0.8
 	github.com/google/go-cmp v0.6.0
-	github.com/google/go-tpm v0.9.1-0.20230914180155-ee6cbcd136f8
+	github.com/google/go-tpm v0.9.2-0.20240919181259-d96ccf715685
 	github.com/google/uuid v1.3.0
 	github.com/gopacket/gopacket v1.2.0
 	github.com/hugelgupf/vmtest v0.0.0-20240228002643-de15f4612e10

--- a/go.sum
+++ b/go.sum
@@ -98,8 +98,8 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/google/go-tpm v0.9.1-0.20230914180155-ee6cbcd136f8 h1:g9RVRZdQrNEK2E94RcFescvXFC9afWsFar4IIdejP34=
-github.com/google/go-tpm v0.9.1-0.20230914180155-ee6cbcd136f8/go.mod h1:FkNVkc6C+IsvDI9Jw1OveJmxGZUUaKxtrpOS47QWKfU=
+github.com/google/go-tpm v0.9.2-0.20240919181259-d96ccf715685 h1:qw848zQ6u6AHBJMisaNVESB45t5BVtbk40LMJVO1/jc=
+github.com/google/go-tpm v0.9.2-0.20240919181259-d96ccf715685/go.mod h1:h9jEsEECg7gtLis0upRBQU+GhYVH6jMjrFxI8u6bVUY=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopacket/gopacket v1.2.0 h1:eXbzFad7f73P1n2EJHQlsKuvIMJjVXK5tXoSca78I3A=

--- a/pkg/dt/print.go
+++ b/pkg/dt/print.go
@@ -12,6 +12,8 @@ import (
 
 // PrintDTS prints the FDT in the .dts format.
 // TODO: not yet implemented
+//
+//nolint:staticcheck
 func (fdt *FDT) PrintDTS(f io.Writer) error {
 	return errors.New("not yet implemented")
 }

--- a/pkg/ipmi/ipmi.go
+++ b/pkg/ipmi/ipmi.go
@@ -27,6 +27,17 @@ var (
 	_IPMICTL_SEND_COMMAND      = ioctl.IOR(_IPMI_IOC_MAGIC, 13, uintptr(unsafe.Sizeof(request{})))
 
 	timeout = time.Second * 10
+
+	shutoffWatchdogCmd = [6]byte{
+		IPM_WATCHDOG_SMS_OS,
+		IPM_WATCHDOG_NO_ACTION,
+		0x00, // pre-timeout interval
+		IPM_WATCHDOG_CLEAR_SMS_OS,
+		0xb8, // countdown lsb (100 ms/count)
+		0x0b, // countdown msb - 5 mins
+	}
+
+	errNotEnoughParams = errors.New("not enough parameters given")
 )
 
 // IPMI represents access to the IPMI interface.
@@ -90,6 +101,10 @@ func (i *IPMI) RawSendRecv(msg Msg) ([]byte, error) {
 	return i.dev.ReceiveResponse(req.msgid, recv, buf)
 }
 
+// WatchdogRunning checks if the watchdog timer is currently running.
+// It sends a command to the BMC to get the watchdog timer status.
+// Returns true if the watchdog timer is running, otherwise false.
+// If there is an error in sending or receiving the command, it returns the error.
 func (i *IPMI) WatchdogRunning() (bool, error) {
 	recv, err := i.SendRecv(_IPMI_NETFN_APP, BMC_GET_WATCHDOG_TIMER, nil)
 	if err != nil {
@@ -103,25 +118,27 @@ func (i *IPMI) WatchdogRunning() (bool, error) {
 	return false, nil
 }
 
+// ShutoffWatchdog disables the watchdog timer on the IPMI device.
+// It sends a command to the BMC to set the watchdog timer to a shutoff state.
+// Returns an error if the command fails to send or receive a response.
 func (i *IPMI) ShutoffWatchdog() error {
-	var data [6]byte
-	data[0] = IPM_WATCHDOG_SMS_OS
-	data[1] = IPM_WATCHDOG_NO_ACTION
-	data[2] = 0x00 // pretimeout interval
-	data[3] = IPM_WATCHDOG_CLEAR_SMS_OS
-	data[4] = 0xb8 // countdown lsb (100 ms/count)
-	data[5] = 0x0b // countdown msb - 5 mins
-
-	_, err := i.SendRecv(_IPMI_NETFN_APP, BMC_SET_WATCHDOG_TIMER, data[:6])
-	return err
+	if _, err := i.SendRecv(_IPMI_NETFN_APP, BMC_SET_WATCHDOG_TIMER, shutoffWatchdogCmd[:6]); err != nil {
+		return err
+	}
+	return nil
 }
 
-// marshall converts the Event struct to binary data and the content of returned data is based on the record type
+// marshall converts the Event struct to binary data.
+// The content of returned data is based on the record type.
 func (e *Event) marshall() ([]byte, error) {
 	buf := &bytes.Buffer{}
 
 	if err := binary.Write(buf, binary.LittleEndian, *e); err != nil {
 		return nil, err
+	}
+
+	if buf.Len() < 2 {
+		return nil, fmt.Errorf("marshall: cannot marshall data, need at least 2, got %d bytes", buf.Len())
 	}
 
 	data := make([]byte, 16)
@@ -132,7 +149,7 @@ func (e *Event) marshall() ([]byte, error) {
 	}
 
 	// OEM timestamped
-	if buf.Bytes()[2] >= 0xC0 {
+	if buf.Bytes()[2] >= 0xC0 && buf.Bytes()[2] <= 0xDF {
 		copy(data[0:3], buf.Bytes()[0:3])
 		copy(data[3:16], buf.Bytes()[16:29])
 	}
@@ -213,6 +230,24 @@ func (i *IPMI) SetSystemFWVersion(version string) error {
 	return nil
 }
 
+// GetDeviceID retrieves the device ID information from the IPMI interface.
+// It sends a command to the BMC to get the device ID and parses the response
+// into a DevID struct.
+//
+// Returns:
+//   - A pointer to a DevID struct containing the device ID information.
+//   - An error if there is any issue in sending the command or parsing the response.
+//
+// The function reads the following fields from the response data:
+//   - DeviceID
+//   - DeviceRevision
+//   - FwRev1
+//   - FwRev2
+//   - IpmiVersion
+//   - AdtlDeviceSupport
+//   - ManufacturerID
+//   - ProductID
+//   - AuxFwRev (conditionally, if additional bytes are present in the response)
 func (i *IPMI) GetDeviceID() (*DevID, error) {
 	data, err := i.SendRecv(_IPMI_NETFN_APP, BMC_GET_DEVICE_ID, nil)
 	if err != nil {
@@ -264,6 +299,10 @@ func (i *IPMI) getGlobalEnables() ([]byte, error) {
 	return i.SendRecv(_IPMI_NETFN_APP, BMC_GET_GLOBAL_ENABLES, nil)
 }
 
+// EnableSEL enables the System Event Log (SEL) if it is supported and not already enabled.
+// It first checks if the SEL device is supported by retrieving the device ID.
+// If supported, it then checks the current global enables to see if SEL is already enabled.
+// If SEL is not enabled, it enables SEL by setting the appropriate global enable flag.
 func (i *IPMI) EnableSEL() (bool, error) {
 	// Check if SEL device is supported or not
 	mcInfo, err := i.GetDeviceID()
@@ -289,6 +328,15 @@ func (i *IPMI) EnableSEL() (bool, error) {
 	return true, nil
 }
 
+// GetChassisStatus retrieves the chassis status from the IPMI interface.
+// It sends a command to the BMC to get the chassis status and parses the response.
+//
+// The response data is expected to be in a specific format as per the IPMI specification v2.0.
+// If the response data is shorter than expected, it will be parsed into a shortened struct.
+//
+// Returns:
+// - A pointer to a ChassisStatus struct containing the current power state, last power event, and miscellaneous chassis state.
+// - An error if there is an issue with sending/receiving the command or parsing the response data.
 func (i *IPMI) GetChassisStatus() (*ChassisStatus, error) {
 	data, err := i.SendRecv(_IPMI_NETFN_CHASSIS, BMC_GET_CHASSIS_STATUS, nil)
 	if err != nil {
@@ -297,7 +345,8 @@ func (i *IPMI) GetChassisStatus() (*ChassisStatus, error) {
 
 	buf := bytes.NewReader(data[1:])
 
-	// The fourth byte of Chassis Status is optional (see p416 of the IPMI spec v2.0, https://www.intel.la/content/dam/www/public/us/en/documents/specification-updates/ipmi-intelligent-platform-mgt-interface-spec-2nd-gen-v2-0-spec-update.pdf)
+	// The fourth byte of Chassis Status is optional (see p416 of the IPMI spec v2.0,
+	// https://www.intel.la/content/dam/www/public/us/en/documents/specification-updates/ipmi-intelligent-platform-mgt-interface-spec-2nd-gen-v2-0-spec-update.pdf)
 	// binary.Read won't do any parsing if it does not find all the needed bytes, so we sometimes read to a shortened
 	// struct instead.
 	if buf.Len() == 3 {
@@ -306,9 +355,11 @@ func (i *IPMI) GetChassisStatus() (*ChassisStatus, error) {
 			LastPowerEvent    byte
 			MiscChassisState  byte
 		}
+
 		if err := binary.Read(buf, binary.LittleEndian, &shortened); err != nil {
 			return nil, err
 		}
+
 		return &ChassisStatus{
 			CurrentPowerState: shortened.CurrentPowerState,
 			LastPowerEvent:    shortened.LastPowerEvent,
@@ -322,6 +373,12 @@ func (i *IPMI) GetChassisStatus() (*ChassisStatus, error) {
 	return &status, nil
 }
 
+// GetSELInfo retrieves the System Event Log (SEL) information from the IPMI interface.
+// It sends a command to the BMC to get the SEL info and parses the response into an SELInfo structure.
+//
+// Returns:
+//   - A pointer to an SELInfo structure containing the SEL information.
+//   - An error if there is an issue with sending the command, receiving the response, or parsing the data.
 func (i *IPMI) GetSELInfo() (*SELInfo, error) {
 	data, err := i.SendRecv(_IPMI_NETFN_STORAGE, BMC_GET_SEL_INFO, nil)
 	if err != nil {
@@ -337,31 +394,34 @@ func (i *IPMI) GetSELInfo() (*SELInfo, error) {
 	return &info, nil
 }
 
+// GetLanConfig retrieves the LAN configuration parameters for a specified channel.
 func (i *IPMI) GetLanConfig(channel byte, param byte) ([]byte, error) {
-	var data [4]byte
-	data[0] = channel
-	data[1] = param
-	data[2] = 0
-	data[3] = 0
+	data := [4]byte{
+		channel,
+		param,
+		0,
+		0,
+	}
 
 	return i.SendRecv(_IPMI_NETFN_TRANSPORT, BMC_GET_LAN_CONFIG, data[:4])
 }
 
+// RawCmd sends a raw IPMI command to the BMC.
 func (i *IPMI) RawCmd(param []byte) ([]byte, error) {
 	if len(param) < 2 {
-		return nil, errors.New("not enough parameters given")
+		return nil, errNotEnoughParams
 	}
 
 	msg := Msg{
 		Netfn: NetFn(param[0]),
 		Cmd:   Command(param[1]),
 	}
+
 	if len(param) > 2 {
 		msg.Data = unsafe.Pointer(&param[2])
 	}
 
 	msg.DataLen = uint16(len(param) - 2)
-
 	return i.RawSendRecv(msg)
 }
 

--- a/pkg/ipmi/ipmi.go
+++ b/pkg/ipmi/ipmi.go
@@ -132,12 +132,12 @@ func (e *Event) marshall() ([]byte, error) {
 	}
 
 	// OEM timestamped
-	if buf.Bytes()[2] >= 0xC0 && buf.Bytes()[2] <= 0xDF {
+	if buf.Bytes()[2] >= 0xC0 {
 		copy(data[0:3], buf.Bytes()[0:3])
 		copy(data[3:16], buf.Bytes()[16:29])
 	}
 
-	// OEM non-timestamped [OxEO .. OxFF]
+	// OEM non-timestamped
 	if buf.Bytes()[2] >= 0xE0 {
 		copy(data[0:3], buf.Bytes()[0:3])
 		copy(data[3:16], buf.Bytes()[29:42])

--- a/vendor/github.com/google/go-tpm/tpm2/constants.go
+++ b/vendor/github.com/google/go-tpm/tpm2/constants.go
@@ -182,7 +182,7 @@ const (
 	TPMCCPolicyPhysicalPresence     TPMCC = 0x00000187
 	TPMCCPolicyDuplicationSelect    TPMCC = 0x00000188
 	TPMCCPolicyGetDigest            TPMCC = 0x00000189
-	TPMCCTestParams                 TPMCC = 0x0000018A
+	TPMCCTestParms                  TPMCC = 0x0000018A
 	TPMCCCommit                     TPMCC = 0x0000018B
 	TPMCCPolicyPassword             TPMCC = 0x0000018C
 	TPMCCZGen2Phase                 TPMCC = 0x0000018D
@@ -634,19 +634,35 @@ const (
 	TPMHTAC            TPMHT = 0x90
 )
 
+// Saved Context transient object handles.
+// See definition in Part 2: Structures, section 14.6.2
+// Context Handle Values come from table 211
+const (
+	// an ordinary transient object
+	TPMIDHSavedTransient TPMIDHSaved = 0x80000000
+	// a sequence object
+	TPMIDHSavedSequence TPMIDHSaved = 0x80000001
+	// a transient object with the stClear attribute SET
+	TPMIDHSavedTransientClear TPMIDHSaved = 0x80000002
+)
+
 // TPMHandle represents a TPM_HANDLE.
 // See definition in Part 2: Structures, section 7.1.
 type TPMHandle uint32
 
 // TPMHandle values come from Part 2: Structures, section 7.4.
 const (
-	TPMRHOwner       TPMHandle = 0x40000001
-	TPMRHNull        TPMHandle = 0x40000007
-	TPMRSPW          TPMHandle = 0x40000009
-	TPMRHLockout     TPMHandle = 0x4000000A
-	TPMRHEndorsement TPMHandle = 0x4000000B
-	TPMRHPlatform    TPMHandle = 0x4000000C
-	TPMRHPlatformNV  TPMHandle = 0x4000000D
+	TPMRHOwner         TPMHandle = 0x40000001
+	TPMRHNull          TPMHandle = 0x40000007
+	TPMRSPW            TPMHandle = 0x40000009
+	TPMRHLockout       TPMHandle = 0x4000000A
+	TPMRHEndorsement   TPMHandle = 0x4000000B
+	TPMRHPlatform      TPMHandle = 0x4000000C
+	TPMRHPlatformNV    TPMHandle = 0x4000000D
+	TPMRHFWOwner       TPMHandle = 0x40000140
+	TPMRHFWEndorsement TPMHandle = 0x40000141
+	TPMRHFWPlatform    TPMHandle = 0x40000142
+	TPMRHFWNull        TPMHandle = 0x40000143
 )
 
 // TPMNT represents a TPM_NT.

--- a/vendor/github.com/google/go-tpm/tpm2/reflect.go
+++ b/vendor/github.com/google/go-tpm/tpm2/reflect.go
@@ -839,9 +839,9 @@ func marshalParameter[R any](buf *bytes.Buffer, cmd Command[R, *R], i int) error
 		return marshal(buf, reflect.ValueOf(TPMRHNull))
 	} else if parm.IsZero() && parm.Kind() == reflect.Uint16 && hasTag(field, "nullable") {
 		return marshal(buf, reflect.ValueOf(TPMAlgNull))
-	} else {
-		return marshal(buf, parm)
 	}
+
+	return marshal(buf, parm)
 }
 
 // cmdParameters returns the parameters area of the command.

--- a/vendor/github.com/google/go-tpm/tpm2/transport/open_other.go
+++ b/vendor/github.com/google/go-tpm/tpm2/transport/open_other.go
@@ -6,17 +6,11 @@ import (
 	legacy "github.com/google/go-tpm/legacy/tpm2"
 )
 
-// Wrap the legacy OpenTPM function so callers don't have to import both the
-// legacy and the new TPM 2.0 API.
-// TODO: When we delete the legacy API, we can make this the only copy of
-// OpenTPM.
-
-// OpenTPM opens a channel to the TPM at the given path. If the file is a
-// device, then it treats it like a normal TPM device, and if the file is a
-// Unix domain socket, then it opens a connection to the socket.
+// OpenTPM opens the TPM at the given path. If no path is provided, it will
+// attempt to use reasonable defaults.
 //
-// This function may also be invoked with no paths, as tpm2.OpenTPM(). In this
-// case, the default paths on Linux (/dev/tpmrm0 then /dev/tpm0), will be used.
+// Deprecated: Please use the individual transport packages (e.g.,
+// go-tpm/tpm2/transport/linuxtpm).
 func OpenTPM(path ...string) (TPMCloser, error) {
 	rwc, err := legacy.OpenTPM(path...)
 	if err != nil {

--- a/vendor/github.com/google/go-tpm/tpm2/transport/open_windows.go
+++ b/vendor/github.com/google/go-tpm/tpm2/transport/open_windows.go
@@ -6,17 +6,10 @@ import (
 	legacy "github.com/google/go-tpm/legacy/tpm2"
 )
 
-// Wrap the legacy OpenTPM function so callers don't have to import both the
-// legacy and the new TPM 2.0 API.
-// TODO: When we delete the legacy API, we can make this the only copy of
-// OpenTPM.
-
-// OpenTPM opens a channel to the TPM at the given path. If the file is a
-// device, then it treats it like a normal TPM device, and if the file is a
-// Unix domain socket, then it opens a connection to the socket.
+// OpenTPM opens the local system TPM.
 //
-// This function may also be invoked with no paths, as tpm2.OpenTPM(). In this
-// case, the default paths on Linux (/dev/tpmrm0 then /dev/tpm0), will be used.
+// Deprecated: Please use the individual transport packages (e.g.,
+// go-tpm/tpm2/transport/windowstpm).
 func OpenTPM() (TPMCloser, error) {
 	rwc, err := legacy.OpenTPM()
 	if err != nil {

--- a/vendor/github.com/google/go-tpm/tpm2/transport/tpm.go
+++ b/vendor/github.com/google/go-tpm/tpm2/transport/tpm.go
@@ -43,6 +43,12 @@ func FromReadWriter(rw io.ReadWriter) TPM {
 	return &wrappedRW{transport: rw}
 }
 
+// FromReadWriteCloser takes in a io.ReadWriteCloser and returns a
+// transport.TPMCloser wrapping the io.ReadWriteCloser.
+func FromReadWriteCloser(rwc io.ReadWriteCloser) TPMCloser {
+	return &wrappedRWC{transport: rwc}
+}
+
 // ToReadWriter takes in a transport TPM and returns an
 // io.ReadWriter wrapping the transport TPM.
 func ToReadWriter(tpm TPM) io.ReadWriter {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -122,8 +122,8 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
-# github.com/google/go-tpm v0.9.1-0.20230914180155-ee6cbcd136f8
-## explicit; go 1.20
+# github.com/google/go-tpm v0.9.2-0.20240919181259-d96ccf715685
+## explicit; go 1.22
 github.com/google/go-tpm/legacy/tpm2
 github.com/google/go-tpm/tpm
 github.com/google/go-tpm/tpm2


### PR DESCRIPTION
To enable the build of more u-root cmdlets @chrisfenner made a patch to fix the build issues. This PR updates the go-tpm module to commit [`d96ccf71568571dba925660724354682fe8e5fa2`](https://github.com/google/go-tpm/tree/d96ccf71568571dba925660724354682fe8e5fa2).
This goes hand in hand with issue [#3105](https://github.com/u-root/u-root/issues/3105) since go-tpm also requires the new go version.