### PR TITLE
pkg/boot/universalpayload: Update trampoline code for tinygo

### DIFF
--- a/pkg/boot/universalpayload/trampoline_tinygo_amd64.h
+++ b/pkg/boot/universalpayload/trampoline_tinygo_amd64.h
@@ -4,52 +4,51 @@
 
 #include <stdint.h>
 
-// globals; initial values taken from pkg/boot/universalpayload/trampoline_amd64.go
-long stack_top = 0xdeadbeef;
-long hob_addr = 0xdeadbeef;
-long entry_point = 0xdeadbeef;
-
 uintptr_t addrOfStartU()
 {
     extern void trampoline_startU();
     return (uintptr_t)trampoline_startU;
 }
 
-uintptr_t addrOfStackTopU()
-{
-    extern long stack_top;
-    return (uintptr_t)&stack_top;
-}
-
-uintptr_t addrOfHobAddrU()
-{
-    extern long hob_addr;
-    return (uintptr_t)&hob_addr;
-}
-
 void trampoline_startU()
 {
-    extern long stack_top;
-    extern long hob_addr;
-    extern long entry_point;
+    // We are using AT&T inline assembly code to implement AMD64 trampoline
+    // bootstrap code. In inline assembly code, we use rip-relative addressing
+    // to fetch corresponding values of stack top, boot parameter and the
+    // real entry point of Universal Payload FIT image.
+    //
+    // In this way, we need to update the actual value of stack top, boot
+    // parameter and entry point after relocation.
+    //
+    // The layout of the trampoline code is shown as follows in Intel Syntax.
+    // Then maintainer, who is familiar with either AT&T or Intel Syntax,
+    // can catch up with the purpose of trampoline code quickly.
+    //
+    // trampoline[32 - 55] will be filled in utilities_arch_amd64_tinygo.go,
+    // keep them here for easy understanding.
+    //
+    // trampoline[0 - 6]   : mov rax, qword ptr [rip+0x19]
+    // trampoline[7 - 9]   : mov rsp, rax
+    // trampoline[10 - 16] : mov rax, qword ptr [rip+0x17]
+    // trampoline[17 - 19] : mov rcx, rax
+    // trampoline[20 - 26] : mov rax, qword ptr [rip+0x15]
+    // trampoline[27 - 28] : jmp rax
+    // trampoline[29 - 31] : padding for alignment
+    // trampoline[32 - 39] : Top of stack address
+    // trampoline[40 - 47] : Base address of bootloader parameter
+    // trampoline[48 - 55] : Entry point of FIT image
 
-    asm volatile(
-        // Load stack_top address into rax
-        "leaq stack_top(%%rip), %%rax\n"
-        "movq (%%rax), %%rax\n"
-        "movq %%rax, %%rsp\n"
-
-        // Load hob_addr into rax and move to rcx
-        "leaq hob_addr(%%rip), %%rax\n"
-        "movq (%%rax), %%rax\n"
-        "movq %%rax, %%rcx\n"
-
-        // Load entry_point into AX and jump
-        "leaq entry_point(%%rip), %%rax\n"
-        "movq (%%rax), %%rax\n"
-        "jmp *%%rax\n"
-        :
-        : "m"(stack_top), "m"(hob_addr), "m"(entry_point)
-        : "rax", "rcx" // Clobbered registers
+    __asm__ __volatile__ (
+        "movq  0x19(%%rip), %%rax\n\t"       // Load value stack_top into RAX
+        "mov   %%rax, %%rsp\n\t"             // Move RAX to RSP
+        "movq  0x17(%%rip), %%rax\n\t"       // Load value hob_addr into RAX
+        "mov   %%rax, %%rcx\n\t"             // Move RAX to RCX
+        "movq  0x15(%%rip), %%rax\n\t"       // Load value entry_point into RAX
+        "jmp   *%%rax\n\t"                   // Jump to address in RAX
+        "int3\n\t"                           // Software BP for alignment
+        "int3\n\t"                           // Software BP for alignment
+        "int3\n\t"                           // Software BP for alignment
+        ::: "rax", "rcx", "rsp"              // Clobbered registers
     );
+
 }

--- a/pkg/boot/universalpayload/utilities_arch_amd64_tinygo.go
+++ b/pkg/boot/universalpayload/utilities_arch_amd64_tinygo.go
@@ -75,32 +75,23 @@ func constructTrampoline(buf []uint8, hobAddr uint64, entry uint64) []uint8 {
 		return data
 	}
 
-	trampBegin := C.addrOfStartU()
-	trampStack := C.addrOfStackTopU()
-	trampHob := C.addrOfHobAddrU()
-
-	padLen := uint64(trampHob - trampStack - 8)
-
-	tramp := ptrToSlice(trampBegin, int(trampStack-trampBegin))
-
-	buf = append(buf, tramp...)
-
-	stackTop := hobAddr + tmpStackTop
 	appendUint64 := func(slice []uint8, value uint64) []uint8 {
 		tmpBytes := make([]uint8, 8)
 		binary.LittleEndian.PutUint64(tmpBytes, value)
 		return append(slice, tmpBytes...)
 	}
 
-	padWithLength := func(slice []uint8, len uint64) []uint8 {
-		tmpBytes := make([]uint8, len)
-		return append(slice, tmpBytes...)
-	}
+	trampBegin := C.addrOfStartU()
 
+	// Please keep 'size' parameter of 'ptrToSlice" align with implementation of
+	// trampoline_startU in trampoline_tinygo_amd64.h
+	tramp := ptrToSlice(trampBegin, 32)
+
+	buf = append(buf, tramp...)
+
+	stackTop := hobAddr + tmpStackTop
 	buf = appendUint64(buf, stackTop)
-	buf = padWithLength(buf, padLen)
 	buf = appendUint64(buf, hobAddr)
-	buf = padWithLength(buf, padLen)
 	buf = appendUint64(buf, entry)
 
 	return buf


### PR DESCRIPTION
Tinygo build utilizes inline assembly code, we can use relative address to fetch all required variables for tramploine. Update trampoline code for both ARM64 and AARCH64 to simplify trampoline boot logic.