### PR TITLE
Change the version in go.mod so go download works

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/u-root/u-root
 
-go 1.24
+go 1.24.0
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2


### PR DESCRIPTION
With recent versions of Go: "Starting in Go 1.21, the Go distribution consists of a go command and a bundled Go toolchain, which is the standard library as well as the compiler, assembler, and other tools."

https://go.dev/doc/toolchain

Sounds like a great idea.

Unfortunately, this breaks badly if go.mod has a version like this: go 1.24
which people have used for several years.

You get the incredibly non-intuitive message:
root@localhost:~/go/src/github.com/u-root/u-root# go version go: downloading go1.24 (linux/amd64)
go: download go1.24 for linux/amd64: toolchain not available

even though go 1.xx has worked for years in go.mod.

Just use the full version in go.mod:
go 1.24.0

and then:
go version
go version go1.24.0 linux/amd64
This has been broken for some time, I just never understood why (and a quick search reveals it has caused trouble for others).