### PR TITLE
cmds/core/echo: remove non-existant \e backslash escape

### DIFF
--- a/cmds/core/echo/echo.go
+++ b/cmds/core/echo/echo.go
@@ -28,7 +28,6 @@ var (
     \a     alert (BEL)
     \b     backspace
     \c     produce no further output
-    \e     escape
     \f     form feed
     \n     new line
     \r     carriage return


### PR DESCRIPTION
Go's printf simply does not support \e to produce, I suppose, ascii 27 ESC. \x1b can be used instead.