### PR TITLE
bump mkuimage to use -skip-ldd flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ names.
 You may also include additional files in the initramfs using the `-files` flag.
 
 If you add binaries with `-files` are listed, their ldd dependencies will be
-included as well.
+included as well by default. See below for how to disable.
 
 ```shell
 $ u-root -files /bin/bash
@@ -192,6 +192,11 @@ executing your currently booted kernel:
 $ u-root -files "$HOME/hello.ko:etc/hello.ko" -files "$HOME/hello2.ko:etc/hello2.ko"
 $ qemu-system-x86_64 -kernel /boot/vmlinuz-$(uname -r) -initrd /tmp/initramfs.linux_amd64.cpio
 ```
+
+Use `-skip-ldd` to not automatically include ldd dependencies for binary files. This can be useful for
+- Reproducible Builds: Ensures builds don't depend on the host system's libraries
+- Cross-compilation: When host libraries are incompatible with target architecture
+- Controlled Dependencies: When you want to manually specify exact library versions
 
 ## Init and Uinit
 

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/u-root/cpuid v0.0.1-0.20250320140348-cc5fe81d966c
 	github.com/u-root/gobusybox/src v0.0.0-20250101170133-2e884e4509c7
-	github.com/u-root/mkuimage v0.0.0-20250701161901-6a9871f2e64f
+	github.com/u-root/mkuimage v0.0.0-20250905073043-9a40452f5d3b
 	go.bug.st/serial v1.6.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -297,12 +297,10 @@ github.com/u-root/gobusybox/src v0.0.0-20250101170133-2e884e4509c7 h1:dtiVT4SeBU
 github.com/u-root/gobusybox/src v0.0.0-20250101170133-2e884e4509c7/go.mod h1:PW3wGFCHjdHxAhra5FKvcARbCGqGfentYuPKmuhv8DY=
 github.com/u-root/iscsinl v0.1.1-0.20210528121423-84c32645822a h1:A0sK7WEodak7eVd21MOEatnh2pfAAwZaEPSIEEsjctQ=
 github.com/u-root/iscsinl v0.1.1-0.20210528121423-84c32645822a/go.mod h1:RWIgJWqm9/0gjBZ0Hl8iR6MVGzZ+yAda2uqqLmetE2I=
-github.com/u-root/mkuimage v0.0.0-20250701161901-6a9871f2e64f h1:TYTO6Hvj2BrRRpWOqL/K2A8tIelVyP+wTbpkWygGRkg=
-github.com/u-root/mkuimage v0.0.0-20250701161901-6a9871f2e64f/go.mod h1:qzJqwYSsU0kBkl1bX/s93hfd64WbL+CP7AobQdvJb9A=
+github.com/u-root/mkuimage v0.0.0-20250905073043-9a40452f5d3b h1:ja/A01alYDScunNPtpH4aIN3cYTvFgeFtCk8nwEloEg=
+github.com/u-root/mkuimage v0.0.0-20250905073043-9a40452f5d3b/go.mod h1:qzJqwYSsU0kBkl1bX/s93hfd64WbL+CP7AobQdvJb9A=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701 h1:pyC9PaHYZFgEKFdlp3G8RaCKgVpHZnecvArXvPXcFkM=
 github.com/u-root/uio v0.0.0-20240224005618-d2acac8f3701/go.mod h1:P3a5rG4X7tI17Nn3aOIAYr5HbIMukwXG0urG0WuL8OA=
-github.com/ulikunitz/xz v0.5.11 h1:kpFauv27b6ynzBNT/Xy+1k+fK4WswhN/6PN5WhFAGw8=
-github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=

--- a/vendor/github.com/u-root/mkuimage/uimage/mkuimage/uflags.go
+++ b/vendor/github.com/u-root/mkuimage/uimage/mkuimage/uflags.go
@@ -110,7 +110,8 @@ type Flags struct {
 	Uinit *string
 	Shell *string
 
-	Files []string
+	Files   []string
+	SkipLDD bool
 
 	BaseArchive     string
 	ArchiveFormat   string
@@ -125,6 +126,9 @@ func (f *Flags) Modifiers(packages ...string) ([]uimage.Modifier, error) {
 	m := []uimage.Modifier{
 		uimage.WithFiles(f.Files...),
 		uimage.WithExistingInit(f.UseExistingInit),
+	}
+	if f.SkipLDD {
+		m = append(m, uimage.WithSkipLDD())
 	}
 	if f.TempDir != nil {
 		m = append(m, uimage.WithTempDir(*f.TempDir))
@@ -167,6 +171,7 @@ func (f *Flags) RegisterFlags(fs *flag.FlagSet) {
 	fs.Var(&optionalStringVar{&f.Shell}, "defaultsh", "Default shell. Can be an absolute path or a Go command name. Use defaultsh=\"\" if you don't want the symlink.")
 
 	fs.Var((*uflag.Strings)(&f.Files), "files", "Additional files, directories, and binaries (with their ldd dependencies) to add to archive. Can be specified multiple times.")
+	fs.BoolVar(&f.SkipLDD, "skip-ldd", f.SkipLDD, "Skip automatic shared library dependency resolution for files. You must manually specify all required libraries.")
 
 	fs.StringVar(&f.BaseArchive, "base", f.BaseArchive, "Base archive to add files to. By default, this is a couple of directories like /bin, /etc, etc. Has a default internally supplied set of files; use base=/dev/null if you don't want any base files.")
 	fs.StringVar(&f.ArchiveFormat, "format", f.ArchiveFormat, "Archival input (for -base) and output (for -o) format.")

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -360,7 +360,7 @@ github.com/u-root/gobusybox/src/pkg/uflag
 # github.com/u-root/iscsinl v0.1.1-0.20210528121423-84c32645822a
 ## explicit; go 1.13
 github.com/u-root/iscsinl
-# github.com/u-root/mkuimage v0.0.0-20250701161901-6a9871f2e64f
+# github.com/u-root/mkuimage v0.0.0-20250905073043-9a40452f5d3b
 ## explicit; go 1.21
 github.com/u-root/mkuimage/cpio
 github.com/u-root/mkuimage/cpio/internal/upath


### PR DESCRIPTION
With the recent update in [github.com/u-root/mkuimage](https://github.com/u-root/mkuimage), there is a new flag available to control the resolution of ldd dependencies when including binary files with the -files flag.

The flag will be registered automatically by the `RegisterFlags()` method of `mkuimage.Flags` in u-root's `main()`, there is no need to also define the flag in here in u-root.

The README was synced with the respective part of the README in [github.com/u-root/mkuimage](https://github.com/u-root/mkuimage).

See https://github.com/u-root/mkuimage/pull/45 for details.