### PR TITLE
pkg/netcat: fix address formatting for listening unix domain, and all IPv6, sockets

### DIFF
--- a/pkg/netcat/config.go
+++ b/pkg/netcat/config.go
@@ -178,6 +178,9 @@ func (c *Config) Address() (string, error) {
 			}
 		}
 
+		if c.ProtocolOptions.SocketType == SOCKET_TYPE_UNIX || c.ProtocolOptions.SocketType == SOCKET_TYPE_UDP_UNIX {
+			return address, nil
+		}
 		return address + ":" + strconv.FormatUint(c.Port, 10), nil
 	default:
 		return "", fmt.Errorf("invalid connection mode %v", c.ConnectionMode)

--- a/pkg/netcat/config.go
+++ b/pkg/netcat/config.go
@@ -147,7 +147,7 @@ func (c *Config) Address() (string, error) {
 
 			if c.ConnectionModeOptions.CurrentPort != 0 {
 				port := c.ConnectionModeOptions.CurrentPort
-				return c.Host + ":" + strconv.FormatUint(port, 10), nil
+				return net.JoinHostPort(c.Host, strconv.FormatUint(port, 10)), nil
 			}
 
 			return net.JoinHostPort(c.Host, strconv.FormatUint(c.Port, 10)), nil

--- a/pkg/netcat/config.go
+++ b/pkg/netcat/config.go
@@ -150,7 +150,7 @@ func (c *Config) Address() (string, error) {
 				return c.Host + ":" + strconv.FormatUint(port, 10), nil
 			}
 
-			return c.Host + ":" + strconv.FormatUint(c.Port, 10), nil
+			return net.JoinHostPort(c.Host, strconv.FormatUint(c.Port, 10)), nil
 		}
 	case CONNECTION_MODE_LISTEN:
 		var address string

--- a/pkg/netcat/config.go
+++ b/pkg/netcat/config.go
@@ -181,7 +181,7 @@ func (c *Config) Address() (string, error) {
 		if c.ProtocolOptions.SocketType == SOCKET_TYPE_UNIX || c.ProtocolOptions.SocketType == SOCKET_TYPE_UDP_UNIX {
 			return address, nil
 		}
-		return address + ":" + strconv.FormatUint(c.Port, 10), nil
+		return net.JoinHostPort(address, strconv.FormatUint(c.Port, 10)), nil
 	default:
 		return "", fmt.Errorf("invalid connection mode %v", c.ConnectionMode)
 	}

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -268,6 +268,30 @@ func TestAddressListenMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "Explicit pathname for UNIX domain socket (stream)",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_LISTEN,
+				Host:           "/tmp/stream.sock",
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_UNIX,
+				},
+			},
+			wantAddr: "/tmp/stream.sock",
+			wantErr:  false,
+		},
+		{
+			name: "Explicit pathname for UNIX domain socket (datagram)",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_LISTEN,
+				Host:           "/tmp/datagram.sock",
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_UDP_UNIX,
+				},
+			},
+			wantAddr: "/tmp/datagram.sock",
+			wantErr:  false,
+		},
+		{
 			name: "Unsupported Socket Type",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -206,6 +206,19 @@ func TestAddressListenMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "TCPv6 Listen with valid host",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_LISTEN,
+				Host:           "::1",
+				Port:           8080,
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:8080",
+			wantErr:  false,
+		},
+		{
 			name: "TCPv4 Listen with valid host and default port",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
@@ -215,6 +228,18 @@ func TestAddressListenMode(t *testing.T) {
 				},
 			},
 			wantAddr: "127.0.0.1:0", // Assuming default port is 0 when not specified
+			wantErr:  false,
+		},
+		{
+			name: "TCPv6 Listen with valid host and default port",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_LISTEN,
+				Host:           "::1",
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:0", // Assuming default port is 0 when not specified
 			wantErr:  false,
 		},
 		{
@@ -253,7 +278,7 @@ func TestAddressListenMode(t *testing.T) {
 					IPType:     IP_V6,
 				},
 			},
-			wantAddr: fmt.Sprintf("%s:%d", DEFAULT_IPV6_ADDRESS, DEFAULT_PORT),
+			wantAddr: fmt.Sprintf("[%s]:%d", DEFAULT_IPV6_ADDRESS, DEFAULT_PORT),
 			wantErr:  false,
 		},
 		{

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -193,7 +193,7 @@ func TestAddressListenMode(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "TCP Listen with valid host",
+			name: "TCPv4 Listen with valid host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
 				Host:           "127.0.0.1",
@@ -206,7 +206,7 @@ func TestAddressListenMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "TCP Listen with valid host and default port",
+			name: "TCPv4 Listen with valid host and default port",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
 				Host:           "127.0.0.1",
@@ -227,7 +227,7 @@ func TestAddressListenMode(t *testing.T) {
 					IPType:     IP_V4_V6,
 				},
 			},
-			wantAddr: DEFAULT_IPV4_ADDRESS + fmt.Sprintf(":%d", DEFAULT_PORT),
+			wantAddr: fmt.Sprintf("%s:%d", DEFAULT_IPV4_ADDRESS, DEFAULT_PORT),
 			wantErr:  false,
 		},
 		{
@@ -240,7 +240,7 @@ func TestAddressListenMode(t *testing.T) {
 					IPType:     IP_V4,
 				},
 			},
-			wantAddr: DEFAULT_IPV4_ADDRESS + fmt.Sprintf(":%d", DEFAULT_PORT),
+			wantAddr: fmt.Sprintf("%s:%d", DEFAULT_IPV4_ADDRESS, DEFAULT_PORT),
 			wantErr:  false,
 		},
 		{
@@ -253,7 +253,7 @@ func TestAddressListenMode(t *testing.T) {
 					IPType:     IP_V6,
 				},
 			},
