### PR TITLE
cmds/core/ip: use group parameter in link set command

### DIFF
--- a/cmds/core/ip/link_linux.go
+++ b/cmds/core/ip/link_linux.go
@@ -128,7 +128,7 @@ func (cmd *cmd) linkSet() error {
 		case "txqueuelen", "txqlen":
 			return cmd.setLinkTxQLen(iface)
 		case "group":
-
+			return cmd.setLinkGroup(iface)
 		}
 	}
 


### PR DESCRIPTION
Add a missing parsing function for the IP link command, as detailed in #3119 