### PR TITLE
add errorlint linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,12 +5,17 @@ linters:
     - ineffassign
     - staticcheck
     - stylecheck
+    - errorlint
 
 linters-settings:
   staticcheck:
     checks: ["all", "-SA1019"]
   stylecheck:
     checks: ["all", "-ST1003"]
+  errorlint:
+    errorf: true
+    asserts: false
+    comparison: false
 
 issues:
   exclude-dirs:

--- a/cmds/cluster/nodestats/main.go
+++ b/cmds/cluster/nodestats/main.go
@@ -66,6 +66,7 @@ func node() *health.Stat {
 	var Stderr [65536]byte
 	n, err := r.Read(Stderr[:])
 	if err != nil && err != io.EOF {
+		//nolint:errorlint
 		errs = errors.Join(errs, fmt.Errorf("stderr read %d bytes, got %v but not %v or nil", n, err, io.EOF))
 	}
 

--- a/cmds/cluster/nodestats/main.go
+++ b/cmds/cluster/nodestats/main.go
@@ -66,8 +66,7 @@ func node() *health.Stat {
 	var Stderr [65536]byte
 	n, err := r.Read(Stderr[:])
 	if err != nil && err != io.EOF {
-		//nolint:errorlint
-		errs = errors.Join(errs, fmt.Errorf("stderr read %d bytes, got %v but not %v or nil", n, err, io.EOF))
+		errs = errors.Join(errs, fmt.Errorf("stderr read %d bytes, got %w but not io.EOF or nil", n, err))
 	}
 
 	stats := &health.Stat{Hostname: hn, Info: host, Kernel: k, Stderr: string(Stderr[:n])}

--- a/cmds/exp/lsfabric/lsfabric.go
+++ b/cmds/exp/lsfabric/lsfabric.go
@@ -183,11 +183,11 @@ func New(n uint8) (*DataFabric, error) {
 	devName := fmt.Sprintf("0000:00:%02x.4", n+0x18)
 	r, err := pci.NewBusReader(devName)
 	if err != nil {
-		return nil, fmt.Errorf("NewBusReader: %v", err)
+		return nil, fmt.Errorf("NewBusReader: %w", err)
 	}
 	devs, err := r.Read()
 	if err != nil {
-		return nil, fmt.Errorf("reading %s: %v", devName, err)
+		return nil, fmt.Errorf("reading %s: %w", devName, err)
 	}
 	if len(devs) != 1 {
 		return nil, fmt.Errorf("%q matches more than one device", devName)
@@ -209,7 +209,7 @@ func New(n uint8) (*DataFabric, error) {
 	v("config is %#x", c)
 	d.Config = cfg(c).Unmarshal()
 	if c, err = d.ReadBroadcast(0, 0x40); err != nil {
-		return nil, fmt.Errorf("read TotalCount: %v", err)
+		return nil, fmt.Errorf("read TotalCount: %w", err)
 	}
 	d.TotalCount = uint(uint8(c))
 	v("Reg 40 is %#x, totalcount %d", c, d.TotalCount)

--- a/cmds/fwtools/spidev/spidev_linux.go
+++ b/cmds/fwtools/spidev/spidev_linux.go
@@ -112,7 +112,7 @@ func run(args []string, spiOpen spiOpenFunc, input io.Reader, output io.Writer) 
 		for _, a := range fs.Args()[1:] {
 			b, err := hex.DecodeString(a)
 			if err != nil {
-				return fmt.Errorf("%v:%w", err, ErrConvert)
+				return fmt.Errorf("%w:%w", err, ErrConvert)
 			}
 			transfers := []spidev.Transfer{
 				{
@@ -160,7 +160,7 @@ func run(args []string, spiOpen spiOpenFunc, input io.Reader, output io.Writer) 
 		return f.SFDP().PrettyPrint(output, sfdp.BasicTableLookup)
 
 	default:
-		return fmt.Errorf("%s:%w:%v", cmd, ErrCommand, err)
+		return fmt.Errorf("%s:%w:%w", cmd, ErrCommand, err)
 	}
 }
 

--- a/pkg/boot/linux/load_linux_amd64.go
+++ b/pkg/boot/linux/load_linux_amd64.go
@@ -77,7 +77,7 @@ func KexecLoad(kernel, ramfs *os.File, cmdline string, dtb io.ReaderAt, reservat
 	// kexec.Memory, as it does not depend on specific boot.
 	mm, err := kexec.MemoryMapFromSysfsMemmap()
 	if err != nil {
-		return fmt.Errorf("parse memory map: %v", err)
+		return fmt.Errorf("parse memory map: %w", err)
 	}
 	for _, r := range reservations {
 		mm.Insert(kexec.TypedRange{Range: r, Type: kexec.RangeReserved})
@@ -129,7 +129,7 @@ func KexecLoad(kernel, ramfs *os.File, cmdline string, dtb io.ReaderAt, reservat
 		// Cmdline must be null-terminated.
 		cmdlineBytes := []byte(cmdline + "\x00")
 		if cmdlineRange, err = kmem.AddKexecSegment(cmdlineBytes); err != nil {
-			return fmt.Errorf("add cmdline segment: %v", err)
+			return fmt.Errorf("add cmdline segment: %w", err)
 		}
 		Debug("Added %d byte of cmdline at %s", len(cmdlineBytes), cmdlineRange)
 		lp.CLPtr = uint32(cmdlineRange.Start)      // 2.02+
@@ -166,7 +166,7 @@ func KexecLoad(kernel, ramfs *os.File, cmdline string, dtb io.ReaderAt, reservat
 		//
 	)
 	if err != nil {
-		return fmt.Errorf("add real mode data and cmdline: %v", err)
+		return fmt.Errorf("add real mode data and cmdline: %w", err)
 	}
 
 	Debug("Loaded real mode data and cmdline at: %v", setupRange)

--- a/pkg/msr/msr_linux_amd64.go
+++ b/pkg/msr/msr_linux_amd64.go
@@ -36,17 +36,17 @@ func parseCPUs(s string) (CPUs, error) {
 		case 1:
 			u, err := strconv.ParseUint(cs[0], 0, 64)
 			if err != nil {
-				return nil, fmt.Errorf("unknown cpu range: %v, failed to parse %v", r, err)
+				return nil, fmt.Errorf("unknown cpu range: %v, failed to parse %w", r, err)
 			}
 			cpus = append(cpus, uint64(u))
 		case 2:
 			ul, err := strconv.ParseUint(cs[0], 0, 64)
 			if err != nil {
-				return nil, fmt.Errorf("unknown cpu range: %v, failed to parse %v", r, err)
+				return nil, fmt.Errorf("unknown cpu range: %v, failed to parse %w", r, err)
 			}
 			uh, err := strconv.ParseUint(cs[1], 0, 64)
 			if err != nil {
-				return nil, fmt.Errorf("unknown cpu range: %v, failed to parse %v", r, err)
+				return nil, fmt.Errorf("unknown cpu range: %v, failed to parse %w", r, err)
 			}
 			if ul > uh {
 				return nil, fmt.Errorf("invalid cpu range, upper bound greater than lower: %v", r)
@@ -332,7 +332,7 @@ func openAll(m []string, o int) ([]*os.File, []error) {
 
 func doIO(msr *os.File, addr MSR, f func(*os.File) error) error {
 	if _, err := msr.Seek(int64(addr), 0); err != nil {
-		return fmt.Errorf("bad address %v: %v", addr, err)
+		return fmt.Errorf("bad address %v: %w", addr, err)
 	}
 	return f(msr)
 }

--- a/tools/vpdbootmanager/get.go
+++ b/tools/vpdbootmanager/get.go
@@ -64,7 +64,7 @@ func (g *Getter) Print(key string) error {
 				return nil
 			}
 			// otherwise print one or both errors.
-			return fmt.Errorf("failed to read variable '%s': RO: %v, RW: %v", key, errRO, errRW)
+			return fmt.Errorf("failed to read variable '%s': RO: %w, RW: %w", key, errRO, errRW)
 		}
 	}
 	for k, v := range allVars[true] {

--- a/uroot_test.go
+++ b/uroot_test.go
@@ -56,7 +56,7 @@ func (v noDeadCode) Validate(a *cpio.Archive) error {
 	cmd := gbbgolang.Default().GoCmd("tool", "nm", tf.Name())
 	nmOutput, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("failed to run nm: %s %s", err, nmOutput)
+		return fmt.Errorf("failed to run nm: %w %s", err, nmOutput)
 	}
 	symScanner := bufio.NewScanner(bytes.NewBuffer(nmOutput))
 	syms := map[string]bool{}
@@ -332,7 +332,7 @@ func buildIt(t *testing.T, args, env []string, want error) (*os.File, []byte, er
 	t.Logf("Commandline: %v u-root %v", strings.Join(env, " "), strings.Join(arg, " "))
 	c.Env = append(c.Env, env...)
 	if out, err := c.CombinedOutput(); err != want {
-		return nil, nil, fmt.Errorf("Error: %v\nOutput:\n%s", err, out)
+		return nil, nil, fmt.Errorf("Error: %w\nOutput:\n%s", err, out)
 	} else if err != nil {
 		h1 := sha256.New()
 		if _, err := io.Copy(h1, f); err != nil {


### PR DESCRIPTION
will catch %v -> %w issues and can be extended in future with errros.Is (comparison) and errros.As (asserts).