### PR TITLE
.vmtest.yaml: amd64: pass "-cpu max"

### DIFF
--- a/.vmtest.yaml
+++ b/.vmtest.yaml
@@ -1,7 +1,7 @@
 amd64:
   VMTEST_QEMU:
     container: "ghcr.io/hugelgupf/vmtest/qemu:main"
-    template: "{{.qemu}}/bin/qemu-system-x86_64 -L {{.qemu}}/pc-bios -m 1G"
+    template: "{{.qemu}}/bin/qemu-system-x86_64 -L {{.qemu}}/pc-bios -m 1G -cpu max"
     directories:
       qemu: "/zqemu"
 


### PR DESCRIPTION
On my laptop (AMD Ryzen 7 7840HS, AlmaLinux 9.5,
golang-1.22.9-2.el9_5.x86_64), the u-root init binary is built such that it requires the x86-64-v2 microarchitecture / ABI compatibility level. However, the QEMU command line template in ".vmtest.yaml" does not enable (all of) the constituent CPU features, and so integration tests fail immediately -- init exits, and the guest kernel panics:

> $ cd integration/generic-tests
> $ runvmtest -q -- go test -run TestIO
>
>     devices.go:275: vm: [1.6644s] Run /init as init process
>     devices.go:275: vm: [1.6788s] This program can only be run on AMD64 processors with v2 microarchitecture support.
>     devices.go:275: vm: [1.6792s] Kernel panic - not syncing: Attempted to kill init! exitcode=0x00000100

(The error message comes from the go runtime:
<https://github.com/golang/go/commit/8c8baad927b2>.)

Enable all CPU features supported by the accelerator with "-cpu max".