### PR TITLE
tinygo port for pkg/memio

### DIFF
--- a/pkg/memio/arch.go
+++ b/pkg/memio/arch.go
@@ -1,0 +1,17 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !tinygo && linux && (amd64 || 386)
+
+package memio
+
+// functions exported by the architecture-specific code in ioprt_linux_amd64.s
+// and ioprt_linux_386.s
+func archInl(uint16) uint32
+func archInw(uint16) uint16
+func archInb(uint16) uint8
+
+func archOutl(uint16, uint32)
+func archOutw(uint16, uint16)
+func archOutb(uint16, uint8)

--- a/pkg/memio/arch_tinygo.go
+++ b/pkg/memio/arch_tinygo.go
@@ -1,0 +1,36 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build tinygo && linux && (amd64 || 386)
+
+package memio
+
+/*
+#include "ioport_linux_tinygo.h"
+*/
+import "C"
+
+func archInl(port uint16) uint32 {
+	return C.archInl(port)
+}
+
+func archInw(port uint16) uint16 {
+	return C.archInw(port)
+}
+
+func archInb(port uint16) uint8 {
+	return C.archInb(port)
+}
+
+func archOutl(port uint16, val uint32) {
+	C.archOutl(port, val)
+}
+
+func archOutw(port uint16, val uint16) {
+	C.archOutw(port, val)
+}
+
+func archOutb(port uint16, val uint8) {
+	C.archOutb(port, val)
+}

--- a/pkg/memio/archport_linux.go
+++ b/pkg/memio/archport_linux.go
@@ -30,10 +30,6 @@ func iopl() error {
 	return ioplError.err
 }
 
-func archInl(uint16) uint32
-func archInw(uint16) uint16
-func archInb(uint16) uint8
-
 // In reads data from the x86 port at address addr. Data must be Uint8, Uint16,
 // Uint32, but not Uint64.
 func (a *ArchPort) In(addr uint16, data UintN) error {
@@ -53,10 +49,6 @@ func (a *ArchPort) In(addr uint16, data UintN) error {
 	}
 	return nil
 }
-
-func archOutl(uint16, uint32)
-func archOutw(uint16, uint16)
-func archOutb(uint16, uint8)
 
 // Out writes data to the x86 port at address addr. data must be Uint8, Uint16
 // uint32, but not Uint64.

--- a/pkg/memio/ioport_linux_tinygo.h
+++ b/pkg/memio/ioport_linux_tinygo.h
@@ -1,0 +1,45 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// This file implements the ioport functions for linux 386 using tinygo.
+// Since we write C and not assembly, the compiler will adjust the instructions
+// to fit for for 32 and 64 bit architectures.
+
+#include <stdint.h>
+
+uint32_t archInl(uint16_t port)
+{
+	uint32_t data;
+	__asm__ __volatile__("inl %1, %0" : "=a"(data) : "d"(port));
+	return data;
+}
+
+uint16_t archInw(uint16_t port)
+{
+	uint16_t data;
+	__asm__ __volatile__("inw %1, %0" : "=a"(data) : "d"(port));
+	return data;
+}
+
+uint8_t archInb(uint16_t port)
+{
+	uint8_t data;
+	__asm__ __volatile__("inb %1, %0" : "=a"(data) : "d"(port));
+	return data;
+}
+
+void archOutl(uint16_t port, uint32_t data)
+{
+	__asm__ __volatile__("outl %0, %1" : : "a"(data), "d"(port));
+}
+
+void archOutw(uint16_t port, uint16_t data)
+{
+	__asm__ __volatile__("outw %0, %1" : : "a"(data), "d"(port));
+}
+
+void archOutb(uint16_t port, uint8_t data)
+{
+	__asm__ __volatile__("outb %0, %1" : : "a"(data), "d"(port));
+}

--- a/tools/tinygo-buildstatus/statusquo.go
+++ b/tools/tinygo-buildstatus/statusquo.go
@@ -52,7 +52,7 @@ var (
 		"id",
 		"init",
 		"insmod",
-		// "io",
+		"io",
 		"ip",
 		// "kexec",
 		"kill",


### PR DESCRIPTION
Add tinygo support for the `memio` package.
When building commands such as `io` the following build error can observed:

```
...
../../../pkg/memio/archport_linux.go:46: linker could not find symbol github.com/u-root/u-root/pkg/memio.archInl
../../../pkg/memio/archport_linux.go:48: linker could not find symbol github.com/u-root/u-root/pkg/memio.archInw
../../../pkg/memio/archport_linux.go:50: linker could not find symbol github.com/u-root/u-root/pkg/memio.archInb
../../../pkg/memio/archport_linux.go:70: linker could not find symbol github.com/u-root/u-root/pkg/memio.archOutl
../../../pkg/memio/archport_linux.go:72: linker could not find symbol github.com/u-root/u-root/pkg/memio.archOutw
../../../pkg/memio/archport_linux.go:74: linker could not find symbol github.com/u-root/u-root/pkg/memio.archOutb
...
```

Adding cgo definitions for the missing functions when building with tinygo should resolve this issue.