### PR TITLE
cmds/core/ip: fix parsing of ip addr show

### DIFF
--- a/cmds/core/ip/address_linux_test.go
+++ b/cmds/core/ip/address_linux_test.go
@@ -119,7 +119,6 @@ func TestParseAddrShow(t *testing.T) {
 				Args:   []string{"ip", "addr", "show"},
 				Out:    new(bytes.Buffer),
 			},
-			wantErr: true,
 		},
 		{
 			name: "values",
@@ -131,6 +130,33 @@ func TestParseAddrShow(t *testing.T) {
 			dev:      "lo",
 			typeName: "bridge",
 		},
+		{
+			name: "fail on dev",
+			cmd: cmd{
+				Cursor: 2,
+				Args:   []string{"ip", "addr", "show", "deva"},
+				Out:    new(bytes.Buffer),
+			},
+			wantErr: true,
+		},
+		{
+			name: "fail on double dev",
+			cmd: cmd{
+				Cursor: 2,
+				Args:   []string{"ip", "addr", "show", "dev", "lo", "123"},
+				Out:    new(bytes.Buffer),
+			},
+			wantErr: true,
+		},
+		{
+			name: "fail on second dev",
+			cmd: cmd{
+				Cursor: 2,
+				Args:   []string{"ip", "addr", "show", "dev", "lo", "dev", "lo2"},
+				Out:    new(bytes.Buffer),
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -140,7 +166,7 @@ func TestParseAddrShow(t *testing.T) {
 				t.Errorf("parseAddrShow() error = %v, wantErr %t", err, tt.wantErr)
 			}
 
-			if !tt.wantErr {
+			if !tt.wantErr && link != nil {
 				if link.Attrs().Name != tt.dev {
 					t.Errorf("link.Name = %v, want %s", link.Attrs().Name, tt.dev)
 				}

--- a/cmds/core/ip/monitor_linux.go
+++ b/cmds/core/ip/monitor_linux.go
@@ -90,7 +90,7 @@ func (cmd *cmd) monitor() error {
 		case "mroute", "netconf", "nexthop", "nsid", "prefix", "rule":
 			return fmt.Errorf("monitoring %s is not yet supported", cmd.currentToken())
 		case "help":
-			fmt.Fprint(cmd.Out, tunnelHelp)
+			fmt.Fprint(cmd.Out, monitorHelp)
 			return nil
 		default:
 			return cmd.usage()

--- a/cmds/core/ip/tcp_metrics_linux_test.go
+++ b/cmds/core/ip/tcp_metrics_linux_test.go
@@ -74,3 +74,81 @@ func TestPrintTCPMetrics(t *testing.T) {
 		t.Errorf("expected %q, got %q", expectedOutput, out.String())
 	}
 }
+
+func TestTcpMetrics(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		family         int
+		cursor         int
+		expectedOutput string
+		expectError    bool
+	}{
+		{
+			name:        "Show TCP Metrics with valid address",
+			args:        []string{"ip", "tcpmetrics", "show", "192.168.1.1"},
+			cursor:      1,
+			family:      netlink.FAMILY_V4,
+			expectError: false,
+		},
+		{
+			name:        "Show TCP Metrics without address",
+			args:        []string{"ip", "tcpmetrics", "show"},
+			family:      netlink.FAMILY_V4,
+			cursor:      1,
+			expectError: false,
+		},
+		{
+			name:        "Show IPv6 TCP Metrics without address",
+			args:        []string{"ip", "tcpmetrics", "show"},
+			family:      netlink.FAMILY_V6,
+			cursor:      1,
+			expectError: false,
+		},
+		{
+			name:        "Show all TCP Metrics without address",
+			args:        []string{"ip", "tcpmetrics", "show"},
+			family:      netlink.FAMILY_ALL,
+			cursor:      1,
+			expectError: false,
+		},
+		{
+			name:           "Help command",
+			args:           []string{"ip", "tcpmetrics", "help"},
+			family:         netlink.FAMILY_V4,
+			expectedOutput: tcpMetricsHelp,
+			cursor:         1,
+			expectError:    false,
+		},
+		{
+			name:        "Invalid command",
+			args:        []string{"ip", "tcpmetrics", "invalid"},
+			family:      netlink.FAMILY_V4,
+			cursor:      1,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			cmd := &cmd{
+				Args:   tt.args,
+				Out:    &out,
+				Cursor: tt.cursor,
+				Family: tt.family,
+			}
+
+			err := cmd.tcpMetrics()
+			if (err != nil) != tt.expectError {
+				t.Errorf("expected error: %v, got: %v", tt.expectError, err)
+			}
+
+			if tt.expectedOutput != "" {
+				if out.String() != tt.expectedOutput {
+					t.Errorf("expected output: %q, got: %q", tt.expectedOutput, out.String())
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
These commit fixes 3 separate minor parsing problems in the IP command.
1. Commit
Current state: 
```
sudo /usr/local/go/bin/go run . address show dev TestDev
1: lo: <UP,LOOPBACK> mtu 65536 state UNKNOWN group default
    link/loopback
    inet 127.0.0.1 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1 scope host
       valid_lft forever preferred_lft forever
2: enp2s0f0: <UP,BROADCAST,MULTICAST> mtu 1500 state DOWN group default
    link/ether 00:2b:67:e1:ac:67
3: enp5s0: <UP,BROADCAST,MULTICAST> mtu 1500 state DOWN group default
    link/ether 00:2b:67:e1:ac:66
4: enp7s0f3u1u2c2: <UP,BROADCAST,MULTICAST> mtu 1500 state UP group default
    link/ether a0:ce:c8:bc:76:a9
    inet 10.93.128.226 brd 10.93.129.255 scope global enp7s0f3u1u2c2
       valid_lft 69555sec preferred_lft 69555sec
    inet6 fe80::78b8:f98d:8c46:2bf9 scope link
       valid_lft forever preferred_lft forever
5: wlp3s0: <BROADCAST,MULTICAST> mtu 1500 state DOWN group default
    link/ether ee:cd:64:49:be:35
6: virbr0: <UP,BROADCAST,MULTICAST> mtu 1500 state DOWN group default
    link/ether 52:54:00:8f:5d:84
    inet 192.168.122.1 brd 192.168.122.255 scope global virbr0
       valid_lft forever preferred_lft forever
7: docker0: <UP,BROADCAST,MULTICAST> mtu 1500 state UP group default
    link/ether 02:42:77:c1:e6:e2
    inet 172.17.0.1 brd 172.17.255.255 scope global docker0
       valid_lft forever preferred_lft forever
    inet6 fe80::42:77ff:fec1:e6e2 scope link
       valid_lft forever preferred_lft forever
9: veth50f555b: <UP,BROADCAST,MULTICAST> mtu 1500 master docker0 state UP group default
    link/ether 06:85:7c:7c:53:d7
    inet6 fe80::485:7cff:fe7c:53d7 scope link
       valid_lft forever preferred_lft forever
16: TestDev: <UP,BROADCAST> mtu 1500 state UNKNOWN group default
    link/ether 6e:66:91:cc:6f:4f
    inet 192.168.11.33 brd 192.168.11.255 scope global TestDev
       valid_lft forever preferred_lft forever
    inet6 fe80::286c:60ff:fe2e:2a1c scope link
       valid_lft forever preferred_lft forever
```
We would expect `ip address show dev TestDev` to only show the TestDev device.
sudo /usr/local/go/bin/go run . address show dev TestDev
```
16: TestDev: <UP,BROADCAST> mtu 1500 state UNKNOWN group default
    link/ether 6e:66:91:cc:6f:4f
    inet 192.168.11.33 brd 192.168.11.255 scope global TestDev
       valid_lft forever preferred_lft forever
    inet6 fe80::286c:60ff:fe2e:2a1c scope link
       valid_lft forever preferred_lft forever
```
2. Commit: Replacing `ip monitor help` text with the correct text.
3. Commit:
```
sudo /usr/local/go/bin/go run . tcpmetrics
2024/11/11 15:17:08 ip: no such file or directory
exit status 1
```
 Currently showing all TCP metrics is not working if no ip family is specified.
 The change loops through ipv4 and ipv6 and display all TCP metrics accordingly.