### PR TITLE
remove tinygo exclusion build tag from kmoudle compression handler

### DIFF
--- a/pkg/kmodule/compression.go
+++ b/pkg/kmodule/compression.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !tinygo
-
 package kmodule
 
 import (


### PR DESCRIPTION
Issues #3232 #3226 #3225 uncovered the failing build of compression-related commands when using tinygo. 