### PR TITLE
cmds/exp/tcpdump: add check if transport layer is present

### DIFF
--- a/cmds/exp/tcpdump/main.go
+++ b/cmds/exp/tcpdump/main.go
@@ -329,6 +329,8 @@ func (cmd *cmd) processPacket(packet gopacket.Packet, num int, lastPkgTimeStamp 
 			data = fmt.Sprintf("UDP, length %d", length)
 		case *layers.UDPLite:
 			data = fmt.Sprintf("UDPLite, length %d", length)
+		case nil:
+			data = fmt.Sprintf("unknown transport layer, length %d", length)
 		default:
 			data = fmt.Sprintf("%s, length %d", layer.LayerType(), length)
 		}

--- a/cmds/exp/tcpdump/main.go
+++ b/cmds/exp/tcpdump/main.go
@@ -318,8 +318,6 @@ func (cmd *cmd) processPacket(packet gopacket.Packet, num int, lastPkgTimeStamp 
 
 		if applicationLayer != nil {
 			length = len(applicationLayer.LayerContents())
-		} else {
-			length = 0
 		}
 
 		switch layer := transportLayer.(type) {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x5dcba5]

Goroutine 1 [running]:
main.(*cmd).processPacket(0xc000029e40, {0x6b9d40, 0xc0002a2f20}, 0x4e, {0xc0000b9d38?, 0x1?, 0x0?})
	/usr/local/google/home/xuehaohu/go/src/github.com/u-root/u-root/cmds/exp/tcpdump/main.go:331 +0x1005
main.(*cmd).run(0xc000029e40)
	/usr/local/google/home/xuehaohu/go/src/github.com/u-root/u-root/cmds/exp/tcpdump/main.go:210 +0x65c
main.main()
	/usr/local/google/home/xuehaohu/go/src/github.com/u-root/u-root/cmds/exp/tcpdump/main.go:370 +0x145
```
A segfault occurs if the transport layer is equal to nil and called upon, i.e. the library cannot determine the type.
This can be mitigated by checking if it is nil and handling appropriately. 
