### PR TITLE
allow compilation of bzimage pkg under GOOS=tamago

### DIFF
--- a/pkg/boot/bzimage/bzimage.go
+++ b/pkg/boot/bzimage/bzimage.go
@@ -20,13 +20,10 @@ import (
 	"hash/crc32"
 	"io"
 	"log"
-	"os"
 	"os/exec"
 	"reflect"
 	"strings"
 	"unsafe"
-
-	"github.com/u-root/u-root/pkg/cpio"
 )
 
 const minBootParamLen = 616
@@ -526,41 +523,6 @@ func Equal(a, b []byte) error {
 	return nil
 }
 
-// AddInitRAMFS adds an initramfs to the BzImage.
-func (b *BzImage) AddInitRAMFS(name string) error {
-	u, err := os.ReadFile(name)
-	if err != nil {
-		return err
-	}
-	// Should we ever want to compress the initramfs this is one
-	// way to do it.
-	d := u
-	if false {
-		d, err = compress(u, "--lzma2=,dict=1MiB")
-		if err != nil {
-			return err
-		}
-	}
-	s, e, err := b.InitRAMFS()
-	if err != nil {
-		return err
-	}
-	l := e - s
-
-	if len(d) > l {
-		return fmt.Errorf("new initramfs is %d bytes, won't fit in %d byte old one", len(d), l)
-	}
-	// Do this in a stupid way that is easy to read.
-	// What's interesting: the kernel decompressor, if I read it right,
-	// finds it easier to skip a bunch of leading nulls. So do that.
-	n := make([]byte, l)
-	Debug("Offset into n is %d\n", len(n)-len(d))
-	copy(n[len(n)-len(d):], d)
-	Debug("Install %d byte initramfs in %d bytes of kernel code, @ %d:%d", len(d), len(n), s, e)
-	copy(b.KernelCode[s:e], n)
-	return nil
-}
-
 // MarshalBinary implements encoding.BinaryMarshaler
 func (h *LinuxHeader) MarshalBinary() ([]byte, error) {
 	var buf bytes.Buffer
@@ -671,93 +633,6 @@ func (h *LinuxHeader) String() string {
 // String stringifies a LinuxParams into comma-separated parts
 func (h *LinuxParams) String() string {
 	return strings.Join(h.Show(), ",")
-}
-
-// InitRAMFS returns a []byte from KernelCode which can be used to save or replace
-// an existing InitRAMFS. The fun part is that there are no symbols; what we do instead
-// is find the programs what are RW and look for the cpio magic in them. If we find it,
-// we see if it can be read as a cpio and, if so, if there is a /dev or /init inside.
-// We repeat until we succeed or there's nothing left.
-func (b *BzImage) InitRAMFS() (int, int, error) {
-	f, err := b.ELF()
-	if err != nil {
-		return -1, -1, err
-	}
-	// Find the program header with RWE.
-	var dat []byte
-	var prog *elf.Prog
-	for _, p := range f.Progs {
-		if p.Flags&(elf.PF_X|elf.PF_W|elf.PF_R) == elf.PF_X|elf.PF_W|elf.PF_R {
-			dat, err = io.ReadAll(p.Open())
-			if err != nil {
-				return -1, -1, err
-			}
-			prog = p
-			break
-		}
-	}
-	if dat == nil {
-		return -1, -1, fmt.Errorf("can't find an RWE prog in kernel")
-	}
-
-	archiver, err := cpio.Format("newc")
-	if err != nil {
-		return -1, -1, fmt.Errorf("format newc not supported: %w", err)
-	}
-	var cur int
-	for cur < len(dat) {
-		x := bytes.Index(dat, []byte("070701"))
-		if x == -1 {
-			return -1, -1, fmt.Errorf("no newc cpio magic found")
-		}
-		if err != nil {
-			return -1, -1, err
-		}
-		cur = x
-		r := bytes.NewReader(dat[cur:])
-		rr := archiver.Reader(r)
-		Debug("r.Len is %v", r.Len())
-		var found bool
-		var size int
-		for {
-			rec, err := rr.ReadRecord()
-			Debug("Check %v", rec)
-			if err == io.EOF {
-				break
-			}
-			if err != nil {
-				Debug("error reading records: %v", err)
-				break
-			}
-			switch rec.Name {
-			case "init", "dev", "bin", "usr":
-				Debug("Found initramfs at %d, %d bytes", cur, len(dat)-r.Len())
-				found = true
-			}
-			size = int(rec.FilePos) + int(rec.FileSize)
-		}
-		Debug("Size is %d", size)
-		// Add the trailer size.
-		y := x + size
-		if found {
-			// The slice consists of the bytes for cur to the length of initramfs.
-			// We can derive the initramfs length by knowing how much is left of the reader.
-			Debug("Return %d %#x slice %d:%d from %d byte dat", len(dat[x:y]), len(dat[x:y]), cur, y, len(dat))
-			x += int(prog.Off)
-			y += int(prog.Off)
-			// We need to round y up to the end of the record. We have to do this after we
-			// add the prog.Off value to it.
-			y = (y + 3) &^ 3
-			// and add the size of the trailer record.
-			y += 120
-			y += 4 // and add at least one word of null
-			y = (y + 3) &^ 3
-			Debug("InitRAMFS: return %d, %d", x, y)
-			return x, y, nil
-		}
-		cur += 6
-	}
-	return -1, -1, fmt.Errorf("no cpio found")
 }
 
 // ErrCfgNotFound is returned if embedded config is not found.

--- a/pkg/boot/bzimage/bzimage_ramfs.go
+++ b/pkg/boot/bzimage/bzimage_ramfs.go
@@ -1,0 +1,139 @@
+// Copyright 2015-2018 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !tamago
+
+package bzimage
+
+import (
+	"bytes"
+	"debug/elf"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/u-root/u-root/pkg/cpio"
+)
+
+// AddInitRAMFS adds an initramfs to the BzImage.
+func (b *BzImage) AddInitRAMFS(name string) error {
+	u, err := os.ReadFile(name)
+	if err != nil {
+		return err
+	}
+	// Should we ever want to compress the initramfs this is one
+	// way to do it.
+	d := u
+	if false {
+		d, err = compress(u, "--lzma2=,dict=1MiB")
+		if err != nil {
+			return err
+		}
+	}
+	s, e, err := b.InitRAMFS()
+	if err != nil {
+		return err
+	}
+	l := e - s
+
+	if len(d) > l {
+		return fmt.Errorf("new initramfs is %d bytes, won't fit in %d byte old one", len(d), l)
+	}
+	// Do this in a stupid way that is easy to read.
+	// What's interesting: the kernel decompressor, if I read it right,
+	// finds it easier to skip a bunch of leading nulls. So do that.
+	n := make([]byte, l)
+	Debug("Offset into n is %d\n", len(n)-len(d))
+	copy(n[len(n)-len(d):], d)
+	Debug("Install %d byte initramfs in %d bytes of kernel code, @ %d:%d", len(d), len(n), s, e)
+	copy(b.KernelCode[s:e], n)
+	return nil
+}
+
+// InitRAMFS returns a []byte from KernelCode which can be used to save or replace
+// an existing InitRAMFS. The fun part is that there are no symbols; what we do instead
+// is find the programs what are RW and look for the cpio magic in them. If we find it,
+// we see if it can be read as a cpio and, if so, if there is a /dev or /init inside.
+// We repeat until we succeed or there's nothing left.
+func (b *BzImage) InitRAMFS() (int, int, error) {
+	f, err := b.ELF()
+	if err != nil {
+		return -1, -1, err
+	}
+	// Find the program header with RWE.
+	var dat []byte
+	var prog *elf.Prog
+	for _, p := range f.Progs {
+		if p.Flags&(elf.PF_X|elf.PF_W|elf.PF_R) == elf.PF_X|elf.PF_W|elf.PF_R {
+			dat, err = io.ReadAll(p.Open())
+			if err != nil {
+				return -1, -1, err
+			}
+			prog = p
+			break
+		}
+	}
+	if dat == nil {
+		return -1, -1, fmt.Errorf("can't find an RWE prog in kernel")
+	}
+
+	archiver, err := cpio.Format("newc")
+	if err != nil {
+		return -1, -1, fmt.Errorf("format newc not supported: %w", err)
+	}
+	var cur int
+	for cur < len(dat) {
+		x := bytes.Index(dat, []byte("070701"))
+		if x == -1 {
+			return -1, -1, fmt.Errorf("no newc cpio magic found")
+		}
+		if err != nil {
+			return -1, -1, err
+		}
+		cur = x
+		r := bytes.NewReader(dat[cur:])
+		rr := archiver.Reader(r)
+		Debug("r.Len is %v", r.Len())
+		var found bool
+		var size int
+		for {
+			rec, err := rr.ReadRecord()
+			Debug("Check %v", rec)
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				Debug("error reading records: %v", err)
+				break
+			}
+			switch rec.Name {
+			case "init", "dev", "bin", "usr":
+				Debug("Found initramfs at %d, %d bytes", cur, len(dat)-r.Len())
+				found = true
+			}
+			size = int(rec.FilePos) + int(rec.FileSize)
+		}
+		Debug("Size is %d", size)
+		// Add the trailer size.
+		y := x + size
+		if found {
+			// The slice consists of the bytes for cur to the length of initramfs.
+			// We can derive the initramfs length by knowing how much is left of the reader.
+			Debug("Return %d %#x slice %d:%d from %d byte dat", len(dat[x:y]), len(dat[x:y]), cur, y, len(dat))
+			x += int(prog.Off)
+			y += int(prog.Off)
+			// We need to round y up to the end of the record. We have to do this after we
+			// add the prog.Off value to it.
+			y = (y + 3) &^ 3
+			// and add the size of the trailer record.
+			y += 120
+			y += 4 // and add at least one word of null
+			y = (y + 3) &^ 3
+			Debug("InitRAMFS: return %d, %d", x, y)
+			return x, y, nil
+		}
+		cur += 6
+	}
+	return -1, -1, fmt.Errorf("no cpio found")
+}


### PR DESCRIPTION
This PR allows compilation of u-root bzimage package under [tamago](https://github.com/usbarmory/tamago) enabling us to [boot Linux kernels in bzImage format](https://github.com/usbarmory/armory-boot/blob/master/exec/linux_amd64.go) on bare metal.

This is the first step for us to run this on real hardware and implement a bare metal Go bootloader.

Example [invocation in tamago-example](https://github.com/usbarmory/tamago-example/blob/development/cmd/linux.go):

```
# tamago-example started in Firecracker

ssh 10.0.0.1
tamago/amd64 (go1.23.6) • 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
...

> 9p
starting 9p remote filesystem server
access with: `mount -t 9p -o trans=tcp,noextend 10.0.0.1 <path>`

# on host
mount -t 9p -o trans=tcp,noextend 10.0.0.1 /tmp/tamago
cp bzImage /tmp/tamago

# on tamago
ssh 10.0.0.1
tamago/amd64 (go1.23.6) • 11th Gen Intel(R) Core(TM) i7-1165G7 @ 2.80GHz
...

> linux bzImage
starting kernel@81000000
Linux version 5.10.233 (root@tamago) (gcc (GCC) 14.2.1 20250128, GNU ld (GNU Binutils) 2.43.1) #3 Wed Feb 5 18:14:25 CET 2025
Command line: console=ttyS0,115200,8n1 mem=4G
BIOS-provided physical RAM map:
BIOS-e820: [mem 0x0000000000000000-0x000000000009efff] usable
BIOS-e820: [mem 0x0000000010000000-0x000000004fffffff] usable
BIOS-e820: [mem 0x0000000080000000-0x000000008fffffff] usable
NX (Execute Disable) protection: active
user-defined physical RAM map:
user: [mem 0x0000000000000000-0x000000000009efff] usable
user: [mem 0x0000000010000000-0x000000004fffffff] usable
user: [mem 0x0000000080000000-0x000000008fffffff] usable
DMI not present or invalid.
Hypervisor detected: KVM
kvm-clock: Using msrs 4b564d01 and 4b564d00
kvm-clock: cpu 0, msr 81c63001, primary cpu clock
kvm-clock: using sched offset of 101794986723 cycles
```