### PR TITLE
cmds/core/ip: update help text for unsupported options

### DIFF
--- a/cmds/core/ip/ip_linux.go
+++ b/cmds/core/ip/ip_linux.go
@@ -52,8 +52,7 @@ type flags struct {
 
 const ipHelp = `Usage: ip [ OPTIONS ] OBJECT { COMMAND | help }
 where  OBJECT := { address |  help | link | monitor | neighbor | neighbour |
-				   route | rule | tap | tcpmetrics |
-                   token | tunnel | tuntap | vrf | xfrm }
+				   route | tap | tcpmetrics | tunnel | tuntap | vrf | xfrm }
        OPTIONS := { -s[tatistics] | -d[etails] | -r[esolve] |
                     -h[uman-readable] | -iec | -j[son] | -p[retty] |
                     -f[amily] { inet | inet6 | mpls | bridge | link } |

--- a/cmds/core/ip/link_linux.go
+++ b/cmds/core/ip/link_linux.go
@@ -51,12 +51,7 @@ const linkHelp = `Usage: ip link add  [ name ] NAME
 
 	ip link help
 
-TYPE := { bareudp | bond |bridge | dummy |
-          geneve | gre | gretap | ifb |
-          ip6gre | ip6gretap | ip6tnl | ipip |
-          ipoib | ipvlan | ipvtap | macvlan |
-          macvlan | sit | vlan | vrf |
-          vti | vxlan | xfrm }
+TYPE := { bareudp | bond |bridge | dummy | ifb | vxlan }
 
 `
 

--- a/cmds/core/ip/tunnel_linux.go
+++ b/cmds/core/ip/tunnel_linux.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	tunnelHelp = `Usage: ip tunnel { add  | del | show } [ NAME ]
+	tunnelHelp = `Usage: ip tunnel { show } [ NAME ]
         [ mode { gre | ipip | sit | vti } ]
         [ remote ADDR ] [ local ADDR ] [ [i|o]key KEY ]
         [ ttl TTL ] [ tos TOS ] [ [no]pmtudisc ] [ dev PHYS_DEV ]

--- a/cmds/core/ip/xfrm_linux.go
+++ b/cmds/core/ip/xfrm_linux.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	xfrmHelp = `Usage: ip xfrm XFRM-OBJECT { COMMAND | help }
-where  XFRM-OBJECT := state | policy | monitor`
+where  XFRM-OBJECT := policy | monitor`
 
 	xfrmMonitorHelp = `Usage: ip xfrm monitor [ nokeys ] [ all | OBJECTS | help ]
 OBJECTS := { acquire | expire | SA | aevent | policy | report }`

--- a/cmds/core/ip/xfrm_policy_linux.go
+++ b/cmds/core/ip/xfrm_policy_linux.go
@@ -16,9 +16,7 @@ const (
 	xfrmPolicyHelp = `Usage: ip xfrm policy { add | update } SELECTOR dir DIR
 	[ mark MARK [ mask MASK ] ] [ index INDEX ] [ ptype PTYPE ]
 	[ action ACTION ] [ priority PRIORITY ] [ if_id IF_ID ] [ TMPL-LIST ]
-Usage: ip xfrm policy { delete | get } { SELECTOR | index INDEX } dir DIR
-	[ mark MARK [ mask MASK ] ] [ if_id IF_ID ]
-Usage: ip xfrm policy { deleteall | list }[ SELECTOR ] [ dir DIR ]
+Usage: ip xfrm policy { list }[ SELECTOR ] [ dir DIR ]
 	[ index INDEX ][ action ACTION ] [ priority PRIORITY ]
 Usage: ip xfrm policy flush 
 Usage: ip xfrm policy count
@@ -92,7 +90,7 @@ func (cmd *cmd) parseXfrmPolicyTmpl() (*netlink.XfrmPolicyTmpl, error) {
 }
 
 func (cmd *cmd) xfrmPolicy() error {
-	switch cmd.findPrefix("add", "update", "delete", "get", "deleteall", "show", "list", "flush", "count", "set", "help") {
+	switch cmd.nextToken("add", "update", "delete", "get", "deleteall", "show", "list", "flush", "count", "set", "help") {
 	case "add":
 		policy, err := cmd.parseXfrmPolicyAddUpdate()
 		if err != nil {


### PR DESCRIPTION
Some of the help-texts of the ip command were not up-to-date with the implementation. I've removed any objects which are currently not supported by the u-root version. This is accordingly to the changes proposed in https://github.com/u-root/u-root/pull/3015.