### PR TITLE
Revert "menu cleanups" to unblock Github CI

### DIFF
--- a/pkg/boot/menu/menu.go
+++ b/pkg/boot/menu/menu.go
@@ -197,8 +197,8 @@ func ShowMenuAndLoad(allowEdit bool, entries ...Entry) Entry {
 func showMenuAndLoadFromFile(file *os.File, allowEdit bool, entries ...Entry) Entry {
 	// Clear the screen (ANSI terminal escape code for screen clear).
 	fmt.Printf("\033[1;1H\033[2J\n\n")
-	fmt.Printf("Welcome to LinuxBoot's Menu\r\n\n")
-	fmt.Printf("Enter a number to boot a kernel:\r\n")
+	fmt.Printf("Welcome to LinuxBoot's Menu\n\n")
+	fmt.Printf("Enter a number to boot a kernel:\n")
 
 	for {
 		t := NewTerminal(file)


### PR DESCRIPTION
Reverts u-root/u-root#3427

Trace log cannot be prompted via same terminal if no entry is selected by user in boot menu after time out. Revert this PR to unblock Github CI integration/generic-tests TestPxeboot4