### PR TITLE
cmds/core/sshd: just use the default shell

### DIFF
--- a/cmds/core/sshd/const_plan9.go
+++ b/cmds/core/sshd/const_plan9.go
@@ -7,6 +7,5 @@
 package main
 
 var (
-	shells = [...]string{"rc"}
-	shell  = "/bin/rc"
+	shell = "/bin/rc"
 )

--- a/cmds/core/sshd/const_unix.go
+++ b/cmds/core/sshd/const_unix.go
@@ -7,6 +7,5 @@
 package main
 
 var (
-	shells = [...]string{"bash", "zsh", "gosh"}
-	shell  = "/bin/sh"
+	shell = "/bin/sh"
 )

--- a/cmds/core/sshd/sshd.go
+++ b/cmds/core/sshd/sshd.go
@@ -119,14 +119,6 @@ func newPTY(b []byte) (*pty.Pty, error) {
 	return p, nil
 }
 
-func init() {
-	for _, s := range shells {
-		if _, err := exec.LookPath(s); err == nil {
-			shell = s
-		}
-	}
-}
-
 func session(chans <-chan ssh.NewChannel) {
 	var p *pty.Pty
 	// Service the incoming Channel channel.


### PR DESCRIPTION
Previously, whenever you ssh into u-root, you'd get gosh as your shell, regardless of what defaultsh is.

Not sure if it was intentional, but the old code would pick the last executable in the list of shells, which is invariably gosh.  The code looked like it might intend to pick bash, then zsh, then gosh.

Either way, just use /bin/sh. (or /bin/rc on Plan 9).

Tested: ssh in, with defaultsh=bash, got bash.