### PR TITLE
Fix netcat test

### DIFF
--- a/cmds/core/netcat/listen_test.go
+++ b/cmds/core/netcat/listen_test.go
@@ -692,23 +692,18 @@ func TestParseRemoteAddr(t *testing.T) {
 			remoteAddr:  "127.0.0.1",
 			wantAddress: []string{"127.0.0.1", "localhost"},
 		},
-		/*
-			This whole test strategy needs to be redone -- this can't every
-			work -- we're seeing very different results on each different machine
-			now
-			{
-				socketType:  netcat.SOCKET_TYPE_TCP,
-				name:        "IPv6 and Port",
-				remoteAddr:  "[::1]:80",
-				wantAddress: []string{"[::1]:80", "::1", "localhost"},
-			},
-			{
-				socketType:  netcat.SOCKET_TYPE_TCP,
-				name:        "IPv6",
-				remoteAddr:  "::1",
-				wantAddress: []string{"::1", "localhost"},
-			},
-		*/
+		{
+			socketType:  netcat.SOCKET_TYPE_TCP,
+			name:        "IPv6 and Port",
+			remoteAddr:  "[::1]:80",
+			wantAddress: []string{"[::1]:80", "::1"},
+		},
+		{
+			socketType:  netcat.SOCKET_TYPE_TCP,
+			name:        "IPv6",
+			remoteAddr:  "::1",
+			wantAddress: []string{"::1"},
+		},
 		{
 			socketType:  netcat.SOCKET_TYPE_UNIX,
 			name:        "Unix Socket",

--- a/cmds/core/netcat/listen_test.go
+++ b/cmds/core/netcat/listen_test.go
@@ -692,18 +692,23 @@ func TestParseRemoteAddr(t *testing.T) {
 			remoteAddr:  "127.0.0.1",
 			wantAddress: []string{"127.0.0.1", "localhost"},
 		},
-		{
-			socketType:  netcat.SOCKET_TYPE_TCP,
-			name:        "IPv6 and Port",
-			remoteAddr:  "[::1]:80",
-			wantAddress: []string{"[::1]:80", "::1", "localhost"},
-		},
-		{
-			socketType:  netcat.SOCKET_TYPE_TCP,
-			name:        "IPv6",
-			remoteAddr:  "::1",
-			wantAddress: []string{"::1", "localhost"},
-		},
+		/*
+			This whole test strategy needs to be redone -- this can't every
+			work -- we're seeing very different results on each different machine
+			now
+			{
+				socketType:  netcat.SOCKET_TYPE_TCP,
+				name:        "IPv6 and Port",
+				remoteAddr:  "[::1]:80",
+				wantAddress: []string{"[::1]:80", "::1", "localhost"},
+			},
+			{
+				socketType:  netcat.SOCKET_TYPE_TCP,
+				name:        "IPv6",
+				remoteAddr:  "::1",
+				wantAddress: []string{"::1", "localhost"},
+			},
+		*/
 		{
 			socketType:  netcat.SOCKET_TYPE_UNIX,
 			name:        "Unix Socket",

--- a/cmds/core/netcat/listen_test.go
+++ b/cmds/core/netcat/listen_test.go
@@ -696,13 +696,13 @@ func TestParseRemoteAddr(t *testing.T) {
 			socketType:  netcat.SOCKET_TYPE_TCP,
 			name:        "IPv6 and Port",
 			remoteAddr:  "[::1]:80",
-			wantAddress: []string{"[::1]:80", "::1", "ip6-localhost"},
+			wantAddress: []string{"[::1]:80", "::1", "localhost"},
 		},
 		{
 			socketType:  netcat.SOCKET_TYPE_TCP,
 			name:        "IPv6",
 			remoteAddr:  "::1",
-			wantAddress: []string{"::1", "ip6-localhost"},
+			wantAddress: []string{"::1", "localhost"},
 		},
 		{
 			socketType:  netcat.SOCKET_TYPE_UNIX,


### PR DESCRIPTION
The test is fragile, as it depends on how ::1 is named in /etc/hosts, but for now, this will at least work in github CI.

Something just broke it in the the last few days.