### PR TITLE
kexec: fix --append switch

### DIFF
--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -12,8 +12,8 @@
 //		 Loads a kernel for later execution.
 //
 // Options:
-//      --append string        Append to the kernel command line
-//  -c, --cmdline string       Append to the kernel command line
+//      --append string        Append to the kernel command line. Implies --reuse-cmdline
+//  -c, --cmdline string       Set the kernel command line
 //  -d, --debug                Print debug info (default true)
 //  -e, --exec                 Execute a currently loaded kernel
 //  -x, --extra string         Add a cpio containing extra files
@@ -51,38 +51,39 @@ type options struct {
 	kernelpath string
 
 	// Flags
-	cmdline      string
-	debug        bool
-	dtb          string
-	exec         bool
-	extra        string
-	initramfs    string
-	load         bool
-	loadSyscall  bool
-	modules      []string
-	purgatory    string
-	reuseCmdline bool
+	cmdline       string
+	appendCmdline string
+	debug         bool
+	dtb           string
+	exec          bool
+	extra         string
+	initramfs     string
+	load          bool
+	loadSyscall   bool
+	modules       []string
+	purgatory     string
+	reuseCmdline  bool
 }
 
 func (o *options) parseCmdline(args []string, f *flag.FlagSet) {
-	f.StringVar(&o.cmdline, "cmdline", "", "Append to the kernel command line")
-	f.StringVar(&o.cmdline, "c", "", "Append to the kernel command line (shorthand)")
+	f.StringVar(&o.cmdline, "cmdline", "", "Set the kernel command line")
+	f.StringVar(&o.cmdline, "c", "", "Set the kernel command line")
 
-	f.StringVar(&o.cmdline, "append", "", "Append to the kernel command line")
+	f.StringVar(&o.appendCmdline, "append", "", "Append to the kernel command line. Implies --reuse-cmdline")
 
 	f.BoolVar(&o.debug, "debug", false, "Print debug info")
-	f.BoolVar(&o.debug, "d", false, "Print debug info (shorthand)")
+	f.BoolVar(&o.debug, "d", false, "Print debug info")
 
 	f.StringVar(&o.dtb, "dtb", "", "FILE used as the flatten device tree blob")
 
 	f.BoolVar(&o.exec, "exec", false, "Execute a currently loaded kernel")
-	f.BoolVar(&o.exec, "e", false, "Execute a currently loaded kernel (shorthand)")
+	f.BoolVar(&o.exec, "e", false, "Execute a currently loaded kernel")
 
 	f.StringVar(&o.extra, "extra", "", "Add a cpio containing extra files")
 	f.StringVar(&o.extra, "x", "", "Add a cpio containing extra files")
 
 	f.StringVar(&o.initramfs, "initrd", "", "Use file as the kernel's initial ramdisk")
-	f.StringVar(&o.initramfs, "i", "", "Use file as the kernel's initial ramdisk (shorthand)")
+	f.StringVar(&o.initramfs, "i", "", "Use file as the kernel's initial ramdisk")
 
 	f.StringVar(&o.initramfs, "initramfs", "", "Use file as the kernel's initial ramdisk")
 
@@ -188,12 +189,12 @@ func run(args []string) error {
 	}
 
 	newCmdline := opts.cmdline
-	if opts.reuseCmdline {
+	if opts.reuseCmdline || len(opts.appendCmdline) != 0 {
 		procCmdLine := cmdline.NewCmdLine()
 		if procCmdLine.Err != nil {
 			return fmt.Errorf("couldn't read /proc/cmdline")
 		}
-		newCmdline = procCmdLine.Raw
+		newCmdline = procCmdLine.Raw + " " + opts.appendCmdline
 
 	}
 

--- a/cmds/core/kexec/kexec_test.go
+++ b/cmds/core/kexec/kexec_test.go
@@ -117,6 +117,15 @@ func TestParseCmdline(t *testing.T) {
 			},
 		},
 		{
+			name: "Test append command line",
+			args: []string{"kexec", "-l", "--append", "${CMDLINE}", "/path/to/kernel"},
+			expected: options{
+				load:          true,
+				appendCmdline: "${CMDLINE}",
+				kernelpath:    "/path/to/kernel",
+			},
+		},
+		{
 			name: "Test all set",
 			args: []string{"kexec", "-c", "${CMDLINE}", "-d", "--dtb", "foo", "-e", "-x", "/some/file", "-i", "/path/to/initrd", "-l", "-L", "--module", "/mod1", "--reuse-cmdline", "/path/to/kernel"},
 			expected: options{


### PR DESCRIPTION
The --append switch claimed to append to the cmdline, but in fact
behaved no differently than -c/--cmdline.

Have the --append switch append to existing cmdline.

Also, redo the confusing documentation of the switches,
which imply that -c/--cmdline "append" to the command line,
which they do not.

Tidying up: remove the (shorthand) comment from the flag help.
It does not add anything useful.