### PR TITLE
[wip] kmodule: add API for setting parameters of dependencies

### DIFF
--- a/pkg/kmodule/kmodule_linux.go
+++ b/pkg/kmodule/kmodule_linux.go
@@ -43,6 +43,7 @@ const (
 // concurrency: struct must be read-only outside of `loadOnce`
 type dependency struct {
 	state    modState
+	params   string
 	deps     []string
 	loadOnce sync.Once
 	err      error
@@ -118,7 +119,7 @@ func Delete(name string, flags uintptr) error {
 
 // parallelProbeDep loads a module and its dependencies
 // Returns once module is loaded.
-func parallelProbeDep(deps depMap, modPath string, params string, opts ProbeOpts, modStack []string) error {
+func parallelProbeDep(deps depMap, modPath string, opts ProbeOpts, modStack []string) error {
 	dep, present := deps[modPath]
 	if !present {
 		return fmt.Errorf("module not in depmap %s", modPath)
@@ -143,7 +144,7 @@ func parallelProbeDep(deps depMap, modPath string, params string, opts ProbeOpts
 		for _, dep := range dep.deps {
 			dep := dep
 			eg.Go(func() error {
-				return parallelProbeDep(deps, dep, "", opts, append(modStack, modPath))
+				return parallelProbeDep(deps, dep, opts, append(modStack, modPath))
 			})
 		}
 
@@ -153,7 +154,7 @@ func parallelProbeDep(deps depMap, modPath string, params string, opts ProbeOpts
 			return
 		}
 
-		err = loadModule(modPath, params, opts)
+		err = loadModule(modPath, dep.params, opts)
 		if err != nil {
 			dep.err = err
 			return
@@ -177,14 +178,46 @@ func NewProber(opts ProbeOpts) (*Prober, error) {
 	}, nil
 }
 
-// Probe loads the given kernel module and its dependencies.
-func (p Prober) Probe(name string, modParams string) error {
+func (p Prober) PrepareProbe(name string, modParams string) error {
 	modPath, err := findModPath(name, p.deps)
 	if err != nil {
 		return fmt.Errorf("could not find module path %q: %w", name, err)
 	}
 
-	return parallelProbeDep(p.deps, modPath, modParams, p.opts, []string{})
+	dep, present := p.deps[modPath]
+	if !present {
+		return fmt.Errorf("module not in depmap %s", modPath)
+	}
+
+	if dep.state != unloaded {
+		if dep.params != modParams {
+			return fmt.Errorf(
+				"module %s already loaded, cannot change parameters", name)
+		}
+		return nil
+	}
+
+	dep.params = modParams
+	return nil
+}
+
+func (p Prober) FinishProbe(name string) error {
+	modPath, err := findModPath(name, p.deps)
+	if err != nil {
+		return fmt.Errorf("could not find module path %q: %w", name, err)
+	}
+
+	return parallelProbeDep(p.deps, modPath, p.opts, []string{})
+}
+
+// Probe loads the given kernel module and its dependencies.
+func (p Prober) Probe(name string, modParams string) error {
+	err := p.PrepareProbe(name, modParams)
+	if err != nil {
+		return err
+	}
+
+	return p.FinishProbe(name)
 }
 
 // Probe loads the given kernel module and its dependencies.


### PR DESCRIPTION
This adds a mechanism for setting the parameters for modules independently of loading the modules, to allow for users to provide an unordered list of modules & modparams, and allow loading the modules in parallel.

This also helps avoid a potential footgun with parallel module loading if a user just calls Probe() concurrently through a list of modules & params, where some modules are dependencies of others. Currently, to do this in a race-free manner, user must pre-identify dependencies and not allow them to race.



----



This also presents an opportunity to error out if a module has unexpected parameters. This though is a change in behavior - so can be dropped. If we think this is useful, we would also want to populate staet for modules that were loaded before we call NewProber