### PR TITLE
Add SMBIOS3 info in device tree node

### DIFF
--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -176,6 +176,10 @@ func run(args []string) error {
 
 	if err := universalpayload.Load(opts.kernelpath, linux.Debug); err != nil {
 		log.Printf("Failed to load universalpayload (%v), try legacy kernel..", err)
+	} else {
+		if err := universalpayload.Exec(); err != nil {
+			log.Printf("Failed to execute universalpayload (%v), try legacy kernel..", err)
+		}
 	}
 
 	if opts.cmdline != "" && opts.reuseCmdline {

--- a/cmds/core/kexec/kexec_linux.go
+++ b/cmds/core/kexec/kexec_linux.go
@@ -174,9 +174,14 @@ func run(args []string) error {
 		return fmt.Errorf("usage: kexec [fs] kernelname OR kexec -e")
 	}
 
-	if err := universalpayload.Load(opts.kernelpath, linux.Debug); err != nil {
+	if err, warningMsg := universalpayload.Load(opts.kernelpath, linux.Debug); err != nil {
 		log.Printf("Failed to load universalpayload (%v), try legacy kernel..", err)
 	} else {
+		// universalpayload package suppresses warning message, we print messages here.
+		if warningMsg != nil {
+			log.Printf("Warning messages from universalpayload:\n%v\n", warningMsg)
+		}
+
 		if err := universalpayload.Exec(); err != nil {
 			log.Printf("Failed to execute universalpayload (%v), try legacy kernel..", err)
 		}

--- a/pkg/boot/universalpayload/universalpayload.go
+++ b/pkg/boot/universalpayload/universalpayload.go
@@ -49,6 +49,7 @@ const (
 var (
 	kexecMemoryMapFromIOMem = kexec.MemoryMapFromIOMem
 	getSMBIOSBase           = smbios.SMBIOSBase
+	getSMBIOS3HdrSize       = smbios.SMBIOS3HeaderSize
 	getAcpiRsdpData         = archGetAcpiRsdpData
 )
 

--- a/pkg/boot/universalpayload/universalpayload.go
+++ b/pkg/boot/universalpayload/universalpayload.go
@@ -598,8 +598,12 @@ func Load(name string, dbg func(string, ...interface{})) error {
 	}
 
 	debug("universalpayload: boot trampoline code at:%x\n", entry)
+
+	return nil
+}
+
+func Exec() error {
 	if err := boot.Execute(); err != nil {
-		debug("universalpayload: Failed to execute with error (%v)\n", err)
 		return errors.Join(ErrKexecExecuteFailed, err)
 	}
 

--- a/pkg/boot/universalpayload/universalpayload.go
+++ b/pkg/boot/universalpayload/universalpayload.go
@@ -115,7 +115,8 @@ var (
 )
 
 var (
-	debug = func(string, ...interface{}) {}
+	debug      = func(string, ...interface{}) {}
+	warningMsg []error
 )
 
 // Create GUID HOB with specified GUID string
@@ -552,7 +553,7 @@ func loadKexecMemWithHOBs(fdt *FdtLoad, data []byte, mem *kexec.Memory) (uintptr
 	return (uintptr)(loadAddr + uint64(trampolineOffset)), nil
 }
 
-func Load(name string, dbg func(string, ...interface{})) error {
+func Load(name string, dbg func(string, ...interface{})) (error, error) {
 	if dbg != nil {
 		debug = dbg
 	}
@@ -561,14 +562,14 @@ func Load(name string, dbg func(string, ...interface{})) error {
 	fdtLoad, err := GetFdtInfo(name)
 	if err != nil {
 		debug("universalpayload: Failed to get FDT information (%v)\n", err)
-		return err
+		return err, errors.Join(warningMsg...)
 	}
 
 	debug("universalpayload: Try to fetch file content\n")
 	data, err := os.ReadFile(name)
 	if err != nil {
 		debug("universalpayload: Failed to fetch file content (%v)\n", err)
-		return fmt.Errorf("%w: file: %s, err: %w", ErrFailToReadFdtFile, name, err)
+		return fmt.Errorf("%w: file: %s, err: %w", ErrFailToReadFdtFile, name, err), errors.Join(warningMsg...)
 	}
 
 	// Prepare memory.
@@ -576,7 +577,7 @@ func Load(name string, dbg func(string, ...interface{})) error {
 	ioMem, err := kexecMemoryMapFromIOMem()
 	if err != nil {
 		debug("universalpayload: Failed to get Memory Map from IOMem\n")
-		return fmt.Errorf("%w: err: %w", ErrMemMapIoMemExecuteFailed, err)
+		return fmt.Errorf("%w: err: %w", ErrMemMapIoMemExecuteFailed, err), errors.Join(warningMsg...)
 	}
 
 	mem := kexec.Memory{
@@ -588,18 +589,18 @@ func Load(name string, dbg func(string, ...interface{})) error {
 	entry, err := loadKexecMemWithHOBs(fdtLoad, data, &mem)
 	if err != nil {
 		debug("universalpayload: Failed to prepare parameters with error (%v)\n", err)
-		return err
+		return err, errors.Join(warningMsg...)
 	}
 
 	debug("universalpayload: Entry:%x, Segments:%v\n", entry, mem.Segments)
 	if err := kexec.Load(entry, mem.Segments, 0); err != nil {
 		debug("universalpayload: Failed to load segments with error (%v)\n", err)
-		return errors.Join(ErrKexecLoadFailed, err)
+		return errors.Join(ErrKexecLoadFailed, err), errors.Join(warningMsg...)
 	}
 
 	debug("universalpayload: boot trampoline code at:%x\n", entry)
 
-	return nil
+	return nil, errors.Join(warningMsg...)
 }
 
 func Exec() error {

--- a/pkg/boot/universalpayload/utilities.go
+++ b/pkg/boot/universalpayload/utilities.go
@@ -707,7 +707,7 @@ func constructReservedMemoryNode(rsdpBase uint64) *dt.Node {
 	if smbios3ChildNode, err := constructSMBIOS3Node(); err != nil {
 		// If we failed to retrieve SMBIOS3 information, prompt error
 		// message to indicate error message, and continue construct DTB.
-		fmt.Printf("WARNING: Failed to build SMBIOS3 Node (%v)\n", err)
+		warningMsg = append(warningMsg, err)
 	} else {
 		rsvdNodes = append(rsvdNodes, smbios3ChildNode)
 	}
@@ -729,14 +729,14 @@ func buildDeviceTreeInfo(buf io.Writer, mem *kexec.Memory, loadAddr uint64, rsdp
 
 	gmaNode, err := buildGraphicNode()
 	if err != nil {
-		fmt.Printf("WARNING: Failed to build Graphic Device Node (%v)\n", err)
+		warningMsg = append(warningMsg, err)
 	}
 
 	fbNode, err := buildFrameBufferNode()
 	if err != nil {
 		// If we failed to retrieve Frame Buffer configurations, prompt error
 		// message to indicate error message, and continue construct DTB.
-		fmt.Printf("WARNING: Failed to build Frame Buffer Node (%v)\n", err)
+		warningMsg = append(warningMsg, err)
 	}
 
 	serialPortNode := constructSerialPortNode()

--- a/pkg/boot/universalpayload/utilities_test.go
+++ b/pkg/boot/universalpayload/utilities_test.go
@@ -422,3 +422,35 @@ func TestRelocatePE(t *testing.T) {
 		})
 	}
 }
+
+func mockGetSMBIOS3Base() (int64, int64, error) {
+	return 0x100, 0x200, nil
+}
+
+func TestConstructSMBIOS3Node(t *testing.T) {
+	// mock data
+	defer func(old func() (int64, int64, error)) { getSMBIOSBase = old }(getSMBIOSBase)
+	getSMBIOSBase = mockGetSMBIOS3Base
+
+	tests := []struct {
+		name     string
+		wantNode *dt.Node
+		wantErr  error
+	}{
+		{
+			name:     "Invalid SMBIOS3 Header size",
+			wantNode: nil,
+			wantErr:  ErrSMBIOS3NotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			smbiosNode, err := constructSMBIOS3Node()
+			expectErr(t, err, tt.wantErr)
+			if smbiosNode != tt.wantNode {
+				t.Fatalf("Unexpected smbios Node: actual(%v) vs. expected(nil)", smbiosNode)
+			}
+		})
+	}
+}

--- a/pkg/smbios/smbios.go
+++ b/pkg/smbios/smbios.go
@@ -23,3 +23,7 @@ func SMBIOSBase() (int64, int64, error) {
 	}
 	return base, size, nil
 }
+
+func SMBIOS3HeaderSize() int64 {
+	return smbios3HeaderSize
+}


### PR DESCRIPTION
smbios package provides method to retrieve SMBIOS info, this method tries to get SMBIOS3 info first, and then SMBIOS info. However, we have no way to figure out this is SMBIOS3 or SMBIOS info.
In order to integrate with TianoCore EDk2 UPL implementation, we need to provide SMBIOS3 info in device tree info since SMBIOS3 info is constructed from device tree info and only can be constructed from device tree info. In this case, we need to ensure that the SMBIOS info that is retrieved from smbios package is SMBIOS3 info not a SMBIOS, and provide SMBIOS3 info in device tree.
