### PR TITLE
simplify dd and let it use go runtime and kernel intelligence

### DIFF
--- a/cmds/core/dd/dd.go
+++ b/cmds/core/dd/dd.go
@@ -68,7 +68,7 @@ var flagMap = map[string]bitClearAndSet{
 
 var allowedFlags = os.O_TRUNC | os.O_SYNC
 
-func dd(r io.Reader, w io.Writer, inBufSize, outBufSize int64, bytesWritten *int64, flags int) error {
+func dd(r io.Reader, w io.Writer, inBufSize, outBufSize int64, bytesWritten *int64) error {
 	if inBufSize == 0 {
 		return fmt.Errorf("inBufSize is not allowed to be zero")
 	}
@@ -317,7 +317,7 @@ func run(stdin io.Reader, stdout io.WriteSeeker, stderr io.Writer, name string, 
 	if err != nil {
 		return err
 	}
-	if err := dd(in, out, ibs.Value, obs.Value, &bytesWritten, flags); err != nil {
+	if err := dd(in, out, ibs.Value, obs.Value, &bytesWritten); err != nil {
 		return err
 	}
 

--- a/cmds/core/dd/dd.go
+++ b/cmds/core/dd/dd.go
@@ -37,7 +37,7 @@
 package main
 
 import (
-	"errors"
+	"bytes"
 	"flag"
 	"fmt"
 	"io"
@@ -45,8 +45,6 @@ import (
 	"math"
 	"os"
 	"strings"
-	"sync"
-	"sync/atomic"
 
 	"github.com/rck/unit"
 	"github.com/u-root/u-root/pkg/progress"
@@ -70,182 +68,32 @@ var flagMap = map[string]bitClearAndSet{
 
 var allowedFlags = os.O_TRUNC | os.O_SYNC
 
-// intermediateBuffer is a buffer that one can write to and read from.
-type intermediateBuffer interface {
-	io.ReaderFrom
-	io.WriterTo
-}
-
-// chunkedBuffer is an intermediateBuffer with a specific size.
-type chunkedBuffer struct {
-	outChunk int64
-	length   int64
-	data     []byte
-	flags    int
-}
-
-// newChunkedBuffer returns an intermediateBuffer that stores inChunkSize-sized
-// chunks of data and writes them to writers in outChunkSize-sized chunks.
-func newChunkedBuffer(inChunkSize int64, outChunkSize int64, flags int) intermediateBuffer {
-	return &chunkedBuffer{
-		outChunk: outChunkSize,
-		length:   0,
-		data:     make([]byte, inChunkSize),
-		flags:    flags,
-	}
-}
-
-// ReadFrom reads an inChunkSize-sized chunk from r into the buffer.
-func (cb *chunkedBuffer) ReadFrom(r io.Reader) (int64, error) {
-	n, err := r.Read(cb.data)
-	cb.length = int64(n)
-
-	// Convert to EOF explicitly.
-	if n == 0 && err == nil {
-		return 0, io.EOF
-	}
-	return int64(n), err
-}
-
-// WriteTo writes from the buffer to w in outChunkSize-sized chunks.
-func (cb *chunkedBuffer) WriteTo(w io.Writer) (int64, error) {
-	var i int64
-	for i = 0; i < int64(cb.length); {
-		chunk := cb.outChunk
-		if i+chunk > cb.length {
-			chunk = cb.length - i
-		}
-		block := cb.data[i : i+chunk]
-		got, err := w.Write(block)
-
-		// Ugh, Go cruft: io.Writer.Write returns (int, error).
-		// io.WriterTo.WriteTo returns (int64, error). So we have to
-		// cast.
-		i += int64(got)
-		if err != nil {
-			return i, err
-		}
-		if int64(got) != chunk {
-			return 0, io.ErrShortWrite
-		}
-	}
-	return i, nil
-}
-
-// bufferPool is a pool of intermediateBuffers.
-type bufferPool struct {
-	f func() intermediateBuffer
-	c chan intermediateBuffer
-}
-
-func newBufferPool(size int64, f func() intermediateBuffer) bufferPool {
-	return bufferPool{
-		f: f,
-		c: make(chan intermediateBuffer, size),
-	}
-}
-
-// Put returns a buffer to the pool for later use.
-func (bp bufferPool) Put(b intermediateBuffer) {
-	// Non-blocking write in case pool has filled up (too many buffers
-	// returned, none being used).
-	select {
-	case bp.c <- b:
-	default:
-	}
-}
-
-// Get returns a buffer from the pool or allocates a new buffer if none is
-// available.
-func (bp bufferPool) Get() intermediateBuffer {
-	select {
-	case buf := <-bp.c:
-		return buf
-	default:
-		return bp.f()
-	}
-}
-
-func (bp bufferPool) Destroy() {
-	close(bp.c)
-}
-
-func parallelChunkedCopy(r io.Reader, w io.Writer, inBufSize, outBufSize int64, bytesWritten *int64, flags int) error {
+func dd(r io.Reader, w io.Writer, inBufSize, outBufSize int64, bytesWritten *int64, flags int) error {
 	if inBufSize == 0 {
 		return fmt.Errorf("inBufSize is not allowed to be zero")
 	}
+	dat := &bytes.Buffer{}
 
-	// Make the channels deep enough to hold a total of 1GiB of data.
-	depth := (1024 * 1024 * 1024) / inBufSize
-	// But keep it reasonable!
-	if depth > 8192 {
-		depth = 8192
-	}
-
-	readyBufs := make(chan intermediateBuffer, depth)
-	pool := newBufferPool(depth, func() intermediateBuffer {
-		return newChunkedBuffer(inBufSize, outBufSize, flags)
-	})
-	defer pool.Destroy()
-
-	// Closing quit makes both goroutines below exit.
-	quit := make(chan struct{})
-
-	// errs contains the error value to be returned.
-	errs := make(chan error, 1)
-	defer close(errs)
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		// Closing this unblocks the writing for-loop below.
-		defer close(readyBufs)
-		defer wg.Done()
-
-		for {
-			select {
-			case <-quit:
-				return
-			default:
-				buf := pool.Get()
-				n, err := buf.ReadFrom(r)
-				if n > 0 {
-					readyBufs <- buf
-				}
-				if errors.Is(err, io.EOF) {
-					return
-				}
-				if n == 0 || err != nil {
-					errs <- fmt.Errorf("input error: %w", err)
-					return
-				}
+	for {
+		for int64(dat.Len()) > outBufSize {
+			if _, err := io.CopyN(w, dat, outBufSize); err != nil {
+				return err
 			}
 		}
-	}()
-
-	var writeErr error
-	for buf := range readyBufs {
-		if n, err := buf.WriteTo(w); err != nil {
-			writeErr = fmt.Errorf("output error: %w", err)
-			break
-		} else {
-			atomic.AddInt64(bytesWritten, n)
+		if _, err := io.CopyN(dat, r, inBufSize); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return err
 		}
-		pool.Put(buf)
+
 	}
-
-	// This will force the goroutine to quit if an error occurred writing.
-	close(quit)
-
-	// Wait for goroutine to exit.
-	wg.Wait()
-
-	select {
-	case readErr := <-errs:
-		return readErr
-	default:
-		return writeErr
+	for dat.Len() > 0 {
+		if _, err := io.CopyN(w, dat, outBufSize); err != nil && err != io.EOF {
+			return err
+		}
 	}
+	return nil
 }
 
 // sectionReader implements a SectionReader on an underlying implementation of
@@ -389,9 +237,9 @@ func run(stdin io.Reader, stdout io.WriteSeeker, stderr io.Writer, name string, 
 	delete(ddUnits, "B")
 
 	var (
-		ibs = unit.MustNewUnit(ddUnits).MustNewValue(512, unit.None)
-		obs = unit.MustNewUnit(ddUnits).MustNewValue(512, unit.None)
-		bs  = unit.MustNewUnit(ddUnits).MustNewValue(512, unit.None)
+		ibs = unit.MustNewUnit(ddUnits).MustNewValue(math.MaxInt64, unit.None)
+		obs = unit.MustNewUnit(ddUnits).MustNewValue(math.MaxInt64, unit.None)
+		bs  = unit.MustNewUnit(ddUnits).MustNewValue(math.MaxInt64, unit.None)
 	)
 	f.Var(ibs, "ibs", "Default input block size")
 	f.Var(obs, "obs", "Default output block size")
@@ -457,7 +305,7 @@ func run(stdin io.Reader, stdout io.WriteSeeker, stderr io.Writer, name string, 
 	if err != nil {
 		return err
 	}
-	if err := parallelChunkedCopy(in, out, ibs.Value, obs.Value, &bytesWritten, flags); err != nil {
+	if err := dd(in, out, ibs.Value, obs.Value, &bytesWritten, flags); err != nil {
 		return err
 	}
 

--- a/cmds/core/dd/dd.go
+++ b/cmds/core/dd/dd.go
@@ -72,6 +72,18 @@ func dd(r io.Reader, w io.Writer, inBufSize, outBufSize int64, bytesWritten *int
 	if inBufSize == 0 {
 		return fmt.Errorf("inBufSize is not allowed to be zero")
 	}
+	// There is an optimization in the Go runtime for zero-copy,
+	// which we can use when inBufSize == outBufSize.
+	for inBufSize == outBufSize {
+		amt, err := io.CopyN(w, r, inBufSize)
+		*bytesWritten += int64(amt)
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+	}
 	dat := &bytes.Buffer{}
 
 	for {

--- a/cmds/core/dd/dd_test.go
+++ b/cmds/core/dd/dd_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -535,7 +534,6 @@ type testBS struct {
 
 // Write implements write.
 func (t *testBS) Write(b []byte) (int, error) {
-	log.Printf("Write:%d", len(b))
 	if t.sz < t.obs && int64(len(b)) == t.sz {
 		return len(b), nil
 	}
@@ -546,7 +544,6 @@ func (t *testBS) Write(b []byte) (int, error) {
 }
 
 func (t *testBS) Read(b []byte) (int, error) {
-	log.Printf("Read:%d", len(b))
 	if int64(len(b)) != t.ibs {
 		return -1, fmt.Errorf("%s: read len is %d want %d:%w", t.name, len(b), t.obs, os.ErrInvalid)
 	}

--- a/cmds/core/dd/dd_test.go
+++ b/cmds/core/dd/dd_test.go
@@ -588,7 +588,7 @@ func TestBS(t *testing.T) {
 
 		t.Run(tt.name, func(t *testing.T) {
 			var bw int64
-			if err := dd(&tt, &tt, tt.ibs, tt.obs, &bw, 0); !errors.Is(err, tt.err) {
+			if err := dd(&tt, &tt, tt.ibs, tt.obs, &bw); !errors.Is(err, tt.err) {
 				t.Fatalf("got %v, want %v", err, tt.err)
 			}
 		})


### PR DESCRIPTION
    With this change, dd runs in a single process, and uses zero copy when possible.
    Before this change, it ran at best 1/2 the speed of the GNU dd.
    WIth this change, it frequently is much faster.

```
    time ./dd if=/dev/zero of=/dev/null ibs=1048576 obs=1048576 status=progress count=65536
    68719476736 bytes (68719.477 MB, 65536.000 MiB) copied, 1.987 s, 34589.234 MB/s

    GNU dd
    time dd if=/dev/zero of=/dev/null ibs=1048576 obs=1048576 status=progress count=65536
    55726571520 bytes (56 GB, 52 GiB) copied, 3 s, 18.6 GB/s
    65536+0 records in
    65536+0 records out
    68719476736 bytes (69 GB, 64 GiB) copied, 3.69293 s, 18.6 GB/s
```

    the u-root dd is twice as fast for lots of data.

    For small data, it is still competitive:
```
    time dd if=4m of=/dev/null ibs=1048576 obs=1048576 status=progress count=65536
    4096+0 records in
    4096+0 records out
    4294967296 bytes (4.3 GB, 4.0 GiB) copied, 0.538755 s, 8.0 GB/s

    real    0m0.541s
    user    0m0.208s
    sys     0m0.333s
    rminnich@pop-os:~/go/src/github.com/u-root/u-root/cmds/core/dd$ time ./dd if=4m of=/dev/null ibs=1048576 obs=1048576 status=progress count=65536
    4294967296 bytes (4294.967 MB, 4096.000 MiB) copied, 0.449 s, 9571.651 MB/s

    real    0m0.453s
    user    0m0.049s
    sys     0m0.412s
```
    Before these changes, it was at best 50% as fast.