### PR TITLE
pkg/pci: Add missing class codes

### DIFF
--- a/pkg/pci/class.go
+++ b/pkg/pci/class.go
@@ -140,7 +140,9 @@ var ClassNames = map[uint32]string{
 	0x010400: "StorageRAID",
 	0x010500: "StorageATA",
 	0x010600: "StorageSATA",
+	0x010601: "StorageAHCI",
 	0x010700: "StorageSAS",
+	0x010802: "StorageNVMHCI",
 	0x018000: "StorageOther",
 
 	0x02:     "Network",


### PR DESCRIPTION
Add commonly used class codes for storage devices.

Fixes: `pci` shows ClassUnknown for AHCI and NVMe disks.