### PR TITLE
ci: updat cifuzz workflow to use artifact@v4

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -20,7 +20,7 @@ jobs:
         report-unreproducible-crashes: false
         language: go
     - name: Upload Crash
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure() && steps.build.outcome == 'success'
       with:
         name: artifacts


### PR DESCRIPTION
In one week [1] `actions/{download,upload}-artifacts@v3` will be deprecated. The CI in PR #3278 failed due to this issue.
This PR updates the fuzzing workflow to use the new version.

[1]: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/