### PR TITLE
.gitignore: add .gdb_history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ initramfs.cpio
 bzImage
 vmlinux
 *.patch
+.gdb_history
 
 # Python Virtual Env
 *.env


### PR DESCRIPTION
When debugging binaries with the GNU Debugger (gdb) it creates history files; they should be ignored by git.