### PR TITLE
pkg/boot/universalpayload: Refine FDT node info; refine assembly code and skip reporting PCI ROOT bridge resource region

### DIFF
--- a/pkg/boot/universalpayload/handoffblock.go
+++ b/pkg/boot/universalpayload/handoffblock.go
@@ -171,6 +171,12 @@ func hobFromMemMap(memMap kexec.MemoryMap) (EFIMemoryMapHOB, uint64) {
 
 		memType := strings.TrimSpace(string(entry.Type))
 
+		// Skip resource region of PCI Bus. UniversalPayload utilizes its own
+		// PciHostBridgeDxe to enumerate all Root Bridges in PCI Bus.
+		if strings.Contains(memType, "PCI Bus") {
+			continue
+		}
+
 		if memType == kexec.RangeRAM.String() {
 			resourceType = EFIResourceSystemMemory
 		} else if memType == kexec.RangeReserved.String() {

--- a/pkg/boot/universalpayload/trampoline_amd64.s
+++ b/pkg/boot/universalpayload/trampoline_amd64.s
@@ -4,8 +4,33 @@
 
 #include "textflag.h"
 
+TEXT trampoline_start(SB),NOSPLIT,$0
+	PCALIGN $2048
+	LEAQ stack_top(SB), AX
+	MOVQ (AX), AX
+	MOVQ AX, SP
+
+	LEAQ hob_addr(SB), AX
+	MOVQ (AX), AX
+	MOVQ AX, CX
+
+	LEAQ entry_point(SB), AX
+	MOVQ (AX), AX
+	JMP  AX
+
+TEXT stack_top(SB),$0
+	PCALIGN $32
+	LONG	$0xdeadbeef
+TEXT hob_addr(SB),$0
+	PCALIGN $32
+	LONG	$0xdeadbeef
+TEXT entry_point(SB),$0
+	PCALIGN $32
+	LONG	$0xdeadbeef
+
 // func addrOfStart() uintptr
 TEXT ·addrOfStart(SB), $0-8
+	PCALIGN $32
 	MOVQ	$trampoline_start(SB), AX
 	MOVQ	AX, ret+0(FP)
 	RET
@@ -21,23 +46,3 @@ TEXT ·addrOfHobAddr(SB), $0-8
 	MOVQ	$hob_addr(SB), AX
 	MOVQ	AX, ret+0(FP)
 	RET
-
-TEXT trampoline_start(SB),NOSPLIT,$0
-	LEAQ stack_top(SB), AX
-	MOVQ (AX), AX
-	MOVQ AX, SP
-
-	LEAQ hob_addr(SB), AX
-	MOVQ (AX), AX
-	MOVQ AX, CX
-
-	LEAQ entry_point(SB), AX
-	MOVQ (AX), AX
-	JMP  AX
-
-TEXT stack_top(SB),$0
-	LONG	$0xdeadbeef
-TEXT hob_addr(SB),$0
-	LONG	$0xdeadbeef
-TEXT entry_point(SB),$0
-	LONG	$0xdeadbeef

--- a/pkg/boot/universalpayload/trampoline_arm64.s
+++ b/pkg/boot/universalpayload/trampoline_arm64.s
@@ -4,8 +4,34 @@
 
 #include "textflag.h"
 
+
+TEXT trampoline_start(SB), NOSPLIT, $0
+	PCALIGN $2048
+	MOVD $entry_point(SB), R4
+	MOVD (R4), R4
+
+	MOVD $hob_addr(SB), R0
+	MOVD (R0), R0
+
+	MOVD $stack_top(SB), R2
+	MOVD (R2), R2
+	MOVD R2, RSP
+
+	JMP  (R4)
+
+TEXT stack_top(SB),$0
+	PCALIGN $32
+	NOP
+TEXT hob_addr(SB),$0
+	PCALIGN $32
+	NOP
+TEXT entry_point(SB),$0
+	PCALIGN $32
+	NOP
+
 // func addrOfStart() uintptr
 TEXT ·addrOfStart(SB), $0-8
+	PCALIGN $32
 	MOVD	$trampoline_start(SB), R0
 	MOVD	R0, ret+0(FP)
 	RET
@@ -21,23 +47,3 @@ TEXT ·addrOfHobAddr(SB), $0-8
 	MOVD	$hob_addr(SB), R0
 	MOVD	R0, ret+0(FP)
 	RET
-
-TEXT trampoline_start(SB),NOSPLIT,$0
-	MOVD $entry_point(SB), R4
-	MOVD (R4), R4
-
-	MOVD $hob_addr(SB), R0
-	MOVD (R0), R0
-
-	MOVD $stack_top(SB), R2
-	MOVD (R2), R2
-	MOVD R2, RSP
-
-	JMP  (R4)
-
-TEXT stack_top(SB),$0
-	NOP
-TEXT hob_addr(SB),$0
-	NOP
-TEXT entry_point(SB),$0
-	NOP


### PR DESCRIPTION
commit 1: "pkg/boot/universalpayload: Move Graphic and Serial Port out of PCI RB" is used to align with logic update in EDK2 UPL impementation.
commit 2: "pkg/boot/universalpayload: Refine trampoline code" is used to fix unexpected behavior, we found this unexpected behavior in when using different Golang tool chain version and integrate with many u-root commands.
commit 3: "pkg/boot/universalpayload: Skip reporting PCI Root Bridge resource region" is used to fix ASSERTION when UPL scan PCI bus.