### PR TITLE
pkg/netstat: fix hexademical parsing

### DIFF
--- a/pkg/netstat/sockets.go
+++ b/pkg/netstat/sockets.go
@@ -247,7 +247,7 @@ func (u *UnixSockets) readData() error {
 	for s.Scan() {
 		e := unixSocket{}
 		line := s.Text()
-		if _, err := fmt.Sscanf(line, "%X: %d %d %x %d %d %d %s",
+		if _, err := fmt.Sscanf(line, "%X: %x %d %x %d %d %d %s",
 			&e.Num,
 			&e.RefCnt,
 			&e.Proto,


### PR DESCRIPTION
on more recent ubuntu versions it fails on this line 0000000000000000: 0000000A 00000000 00000000 0002 03  6825 /run/systemd/journal/socket

trying to parse 000000A as %d