### PR TITLE
cmds/core/ip: add newline to end of tcpmetrics subcommand help text

### DIFF
--- a/cmds/core/ip/tcp_metrics_linux.go
+++ b/cmds/core/ip/tcp_metrics_linux.go
@@ -14,7 +14,8 @@ import (
 
 const tcpMetricsHelp = `Usage:	ip tcp_metrics/tcpmetrics { COMMAND | help }
 	ip tcp_metrics show SELECTOR
-SELECTOR := [ [ address ] PREFIX ]`
+SELECTOR := [ [ address ] PREFIX ]
+`
 
 func (cmd *cmd) tcpMetrics() error {
 	if !cmd.tokenRemains() {


### PR DESCRIPTION
Added a newline to the help text of the tcpdump command:
```
➜ ./ip tcpmetrics help
Usage:  ip tcp_metrics/tcpmetrics { COMMAND | help }
        ip tcp_metrics show SELECTOR
SELECTOR := [ [ address ] PREFIX ]

```

resolves #3198 