-			wantAddr: DEFAULT_IPV6_ADDRESS + fmt.Sprintf(":%d", DEFAULT_PORT),
+			wantAddr: fmt.Sprintf("%s:%d", DEFAULT_IPV6_ADDRESS, DEFAULT_PORT),
 			wantErr:  false,
 		},
 		{

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -96,6 +96,43 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "TCPv4 Portscan",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "127.0.0.1",
+				Port:           1234,
+				ConnectionModeOptions: ConnectModeOptions{
+					ScanPorts:   true,
+					CurrentPort: 2345,
+					EndPort:     3456,
+				},
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "127.0.0.1:2345",
+			wantErr:  false,
+		},
+		{
+			name: "TCPv6 Portscan",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "::1",
+				Port:           1234,
+				ConnectionModeOptions: ConnectModeOptions{
+					ScanPorts:   true,
+					CurrentPort: 2345,
+					EndPort:     3456,
+				},
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:2345",
+			wantErr:  false,
+		},
+
+		{
 			name: "TCP Connect with no DNS host failing",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -38,7 +38,7 @@ func TestAddressConnectMode(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "TCP Connect with valid host",
+			name: "TCPv4 Connect with valid host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,
 				Host:           "127.0.0.1",
@@ -51,7 +51,7 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "TCP Connect with no DNS host",
+			name: "TCPv4 Connect with no DNS host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,
 				Host:           "127.0.0.1",
@@ -82,7 +82,7 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "TCP Connect with valid host and default port",
+			name: "TCPv4 Connect with valid host and default port",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,
 				Host:           "127.0.0.1",
@@ -132,7 +132,7 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "SCTP",
+			name: "SCTPv4",
 			config: &Config{
 				Host:           "127.0.0.1",
 				Port:           8080,

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -193,7 +193,7 @@ func TestAddressListenMode(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name: "TCP Connect with valid host",
+			name: "TCP Listen with valid host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
 				Host:           "127.0.0.1",
@@ -206,7 +206,7 @@ func TestAddressListenMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
-			name: "TCP Connect with valid host and default port",
+			name: "TCP Listen with valid host and default port",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_LISTEN,
 				Host:           "127.0.0.1",

--- a/pkg/netcat/config_test.go
+++ b/pkg/netcat/config_test.go
@@ -51,6 +51,19 @@ func TestAddressConnectMode(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "TCPv6 Connect with valid host",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "::1",
+				Port:           8080,
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:8080",
+			wantErr:  false,
+		},
+		{
 			name: "TCPv4 Connect with no DNS host",
 			config: &Config{
 				ConnectionMode: CONNECTION_MODE_CONNECT,
@@ -64,6 +77,22 @@ func TestAddressConnectMode(t *testing.T) {
 				},
 			},
 			wantAddr: "127.0.0.1:8080",
+			wantErr:  false,
+		},
+		{
+			name: "TCPv6 Connect with no DNS host",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "::1",
+				Port:           8080,
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+				Misc: MiscOptions{
+					NoDNS: true,
+				},
+			},
+			wantAddr: "[::1]:8080",
 			wantErr:  false,
 		},
 		{
@@ -91,6 +120,18 @@ func TestAddressConnectMode(t *testing.T) {
 				},
 			},
 			wantAddr: "127.0.0.1:0", // Assuming default port is 0 when not specified
+			wantErr:  false,
+		},
+		{
+			name: "TCPv6 Connect with valid host and default port",
+			config: &Config{
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				Host:           "::1",
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_TCP,
+				},
+			},
+			wantAddr: "[::1]:0", // Assuming default port is 0 when not specified
 			wantErr:  false,
 		},
 
@@ -142,6 +183,18 @@ func TestAddressConnectMode(t *testing.T) {
 				},
 			},
 			wantAddr: "127.0.0.1:8080",
+		},
+		{
+			name: "SCTPv6",
+			config: &Config{
+				Host:           "::1",
+				Port:           8080,
+				ConnectionMode: CONNECTION_MODE_CONNECT,
+				ProtocolOptions: ProtocolOptions{
+					SocketType: SOCKET_TYPE_SCTP,
+				},
+			},
+			wantAddr: "[::1]:8080",
 		},
 		{
 			name: "VSOCK",

--- a/pkg/netcat/const.go
+++ b/pkg/netcat/const.go
@@ -17,7 +17,7 @@ const (
 	DEFAULT_SHELL           = "/bin/sh"
 	DEFAULT_UNIX_SOCKET     = "/tmp/netcat.sock"
 	DEFAULT_IPV4_ADDRESS    = "0.0.0.0"
-	DEFAULT_IPV6_ADDRESS    = "[::]"
+	DEFAULT_IPV6_ADDRESS    = "::"
 	DEFAULT_WAIT            = time.Duration(10) * time.Second
 )
 


### PR DESCRIPTION
1. The commands

       netcat --listen --unixsock       PATHNAME
       netcat --listen --unixsock --udp PATHNAME

   uselessly append the default port (":31337") to PATHNAME, leading to unix domain socket names such as PATHNAME:31337 in the filesystem.

   Fix the bug, and add the missing unit test cases.

2. Netcat currently requires the user to pass IPv6 addresses on the command line in square bracket notation. This is inconsistent with Nmap's netcat.

   Take IPv6 addresses from the user without square brackets, and supply them internally with `net.JoinHostPort()`. This affects multiple IPv6-related code paths (listen mode, connect mode with portscan off, connect mode with portscan on).
