### PR TITLE
core/ps: when using /proc/<pid>/cmdline, replace null by space

### DIFF
--- a/cmds/core/ps/ps_linux.go
+++ b/cmds/core/ps/ps_linux.go
@@ -150,7 +150,7 @@ func (p *Process) readStat(s string) error {
 	p.Ctty = p.getCtty()
 	p.Cmd = strings.TrimSuffix(strings.TrimPrefix(p.Cmd, "("), ")")
 	if x && p.cmdline != "" {
-		p.Cmd = p.cmdline
+		p.Cmd = strings.ReplaceAll(p.cmdline, "\x00", " ")
 	}
 
 	return nil


### PR DESCRIPTION
This is very old code, which I guess none of us ever noticed. /proc/pid/cmdline has embedded NULLs, which need to be changed to space.