### PR TITLE
pkg/boot/universalpayload: Skip system memory in handoff blocks.

### DIFF
--- a/pkg/boot/universalpayload/handoffblock.go
+++ b/pkg/boot/universalpayload/handoffblock.go
@@ -182,7 +182,8 @@ func hobFromMemMap(memMap kexec.MemoryMap) (EFIMemoryMapHOB, uint64) {
 		}
 
 		if memType == kexec.RangeRAM.String() {
-			resourceType = EFIResourceSystemMemory
+			// Skip system memory since they have been constructed at DTB
+			continue
 		} else if memType == kexec.RangeReserved.String() {
 			resourceType = EFIResourceMemoryReserved
 		} else {

--- a/pkg/boot/universalpayload/universalpayload_test.go
+++ b/pkg/boot/universalpayload/universalpayload_test.go
@@ -166,10 +166,10 @@ func TestAppendMemMapHOB(t *testing.T) {
 		deserializedHOB = append(deserializedHOB, hob)
 	}
 
-	// We will pass all memory regions info to UPL, update to the actual
+	// We will pass all non system memory regions info to UPL, update to the actual
 	// memory region numbers provided in test case.
-	if len(deserializedHOB) != 2 {
-		t.Fatalf("Unexpected hob size = %d, want = %d", len(deserializedHOB), 2)
+	if len(deserializedHOB) != 1 {
+		t.Fatalf("Unexpected hob size = %d, want = %d", len(deserializedHOB), 1)
 	}
 }
 


### PR DESCRIPTION
System memory information has been provided in DTB, there is no need to provide system memory info again in handoff blocks.