### PR TITLE
Improve `tsort` performance

### DIFF
--- a/cmds/extra/tsort/bench.sh
+++ b/cmds/extra/tsort/bench.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Copyright 2012-2024 the u-root Authors. All rights reserved
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# bench.sh runs Go and hyperfine benchmarks against two given Git-commit-based
+# versions of tsort. The hyperfine benchmarks also compare these versions of
+# tsort with uutils/coreutils' [2] tsort.
+#
+# This script accepts two arguments, each containing a Git commit pointing at
+# two different versions of tsort.
+#
+# Usage
+#
+#     ./cmds/extra/tsort/bench.sh <commit-before> <commit-after>
+#
+# Note: This script assumes that hyperfine [1] is installed and that
+# uutils/coreutils is installed on the PATH with a "uu" prefix such their tsort
+# is named `uutsort`.
+#
+# [1] https://github.com/sharkdp/hyperfine
+# [2] https://github.com/uutils/coreutils
+
+set -euo pipefail
+
+git switch --detach "$1"
+go build -o ./tsort-before ./cmds/extra/tsort
+echo "Running warmup benchmarks..."
+go test -run=XXX -bench=Tsort -benchmem -count=10 ./cmds/extra/tsort/...
+echo "Running real benchmarks..."
+go test -run=XXX -bench=Tsort -benchmem -count=20 ./cmds/extra/tsort/... | tee tsort-bench-before.txt
+
+git switch --detach "$2"
+go build -o ./tsort-after ./cmds/extra/tsort
+echo "Running warmup benchmarks..."
+go test -run=XXX -bench=Tsort -benchmem -count=10 ./cmds/extra/tsort/...
+echo "Running real benchmarks..."
+go test -run=XXX -bench=Tsort -benchmem -count=20 ./cmds/extra/tsort/... | tee tsort-bench-after.txt
+
+go run golang.org/x/perf/cmd/benchstat@latest tsort-bench-before.txt tsort-bench-after.txt | tee tsort-bench-comparison.txt
+
+go run ./cmds/extra/tsort/generate_graph_fixtures.go
+hyperfine --warmup 5 --shell=none --export-markdown=acyclic.md \
+    "./tsort-before ./some-random-acyclic-graph.txt" \
+    "./tsort-after ./some-random-acyclic-graph.txt" \
+    "uutsort ./some-random-acyclic-graph.txt"
+hyperfine --warmup 5 --shell=none --export-markdown=cyclic.md --ignore-failure \
+    "./tsort-before ./some-random-cyclic-graph.txt" \
+    "./tsort-after ./some-random-cyclic-graph.txt" \
+    "uutsort ./some-random-cyclic-graph.txt"
+
+rm ./some-random-acyclic-graph.txt
+rm ./some-random-cyclic-graph.txt
+rm ./tsort-before
+rm ./tsort-after

--- a/cmds/extra/tsort/generate_graph_fixtures.go
+++ b/cmds/extra/tsort/generate_graph_fixtures.go
@@ -1,0 +1,52 @@
+// Copyright 2012-2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build ignore
+// +build ignore
+
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+)
+
+func main() {
+	func() {
+		f, err := os.OpenFile(
+			"some-random-acyclic-graph.txt",
+			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+			0o666)
+		if err != nil {
+			panic(err)
+		}
+
+		rnd := rand.New(rand.NewSource(1))
+		n := 10_000
+		for range 100 * n {
+			x := rnd.Intn(n + 1)
+			y := rnd.Intn(n + 1)
+			_, _ = fmt.Fprintln(f, min(x, y), max(x, y))
+		}
+	}()
+
+	func() {
+		f, err := os.OpenFile(
+			"some-random-cyclic-graph.txt",
+			os.O_WRONLY|os.O_CREATE|os.O_TRUNC,
+			0o666)
+		if err != nil {
+			panic(err)
+		}
+
+		rnd := rand.New(rand.NewSource(1))
+		n := 200
+		for range 100 * n {
+			x := rnd.Intn(n + 1)
+			y := rnd.Intn(n + 1)
+			_, _ = fmt.Fprintln(f, x, y)
+		}
+	}()
+}

--- a/cmds/extra/tsort/graph_test.go
+++ b/cmds/extra/tsort/graph_test.go
@@ -140,11 +140,3 @@ func testRemoveEdge(t *testing.T, g *graph) {
 			g.inDegree("e"))
 	}
 }
-
-func setOf(values ...string) set {
-	s := make(set)
-	for _, v := range values {
-		s.add(v)
-	}
-	return s
-}

--- a/cmds/extra/tsort/set.go
+++ b/cmds/extra/tsort/set.go
@@ -6,6 +6,10 @@ package main
 
 type set map[string]struct{}
 
+func makeSet() set {
+	return make(set)
+}
+
 func (s set) add(value string) {
 	s[value] = struct{}{}
 }
