### PR TITLE
ci: add ignore list to not throw error

### DIFF
--- a/tools/tinygo-buildstatus/statusquo.go
+++ b/tools/tinygo-buildstatus/statusquo.go
@@ -195,6 +195,11 @@ var (
 		"zbi",
 		"zimage",
 	}
-
 	StatusQuo = append(tinygoCore, tinygoExp...)
+
+	// There are good reasons to ignore some packages, e.g. they are guaranteed
+	// not to build for a certain OS, e.g. bind only works for p9 builds.
+	Ignore = map[string][]string{
+		"bind": {"linux", "freebsd", "darwin", "windows"},
+	}
 )


### PR DESCRIPTION
There are cmdlets that can and should be ingored for target oses, such as the bind command. These commands are designed specifically for other OSes and will never be ported. This skipping is reported to the logs of the builder