### PR TITLE
Remove all references to removed Baseboard Info table

### DIFF
--- a/pkg/smbios/table_type.go
+++ b/pkg/smbios/table_type.go
@@ -14,18 +14,19 @@ type TableType uint8
 
 // Supported table types.
 const (
-	TableTypeBIOSInfo       TableType = 0
-	TableTypeSystemInfo     TableType = 1
-	TableTypeBaseboardInfo  TableType = 2
-	TableTypeChassisInfo    TableType = 3
-	TableTypeProcessorInfo  TableType = 4
-	TableTypeCacheInfo      TableType = 7
-	TableTypeSystemSlots    TableType = 9
-	TableTypeMemoryDevice   TableType = 17
-	TableTypeIPMIDeviceInfo TableType = 38
-	TableTypeTPMDevice      TableType = 43
-	TableTypeInactive       TableType = 126
-	TableTypeEndOfTable     TableType = 127
+	TableTypeBIOSInfo         TableType = 0
+	TableTypeSystemInfo       TableType = 1
+	TableTypeBaseboardInfo    TableType = 2
+	TableTypeChassisInfo      TableType = 3
+	TableTypeProcessorInfo    TableType = 4
+	TableTypeCacheInfo        TableType = 7
+	TableTypeSystemSlots      TableType = 9
+	TableTypeGroupAssociation TableType = 14
+	TableTypeMemoryDevice     TableType = 17
+	TableTypeIPMIDeviceInfo   TableType = 38
+	TableTypeTPMDevice        TableType = 43
+	TableTypeInactive         TableType = 126
+	TableTypeEndOfTable       TableType = 127
 )
 
 func (t TableType) String() string {
@@ -42,6 +43,8 @@ func (t TableType) String() string {
 		return "Processor Information"
 	case TableTypeCacheInfo:
 		return "Cache Information"
+	case TableTypeGroupAssociation:
+		return "Group Associations"
 	case TableTypeSystemSlots:
 		return "System Slots"
 	case TableTypeMemoryDevice:

--- a/pkg/smbios/type14_group_association.go
+++ b/pkg/smbios/type14_group_association.go
@@ -1,0 +1,123 @@
+package smbios
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+)
+
+// GroupAssociation is defined in DSP0134 7.24.
+type GroupAssociation struct {
+	Header
+	GroupName  string      // 04h
+	ItemType   []TableType `smbios:"-"` // 05h
+	ItemHandle []uint16    `smbios:"-"` // 06h
+}
+
+// MarshalBinary encodes the BaseboardInfo content into a binary
+func (ga *GroupAssociation) MarshalBinary() ([]byte, error) {
+	t, err := ga.toTable()
+	if err != nil {
+		return nil, err
+	}
+	return t.MarshalBinary()
+}
+
+func (ga *GroupAssociation) toTable() (*Table, error) {
+	h, err := ga.Header.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	var d []byte
+	var tableStr []string
+	id := byte(1)
+
+	d = append(d, h...)
+	if ga.GroupName != "" {
+		d = append(d, id)
+		id++
+		tableStr = append(tableStr, ga.GroupName)
+	} else {
+		d = append(d, 0)
+	}
+
+	if len(ga.ItemType) != len(ga.ItemHandle) {
+		return nil, fmt.Errorf("item type and item handle have different lengths, len of ItemType: %d, len of ItemHandle: %d", len(ga.ItemType), len(ga.ItemHandle))
+	}
+
+	if ga.Length != uint8((len(ga.ItemType)*3)+5) {
+		return nil, fmt.Errorf("invalid length, length: %d, len of ItemType: %d, len of ItemHandle: %d", ga.Length, len(ga.ItemType), len(ga.ItemHandle))
+	}
+
+	for i, it := range ga.ItemType {
+		d = append(d, byte(it))
+		ih := ga.ItemHandle[i]
+		ihb := make([]byte, 2)
+		binary.LittleEndian.PutUint16(ihb, ih)
+		d = append(d, ihb...)
+	}
+
+	t := &Table{
+		Header:  ga.Header,
+		data:    d,
+		strings: tableStr,
+	}
+	return t, nil
+}
+
+// ParseGroupAssociation parses a generic Table into GroupAssociation.
+func ParseGroupAssociation(t *Table) (*GroupAssociation, error) {
+	return parseGroupAssociation(parseStruct, t)
+}
+
+func parseGroupAssociation(parseFn parseStructure, t *Table) (*GroupAssociation, error) {
+	if t.Type != TableTypeGroupAssociation {
+		return nil, fmt.Errorf("invalid table type %d", t.Type)
+	}
+	ga := &GroupAssociation{Header: t.Header}
+	off, err := parseFn(t, 0 /* off */, false /* complete */, ga)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := 0; i < int((ga.Length-5)/3); i++ {
+		itemType, err := t.GetByteAt(off)
+		if err != nil {
+			return nil, err
+		}
+		ga.ItemType = append(ga.ItemType, TableType(itemType))
+		off++
+
+		ih, err := t.GetWordAt(off)
+		if err != nil {
+			return nil, err
+		}
+		ga.ItemHandle = append(ga.ItemHandle, ih)
+		off += 2
+	}
+
+	if len(ga.ItemType) != len(ga.ItemHandle) {
+		return nil, fmt.Errorf("item type and item handle have different lengths, len of ItemType: %d, len of ItemHandle: %d", len(ga.ItemType), len(ga.ItemHandle))
+	}
+
+	// Check if the length of ItemType is correct.
+	numOfItemType := float64((ga.Length - 5) / 3)
+	if float64(len(ga.ItemType)) != numOfItemType {
+		return nil, fmt.Errorf("Mismatch between length and item type and item handle lengths, len of ItemType: %d, len of ItemHandle: %d, length: %f", len(ga.ItemType), len(ga.ItemHandle), numOfItemType)
+	}
+
+	return ga, nil
+}
+
+func (ga *GroupAssociation) String() string {
+	lines := []string{
+		ga.Header.String(),
+		fmt.Sprintf("Name: %s", ga.GroupName),
+		fmt.Sprintf("Items: %d", int((ga.Length-5)/3)),
+	}
+	for i, it := range ga.ItemType {
+		lines = append(lines, fmt.Sprintf("0x%04X (%s)", ga.ItemHandle[i], it))
+	}
+	return strings.Join(lines, "\n\t")
+}

--- a/pkg/smbios/type14_group_association_test.go
+++ b/pkg/smbios/type14_group_association_test.go
@@ -1,0 +1,205 @@
+package smbios
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestGroupAssociationString(t *testing.T) {
+	tests := []struct {
+		name string
+		val  GroupAssociation
+		want string
+	}{
+		{
+			name: "Fully populated",
+			val: GroupAssociation{
+				Header: Header{
+					Type:   TableTypeGroupAssociation,
+					Length: 11,
+					Handle: 0,
+				},
+				GroupName:  "Group",
+				ItemType:   []TableType{TableTypeBaseboardInfo, TableTypeProcessorInfo},
+				ItemHandle: []uint16{10, 11},
+			},
+			want: `Handle 0x0000, DMI type 14, 11 bytes
+Group Associations
+	Name: Group
+	Items: 2
+	0x000A (Base Board Information)
+	0x000B (Processor Information)`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tt.val.String()
+			if result != tt.want {
+				t.Errorf("BaseboardInfo().String(): '%s', want '%s'", result, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseGroupAssociationInfo(t *testing.T) {
+	tests := []struct {
+		name  string
+		val   GroupAssociation
+		table Table
+		want  error
+	}{
+		{
+			name: "Invalid Type",
+			val:  GroupAssociation{},
+			table: Table{
+				Header: Header{
+					Type: TableTypeBIOSInfo,
+				},
+				data: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+					0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+					0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+					0x1a},
+			},
+			want: fmt.Errorf("invalid table type 0"),
+		},
+		{
+			name: "Required fields are missing",
+			val:  GroupAssociation{},
+			table: Table{
+				Header: Header{
+					Type: TableTypeGroupAssociation,
+				},
+				data: []byte{},
+			},
+			want: fmt.Errorf("required fields missing"),
+		},
+		{
+			name: "Error parsing structure",
+			val:  GroupAssociation{},
+			table: Table{
+				Header: Header{
+					Type: TableTypeGroupAssociation,
+				},
+				data: []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+					0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+					0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19,
+					0x1a},
+			},
+			want: fmt.Errorf("error parsing structure"),
+		},
+		{
+			name: "Parse valid GroupAssociation",
+			val:  GroupAssociation{},
+			table: Table{
+				Header: Header{
+					Type:   TableTypeGroupAssociation,
+					Length: 8,
+					Handle: 0,
+				},
+				data: []byte{0x00, 0x01, 0x02, 0x03},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parseStruct := func(t *Table, off int, complete bool, sp interface{}) (int, error) {
+				return 1, tt.want
+			}
+			_, err := parseGroupAssociation(parseStruct, &tt.table)
+
+			if !checkError(err, tt.want) {
+				t.Errorf("parseGroupAssociation(): '%v', want '%v'", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestGroupAssociationToTablePass(t *testing.T) {
+	tests := []struct {
+		name string
+		ga   *GroupAssociation
+		want *Table
+	}{
+		{
+			name: "Simple Table",
+			ga: &GroupAssociation{
+				Header: Header{
+					Type:   TableTypeGroupAssociation,
+					Length: 11,
+					Handle: 0,
+				},
+				GroupName:  "Group",
+				ItemType:   []TableType{TableTypeBaseboardInfo, TableTypeProcessorInfo},
+				ItemHandle: []uint16{10, 11},
+			},
+			want: &Table{
+				Header: Header{
+					Type:   TableTypeGroupAssociation,
+					Length: 11,
+					Handle: 0,
+				},
+				data: []byte{
+					14, 11, 0, 0, // Header
+					1,        // string number
+					2, 10, 0, // ItemType, ItemHandle
+					4, 11, 0,
+				},
+				strings: []string{"Group"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		got, err := tt.ga.toTable()
+		if err != nil {
+			t.Errorf("toTable() should pass but return error: %v", err)
+		}
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("toTable(): '%v', want '%v'", got, tt.want)
+		}
+	}
+}
+
+func TestGroupAssociationToTableFail(t *testing.T) {
+
+	tests := []struct {
+		name string
+		ga   *GroupAssociation
+	}{
+		{
+			name: "Invalid Length",
+			ga: &GroupAssociation{
+				Header: Header{
+					Type:   TableTypeGroupAssociation,
+					Length: 10,
+					Handle: 0,
+				},
+				ItemType:   []TableType{TableTypeBaseboardInfo, TableTypeProcessorInfo},
+				ItemHandle: []uint16{10, 11},
+			},
+		},
+		{
+			name: "Mismatch Item Type and Item Handle Lengths",
+			ga: &GroupAssociation{
+				Header: Header{
+					Type:   TableTypeGroupAssociation,
+					Length: 11,
+					Handle: 0,
+				},
+				ItemType:   []TableType{TableTypeBaseboardInfo},
+				ItemHandle: []uint16{10, 11},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		_, err := tt.ga.toTable()
+		if err == nil {
+			t.Fatalf("toTable() should fail but pass")
+		}
+	}
+}
+


### PR DESCRIPTION
There may be references to the baseboard table we want to remove. This allows us to remove all instances in other baseboard tables or group association tables.