### PR TITLE
Netstat tweaks

### DIFF
--- a/cmds/core/netstat/netstat_linux.go
+++ b/cmds/core/netstat/netstat_linux.go
@@ -24,7 +24,7 @@ var (
        netstat { [-vWeenNac] -I[<Iface>] | [-veenNac] -i | [-cnNe] -M | -s [-6tuw] } [delay]
 
         -r, --route              display routing table
-        -I, --interfaces=<Iface> display interface table for <Iface>
+        -I, --interface=<Iface> display interface table for <Iface>
         -i, --interfaces         display interface table
         -g, --groups             display multicast group memberships
         -s, --statistics         display networking statistics (like SNMP)

--- a/cmds/core/netstat/netstat_linux.go
+++ b/cmds/core/netstat/netstat_linux.go
@@ -23,30 +23,30 @@ var (
        netstat [-vWnNcaeol] [<Socket> ...]
        netstat { [-vWeenNac] -I[<Iface>] | [-veenNac] -i | [-cnNe] -M | -s [-6tuw] } [delay]
 
-        -r, --route              display routing table
+        -r, --route             display routing table
         -I, --interface=<Iface> display interface table for <Iface>
-        -i, --interfaces         display interface table
-        -g, --groups             display multicast group memberships
-        -s, --statistics         display networking statistics (like SNMP)
-        -M, --masquerade         display masqueraded connections
+        -i, --interfaces        display interface table
+        -g, --groups            display multicast group memberships
+        -s, --statistics        display networking statistics (like SNMP)
+        -M, --masquerade        display masqueraded connections
 
-        -v, --verbose            be verbose
-        -W, --wide               don't truncate IP addresses
-        -n, --numeric            don't resolve names
-        --numeric-hosts          don't resolve host names
-        --numeric-ports          don't resolve port names
-        --numeric-users          don't resolve user names
-        -N, --symbolic           resolve hardware names
-        -e, --extend             display other/more information
-        -p, --programs           display PID/Program name for sockets
-        -o, --timers             display timers
-        -c, --continuous         continuous listing
+        -v, --verbose           be verbose
+        -W, --wide              don't truncate IP addresses
+        -n, --numeric           don't resolve names
+        --numeric-hosts         don't resolve host names
+        --numeric-ports         don't resolve port names
+        --numeric-users         don't resolve user names
+        -N, --symbolic          resolve hardware names
+        -e, --extend            display other/more information
+        -p, --programs          display PID/Program name for sockets
+        -o, --timers            display timers
+        -c, --continuous        continuous listing
 
-        -l, --listening          display listening server sockets
-        -a, --all                display all sockets (default: connected)
-        -F, --fib                display Forwarding Information Base (default)
-        -C, --cache              display routing cache instead of FIB
-        -Z, --context            display SELinux security context for sockets
+        -l, --listening         display listening server sockets
+        -a, --all               display all sockets (default: connected)
+        -F, --fib               display Forwarding Information Base (default)
+        -C, --cache             display routing cache instead of FIB
+        -Z, --context           display SELinux security context for sockets
 
   <Socket>={-t|--tcp} {-u|--udp} {-U|--udplite} {-S|--sctp} {-w|--raw}
            {-x|--unix} --ax25 --ipx --netrom

--- a/cmds/core/netstat/netstat_linux.go
+++ b/cmds/core/netstat/netstat_linux.go
@@ -404,23 +404,19 @@ func command(out io.Writer, args []string) *cmd {
 	fs.BoolVar(&c.all, "a", false, "display all sockets (default: connected)")
 
 	fs.Usage = printHelp
-
 	fs.Parse(unixflag.ArgsToGoArgs(args[1:]))
-
-	// Validate info source flags
-	// none or one allowed to be set
-	if !xorFlags(c.route, c.interfaces, c.groups, c.stats, c.iface != "") {
-		fmt.Printf("%s\n", help)
-		return nil
-	}
-
 	c.out = out
-
 	return &c
 }
 
 func main() {
-	if err := command(os.Stdout, os.Args).run(); err != nil {
+	switch err := command(os.Stdout, os.Args).run(); err {
+	case nil:
+	case errMutualExcludeFlags:
+		printHelp()
+		log.Print(err)
+		os.Exit(2)
+	default:
 		log.Fatal(err)
 	}
 }

--- a/pkg/netstat/interfaces.go
+++ b/pkg/netstat/interfaces.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"time"
 
 	"golang.org/x/sys/unix"
 )
@@ -64,6 +65,7 @@ func PrintInterfaceTable(ifstr string, cont bool, out io.Writer) error {
 		if !cont {
 			break
 		}
+		time.Sleep(2 * time.Second)
 	}
 
 	return nil


### PR DESCRIPTION
* Fix crash upon conflicting `netstat_linux` options.
* Fix typo in `--interface` help text.
* Add delay to `--continuous` loop when used with `--interface` or `--interfaces`.