### PR TITLE
ci: Add pre-built OVMF binaries for AMD64 and ARM64

### DIFF
--- a/.circleci/images/ovmf-amd64/Dockerfile
+++ b/.circleci/images/ovmf-amd64/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright 2025 the u-root Authors. All rights reserved
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+FROM ubuntu:rolling as base
+
+# Install dependencies
+RUN apt-get update &&                          \
+    apt-get install -y --no-install-recommends \
+        ovmf
+
+FROM scratch
+COPY --from=base /usr/share/ovmf/OVMF.fd /OVMF.fd

--- a/.circleci/images/ovmf-arm64/Dockerfile
+++ b/.circleci/images/ovmf-arm64/Dockerfile
@@ -1,0 +1,13 @@
+# Copyright 2025 the u-root Authors. All rights reserved
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+FROM ubuntu:rolling as base
+
+# Install dependencies
+RUN apt-get update &&                          \
+    apt-get install -y --no-install-recommends \
+        qemu-system-arm
+
+FROM scratch
+COPY --from=base /usr/share/qemu-efi-aarch64/QEMU_EFI.fd /QEMU_EFI.fd


### PR DESCRIPTION
Add pre-built AMD64 OVMF binary from Ubuntu offical ovmf package, pre-built ARM64 OVMF binary released from Linaro organization.