### PR TITLE
cmds/core/tar: use FlagSet.Args to pass args

### DIFF
--- a/cmds/core/tar/tar.go
+++ b/cmds/core/tar/tar.go
@@ -159,7 +159,7 @@ func main() {
 	f.BoolVar(&verbose, "v", false, "print each filename (shorthand)")
 
 	f.Parse(unixflag.OSArgsToGoArgs())
-	cmd, err := command(params{file: file, create: create, extract: extract, list: list, noRecursion: noRecursion, verbose: verbose}, flag.Args())
+	cmd, err := command(params{file: file, create: create, extract: extract, list: list, noRecursion: noRecursion, verbose: verbose}, f.Args())
 	if err != nil {
 		f.Usage()
 		log.Fatal(err)


### PR DESCRIPTION
This patch is to fix #3113 

`FlagSet` is used to parse args.
However `flag.Args()` is passed to `command` and I think it should be `FlagSet.Args()`.

I confirmed the issue was fixed.

```
> cd /tmp                                                                      
> echo aaa > aaa                                                               
> tar -cvf a.tar aaa                                                           
aaa
> tar --list -f a.tar                                                          
aaa
> mkdir test                                                                   
> tar -xvf a.tar test                                                          
aaa
> ls test                                                                      
aaa

```