### PR TITLE
ci: Update EDK2 UPL Fit code base to tianocore/edk2-stable202508

### DIFF
--- a/.circleci/images/upl-fit-amd64/Dockerfile
+++ b/.circleci/images/upl-fit-amd64/Dockerfile
@@ -7,10 +7,10 @@ FROM ubuntu:rolling AS base
 # Install dependencies
 RUN apt-get update &&                          \
     apt-get install -y --no-install-recommends \
-        ca-certificates                             \
+        ca-certificates                        \
         git;
 
-RUN git clone --branch master --recursive https://github.com/tianocore/edk2 upl-fit;
+RUN git clone --branch edk2-stable202508 --recursive https://github.com/tianocore/edk2 upl-fit;
 
 RUN apt-get install -y --no-install-recommends \
         make             \
@@ -32,11 +32,11 @@ SHELL ["/bin/bash", "-c"]
 RUN cd upl-fit;                                                              \
     source ./edksetup.sh;                                                    \
     make -C BaseTools;                                                       \
-	python3 UefiPayloadPkg/UniversalPayloadBuild.py -t GCC5 -b DEBUG         \
+    python3 UefiPayloadPkg/UniversalPayloadBuild.py -t GCC5 -b DEBUG         \
       --Fit -DCPU_TIMER_LIB_ENABLE=FALSE                                     \
       -DTIMER_SUPPORT=LAPIC -DHAND_OFF_FDT_ENABLE=TRUE                       \
       --add_cc_flag=-mno-sse --add_cc_flag=-mno-mmx;                         \
-	cp /upl-fit/Build/UefiPayloadPkgX64/UniversalPayload.fit /UplFitX64.fit;
+    cp /upl-fit/Build/UefiPayloadPkgX64/UniversalPayload.fit /UplFitX64.fit;
 
 FROM scratch
 COPY --from=base /UplFitX64.fit /UplFitX64.fit

--- a/.circleci/images/upl-fit-arm64/Dockerfile
+++ b/.circleci/images/upl-fit-arm64/Dockerfile
@@ -7,10 +7,10 @@ FROM ubuntu:rolling AS base
 # Install dependencies
 RUN apt-get update &&                          \
     apt-get install -y --no-install-recommends \
-        ca-certificates                             \
+        ca-certificates                        \
         git;
 
-RUN git clone --branch master --recursive https://github.com/tianocore/edk2 upl-fit;
+RUN git clone --branch edk2-stable202508 --recursive https://github.com/tianocore/edk2 upl-fit;
 
 RUN apt-get install -y --no-install-recommends \
         make             \
@@ -34,9 +34,9 @@ RUN cd upl-fit;                                                              \
     export GCC5_AARCH64_PREFIX=aarch64-linux-gnu-;                           \
     source ./edksetup.sh;                                                    \
     make -C BaseTools;                                                       \
-	python3 UefiPayloadPkg/UniversalPayloadBuild.py -a AARCH64 -t GCC5       \
+    python3 UefiPayloadPkg/UniversalPayloadBuild.py -a AARCH64 -t GCC5       \
       -b DEBUG --Fit -DHAND_OFF_FDT_ENABLE=TRUE;                             \
-	cp /upl-fit/Build/UefiPayloadPkgAARCH64/UniversalPayload.fit /UplFitARM64.fit;
+    cp /upl-fit/Build/UefiPayloadPkgAARCH64/UniversalPayload.fit /UplFitARM64.fit;
 
 FROM scratch
 COPY --from=base /upl-fit/Build/UefiPayloadPkgAARCH64/UniversalPayload.fit /UplFitARM64.fit


### PR DESCRIPTION
Update code base for UPL Fit code base for both AMD64 and ARM64 on top of tianocore/edk2-stable202508.

edk2-stable202508 is official release from tianocore EDK2 code base, it ensures code base of UPL Fit image easy to trace.