### PR TITLE
acpi: Get RSDP/XSDT pointer using EFI variable

### DIFF
--- a/pkg/acpi/bios.go
+++ b/pkg/acpi/bios.go
@@ -24,11 +24,14 @@ type BiosTable struct {
 // i.e. it goes straight to memory and gets them there. We optimistically
 // hope the bios has not stomped around in low memory messing around.
 func ReadBiosTables() (*BiosTable, error) {
-	r, err := GetRSDPEBDA()
+	r, err := GetRSDPEFI()
 	if err != nil {
-		r, err = GetRSDPMem()
+		r, err = GetRSDPEBDA()
 		if err != nil {
-			return nil, err
+			r, err = GetRSDPMem()
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	Debug("Found an RSDP at %#x", r.base)


### PR DESCRIPTION
GetRSDPEBDA() and GetRSDPMem() implementations are based on memory layout for x86 systems. ARM64 systems may not follow this exact memory layout.

So, relying on EFI variable to give the pointer for XSDT table.

Signed-off-by: Vignesh Soundararajan <vsoundar@google.com>