### PR TITLE
tinygo: add archGetAcpiRsdpData function for amd64

### DIFF
--- a/pkg/boot/universalpayload/utilities_arch_amd64_tinygo.go
+++ b/pkg/boot/universalpayload/utilities_arch_amd64_tinygo.go
@@ -22,7 +22,11 @@ import (
 	"regexp"
 	"strconv"
 	"unsafe"
+
+	"github.com/u-root/u-root/pkg/acpi"
 )
+
+var getAcpiRsdp = acpi.GetRSDP
 
 // Get Physical Address size from sysfs node /proc/cpuinfo.
 // Both Physical and Virtual Address size will be prompted as format:
@@ -95,6 +99,18 @@ func constructTrampoline(buf []uint8, hobAddr uint64, entry uint64) []uint8 {
 	buf = appendUint64(buf, entry)
 
 	return buf
+}
+
+// Get the base address and data from RDSP table
+func archGetAcpiRsdpData() (uint64, []byte, error) {
+	rsdp, _ := getAcpiRsdp()
+	rsdpLen := rsdp.Len()
+
+	if rsdpLen > uint32(pageSize) {
+		return 0, nil, ErrDTRsdpLenOverBound
+	}
+
+	return 0, rsdp.AllData(), nil
 }
 
 func appendAddonMemMap(_ *EFIMemoryMapHOB) uint64 {

--- a/tools/tinygo-buildstatus/statusquo.go
+++ b/tools/tinygo-buildstatus/statusquo.go
@@ -54,7 +54,7 @@ var (
 		"insmod",
 		"io",
 		"ip",
-		// "kexec",
+		"kexec",
 		"kill",
 		"lddfiles",
 		"ln",


### PR DESCRIPTION
Add `archGetAcpiRsdpData()` to amd64 tinygo utilities for universalpayload. This removes the current `kexec` build error:

```
# github.com/u-root/u-root/pkg/boot/universalpayload
../../../pkg/boot/universalpayload/universalpayload.go:51:28: undefined: archGetAcpiRsdpData
```