### PR TITLE
Netcat integration test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,7 @@ jobs:
     environment:
       - UROOT_SOURCE: /home/circleci/go/src/github.com/u-root/u-root
       - CGO_ENABLED: 1
+      - NETCAT_CONNECT_TEST_DISABLE_IPV6: 1
     steps:
       - checkout
       - run:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,8 @@ jobs:
           mkdir gocov
           VMTEST_GOCOVERDIR=$(pwd)/gocov \
             VMTEST_GO_PROFILE=vmcoverage.txt runvmtest -- \
-            go test -v -covermode=atomic ${{ matrix.extra-arg }} \
+            go test -v -timeout=15m \
+            -covermode=atomic ${{ matrix.extra-arg }} \
             -coverprofile=coverage.txt ./${{ matrix.pattern }}
 
       - name: Convert GOCOVERDIR coverage data

--- a/cmds/core/netcat/connect.go
+++ b/cmds/core/netcat/connect.go
@@ -13,9 +13,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -54,6 +56,12 @@ func (c *cmd) connect(output io.WriteCloser, network, address string) error {
 		return c.scanPorts()
 	}
 
+	if c.config.ProtocolOptions.SocketType == netcat.SOCKET_TYPE_UDP_UNIX &&
+		c.config.ConnectionModeOptions.SourceHost == "" {
+		c.config.ConnectionModeOptions.SourceHost = filepath.Join(os.TempDir(), fmt.Sprintf("netcat.%x.sock", rand.Uint64()))
+		defer os.Remove(c.config.ConnectionModeOptions.SourceHost)
+	}
+
 	conn, err := c.establishConnection(network, address)
 	if err != nil {
 		return fmt.Errorf("failed to establish connection: %w", err)
@@ -65,6 +73,11 @@ func (c *cmd) connect(output io.WriteCloser, network, address string) error {
 	// Return immediately if Zero-I/O mode is enabled and connection is established
 	if c.config.ConnectionModeOptions.ZeroIO {
 		return nil
+	}
+
+	if c.config.ProtocolOptions.SocketType == netcat.SOCKET_TYPE_UDP ||
+		c.config.ProtocolOptions.SocketType == netcat.SOCKET_TYPE_UDP_UNIX {
+		return c.transferPackets(output, conn.(net.PacketConn), false)
 	}
 
 	var wg sync.WaitGroup

--- a/cmds/core/netcat/connect.go
+++ b/cmds/core/netcat/connect.go
@@ -128,13 +128,13 @@ func (c *cmd) establishConnection(network, address string) (net.Conn, error) {
 		switch c.config.ProtocolOptions.SocketType {
 
 		case netcat.SOCKET_TYPE_TCP:
-			dialer.LocalAddr, err = net.ResolveTCPAddr(network, fmt.Sprintf("%v:%v", c.config.ConnectionModeOptions.SourceHost, c.config.ConnectionModeOptions.SourcePort))
+			dialer.LocalAddr, err = net.ResolveTCPAddr(network, net.JoinHostPort(c.config.ConnectionModeOptions.SourceHost, c.config.ConnectionModeOptions.SourcePort))
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve source address %w", err)
 			}
 
 		case netcat.SOCKET_TYPE_UDP:
-			dialer.LocalAddr, err = net.ResolveUDPAddr(network, fmt.Sprintf("%v:%v", c.config.ConnectionModeOptions.SourceHost, c.config.ConnectionModeOptions.SourcePort))
+			dialer.LocalAddr, err = net.ResolveUDPAddr(network, net.JoinHostPort(c.config.ConnectionModeOptions.SourceHost, c.config.ConnectionModeOptions.SourcePort))
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve source address %w", err)
 			}

--- a/cmds/core/netcat/connect_test.go
+++ b/cmds/core/netcat/connect_test.go
@@ -502,6 +502,22 @@ func TestEstablishConnectionUnix(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:    "Successful Unix connection (unnamed client socket)",
+			network: "unix",
+			address: socketPath,
+			config: &netcat.Config{
+				ProtocolOptions: netcat.ProtocolOptions{
+					SocketType: netcat.SOCKET_TYPE_UNIX,
+				},
+				Timing: netcat.TimingOptions{
+					Wait:    5 * time.Second,
+					Timeout: 5 * time.Second,
+				},
+			},
+
+			expectError: false,
+		},
+		{
 			name:    "Successful UDP Unix connection",
 			network: "unixgram",
 			address: socketPath,
@@ -509,6 +525,22 @@ func TestEstablishConnectionUnix(t *testing.T) {
 				ConnectionModeOptions: netcat.ConnectModeOptions{
 					SourceHost: sourcePath,
 				},
+				ProtocolOptions: netcat.ProtocolOptions{
+					SocketType: netcat.SOCKET_TYPE_UDP_UNIX,
+				},
+				Timing: netcat.TimingOptions{
+					Wait:    5 * time.Second,
+					Timeout: 5 * time.Second,
+				},
+			},
+
+			expectError: false,
+		},
+		{
+			name:    "Successful UDP Unix connection  (temporary client socket)",
+			network: "unixgram",
+			address: socketPath,
+			config: &netcat.Config{
 				ProtocolOptions: netcat.ProtocolOptions{
 					SocketType: netcat.SOCKET_TYPE_UDP_UNIX,
 				},

--- a/cmds/core/netcat/connect_test.go
+++ b/cmds/core/netcat/connect_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
@@ -258,6 +259,7 @@ func TestConnect(t *testing.T) {
 
 func TestEstablishConnection(t *testing.T) {
 	addr := "localhost:3000"
+	addr6 := "[::1]:3000"
 
 	tests := []struct {
 		name        string
@@ -273,6 +275,26 @@ func TestEstablishConnection(t *testing.T) {
 			config: &netcat.Config{
 				ConnectionModeOptions: netcat.ConnectModeOptions{
 					SourceHost: "localhost",
+					SourcePort: "8081",
+				},
+				ProtocolOptions: netcat.ProtocolOptions{
+					SocketType: netcat.SOCKET_TYPE_TCP,
+				},
+				Timing: netcat.TimingOptions{
+					Wait:    5 * time.Second,
+					Timeout: 5 * time.Second,
+				},
+			},
+
+			expectError: false,
+		},
+		{
+			name:    "Successful TCPv6 connection",
+			network: "tcp6",
+			address: addr6,
+			config: &netcat.Config{
+				ConnectionModeOptions: netcat.ConnectModeOptions{
+					SourceHost: "::1",
 					SourcePort: "8081",
 				},
 				ProtocolOptions: netcat.ProtocolOptions{
@@ -326,6 +348,25 @@ func TestEstablishConnection(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:    "Successful UDPv6 connection",
+			network: "udp6",
+			address: addr6,
+			config: &netcat.Config{
+				ConnectionModeOptions: netcat.ConnectModeOptions{
+					SourceHost: "::1",
+					SourcePort: "8081",
+				},
+				ProtocolOptions: netcat.ProtocolOptions{
+					SocketType: netcat.SOCKET_TYPE_UDP,
+				},
+				Timing: netcat.TimingOptions{
+					Wait:    5 * time.Second,
+					Timeout: 5 * time.Second,
+				},
+			},
+			expectError: false,
+		},
+		{
 			name:    "unimplemented socket",
 			network: "unix",
 			address: "localhost:3077",
@@ -351,11 +392,26 @@ func TestEstablishConnection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var listenAddr string
 			var wg sync.WaitGroup
 
+			// github does not enable IPv6 for docker containers
+			if tt.network == "tcp6" || tt.network == "udp6" {
+				_, disable_ipv6 := os.LookupEnv("NETCAT_CONNECT_TEST_DISABLE_IPV6")
+				if disable_ipv6 {
+					log.Printf("skipping %s", tt.name)
+					return
+				}
+			}
+
 			switch tt.network {
-			case "tcp":
-				l, err := net.Listen(tt.network, addr)
+			case "tcp", "tcp6":
+				if tt.network == "tcp" {
+					listenAddr = addr
+				} else {
+					listenAddr = addr6
+				}
+				l, err := net.Listen(tt.network, listenAddr)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -376,8 +432,13 @@ func TestEstablishConnection(t *testing.T) {
 
 					defer conn.Close()
 				}()
-			case "udp":
-				l, err := net.ListenPacket(tt.network, addr)
+			case "udp", "udp6":
+				if tt.network == "udp" {
+					listenAddr = addr
+				} else {
+					listenAddr = addr6
+				}
+				l, err := net.ListenPacket(tt.network, listenAddr)
 				if err != nil {
 					t.Fatal(err)
 				}

--- a/cmds/core/netcat/netcat.go
+++ b/cmds/core/netcat/netcat.go
@@ -223,6 +223,10 @@ func evalParams(args []string, f flags) (*netcat.Config, error) {
 	config.Output.AppendOutput = f.appendOutput
 
 	// Listen Mode Options
+	if (f.keepOpen || f.brokerMode || f.chatMode) && f.udpSocket {
+		return nil, fmt.Errorf("%w: keep-open mode and broker mode are unavailable with UDP", os.ErrInvalid)
+	}
+
 	config.ListenModeOptions.MaxConnections = uint32(f.maxConnections)
 	config.ListenModeOptions.KeepOpen = f.keepOpen
 	config.ListenModeOptions.BrokerMode = f.brokerMode

--- a/cmds/core/netcat/netcat_test.go
+++ b/cmds/core/netcat/netcat_test.go
@@ -368,6 +368,33 @@ func TestEvalParams(t *testing.T) {
 			wantConfig: &chatModeConfig,
 		},
 		{
+			name: "invalid keep-open mode",
+			modify: func(f flags) flags {
+				f.udpSocket = true
+				f.keepOpen = true
+				return f
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid broker mode",
+			modify: func(f flags) flags {
+				f.udpSocket = true
+				f.brokerMode = true
+				return f
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid chat mode",
+			modify: func(f flags) flags {
+				f.udpSocket = true
+				f.chatMode = true
+				return f
+			},
+			wantErr: true,
+		},
+		{
 			name:       "port scan",
 			args:       []string{"testhost", "1234-1345"},
 			modify:     func(f flags) flags { return f },

--- a/cmds/core/netcat/packet.go
+++ b/cmds/core/netcat/packet.go
@@ -1,0 +1,159 @@
+// Copyright 2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//go:build !tinygo || tinygo.enable
+
+package main
+
+import (
+	"errors"
+	"io"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/u-root/u-root/pkg/netcat"
+)
+
+// buffer represents a fixed size (64 KB) byte array, with the number of bytes
+// used (at the front) given by n.
+type buffer struct {
+	b [65536]byte
+	n int
+}
+
+// transferPackets copies data from c.stdin to packetConn, and from packetConn
+// to output. Packet size is limited to 64 KB.
+//
+// If listenMode is true, then transferPackets doesn't start reading c.stdin
+// until such a packet is received from packetConn whose sender passes the
+// allow list. Once that happens, said sender address determines where
+// transferPackets sends data from c.stdin. transferPackets only returns upon
+// errors; reading EOF from c.stdin is not considered an exit condition.
+//
+// If listenMode is false, then packetConn is expected to implement net.Conn,
+// and to have a default destination address. transferPackets returns upon
+// errors, plus it returns nil if EOF is seen on c.stdin.
+func (c *cmd) transferPackets(output io.Writer, packetConn net.PacketConn, listenMode bool) error {
+	var connToOutput buffer
+	var clientAddr net.Addr
+	var wg sync.WaitGroup
+	var stdinToConnError error
+	var connToOutputError error
+
+	if listenMode {
+		for {
+			var err error
+
+			connToOutput.n, clientAddr, err = packetConn.ReadFrom(connToOutput.b[:])
+			if err != nil {
+				return err
+			}
+			if c.config.ProtocolOptions.SocketType == netcat.SOCKET_TYPE_UDP &&
+				!c.config.AccessControl.IsAllowed(parseRemoteAddr(netcat.SOCKET_TYPE_UDP, clientAddr.String())) {
+				continue
+			}
+			log.Printf("receiving packets from %v", clientAddr)
+			break
+		}
+	}
+
+	// Upon reading EOF from c.stdin, the goroutine that copies c.stdin to
+	// packetConn aborts the goroutine that copies packetConn to output, by
+	// sending an empty message over a channel. However, the latter goroutine may
+	// have exited meanwhile, due to an independent error. The former goroutine
+	// should not block in its abort attempt indefinitely in this case (just
+	// because nothing is reading the channel anymore); thus, make the channel
+	// buffered (with buffer size 1). If the latter goroutine is no longer there,
+	// the empty message in the channel buffer is ignored.
+	abortConnToOutput := make(chan struct{}, 1)
+
+	wg.Add(2)
+
+	// copy c.stdin to packetConn
+	go func() {
+		defer wg.Done()
+
+		for {
+			var stdinToConn buffer
+			var readError error
+			var sendError error
+
+			stdinToConn.n, readError = c.stdin.Read(stdinToConn.b[:])
+			if stdinToConn.n > 0 {
+				if listenMode {
+					_, sendError = packetConn.WriteTo(stdinToConn.b[:stdinToConn.n], clientAddr)
+				} else {
+					_, sendError = packetConn.(net.Conn).Write(stdinToConn.b[:stdinToConn.n])
+				}
+			}
+
+			if readError != nil {
+				if readError == io.EOF {
+					if !listenMode {
+						abortConnToOutput <- struct{}{}
+					}
+				} else {
+					abortConnToOutput <- struct{}{}
+					stdinToConnError = readError
+				}
+				return
+			}
+			if sendError != nil {
+				abortConnToOutput <- struct{}{}
+				stdinToConnError = sendError
+				return
+			}
+		}
+	}()
+
+	// copy packetConn to output
+	go func() {
+		defer wg.Done()
+
+		var receiveError error
+		for {
+			var writeError error
+			var deadlineError error
+			var addr net.Addr
+
+			if connToOutput.n > 0 {
+				_, writeError = output.Write(connToOutput.b[:connToOutput.n])
+			}
+			if receiveError != nil && !errors.Is(receiveError, os.ErrDeadlineExceeded) {
+				connToOutputError = receiveError
+				return
+			}
+			if writeError != nil {
+				connToOutputError = writeError
+				return
+			}
+
+			select {
+			case <-abortConnToOutput:
+				return
+			default:
+			}
+
+			deadlineError = packetConn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			if deadlineError != nil {
+				connToOutputError = deadlineError
+				return
+			}
+
+			connToOutput.n, addr, receiveError = packetConn.ReadFrom(connToOutput.b[:])
+			if listenMode && connToOutput.n > 0 && addr.String() != clientAddr.String() {
+				log.Printf("ignoring packet from %v", addr)
+				connToOutput.n = 0
+			}
+		}
+	}()
+
+	wg.Wait()
+	if stdinToConnError != nil {
+		return stdinToConnError
+	}
+	return connToOutputError
+}

--- a/integration/generic-tests/netcat_test.go
+++ b/integration/generic-tests/netcat_test.go
@@ -1,0 +1,337 @@
+// Copyright 2018-2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !race
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/hugelgupf/vmtest/qemu"
+	"github.com/hugelgupf/vmtest/qemu/qnetwork"
+	"github.com/hugelgupf/vmtest/scriptvm"
+	"github.com/u-root/mkuimage/uimage"
+)
+
+func netcatVM(t *testing.T, name, script string, net *qnetwork.InterVM) *qemu.VM {
+	return scriptvm.Start(t, name, script,
+		scriptvm.WithUimage(
+			uimage.WithBusyboxCommands(
+				"github.com/u-root/u-root/cmds/core/basename",
+				"github.com/u-root/u-root/cmds/core/cat",
+				"github.com/u-root/u-root/cmds/core/dirname",
+				"github.com/u-root/u-root/cmds/core/echo",
+				"github.com/u-root/u-root/cmds/core/grep",
+				"github.com/u-root/u-root/cmds/core/ip",
+				"github.com/u-root/u-root/cmds/core/kill",
+				// loopback tests disabled due to https://github.com/mvdan/sh/issues/1142
+				// "github.com/u-root/u-root/cmds/core/mkfifo",
+				// "github.com/u-root/u-root/cmds/core/rm",
+				"github.com/u-root/u-root/cmds/core/seq",
+				"github.com/u-root/u-root/cmds/core/shasum",
+				"github.com/u-root/u-root/cmds/core/sleep",
+			),
+			uimage.WithCoveredCommands(
+				"github.com/u-root/u-root/cmds/core/netcat",
+			),
+		),
+		scriptvm.WithQEMUFn(
+			qemu.WithVMTimeout(2*time.Minute),
+			net.NewVM(),
+		),
+	)
+}
+
+func TestNetcatStream(t *testing.T) {
+	net := qnetwork.NewInterVM()
+
+	serverScript := `
+		# Disable IPv6 Duplicate Address Discovery. We don't need it on this virtual
+		# network, and it will only prevent netcat from binding our unique local
+		# address (ULA) for several seconds.
+		echo 0 >/proc/sys/net/ipv6/conf/eth0/accept_dad
+
+		ip    addr add 192.168.0.2/24        dev eth0
+		ip -6 addr add fd51:3681:1eb4::2/126 dev eth0
+		ip link set eth0 up
+		ip    route add 0.0.0.0/0 dev eth0
+		ip -6 route add ::/0      dev eth0
+		echo "192.168.0.1       netcat_client" >>/etc/hosts
+		echo "fd51:3681:1eb4::1 netcat_client" >>/etc/hosts
+		echo "192.168.0.2       netcat_server" >>/etc/hosts
+		echo "fd51:3681:1eb4::2 netcat_server" >>/etc/hosts
+
+		seq -w 0 99999 >input.txt
+
+		# loopback tests disabled due to https://github.com/mvdan/sh/issues/1142
+		#
+		# mkfifo fifo fifo6
+		#
+		# # TCPv4 server: loopback
+		# : >fifo &
+		# netcat -l 192.168.0.2 5005 <fifo >fifo &
+		#
+		# # TCPv4 server: checksum
+		# netcat -l 192.168.0.2 5006 <input.txt | shasum >5006.out &
+		#
+		# # TCPv6 server: loopback
+		# : >fifo6 &
+		# netcat -l fd51:3681:1eb4::2 5005 <fifo6 >fifo6 &
+		#
+		# # TCPv6 server: checksum
+		# netcat -l fd51:3681:1eb4::2 5006 <input.txt | shasum >5006-6.out &
+
+		# accept file from TCPv4 client
+		netcat -l 192.168.0.2 5007 </dev/null | shasum >5007.out &
+
+		# send file to TCPv4 client
+		netcat -l 192.168.0.2 5008 <input.txt &
+
+		# exchange files with TCPv4 client
+		netcat -l 192.168.0.2 5009 <input.txt | shasum >5009.out &
+
+		# accept file from TCPv6 client
+		netcat -l fd51:3681:1eb4::2 5007 </dev/null | shasum >5007-6.out &
+
+		# send file to TCPv6 client
+		netcat -l fd51:3681:1eb4::2 5008 <input.txt &
+
+		# exchange files with TCPv6 client
+		netcat -l fd51:3681:1eb4::2 5009 <input.txt | shasum >5009-6.out &
+
+		wait
+
+		# loopback tests disabled due to https://github.com/mvdan/sh/issues/1142
+		# grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5006.out
+		# grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5006-6.out
+
+		# verify files from TCPv4 client
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5007.out
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5009.out
+
+		# verify files from TCPv6 client
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5007-6.out
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5009-6.out
+
+		# run TCPv4/v6 servers in keep-open mode for about 20 seconds
+		# run TCPv4/v6 servers in broker (chat) mode for about 20 seconds
+		netcat -l -k     192.168.0.2       5010 </dev/null | shasum >5010.out   &
+		netcat -l -k     fd51:3681:1eb4::2 5010 </dev/null | shasum >5010-6.out &
+		netcat -l --chat 192.168.0.2       5011 >5011.out   &
+		netcat -l --chat fd51:3681:1eb4::2 5011 >5011-6.out &
+		sleep 20
+		grep -l netcat /proc/*/comm |
+			while read P; do
+				kill $(basename $(dirname $P))
+			done
+		wait
+
+
+		# verify output from keep-open mode servers
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5010.out
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5010-6.out
+
+		# verify output from chat servers
+		expected=$(
+			echo 'user<1>: hello-1'
+			echo 'user<2>: hello-2'
+			echo 'user<3>: hello-3'
+		)
+		got=$(cat 5011.out)
+		test "$expected" = "$got"
+		got=$(cat 5011-6.out)
+		test "$expected" = "$got"
+	`
+	clientScript := `
+		# Disable IPv6 Duplicate Address Discovery. We don't need it on this virtual
+		# network, and it will only prevent netcat from binding our unique local
+		# address (ULA) for several seconds.
+		echo 0 >/proc/sys/net/ipv6/conf/eth0/accept_dad
+
+		ip    addr add 192.168.0.1/24        dev eth0
+		ip -6 addr add fd51:3681:1eb4::1/126 dev eth0
+		ip link set eth0 up
+		ip    route add 0.0.0.0/0 dev eth0
+		ip -6 route add ::/0      dev eth0
+		echo "192.168.0.1       netcat_client" >>/etc/hosts
+		echo "fd51:3681:1eb4::1 netcat_client" >>/etc/hosts
+		echo "192.168.0.2       netcat_server" >>/etc/hosts
+		echo "fd51:3681:1eb4::2 netcat_server" >>/etc/hosts
+
+		seq -w     0 49999 >input-1.txt
+		seq -w 50000 99999 >input-2.txt
+		cat input-1.txt input-2.txt >input.txt
+
+		# wait a bit for the server to come up
+		sleep 3
+
+		# loopback tests disabled due to https://github.com/mvdan/sh/issues/1142
+		#
+		# mkfifo fifo
+		#
+		# # TCPv4 client: checksum
+		# netcat 192.168.0.2 5005 <input.txt | shasum >5005.out
+		# grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5005.out
+		#
+		# # TCPv4 client: loopback
+		# : >fifo &
+		# netcat 192.168.0.2 5006 <fifo >fifo
+		#
+		# # TCPv6 client: checksum
+		# netcat fd51:3681:1eb4::2 5005 <input.txt | shasum >5005-6.out
+		# grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5005-6.out
+		#
+		# # TCPv6 client: loopback
+		# : >fifo &
+		# netcat fd51:3681:1eb4::2 5006 <fifo >fifo
+		#
+		# # unix server: loopback
+		# : >fifo &
+		# netcat -l -U stream.sock <fifo >fifo &
+		# sleep 1
+		#
+		# # unix client: checksum
+		# netcat -U stream.sock <input.txt | shasum >stream.client.out
+		# grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa stream.client.out
+		# wait
+		# rm stream.sock
+		#
+		# # unix server: checksum
+		# netcat -l -U stream.sock <input.txt | shasum >stream.server.out &
+		# sleep 1
+		#
+		# # unix client: loopback
+		# : >fifo &
+		# netcat -U stream.sock <fifo >fifo
+		#
+		# wait
+		# rm stream.sock
+		# grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa stream.server.out
+
+		# upload file to TCPv4 server
+		netcat 192.168.0.2 5007 <input.txt
+
+		# download file from TCPv4 server
+		netcat 192.168.0.2 5008 </dev/null | shasum >5008.out
+
+		# exchange files with TCPv4 server
+		netcat 192.168.0.2 5009 <input.txt | shasum >5009.out
+
+		# verify files from TCPv4 server
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5008.out
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5009.out
+
+		# upload file to TCPv6 server
+		netcat fd51:3681:1eb4::2 5007 <input.txt
+
+		# download file from TCPv6 server
+		netcat fd51:3681:1eb4::2 5008 </dev/null | shasum >5008-6.out
+
+		# exchange files with TCPv6 server
+		netcat fd51:3681:1eb4::2 5009 <input.txt | shasum >5009-6.out
+
+		# verify files from TCPv6 server
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5008-6.out
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa 5009-6.out
+
+
+		# wait a bit until the keep-open and chat servers start up
+		sleep 3
+
+		# upload file in two parts to each keep-open server
+		netcat 192.168.0.2	 5010 <input-1.txt
+		netcat 192.168.0.2	 5010 <input-2.txt
+		netcat fd51:3681:1eb4::2 5010 <input-1.txt
+		netcat fd51:3681:1eb4::2 5010 <input-2.txt
+
+		# Connect with three clients to each chat server in a predefined order (at 0,
+		# 2, and 4 seconds), and once they're all connected (which happens slightly
+		# after the 4 second mark), make them send strings in a predefined order (at
+		# 6, 8, and 10 seconds from the start). Each client lingers until the 12
+		# second mark (so that everyone can hear everyone).
+
+		(sleep 6; echo hello-1; sleep 6) | netcat 192.168.0.2       5011 >5011-1.out   &
+		(sleep 6; echo hello-1; sleep 6) | netcat fd51:3681:1eb4::2 5011 >5011-6-1.out &
+		sleep 2
+		(sleep 6; echo hello-2; sleep 4) | netcat 192.168.0.2       5011 >5011-2.out   &
+		(sleep 6; echo hello-2; sleep 4) | netcat fd51:3681:1eb4::2 5011 >5011-6-2.out &
+		sleep 2
+		(sleep 6; echo hello-3; sleep 2) | netcat 192.168.0.2       5011 >5011-3.out   &
+		(sleep 6; echo hello-3; sleep 2) | netcat fd51:3681:1eb4::2 5011 >5011-6-3.out &
+		wait
+
+		# verify output from each chat client
+		expected1=$(
+			echo 'user<2>: hello-2'
+			echo 'user<3>: hello-3'
+		)
+		expected2=$(
+			echo 'user<1>: hello-1'
+			echo 'user<3>: hello-3'
+		)
+		expected3=$(
+			echo 'user<1>: hello-1'
+			echo 'user<2>: hello-2'
+		)
+
+		got1=$(cat 5011-1.out)
+		got2=$(cat 5011-2.out)
+		got3=$(cat 5011-3.out)
+		test "$expected1" = "$got1"
+		test "$expected2" = "$got2"
+		test "$expected3" = "$got3"
+
+		got1=$(cat 5011-6-1.out)
+		got2=$(cat 5011-6-2.out)
+		got3=$(cat 5011-6-3.out)
+		test "$expected1" = "$got1"
+		test "$expected2" = "$got2"
+		test "$expected3" = "$got3"
+
+
+		# accept file from unix client
+		netcat -l -U stream-1.sock </dev/null | shasum >stream-1.server.out &
+
+		# send file to unix client
+		netcat -l -U stream-2.sock <input.txt &
+
+		# exchange files with unix client
+		netcat -l -U stream-3.sock <input.txt | shasum >stream-3.server.out &
+
+		sleep 1
+
+		# upload file to unix server
+		netcat -U stream-1.sock <input.txt
+
+		# download file from unix server
+		netcat -U stream-2.sock </dev/null | shasum >stream-2.client.out
+
+		# exchange files with unix server
+		netcat -U stream-3.sock <input.txt | shasum >stream-3.client.out
+
+		# verify files from unix client
+		wait
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa stream-1.server.out
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa stream-3.server.out
+
+		# verify files from unix server
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa stream-2.client.out
+		grep -q a7ffaef825af40e08daef5a1e0804d851904b5aa stream-3.client.out
+	`
+
+	serverVM := netcatVM(t, "netcat_server", serverScript, net)
+	clientVM := netcatVM(t, "netcat_client", clientScript, net)
+
+	if _, err := serverVM.Console.ExpectString("TESTS PASSED MARKER"); err != nil {
+		t.Errorf("serverVM: %v", err)
+	}
+	if _, err := clientVM.Console.ExpectString("TESTS PASSED MARKER"); err != nil {
+		t.Errorf("clientVM: %v", err)
+	}
+
+	clientVM.Wait()
+	serverVM.Wait()
+}


### PR DESCRIPTION
The front of the series fixes some further problems in the `netcat` command. The tail of the series adds stream (TCPv4, TCPv6, UNIX) and datagram (UDPv4, UDPv6, UNIX) integration tests, using two VMs.