### PR TITLE
Update logic to construct PCI Root Bridge device tree nodes.

### DIFF
--- a/pkg/boot/universalpayload/utilities.go
+++ b/pkg/boot/universalpayload/utilities.go
@@ -190,12 +190,14 @@ type ResourceInfo struct {
 }
 
 type ResourceRegions struct {
-	MMIO64Base  uint64
-	MMIO64Limit uint64
-	MMIO32Base  uint64
-	MMIO32Limit uint64
-	IOPortBase  uint64
-	IOPortLimit uint64
+	MMIO64Base uint64
+	MMIO64End  uint64
+	MMIO32Base uint64
+	MMIO32End  uint64
+	IOPortBase uint64
+	IOPortEnd  uint64
+	StartBus   uint32
+	EndBus     uint32
 }
 
 const (
@@ -208,7 +210,7 @@ const (
 )
 
 const (
-	PCISearchPath   = "/sys/bus/pci/devices/"
+	PCISearchPath   = "/sys/devices/"
 	PCIMMIO64Attr   = 0x140204
 	PCIMMIO32Attr   = 0x40200
 	PCIIOPortAttr   = 0x40100
@@ -218,9 +220,7 @@ const (
 	PCIMMIO32Type   = "MMIO32"
 	PCIIOPortType   = "IOPORT"
 
-	PCIMMIO64InvalidBase = 0xFFFF_FFFF_FFFF_FFFF
-	PCIMMIO32InvalidBase = 0xFFFF_FFFF
-	PCIIOPortInvalidBase = 0xFFFF
+	PCIInvalidBase = 0xFFFF_FFFF_FFFF_FFFF
 )
 
 type FdtLoad struct {
@@ -787,22 +787,19 @@ func getReservedMemoryMap() (kexec.MemoryMap, error) {
 	return rsvd, nil
 }
 
-func skipReservedRange(mm kexec.MemoryMap, base uint64, attr uint64) bool {
+func getBusNumber(bus uint64) uint32 {
+	//According to PCI spec, bus number never exceeds 255
+	//Its safe to get low 32-bit value for bus number
+	return uint32(bus & 0x0000_0000_FFFF_FFFF)
+}
+
+func skipReservedRange(mm kexec.MemoryMap, base uintptr, attr uint64) bool {
 	if attr&PCIIOPortRes == PCIIOPortRes {
 		return false
 	}
 
 	// Skip ReadOnly MMIO, this is ROM region
-	if attr&PCIMMIOReadOnly != 0 {
-		return true
-	}
-
-	// Some platform provides 64-bit MMIO with all zero in high 32 bits,
-	// it leads to huge MMIO region for 64-bit, and triggers assertation
-	// in EDK2 since it is actual a 32-bit address, not a 64-bit address.
-	//
-	// Skip this scenario to address above issue.
-	if (attr&PCIMMIO64Attr == PCIMMIO64Attr) && (base>>32 == 0) {
+	if attr&PCIMMIOReadOnly == PCIMMIOReadOnly {
 		return true
 	}
 
@@ -815,7 +812,11 @@ func skipReservedRange(mm kexec.MemoryMap, base uint64, attr uint64) bool {
 	// indicated its available
 	// 2. Firmware or BIOS reserved above memory region as "Reserved" type.
 	for _, m := range mm {
-		if m.Range.Contains(uintptr(base)) {
+		// It safe to convert base from uint64 to uintptr, since uintptr covers
+		// 64-bits as described in buildin.go:
+		// uintptr is an integer type that is large enough to hold the bit pattern of
+		// any pointer.
+		if m.Range.Contains(base) {
 			return true
 		}
 	}
@@ -823,87 +824,192 @@ func skipReservedRange(mm kexec.MemoryMap, base uint64, attr uint64) bool {
 	return false
 }
 
-func retrieveRootBridgeResources(path string, item MCFGBaseAddressAllocation) (*ResourceRegions, error) {
-	domainIDHex := fmt.Sprintf("%04x", item.PCISegGrp)
+// isValidPCIDeviceName validates if folder name is a valid PCI BDF format
+func isValidPCIDeviceName(name string) bool {
+	// In /sys/devices/pci$DOMAINID:$BUSID, there exists two types of folders,
+	// if current device is a PCI bridge device, there exists a folder named
+	// as BDF:pciexx folder, and also next BUS ID.
+	// For instance, 0000:00:1c.0 is a PCI bridge device, it contains folders:
+	//     0000:00:1c.0:pcie002
+	//     0000:00:1c.0:pcie010
+	//     0000:01:00.0
+	// And the PCI hierarchy is like:
+	// -[0000:00]-+-00.0
+	//            ... (omitted)
+	//            +-1c.0-[01]----00.0
+	// In above case, 0000:00:1c.0:pcie002 is not a valid PCI device name.
+	if len(name) != 12 {
+		return false
+	}
 
-	var MMIO64Base uint64 = PCIMMIO64InvalidBase
-	var MMIO32Base uint64 = PCIMMIO32InvalidBase
-	var IOPortBase uint64 = PCIIOPortInvalidBase
-	var mmio64End uint64
-	var mmio32End uint64
-	var ioPortEnd uint64
+	parts := strings.Split(name, ":")
+	if len(parts) != 3 {
+		return false
+	}
+
+	// Validate each part of the name
+	if len(parts[0]) != 4 || // domain (32 bits)
+		len(parts[1]) != 2 || // bus (16 bits)
+		len(parts[2]) != 4 { // device.function (8bits.4bits format)
+		return false
+	}
+
+	// Validate device.function format
+	devFunc := strings.Split(parts[2], ".")
+	return len(devFunc) == 2 && len(devFunc[0]) == 2 && len(devFunc[1]) == 1
+}
+
+// updateResourceRanges updates the resource ranges based on the resource type
+func updateResourceRanges(resourceRegion *ResourceRegions, resType string, base, end uint64) {
+	switch resType {
+	case PCIMMIO64Type:
+		resourceRegion.MMIO64Base = min(base, resourceRegion.MMIO64Base)
+		resourceRegion.MMIO64End = max(align.UpPage(end)-1, resourceRegion.MMIO64End)
+	case PCIMMIO32Type:
+		resourceRegion.MMIO32Base = min(base, resourceRegion.MMIO32Base)
+		resourceRegion.MMIO32End = max(align.UpPage(end)-1, resourceRegion.MMIO32End)
+	case PCIIOPortType:
+		resourceRegion.IOPortBase = min(base, resourceRegion.IOPortBase)
+		resourceRegion.IOPortEnd = max(end, resourceRegion.IOPortEnd)
+	}
+}
+
+// processDeviceResources processes the resources of a device and updates the resource ranges
+func processDeviceResources(dirPath string, resourceRegion *ResourceRegions, rsvdMem kexec.MemoryMap) error {
+	resourcePath := filepath.Join(dirPath, "resource")
+	resources, err := retrieveDeviceResources(resourcePath, rsvdMem)
+	if err != nil {
+		return nil // Continue scanning other devices
+	}
+
+	// Update resource ranges
+	for _, res := range resources {
+		if base, err := strconv.ParseUint(res.BaseAddress, 0, 64); err != nil {
+			continue
+		} else if end, err := strconv.ParseUint(res.EndAddress, 0, 64); err != nil {
+			continue
+		} else {
+			// This scenario occurs when the 'base, end and attribute' are all zero.
+			// If base and end are all zero, it means no resource assigned to this device.
+			if (base != 0) && (end != 0) {
+				updateResourceRanges(resourceRegion, res.Type, base, end)
+			}
+		}
+	}
+	return nil
+}
+
+// processSubdirectories processes all subdirectories of a given path
+func processSubdirectories(dirPath string, resourceRegion *ResourceRegions, rsvdMem kexec.MemoryMap) error {
+	subDirs, err := os.ReadDir(dirPath)
+	if err != nil {
+		return nil
+	}
+
+	for _, subDir := range subDirs {
+		if !subDir.IsDir() {
+			continue
+		}
+
+		subName := subDir.Name()
+		if !isValidPCIDeviceName(subName) {
+			continue
+		}
+
+		// Parse bus ID and update EndBus if needed
+		parts := strings.Split(subName, ":")
+		if bus, err := strconv.ParseUint(parts[1], 16, 64); err == nil {
+			if getBusNumber(bus) > resourceRegion.EndBus {
+				resourceRegion.EndBus = getBusNumber(bus)
+			}
+		}
+
+		// Process resources from subdirectory
+		if err := processDeviceResources(filepath.Join(dirPath, subName), resourceRegion, rsvdMem); err != nil {
+			continue
+		}
+
+		// Recursively process the subdirectory
+		if err := processDir(filepath.Join(dirPath, subName), resourceRegion, rsvdMem); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// processDir processes a single directory and its contents
+func processDir(dirPath string, resourceRegion *ResourceRegions, rsvdMem kexec.MemoryMap) error {
+	deviceName := filepath.Base(dirPath)
+	parts := strings.Split(deviceName, ":")
+
+	// Skip if not a valid PCI device name format
+	if len(parts) != 3 || len(deviceName) != 12 {
+		return nil
+	}
+
+	// Parse bus ID and update EndBus if needed
+	bus, err := strconv.ParseUint(parts[1], 16, 64)
+	if err != nil {
+		return err
+	}
+
+	// Update EndBus if this bus is higher
+	if getBusNumber(bus) > resourceRegion.EndBus {
+		resourceRegion.EndBus = getBusNumber(bus)
+	}
+
+	// Process resources from current directory
+	if err := processDeviceResources(dirPath, resourceRegion, rsvdMem); err != nil {
+		return err
+	}
+
+	// Process subdirectories
+	return processSubdirectories(dirPath, resourceRegion, rsvdMem)
+}
+
+func retrieveRootBridgeResources(path string, item MCFGBaseAddressAllocation) ([]*ResourceRegions, error) {
+	domainIDHex := fmt.Sprintf("%04x", item.PCISegGrp)
+	var resourceRegions []*ResourceRegions
 
 	rsvdMem, err := getReservedMemoryMap()
 	if err != nil {
 		return nil, err
 	}
 
-	err = filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
+	// Start processing from /sys/devices/pci$DOMAINID:$BUSID
+	for bus := uint32(item.StartBus); bus <= uint32(item.EndBus); bus++ {
+		pciPath := filepath.Join(path, fmt.Sprintf("pci%s:%02x", domainIDHex, bus))
+
+		// Check if the bus directory exists
+		if _, err := os.Stat(pciPath); os.IsNotExist(err) {
+			continue
 		}
 
-		deviceName := filepath.Base(path)
-		parts := strings.Split(deviceName, ":")
-		// deviceName fetched from filepath can be separated into 3 parts:
-		// 0000:00:00.0 which is DOMAIN_ID:BUS_ID:DEVICE_ID:FUNCTION_ID
-		// To retrieve the memory resource regions for 64-bit/32-bit MMIO
-		// and IO, we need to ensure:
-		// 1. Domain ID matches
-		// 2. Bus ID is valid
-		if len(parts) != 3 || parts[0] != domainIDHex {
-			// Skip unmatched Bus number
-			return nil
+		// Create a new resource region for this bus
+		resourceRegion := &ResourceRegions{
+			MMIO64Base: PCIInvalidBase,
+			MMIO32Base: PCIInvalidBase,
+			IOPortBase: PCIInvalidBase,
+			StartBus:   bus,
+			EndBus:     bus,
 		}
 
-		if bus, err := strconv.ParseUint(parts[1], 16, 64); err != nil {
-			// Should not happen, if failed to parse Bus number, return error directly
-			return err
-		} else if (bus >= uint64(item.StartBus)) && (bus <= uint64(item.EndBus)) {
-			resourcePath := filepath.Join(path, "resource")
-			resources, err := retrieveDeviceResources(resourcePath, rsvdMem)
+		// Start processing from the root path
+		if err = filepath.Walk(pciPath, func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				return nil // Continue scanning other devices
+				return err
 			}
-			for _, res := range resources {
-				if base, err := strconv.ParseUint(res.BaseAddress, 0, 64); err != nil {
-					// Should not happen, if failed to parse uint, skip this region
-					continue
-				} else if end, err := strconv.ParseUint(res.EndAddress, 0, 64); err != nil {
-					// Should not happen, if failed to parse uint, skip this region
-					continue
-				} else {
-					// Region found, merge it to domain resource region
-					switch res.Type {
-					case PCIMMIO64Type:
-						MMIO64Base = min(base, MMIO64Base)
-						mmio64End = max(end, mmio64End)
-					case PCIMMIO32Type:
-						MMIO32Base = min(base, MMIO32Base)
-						mmio32End = max(end, mmio32End)
-					case PCIIOPortType:
-						IOPortBase = min(base, IOPortBase)
-						ioPortEnd = max(end, ioPortEnd)
-					}
-				}
-			}
+
+			return processDir(path, resourceRegion, rsvdMem)
+		}); err != nil {
+			return nil, err
 		}
 
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
+		// Add the resource region to our collection
+		resourceRegions = append(resourceRegions, resourceRegion)
 	}
 
-	return &ResourceRegions{
-		MMIO64Base:  MMIO64Base,
-		MMIO64Limit: mmio64End - MMIO64Base + 1,
-		MMIO32Base:  MMIO32Base,
-		MMIO32Limit: mmio32End - MMIO32Base + 1,
-		IOPortBase:  IOPortBase,
-		IOPortLimit: ioPortEnd - IOPortBase + 1,
-	}, nil
+	return resourceRegions, nil
 }
 
 func retrieveDeviceResources(resourcePath string, mm kexec.MemoryMap) ([]ResourceInfo, error) {
@@ -933,15 +1039,24 @@ func retrieveDeviceResources(resourcePath string, mm kexec.MemoryMap) ([]Resourc
 				continue
 			} else {
 				var resourceType string
-
 				base64, err := strconv.ParseUint(base, 0, 64)
-				if err != nil {
+				if err != nil || base64 == 0 {
 					continue
 				}
 
 				// Skip corner case when parsing resource region and attribute.
-				if skip := skipReservedRange(mm, base64, attrInt); skip == true {
+				if skip := skipReservedRange(mm, uintptr(base64), attrInt); skip {
 					continue
+				}
+
+				// Special case to adapt TianoCore EDK2 logic:
+				// Base address of memory region with attribute of '64bit' or '64bit pref'
+				// should be higher than 32bit, however, some platforms provide 64-bit MMIO
+				// with all zero in high 32 bits, it triggers assertation in EDK2 since this
+				// base address is actual a 32-bit address. To resolve this issue, convert
+				// attribute from 64bit to 32bit, and merge it with other 32bit memory regions.
+				if (attrInt&PCIMMIO64Attr == PCIMMIO64Attr) && (base64>>32 == 0) {
+					attrInt = PCIMMIO32Attr
 				}
 
 				if attrInt&PCIMMIO64Attr == PCIMMIO64Attr {
@@ -1002,7 +1117,7 @@ func fetchACPIMCFGData(data []byte) ([]MCFGBaseAddressAllocation, error) {
 	return mcfgDataArray, nil
 }
 
-func createPCIRootBridgeNode(path string, item MCFGBaseAddressAllocation) (*dt.Node, error) {
+func createPCIRootBridgeNode(path string, item MCFGBaseAddressAllocation) ([]*dt.Node, error) {
 	high64 := func(val uint64) uint32 {
 		return uint32(val >> 32)
 	}
@@ -1011,30 +1126,57 @@ func createPCIRootBridgeNode(path string, item MCFGBaseAddressAllocation) (*dt.N
 		return uint32(val & 0x0000_0000_FFFF_FFFF)
 	}
 
-	resource, err := retrieveRootBridgeResources(path, item)
+	resources, err := retrieveRootBridgeResources(path, item)
 	if err != nil {
 		return nil, err
 	}
 
-	return dt.NewNode("pci-rb", dt.WithProperty(
-		dt.PropertyString("compatible", "pci-rb"),
-		dt.PropertyU64("reg", uint64(item.BaseAddr)),
-		dt.PropertyU32Array("bus-range", []uint32{uint32(item.StartBus), uint32(item.EndBus)}),
-		dt.PropertyU32Array("ranges", []uint32{
-			0x300_0000, // 64BITS
-			high64(resource.MMIO64Base), low64(resource.MMIO64Base),
-			0x0, 0x0,
-			high64(resource.MMIO64Limit), low64(resource.MMIO64Limit),
-			0x200_0000, // 32BITS
-			high64(resource.MMIO32Base), low64(resource.MMIO32Base),
-			0x0, 0x0,
-			high64(resource.MMIO32Limit), low64(resource.MMIO32Limit),
-			0x100_0000, // IO
-			high64(resource.IOPortBase), low64(resource.IOPortBase),
-			0x0, 0x0,
-			high64(resource.IOPortLimit), low64(resource.IOPortLimit),
-		}),
-	)), nil
+	var nodes []*dt.Node
+	for _, resource := range resources {
+		// The initial value of MMIO64Base, MMIO32Base, IOPortBase is set
+		// as invalid value. If the base address is valid, the limit is
+		// calculated as end address - base address + 1. Otherwise, the
+		// limit is set as 0.
+		var MMIO64Limit uint64
+		var MMIO32Limit uint64
+		var IOPortLimit uint64
+
+		if resource.MMIO64Base != PCIInvalidBase {
+			MMIO64Limit = resource.MMIO64End - resource.MMIO64Base + 1
+		}
+
+		if resource.MMIO32Base != PCIInvalidBase {
+			MMIO32Limit = resource.MMIO32End - resource.MMIO32Base + 1
+		}
+
+		if resource.IOPortBase != PCIInvalidBase {
+			IOPortLimit = resource.IOPortEnd - resource.IOPortBase + 1
+		}
+
+		node := dt.NewNode("pci-rb", dt.WithProperty(
+			dt.PropertyString("compatible", "pci-rb"),
+			dt.PropertyU64("reg", uint64(item.BaseAddr)),
+			dt.PropertyU32Array("bus-range", []uint32{uint32(resource.StartBus), uint32(resource.EndBus)}),
+			dt.PropertyU32Array("ranges", []uint32{
+				0x300_0000, // 64BITS
+				high64(resource.MMIO64Base), low64(resource.MMIO64Base),
+				0x0, 0x0,
+				high64(MMIO64Limit), low64(MMIO64Limit),
+				0x200_0000, // 32BITS
+				high64(resource.MMIO32Base), low64(resource.MMIO32Base),
+				0x0, 0x0,
+				high64(MMIO32Limit), low64(MMIO32Limit),
+				0x100_0000, // IO
+				high64(resource.IOPortBase), low64(resource.IOPortBase),
+				0x0, 0x0,
+				high64(IOPortLimit), low64(IOPortLimit),
+			}),
+		))
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes, nil
 }
 
 func constructPCIRootBridgeNodes() ([]*dt.Node, error) {
@@ -1050,13 +1192,35 @@ func constructPCIRootBridgeNodes() ([]*dt.Node, error) {
 		return nil, err
 	}
 
+	/*
+	 * Create PCI Root Bridge nodes based on information retrieved from device hierarchy
+	 * information from /sys/devices/pci*.
+	 *
+	 * Command 'lspci -t' can be used to get the hierarchy of PCI devices, for instance:
+	 * Some information is omitted for brevity.
+	 * \-[0000:00]-+-00.0
+	 *      +-1c.0-[01]--+-00.0
+	 *                   \-00.1
+	 *      +-1c.5-[03-04]----00.0-[04]----00.0
+	 * In above case:
+	 *	bus 01 is connected to bus 00 via device 0000:00.1c.0 (bridge device)
+	 *	bus 03 and 04 are connected to bus 00 via device 0000:00.1c.5 (bridge device)
+	 *
+	 * Corresponding device node layout in /sys/devices/pci* is as follows:
+	 *  /sys/devices/pci0000:00/0000:00:1c.0/0000:01:00.0
+	 *  /sys/devices/pci0000:00/0000:00:1c.5/0000:03:00.0/0000:04:00.0
+	 *
+	 * In this case, we need to recrusively process the subdirectory of
+	 * /sys/devices/pci0000:00 to retrieve the resource region information
+	 * about MMIO64/MMIO32/IOPort, and the bus region information.
+	 */
 	for _, item := range mcfgData {
 		rbNode, err := createPCIRootBridgeNode(PCISearchPath, item)
 		if err != nil {
 			return nil, err
 		}
 
-		rbNodes = append(rbNodes, rbNode)
+		rbNodes = append(rbNodes, rbNode...)
 
 	}
 	return rbNodes, nil

--- a/pkg/boot/universalpayload/utilities.go
+++ b/pkg/boot/universalpayload/utilities.go
@@ -770,13 +770,8 @@ func constructReservedMemoryNode(rsdpBase uint64) *dt.Node {
 	return dt.NewNode("reserved-memory", dt.WithChildren(rsvdNodes...))
 }
 
-func getReservedMemoryMap() (kexec.MemoryMap, error) {
+func getReservedMemoryMap(mm kexec.MemoryMap) (kexec.MemoryMap, error) {
 	var rsvd kexec.MemoryMap
-
-	mm, err := kexecMemoryMapFromIOMem()
-	if err != nil {
-		return nil, ErrRsvdMemoryMapNotFound
-	}
 
 	for _, m := range mm {
 		if m.Type.String() == "Reserved" {
@@ -971,7 +966,12 @@ func retrieveRootBridgeResources(path string, item MCFGBaseAddressAllocation) ([
 	domainIDHex := fmt.Sprintf("%04x", item.PCISegGrp)
 	var resourceRegions []*ResourceRegions
 
-	rsvdMem, err := getReservedMemoryMap()
+	mm, err := kexecMemoryMapFromIOMem()
+	if err != nil {
+		return nil, ErrRsvdMemoryMapNotFound
+	}
+
+	rsvdMem, err := getReservedMemoryMap(mm)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/boot/universalpayload/utilities_64bit_test.go
+++ b/pkg/boot/universalpayload/utilities_64bit_test.go
@@ -1,0 +1,84 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build amd64 || arm64
+
+package universalpayload
+
+import (
+	"testing"
+
+	"github.com/u-root/u-root/pkg/boot/kexec"
+)
+
+// TestSkipReservedRange64Bit tests 64-bit specific cases for skipReservedRange
+func TestSkipReservedRange64Bit(t *testing.T) {
+	// Create a test memory map with 64-bit reserved regions
+	testMemoryMap := kexec.MemoryMap{
+		kexec.TypedRange{Range: kexec.Range{Start: 0x500000, Size: 0x100000}, Type: kexec.RangeReserved},
+		kexec.TypedRange{Range: kexec.Range{Start: 0x800000, Size: 0x50000}, Type: kexec.RangeReserved},
+		kexec.TypedRange{Range: kexec.Range{Start: 0x100000000, Size: 0x1000000}, Type: kexec.RangeReserved}, // 64-bit address
+	}
+
+	tests := []struct {
+		name           string
+		memoryMap      kexec.MemoryMap
+		base           uintptr
+		attr           uint64
+		expectedResult bool
+		description    string
+	}{
+		{
+			name:           "Base in 64-bit reserved memory region should skip",
+			memoryMap:      testMemoryMap,
+			base:           0x100000000, // Start of 64-bit reserved region
+			attr:           0x40200,     // PCIMMIO32Attr
+			expectedResult: true,
+			description:    "Base address at start of 64-bit reserved memory region should be skipped",
+		},
+		{
+			name:           "Base in middle of 64-bit reserved memory region should skip",
+			memoryMap:      testMemoryMap,
+			base:           0x100800000, // Middle of 64-bit reserved region (0x100000000 + 0x800000)
+			attr:           0x40200,     // PCIMMIO32Attr
+			expectedResult: true,
+			description:    "Base address in middle of 64-bit reserved memory region should be skipped",
+		},
+		{
+			name:           "Base at end of 64-bit reserved memory region should skip",
+			memoryMap:      testMemoryMap,
+			base:           0x100FFFFFF, // End of 64-bit reserved region (0x100000000 + 0x1000000 - 1)
+			attr:           0x40200,     // PCIMMIO32Attr
+			expectedResult: true,
+			description:    "Base address at end of 64-bit reserved memory region should be skipped",
+		},
+		{
+			name:           "Base outside 64-bit reserved memory region should not skip",
+			memoryMap:      testMemoryMap,
+			base:           0x101000000, // Just outside 64-bit reserved region
+			attr:           0x40200,     // PCIMMIO32Attr
+			expectedResult: false,
+			description:    "Base address outside 64-bit reserved memory region should not be skipped",
+		},
+		{
+			name:           "Base in 64-bit reserved region with 64-bit MMIO attribute should skip",
+			memoryMap:      testMemoryMap,
+			base:           0x100000000, // Start of 64-bit reserved region
+			attr:           0x140204,    // PCIMMIO64Attr
+			expectedResult: true,
+			description:    "64-bit MMIO in 64-bit reserved memory region should be skipped",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := skipReservedRange(tt.memoryMap, tt.base, tt.attr)
+
+			if result != tt.expectedResult {
+				t.Errorf("skipReservedRange:\n%v, (base: 0x%x, attr: 0x%x) = %v, want %v\nDescription: %s",
+					tt.memoryMap, tt.base, tt.attr, result, tt.expectedResult, tt.description)
+			}
+		})
+	}
+}

--- a/pkg/boot/universalpayload/utilities_test.go
+++ b/pkg/boot/universalpayload/utilities_test.go
@@ -1288,3 +1288,177 @@ func TestSkipReservedRange(t *testing.T) {
 	}
 
 }
+
+func TestIsValidPCIDeviceName(t *testing.T) {
+	tests := []struct {
+		name           string
+		deviceName     string
+		expectedResult bool
+		description    string
+	}{
+		// Positive test cases - valid PCI device names
+		{
+			name:           "Valid PCI device name with all zeros",
+			deviceName:     "0000:00:00.0",
+			expectedResult: true,
+			description:    "Standard valid PCI device name with all zero values",
+		},
+		{
+			name:           "Valid PCI device name with hex values",
+			deviceName:     "0001:0a:1f.3",
+			expectedResult: true,
+			description:    "Valid PCI device name with non-zero hex values",
+		},
+		{
+			name:           "Valid PCI device name with maximum values",
+			deviceName:     "ffff:ff:ff.f",
+			expectedResult: true,
+			description:    "Valid PCI device name with maximum hex values",
+		},
+		{
+			name:           "Valid PCI device name with mixed case hex",
+			deviceName:     "aBcD:1f:2e.5",
+			expectedResult: true,
+			description:    "Valid PCI device name with mixed case hex characters",
+		},
+		{
+			name:           "Valid PCI device name with function 0",
+			deviceName:     "0000:01:02.0",
+			expectedResult: true,
+			description:    "Valid PCI device name with function number 0",
+		},
+		{
+			name:           "Valid PCI device name with function 7",
+			deviceName:     "0000:01:02.7",
+			expectedResult: true,
+			description:    "Valid PCI device name with function number 7",
+		},
+		{
+			name:           "Valid PCI device name with function f",
+			deviceName:     "0000:01:02.f",
+			expectedResult: true,
+			description:    "Valid PCI device name with function number f (15)",
+		},
+
+		// Negative test cases - invalid PCI device names
+		{
+			name:           "Empty string",
+			deviceName:     "",
+			expectedResult: false,
+			description:    "Empty string should be invalid",
+		},
+		{
+			name:           "Too short - missing parts",
+			deviceName:     "0000:00",
+			expectedResult: false,
+			description:    "Device name too short, missing device.function part",
+		},
+		{
+			name:           "Too long - extra parts",
+			deviceName:     "0000:00:00.0:extra",
+			expectedResult: false,
+			description:    "Device name too long, has extra parts",
+		},
+		{
+			name:           "Wrong length - 11 characters",
+			deviceName:     "000:00:00.0",
+			expectedResult: false,
+			description:    "Device name with wrong total length (11 instead of 12)",
+		},
+		{
+			name:           "Wrong length - 13 characters",
+			deviceName:     "0000:00:00.00",
+			expectedResult: false,
+			description:    "Device name with wrong total length (13 instead of 12)",
+		},
+		{
+			name:           "Domain too short",
+			deviceName:     "000:00:00.0",
+			expectedResult: false,
+			description:    "Domain part too short (3 chars instead of 4)",
+		},
+		{
+			name:           "Domain too long",
+			deviceName:     "00000:00:00.0",
+			expectedResult: false,
+			description:    "Domain part too long (5 chars instead of 4)",
+		},
+		{
+			name:           "Bus too short",
+			deviceName:     "0000:0:00.0",
+			expectedResult: false,
+			description:    "Bus part too short (1 char instead of 2)",
+		},
+		{
+			name:           "Bus too long",
+			deviceName:     "0000:000:00.0",
+			expectedResult: false,
+			description:    "Bus part too long (3 chars instead of 2)",
+		},
+		{
+			name:           "Device part too short",
+			deviceName:     "0000:00:0.0",
+			expectedResult: false,
+			description:    "Device part too short (1 char instead of 2)",
+		},
+		{
+			name:           "Device part too long",
+			deviceName:     "0000:00:000.0",
+			expectedResult: false,
+			description:    "Device part too long (3 chars instead of 2)",
+		},
+		{
+			name:           "Function part too short",
+			deviceName:     "0000:00:00.",
+			expectedResult: false,
+			description:    "Function part missing (0 chars instead of 1)",
+		},
+		{
+			name:           "Function part too long",
+			deviceName:     "0000:00:00.00",
+			expectedResult: false,
+			description:    "Function part too long (2 chars instead of 1)",
+		},
+		{
+			name:           "Missing first colon",
+			deviceName:     "000000:00.0",
+			expectedResult: false,
+			description:    "Missing first colon separator",
+		},
+		{
+			name:           "Missing second colon",
+			deviceName:     "0000:0000.0",
+			expectedResult: false,
+			description:    "Missing second colon separator",
+		},
+		{
+			name:           "Missing dot separator",
+			deviceName:     "0000:00:000",
+			expectedResult: false,
+			description:    "Missing dot separator between device and function",
+		},
+		{
+			name:           "Extra separators",
+			deviceName:     "0000::00:00.0",
+			expectedResult: false,
+			description:    "Extra colon separator",
+		},
+		{
+			name:           "PCI bridge device info",
+			deviceName:     "0000:00:1c.0:pcie002",
+			expectedResult: false,
+			description:    "Not a valid PCI device name",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isValidPCIDeviceName(tt.deviceName)
+
+			if result != tt.expectedResult {
+				t.Errorf("isValidPCIDeviceName(%q) = %v, want %v\nDescription: %s",
+					tt.deviceName, result, tt.expectedResult, tt.description)
+			}
+		})
+	}
+}


### PR DESCRIPTION
pkg/boot/universalpayload: Update PCI Root Bridge fetch logic
Previous, PCI Root Bridge info is constructed from all resource files
in /sys/bus/pci/devices folder, it applies to single segment platform.

In order to support multiple segments platform, we need to get PCI
hierarchy from /sys/devices/pci* device nodes. Since PCI device nodes
under this format of path are align with actual PCI hierarchy.

For instance, following is hierarchy snippet from command "lspci -t":
 \-[0000:00]-+-00.0
      +-1c.0-[01]--+-00.0
                   \-00.1
      +-1c.5-[03-04]----00.0-[04]----00.0

Corresponding device nodes layout in /sys/devices/pci* are as follows:
  /sys/devices/pci0000:00/0000:00:1c.0/0000:01:00.0
  /sys/devices/pci0000:00/0000:00:1c.5/0000:03:00.0/0000:04:00.0