### PR TITLE
cmds/core/ip: fix parsing of ip addr flush

### DIFF
--- a/cmds/core/ip/address_linux.go
+++ b/cmds/core/ip/address_linux.go
@@ -247,6 +247,9 @@ func (cmd *cmd) addressFlush() error {
 		}
 
 		for idx := 1; idx <= cmd.Opts.Loops; idx++ {
+
+			fmt.Printf("Deleting %v from %v\n", a, iface.Attrs().Name)
+
 			if err := cmd.handle.AddrDel(iface, &a); err != nil {
 				if idx != cmd.Opts.Loops {
 					continue
@@ -263,11 +266,11 @@ func (cmd *cmd) addressFlush() error {
 }
 
 func skipAddr(addr netlink.Addr, filter netlink.Addr) bool {
-	if addr.Scope != 0 && addr.Scope != filter.Scope {
+	if filter.Scope != 0 && addr.Scope != filter.Scope {
 		return true
 	}
 
-	if addr.Label != "" && addr.Label != filter.Label {
+	if filter.Label != "" && addr.Label != filter.Label {
 		return true
 	}
 


### PR DESCRIPTION
Under certain conditions, the addresses of a device to be filtered were skipped because the function that checks the filter of the command had erroneous checks. 
Working example with the fix:  
```
❯ ./ip addr show dev Test
144: Test: <BROADCAST> mtu 4000 state DOWN group default
    link/ether 56:ef:8e:34:50:04

cmds/core/ip [ main][$!][🐹 v1.23.0][☁️  (eu-central-1)][☁️  fabian.wienand@9elements.com]
➜ sudo ./ip addr add 192.0.0.2/24 dev Test

cmds/core/ip [ main][$!][🐹 v1.23.0][☁️  (eu-central-1)][☁️  fabian.wienand@9elements.com]
➜ ./ip addr show dev Test
144: Test: <BROADCAST> mtu 4000 state DOWN group default
    link/ether 56:ef:8e:34:50:04
    inet 192.0.0.2 brd 192.0.0.255 scope global Test
       valid_lft forever preferred_lft forever

cmds/core/ip [ main][$!][🐹 v1.23.0][☁️  (eu-central-1)][☁️  fabian.wienand@9elements.com]
➜ sudo ./ip addr flush dev Test
Deleting 192.0.0.2/24 Test from Test

cmds/core/ip [ main][$!][🐹 v1.23.0][☁️  (eu-central-1)][☁️  fabian.wienand@9elements.com]
➜ ./ip addr show dev Test
144: Test: <BROADCAST> mtu 4000 state DOWN group default
    link/ether 56:ef:8e:34:50:04
```
resolves #3189 