### PR TITLE
cmds/core/tty: fix /dev/fd symbolic link

### DIFF
--- a/cmds/core/tty/tty.go
+++ b/cmds/core/tty/tty.go
@@ -29,7 +29,11 @@ func run(stdout io.Writer) error {
 	return filepath.WalkDir("/dev", func(path string, dir os.DirEntry, _ error) error {
 		switch path {
 		case "/dev/fd":
-			return filepath.SkipDir
+			// On some systems, /dev/fd is a directory. On Linux, /dev/fd is a symlink.
+			// If /dev/fd is a directory, it should not be walked, so return file path.SkipDir.
+			if dir.IsDir() {
+				return filepath.SkipDir
+			}
 		case "/dev/stdin", "/dev/stdout", "/dev/stderr":
 			return nil
 		}


### PR DESCRIPTION
On systems where /dev/fd is a symbolic link traverse of a /dev directory will be stopped early.