### PR TITLE
cmds/core/strings: use FlagSet.Args to pass args

### DIFF
--- a/cmds/core/strings/strings.go
+++ b/cmds/core/strings/strings.go
@@ -155,7 +155,7 @@ func main() {
 	f.IntVar(&n, "n", 4, "the minimum string length")
 	f.StringVar(&t, "t", "", "write each string preceded by its byte offset from the start of the file (d decimal, o octal, x hexadecimal)")
 	f.Parse(unixflag.OSArgsToGoArgs())
-	if err := command(os.Stdin, os.Stdout, params{n: n, t: t}, flag.Args()).run(); err != nil {
+	if err := command(os.Stdin, os.Stdout, params{n: n, t: t}, f.Args()).run(); err != nil {
 		log.Fatalf("strings: %v", err)
 	}
 }


### PR DESCRIPTION
This patch is to fix https://github.com/u-root/u-root/issues/3122

`FlagSet` is used to parse args.
However `flag.Args()` is passed to command and I think it should be `FlagSet.Args().`

I confirmed the issue was fixed.
```
> strings /proc/uptime                                                        
13.63 3.74
```