### PR TITLE
ci: update golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,17 +21,17 @@ issues:
   exclude-dirs:
     - pkg/uroot/test
   exclude-rules:
-    - linters: revive
+    - linters: [revive]
       text: "don't use underscores"
-    - linters: revive
+    - linters: [revive]
       text: "don't use ALL_CAPS"
-    - linters: revive
+    - linters: [revive]
       text: "stutter"
-    - linters: revive
+    - linters: [revive]
       text: "unexported-return"
-    - linters: revive
+    - linters: [revive]
       text: "unused-parameter"
-    - linters: revive
+    - linters: [revive]
       text: "superfluous-else"
-    - linters: revive
+    - linters: [revive]
       text: "empty-block"


### PR DESCRIPTION
Release v6.5.0 adds the feature that the JSON schema is automatically verified. Update config to adhere to the scheme. The error was first discovered in the [CI run](https://github.com/u-root/u-root/actions/runs/13355556419/job/37325126174?pr=3295#step:4:34) for PR #3295.

This can be verified locally by

```
$ tinygoci-lint config verify
```