### PR TITLE
integration/generic-tests/netstat_test: remove leftover line

### DIFF
--- a/integration/generic-tests/netstat_test.go
+++ b/integration/generic-tests/netstat_test.go
@@ -211,5 +211,4 @@ func TestNetstat(t *testing.T) {
 	if err := vm.Wait(); err != nil {
 		t.Errorf("Wait: %v", err)
 	}
-	_ = vm.Wait()
 }


### PR DESCRIPTION
While working on the patch that would become commit e7b6bdb7129c ("integration/generic-tests: add netstat_test", 2025-03-20), I replaced the Kill in the final sequence

	if err := vm.Kill(); err != nil {
		t.Errorf("Kill: %v", err)
	}
	_ = vm.Wait()

with Wait, but failed to remove the now-superfluous second Wait. Do that now.

(The Kill is unnecessary because the VM shuts down gracefully anyway, with "TESTS PASSED MARKER".)