@@ -13,4 +17,8 @@ func (s set) add(value string) {
 func (s set) has(value string) bool {
 	_, ok := s[value]
 	return ok
+}
+
+func (s set) remove(value string) {
+	delete(s, value)
 }

--- a/cmds/extra/tsort/set_test.go
+++ b/cmds/extra/tsort/set_test.go
@@ -6,13 +6,26 @@ package main
 
 import (
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestSet(t *testing.T) {
-	s := set{}
-	s.add("a")
+	s := makeSet()
+
+	if s.has("a") {
+		t.Errorf(`set %#v: want to not have "a", but did have it`, s)
+	}
+	if len(s) != 0 {
+		t.Errorf(`set %#v: want len of 0, got %d`, s, len(s))
+	}
+
 	s.add("b")
+	s.add("d")
 	s.add("c")
+	s.add("c")
+	s.add("e")
+	s.add("a")
 
 	if !s.has("a") {
 		t.Errorf(`set %#v: want to have "a", but did not`, s)
@@ -23,7 +36,50 @@ func TestSet(t *testing.T) {
 	if !s.has("c") {
 		t.Errorf(`set %#v: want to have "c", but did not`, s)
 	}
-	if s.has("absent-value") {
-		t.Errorf(`set %#v: want to not have "absent-value", but did`, s)
+	if !s.has("d") {
+		t.Errorf(`set %#v: want to have "d", but did not`, s)
 	}
+	if !s.has("e") {
+		t.Errorf(`set %#v: want to have "e", but did not`, s)
+	}
+	if s.has("absent-value") {
+		t.Errorf(`set %#v: want to not have "absent-value", but did have it`, s)
+	}
+	if diff := cmp.Diff(s, setOf("a", "b", "c", "d", "e")); diff != "" {
+		t.Errorf("set mismatch (-s +expected):\n%s", diff)
+	}
+
+	s.remove("a")
+	s.remove("e")
+	s.remove("c")
+
+	if s.has("a") {
+		t.Errorf(`set %#v: want to not have "a", but did have it`, s)
+	}
+	if !s.has("b") {
+		t.Errorf(`set %#v: want to have "b", but did not`, s)
+	}
+	if s.has("c") {
+		t.Errorf(`set %#v: want to not have "c", but did have it`, s)
+	}
+	if !s.has("d") {
+		t.Errorf(`set %#v: want to have "d", but did not`, s)
+	}
+	if s.has("e") {
+		t.Errorf(`set %#v: want to not have "e", but did have it`, s)
+	}
+	if s.has("absent-value") {
+		t.Errorf(`set %#v: want to not have "absent-value", but did have it`, s)
+	}
+	if diff := cmp.Diff(s, setOf("b", "d")); diff != "" {
+		t.Errorf("set mismatch (-s +expected):\n%s", diff)
+	}
+}
+
+func setOf(values ...string) set {
+	s := makeSet()
+	for _, v := range values {
+		s.add(v)
+	}
+	return s
 }

--- a/cmds/extra/tsort/tsort_test.go
+++ b/cmds/extra/tsort/tsort_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"slices"
@@ -395,6 +396,48 @@ func TestTsort(t *testing.T) {
 	})
 }
 
+var rndAcyclicGraph = func() string {
+	rnd := rand.New(rand.NewSource(1))
+	var result strings.Builder
+	n := 10_000
+	for range 100 * n {
+		x := rnd.Intn(n + 1)
+		y := rnd.Intn(n + 1)
+		_, _ = fmt.Fprintln(&result, min(x, y), max(x, y))
+	}
+	return result.String()
+}()
+
+var rndCyclicGraph = func() string {
+	rnd := rand.New(rand.NewSource(1))
+	var result strings.Builder
+	n := 200
+	for range 100 * n {
+		x := rnd.Intn(n + 1)
+		y := rnd.Intn(n + 1)
+		_, _ = fmt.Fprintln(&result, x, y)
+	}
+	return result.String()
+}()
+
+func BenchmarkTsortAcyclicGraph(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		err := run(strings.NewReader(rndAcyclicGraph), io.Discard, io.Discard)
+		if err != nil {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
+func BenchmarkTsortCyclicGraph(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		err := run(strings.NewReader(rndCyclicGraph), io.Discard, io.Discard)
+		if err != nil && !errors.Is(err, errNonFatal) {
+			b.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
+
 func tempFile(t *testing.T, contents string) (file string) {
 	dir := t.TempDir()
 	n := filepath.Join(dir, "file")
@@ -554,7 +597,7 @@ func checkValidTopologicalOrdering(
 
 func nodes(graph string) []string {
 	fields := strings.Fields(graph)
-	s := make(set)
+	s := makeSet()
 
 	var result []string
 	for _, value := range fields {
@@ -587,7 +630,7 @@ func orderInsensitiveDiff(a []string, b []string) string {
 }
 
 func hasDuplicates(values []string) bool {
-	s := make(set)
+	s := makeSet()
 	for _, value := range values {
 		if s.has(value) {
 			return true

--- a/cmds/extra/tsort/tsort_test.go
+++ b/cmds/extra/tsort/tsort_test.go
@@ -396,9 +396,9 @@ func TestTsort(t *testing.T) {
 	})
 }
 
-var rndAcyclicGraph = func() string {
-	rnd := rand.New(rand.NewSource(1))
+var acyclicGraph = func() string {
 	var result strings.Builder
+	rnd := rand.New(rand.NewSource(1))
 	n := 10_000
 	for range 100 * n {
 		x := rnd.Intn(n + 1)
@@ -408,9 +408,9 @@ var rndAcyclicGraph = func() string {
 	return result.String()
 }()
 
-var rndCyclicGraph = func() string {
-	rnd := rand.New(rand.NewSource(1))
+var cyclicGraph = func() string {
 	var result strings.Builder
+	rnd := rand.New(rand.NewSource(1))
 	n := 200
 	for range 100 * n {
 		x := rnd.Intn(n + 1)
@@ -422,7 +422,7 @@ var rndCyclicGraph = func() string {
 
 func BenchmarkTsortAcyclicGraph(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		err := run(strings.NewReader(rndAcyclicGraph), io.Discard, io.Discard)
+		err := run(strings.NewReader(acyclicGraph), io.Discard, io.Discard)
 		if err != nil {
 			b.Fatalf("unexpected error: %v", err)
 		}
@@ -431,7 +431,7 @@ func BenchmarkTsortAcyclicGraph(b *testing.B) {
 
 func BenchmarkTsortCyclicGraph(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		err := run(strings.NewReader(rndCyclicGraph), io.Discard, io.Discard)
+		err := run(strings.NewReader(cyclicGraph), io.Discard, io.Discard)
 		if err != nil && !errors.Is(err, errNonFatal) {
 			b.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
This PR improves the performance of `tsort` on acyclic graphs (the usual kind of input) by ~12% and reduces the number of memory allocations by ~94%, at the cost of ~38% extra memory in total.

I'd totally understand if the extra memory cost of this change is seen as too prohibitive to merge in. 😁 

For cyclic graphs, allocations improved by ~7% but other performance/allocation changes seem inconclusive.

Benchmarks were ran with `./bench.sh`. They assume that [uutils](https://github.com/uutils/coreutils), a competing coreutils implementation in Rust, has been installed on the path with their tsort at `uutsort`. I'd be more than happy to remove or change `./bench.sh` or move it somewhere else later.

For context, the benchmarks show that for the optimized u-root tsort vs uutils tsort, uutils is still ~3x faster on the test acyclic graph and ~230x faster(!) on the test cyclic graph (probably because the cyclic graph has many, many cycles and uutils tsort doesn't try to handle them all).

**Go benchmarks**

```
goos: darwin
goarch: arm64
pkg: github.com/u-root/u-root/cmds/extra/tsort
cpu: Apple M1
                    │ tsort-bench-before.txt │        tsort-bench-after.txt         │
                    │         sec/op         │    sec/op     vs base                │
TsortAcyclicGraph-8             454.2m ±  0%   398.7m ±  0%  -12.23% (p=0.000 n=15)
TsortCyclicGraph-8              807.0m ± 38%   749.7m ± 48%        ~ (p=0.595 n=15)
geomean                         605.4m         546.7m         -9.70%

                    │ tsort-bench-before.txt │         tsort-bench-after.txt         │
                    │          B/op          │     B/op       vs base                │
TsortAcyclicGraph-8             80.71Mi ± 0%   111.52Mi ± 0%  +38.17% (p=0.000 n=15)
TsortCyclicGraph-8              258.4Mi ± 0%    257.9Mi ± 0%        ~ (p=0.367 n=15)
geomean                         144.4Mi         169.6Mi       +17.43%

                    │ tsort-bench-before.txt │        tsort-bench-after.txt        │
                    │       allocs/op        │  allocs/op   vs base                │
TsortAcyclicGraph-8             2104.7k ± 0%   116.3k ± 0%  -94.48% (p=0.000 n=15)
TsortCyclicGraph-8               517.8k ± 0%   479.2k ± 0%   -7.45% (p=0.000 n=15)
geomean                          1.044M        236.1k       -77.39%
```

**[Hyperfine](https://github.com/sharkdp/hyperfine/) benchmarks**

*Acyclic graph*

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./tsort-before ./some-random-acyclic-graph.txt` | 486.2 ± 6.0 | 480.6 | 497.1 | 3.39 ± 0.06 |
| `./tsort-after ./some-random-acyclic-graph.txt` | 419.9 ± 3.6 | 415.4 | 428.7 | 2.93 ± 0.04 |
| `uutsort ./some-random-acyclic-graph.txt` | 143.4 ± 1.6 | 141.7 | 148.4 | 1.00 |

*Cyclic graph*

| Command | Mean [ms] | Min [ms] | Max [ms] | Relative |
|:---|---:|---:|---:|---:|
| `./tsort-before ./some-random-cyclic-graph.txt` | 887.1 ± 144.0 | 683.9 | 1094.5 | 229.32 ± 38.58 |
| `./tsort-after ./some-random-cyclic-graph.txt` | 902.3 ± 271.4 | 623.0 | 1531.1 | 233.25 ± 70.91 |
| `uutsort ./some-random-cyclic-graph.txt` | 3.9 ± 0.2 | 3.6 | 5.2 | 1.00 |