### PR TITLE
ip neigh improvements + integration test

### DIFF
--- a/cmds/core/ip/neigh_linux.go
+++ b/cmds/core/ip/neigh_linux.go
@@ -32,8 +32,8 @@ func (cmd *cmd) neigh() error {
 		return cmd.showAllNeighbours(nil, nil, -1, false)
 	}
 
-	switch c := cmd.findPrefix("show", "add", "del", "replace", "flush", "get", "help"); c {
-	case "add", "del", "replace":
+	switch c := cmd.findPrefix("show", "add", "delete", "replace", "flush", "get", "help"); c {
+	case "add", "delete", "replace":
 		neigh, err := cmd.parseNeighAddDelReplaceParams()
 		if err != nil {
 			return err
@@ -42,10 +42,13 @@ func (cmd *cmd) neigh() error {
 		switch c {
 		case "add":
 			return cmd.handle.NeighAdd(neigh)
-		case "del":
+		case "delete":
 			return cmd.handle.NeighDel(neigh)
 		case "replace":
 			return cmd.handle.NeighSet(neigh)
+		default:
+			fmt.Fprint(cmd.Out, neighHelp)
+			return nil
 		}
 
 	case "show":

--- a/cmds/core/ip/neigh_linux.go
+++ b/cmds/core/ip/neigh_linux.go
@@ -90,7 +90,7 @@ func (cmd *cmd) parseNeighAddDelReplaceParams() (*netlink.Neigh, error) {
 		iface       netlink.Link
 		llAddr      net.HardwareAddr
 		deviceFound bool
-		state       int
+		state       int = netlink.NUD_PERMANENT
 		flag        int
 	)
 

--- a/cmds/core/ip/neigh_linux.go
+++ b/cmds/core/ip/neigh_linux.go
@@ -213,6 +213,10 @@ func parseNUD(input string) (int, error) {
 			return nud, fmt.Errorf(`argument "%v" is wrong: nud state is bad`, input)
 		}
 
+		if nudInt64 < 0 {
+			return 0, fmt.Errorf(`argument "%v" is wrong: nud state is bad`, input)
+		}
+
 		nud = int(nudInt64)
 
 		if _, ok := neighStates[nud]; !ok {

--- a/cmds/core/ip/parsing_linux.go
+++ b/cmds/core/ip/parsing_linux.go
@@ -123,6 +123,26 @@ func (cmd *cmd) parseIPNet() (*net.IPNet, error) {
 	return ipNet, nil
 }
 
+func (cmd *cmd) parseAddressorCIDR() (net.IP, *net.IPNet, error) {
+	addrStr := cmd.nextToken("PREFIX")
+
+	// Check if it's a CIDR notation
+	if strings.Contains(addrStr, "/") {
+		ip, ipNet, err := net.ParseCIDR(addrStr)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to parse address: %s", addrStr)
+		}
+		return ip, ipNet, nil
+	}
+
+	// Regular IP address
+	ip := net.ParseIP(addrStr)
+	if ip == nil {
+		return nil, nil, fmt.Errorf("failed to parse address: %s", addrStr)
+	}
+	return ip, nil, nil
+}
+
 func (cmd *cmd) parseHardwareAddress() (net.HardwareAddr, error) {
 	return net.ParseMAC(cmd.nextToken("<MAC-ADDR>"))
 }

--- a/cmds/core/ip/parsing_linux_test.go
+++ b/cmds/core/ip/parsing_linux_test.go
@@ -218,6 +218,13 @@ func TestParseAddressorCIDR(t *testing.T) {
 			wantIPNet: nil,
 			wantErr:   true,
 		},
+		{
+			name:      "Invalid IPv6 CIDR",
+			cmd:       cmd{Args: []string{"cmd", "fe80::/invalid"}},
+			wantIP:    nil,
+			wantIPNet: nil,
+			wantErr:   true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/integration/generic-tests/ip_test.go
+++ b/integration/generic-tests/ip_test.go
@@ -165,12 +165,18 @@ func TestIP(t *testing.T) {
         ip link set ipip_tunnel down || exit 1
         ip tunnel del ipip_tunnel || exit 1
         ! grep -q "ipip_tunnel" /proc/net/dev || exit 1
+
         # Add a neighbor (ARP entry) on eth0
 		cat /proc/net/arp
 		ip neigh add 192.168.1.2 lladdr 00:11:22:33:44:55 dev eth0 || exit 1
 		sleep 1
 		cat /proc/net/arp
 		grep -q "192.168.1.2" /proc/net/arp || exit 1
+
+		# Verify the neighbor entry
+		ip neigh show dev eth0 || exit 1
+		neigh_entry=$(ip neigh show dev eth0 | grep "192.168.1.2")
+		test "$neigh_entry" = "192.168.1.2 dev eth0 lladdr 00:11:22:33:44:55 PERMANENT" || exit 1
 
 		# Delete the neighbor
 		ip neigh del 192.168.1.2 dev eth0 || exit 1

--- a/integration/generic-tests/ip_test.go
+++ b/integration/generic-tests/ip_test.go
@@ -169,7 +169,6 @@ func TestIP(t *testing.T) {
         # Add a neighbor (ARP entry) on eth0
 		cat /proc/net/arp
 		ip neigh add 192.168.1.2 lladdr 00:11:22:33:44:55 dev eth0 || exit 1
-		sleep 1
 		cat /proc/net/arp
 		grep -q "192.168.1.2" /proc/net/arp || exit 1
 
@@ -177,6 +176,16 @@ func TestIP(t *testing.T) {
 		ip neigh show dev eth0 || exit 1
 		neigh_entry=$(ip neigh show dev eth0 | grep "192.168.1.2")
 		test "$neigh_entry" = "192.168.1.2 dev eth0 lladdr 00:11:22:33:44:55 PERMANENT" || exit 1
+
+		# Replace the entry with different flags
+		ip neigh replace 192.168.1.2 lladdr 11:22:33:44:55:66 dev eth0 nud stale router || exit 1
+
+		# Verify the modified flags
+		ip neigh show dev eth0 || exit 1
+		modified_entry=$(ip neigh show dev eth0 | grep "192.168.1.2")
+		test "$modified_entry" = "192.168.1.2 dev eth0 lladdr 11:22:33:44:55:66 router STALE" || exit 1
+		echo "Modified neighbor entry verified with router flag and STALE state"
+
 
 		# Delete the neighbor
 		ip neigh del 192.168.1.2 dev eth0 || exit 1

--- a/integration/generic-tests/ip_test.go
+++ b/integration/generic-tests/ip_test.go
@@ -165,6 +165,17 @@ func TestIP(t *testing.T) {
         ip link set ipip_tunnel down || exit 1
         ip tunnel del ipip_tunnel || exit 1
         ! grep -q "ipip_tunnel" /proc/net/dev || exit 1
+        # Add a neighbor (ARP entry) on eth0
+		cat /proc/net/arp
+		ip neigh add 192.168.1.2 lladdr 00:11:22:33:44:55 dev eth0 || exit 1
+		sleep 1
+		cat /proc/net/arp
+		grep -q "192.168.1.2" /proc/net/arp || exit 1
+
+		# Delete the neighbor
+		ip neigh del 192.168.1.2 dev eth0 || exit 1
+		cat /proc/net/arp
+		! grep -q "192.168.1.2" /proc/net/arp || exit 1
 
 		# Bring the eth0 interface down
 		ip link set eth0 down || exit 1

--- a/integration/generic-tests/ip_test.go
+++ b/integration/generic-tests/ip_test.go
@@ -184,6 +184,26 @@ func TestIP(t *testing.T) {
 		ip neigh del 192.168.1.2 dev eth0 || exit 1
 		! grep -q "192.168.1.2" /proc/net/arp || exit 1
 
+
+		# Test IP Neighbor flush capability
+		# Add 3 neighbors
+		ip neigh add 192.168.1.5 lladdr aa:bb:cc:dd:ee:ff nud stale dev eth0 || exit 1
+		ip neigh add 192.168.1.6 lladdr aa:bb:cc:11:22:33 nud stale dev eth0 || exit 1
+		ip neigh add 192.168.1.7 lladdr aa:bb:cc:44:55:66 dev eth0 || exit 1
+
+		# Verify all entries exist
+		grep -q "192.168.1.5" /proc/net/arp || exit 1
+		grep -q "192.168.1.6" /proc/net/arp || exit 1
+		grep -q "192.168.1.7" /proc/net/arp || exit 1
+
+		# Flush the 2 stale neighbors from the table for eth0
+		ip neigh flush dev eth0 || exit 1
+
+		# Verify the 2 stale entries are gone, the permanent one remains
+		! grep -q "192.168.1.5" /proc/net/arp || exit 1
+		! grep -q "192.168.1.6" /proc/net/arp || exit 1
+		grep -q "192.168.1.7" /proc/net/arp || exit 1
+
 		# Bring the eth0 interface down
 		ip link set eth0 down || exit 1
 		sleep 2

--- a/integration/generic-tests/ip_test.go
+++ b/integration/generic-tests/ip_test.go
@@ -61,18 +61,14 @@ func TestIP(t *testing.T) {
 		grep -q "192.168.1.1" /proc/net/fib_trie || exit 1
 
 		# Add a route via eth0
-		cat /proc/net/route
 		ip route add 192.168.2.0/24 via 192.168.1.1 dev eth0 || exit 1
-		cat /proc/net/route
 		hex_destination=$(ip_to_route_hex "192.168.2.0")
 		hex_gateway=$(ip_to_route_hex "192.168.1.1")
 		grep -iq "$hex_destination" /proc/net/route || exit 1
 		grep -iq "$hex_gateway" /proc/net/route || exit 1
 
 		# Delete the route
-		cat /proc/net/route
 		ip route del 192.168.2.0/24 || exit 1
-		cat /proc/net/route
 		#! grep -iq "$hex_destination" /proc/net/route || exit 1
 
 		# Add a tunnel
@@ -167,9 +163,7 @@ func TestIP(t *testing.T) {
         ! grep -q "ipip_tunnel" /proc/net/dev || exit 1
 
         # Add a neighbor (ARP entry) on eth0
-		cat /proc/net/arp
 		ip neigh add 192.168.1.2 lladdr 00:11:22:33:44:55 dev eth0 || exit 1
-		cat /proc/net/arp
 		grep -q "192.168.1.2" /proc/net/arp || exit 1
 
 		# Verify the neighbor entry
@@ -177,7 +171,7 @@ func TestIP(t *testing.T) {
 		neigh_entry=$(ip neigh show dev eth0 | grep "192.168.1.2")
 		test "$neigh_entry" = "192.168.1.2 dev eth0 lladdr 00:11:22:33:44:55 PERMANENT" || exit 1
 
-		# Replace the entry with different flags
+		# Replace the entry with another hwaddress, nud state and router flag
 		ip neigh replace 192.168.1.2 lladdr 11:22:33:44:55:66 dev eth0 nud stale router || exit 1
 
 		# Verify the modified flags
@@ -186,10 +180,8 @@ func TestIP(t *testing.T) {
 		test "$modified_entry" = "192.168.1.2 dev eth0 lladdr 11:22:33:44:55:66 router STALE" || exit 1
 		echo "Modified neighbor entry verified with router flag and STALE state"
 
-
 		# Delete the neighbor
 		ip neigh del 192.168.1.2 dev eth0 || exit 1
-		cat /proc/net/arp
 		! grep -q "192.168.1.2" /proc/net/arp || exit 1
 
 		# Bring the eth0 interface down


### PR DESCRIPTION
Overhauled some parts of the `ip neigh` cmd. 
- `ip neigh add` had a bug, which defaulted the entry to an erroneous state.
- `ip neigh flush` and `ip neigh show` have new filter capabilities. 
- added the `neigh` cmds to the ip integration test.