### PR TITLE
chore(go.mod): reduce required go version from 1.24 to 1.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/u-root/u-root
 
-go 1.24.0
+go 1.23.11
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2


### PR DESCRIPTION
It's a common pattern for Go projects to support the latest two major Go versions, if possible.