### PR TITLE
cmd/exp: propagate -p/-port in traceroute

### DIFF
--- a/cmds/exp/traceroute/main.go
+++ b/cmds/exp/traceroute/main.go
@@ -52,7 +52,6 @@ func parseFlags(args []string) (*traceroute.Flags, error) {
 	}
 
 	trargs.Host = leftoverArgs[0]
-
 	flags.Host = trargs.Host
 
 	// Evaluate AF and Module

--- a/pkg/traceroute/defaults.go
+++ b/pkg/traceroute/defaults.go
@@ -27,6 +27,7 @@ const (
 	IPV6HdrLen    = 40
 
 	TCPDEFPORT   = 443
+	UDPDEFPORT   = 33434
 	DEFNUMHOPS   = 20
 	DEFNUMTRACES = 3
 )

--- a/pkg/traceroute/tcp4.go
+++ b/pkg/traceroute/tcp4.go
@@ -32,13 +32,14 @@ func (t *Trace) SendTracesTCP4() {
 	mod := uint32(1 << 30)
 	for ttl := 1; ttl <= int(t.MaxHops); ttl++ {
 		for j := 0; j < t.TracesPerHop; j++ {
-			hdr, payload := t.BuildTCP4SYNPkt(sport, t.destPort, uint8(ttl), seq, 0)
+			hdr, payload := t.BuildTCP4SYNPkt(sport, t.DestPort, uint8(ttl), seq, 0)
 			rSocket.WriteTo(hdr, payload, nil)
 			pb := &Probe{
 				ID:       seq,
 				Dest:     t.DestIP,
 				TTL:      ttl,
 				Sendtime: time.Now(),
+				Port:     t.DestPort,
 			}
 			t.SendChan <- pb
 			seq = (seq + 4) % mod

--- a/pkg/traceroute/tcp6.go
+++ b/pkg/traceroute/tcp6.go
@@ -32,13 +32,14 @@ func (t *Trace) SendTracesTCP6() {
 	mod := uint32(1 << 30)
 	for ttl := 1; ttl <= int(t.MaxHops); ttl++ {
 		for j := 0; j < t.TracesPerHop; j++ {
-			cm, payload := t.BuildTCP6SYNPkt(sport, t.destPort, uint16(ttl), seq, 0)
+			cm, payload := t.BuildTCP6SYNPkt(sport, t.DestPort, uint16(ttl), seq, 0)
 			rSocket.WriteTo(payload, cm, &net.IPAddr{IP: t.DestIP})
 			pb := &Probe{
 				ID:       seq,
 				Dest:     t.DestIP,
 				TTL:      ttl,
 				Sendtime: time.Now(),
+				Port:     t.DestPort,
 			}
 			t.SendChan <- pb
 			seq = (seq + 4) % mod

--- a/pkg/traceroute/traceroute.go
+++ b/pkg/traceroute/traceroute.go
@@ -52,6 +52,8 @@ func RunTraceroute(f *Flags) error {
 		go mod.SendTracesTCP6()
 	case "icmp6":
 		go mod.SendTracesICMP6()
+	default:
+		return fmt.Errorf("unsupported protocol: %s", f.Proto)
 	}
 
 	printMap := runTransmission(cc)

--- a/pkg/traceroute/udp4.go
+++ b/pkg/traceroute/udp4.go
@@ -18,7 +18,7 @@ import (
 // SendTrace in a routine
 func (t *Trace) SendTracesUDP4() {
 	id := uint16(1)
-	dport := uint16(int32(t.destPort) + rand.Int31n(64))
+	dport := uint16(int32(t.DestPort) + rand.Int31n(64))
 	sport := uint16(1000 + t.PortOffset + rand.Int31n(500))
 	mod := uint16(1 << 15)
 
@@ -49,7 +49,8 @@ func (t *Trace) SendTracesUDP4() {
 			}
 
 			t.SendChan <- pb
-			dport = uint16(int32(t.destPort) + rand.Int31n(64))
+
+			dport = uint16(int32(t.DestPort) + rand.Int31n(64))
 			id = (id + 1) % mod
 			go t.ReceiveTracesUDP4()
 			time.Sleep(time.Microsecond * time.Duration(100000))

--- a/pkg/traceroute/udp6.go
+++ b/pkg/traceroute/udp6.go
@@ -17,7 +17,7 @@ import (
 
 func (t *Trace) SendTracesUDP6() {
 	id := uint16(1)
-	dport := uint16(int32(t.destPort) + rand.Int31n(64))
+	dport := uint16(int32(t.DestPort) + rand.Int31n(64))
 	sport := uint16(1000 + t.PortOffset + rand.Int31n(500))
 	mod := uint16(1 << 15)
 
@@ -44,7 +44,8 @@ func (t *Trace) SendTracesUDP6() {
 			rSock.WriteTo(payload, cm, &net.IPAddr{IP: t.DestIP})
 
 			t.SendChan <- pb
-			dport = uint16(int32(t.destPort) + rand.Int31n(64))
+
+			dport = uint16(int32(t.DestPort) + rand.Int31n(64))
 			id = (id + 1) % mod
 			go t.ReceiveTracesUDP6()
 			time.Sleep(time.Microsecond * time.Duration(100000))


### PR DESCRIPTION
Currently, the CLI offers the option to set a custom destination port for trace probes, which is currently unused. This PR adds functionality to propagate it into the trace.

According to the man page, the `--port` option behaves differently depending on the protocol type:
- UDP: base port for randomization
- ICMP: start of sequence number
- TCP: exact port to probe on