### PR TITLE
cmds/exp/tcpdump: add flag description to output of -h flag

### DIFF
--- a/cmds/exp/tcpdump/main.go
+++ b/cmds/exp/tcpdump/main.go
@@ -103,6 +103,7 @@ func parseFlags(args []string, out io.Writer) (cmd, error) {
 	fs.Usage = func() {
 		fmt.Fprintf(out, "%s\n\n", tcpdumpHelp)
 
+		fs.SetOutput(out)
 		fs.PrintDefaults()
 	}
 
@@ -129,12 +130,14 @@ func parseFlags(args []string, out io.Writer) (cmd, error) {
 		}
 	}
 
-	return cmd{Opts: opts, Out: out}, nil
+	return cmd{Opts: opts, Out: out, usage: fs.Usage}, nil
 }
 
 type cmd struct {
 	Out  io.Writer
 	Opts flags
+
+	usage func()
 }
 
 func (cmd *cmd) run() error {
@@ -144,7 +147,7 @@ func (cmd *cmd) run() error {
 	)
 
 	if cmd.Opts.Help {
-		fmt.Println(tcpdumpHelp)
+		cmd.usage()
 
 		return nil
 	}

--- a/cmds/exp/tcpdump/main_test.go
+++ b/cmds/exp/tcpdump/main_test.go
@@ -86,7 +86,7 @@ func TestParseFlags(t *testing.T) {
 			}
 
 			if !tt.expectedErr {
-				if diff := cmp.Diff(tt.expectedCmd, cmd, cmpopts.IgnoreFields(cmd, "Out")); diff != "" {
+				if diff := cmp.Diff(tt.expectedCmd, cmd, cmpopts.IgnoreFields(cmd, "Out", "usage")); diff != "" {
 					t.Errorf("parseFlags() mismatch (-want +got):\n%s", diff)
 				}
 			}


### PR DESCRIPTION
The description of the flag was already present, but only printed on invalid use, not on `-h` flag. 
This PR fixes this and also prints the flag descriptions when calling the command with `-h`