### PR TITLE
Enable UniveralPayload solution in Github CI

### DIFF
--- a/.vmtest.yaml
+++ b/.vmtest.yaml
@@ -23,6 +23,18 @@ amd64:
     files:
       payload: "/UEFIPAYLOAD.fd"
 
+  VMTEST_OVMF:
+    container: "ghcr.io/u-root/u-root/test-ovmf-amd64@sha256:8852700b3d5f030918b9e5710b422edc5ab09579245eb566568953756815ecbb"
+    template: "{{.ovmf}}"
+    files:
+      ovmf: "/OVMF.fd"
+  
+  UROOT_TEST_UPLFIT:
+    container: "ghcr.io/u-root/u-root/test-upl-fit-amd64@sha256:1133b7242c7b91cd75e6f232a9a099e7ed6e343aaa19b61517a5cce69f40375f"
+    template: "{{.uplfit}}"
+    files:
+      uplfit: "/UplFitX64.fit"
+
 arm:
   VMTEST_QEMU:
     container: "ghcr.io/hugelgupf/vmtest/qemu:main@sha256:d5b3d31f39edb6394d20bdd76027512f956d78af9c6e49ecf2ab9ab59944638a"
@@ -48,3 +60,15 @@ arm64:
     template: "{{.Image}}"
     files:
       Image: "/Image"
+  
+  VMTEST_OVMF:
+    container: "ghcr.io/u-root/u-root/test-ovmf-arm64@sha256:eb0616a30523707fed22e7ca739ec04fcf60005847fc35b1a52732dbeb4340da"
+    template: "{{.ovmf}}"
+    files:
+      ovmf: "/QEMU_EFI.fd"
+  
+  UROOT_TEST_UPLFIT:
+    container: "ghcr.io/u-root/u-root/test-upl-fit-arm64@sha256:4dc0bd2393ebbec53e2b4855ebeb338f4458cfb9b4c3d5091bc9d7863365b2ee"
+    template: "{{.uplfit}}"
+    files:
+      uplfit: "/UplFitARM64.fit"

--- a/integration/generic-tests/universalpayload_amd64_test.go
+++ b/integration/generic-tests/universalpayload_amd64_test.go
@@ -1,0 +1,99 @@
+// Copyright 2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build amd64 && !race
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Netflix/go-expect"
+	"github.com/hugelgupf/vmtest/qemu"
+	"github.com/hugelgupf/vmtest/scriptvm"
+	"github.com/u-root/mkuimage/uimage"
+)
+
+// TestUPLBootAmd64 tests '/bbin/kexec UplFitX64.fit' to boot to UEFI Shell.
+func TestUPLBootAmd64(t *testing.T) {
+	//os.Setenv("VMTEST_ARCH", "amd64")
+	qemu.SkipIfNotArch(t, qemu.ArchAMD64)
+
+	// Check required images, including:
+	//   OVMF.fd 		-- UEFI OVMF binary
+	//   bzImage 		-- Linuxboot kernel image
+	//   UplFitX64.fit	-- UPL Amd64 image with FDT enabled
+
+	var ovmf string
+	var bzImage string
+	var upl string
+
+	if img := os.Getenv("VMTEST_OVMF"); len(img) == 0 {
+		t.Skipf("VMTEST_OVMF not set!!")
+	} else {
+		ovmf = img
+	}
+
+	if _, err := os.Stat(ovmf); err != nil && os.IsNotExist(err) {
+		t.Skipf("OVMF.fd image is not found: %s\n", ovmf)
+	}
+
+	if img := os.Getenv("VMTEST_KERNEL"); len(img) == 0 {
+		t.Skipf("VMTEST_KERNEL not set!!")
+	} else {
+		bzImage = img
+	}
+
+	if _, err := os.Stat(bzImage); err != nil && os.IsNotExist(err) {
+		t.Skipf("Linux kernel bzImage image is not found: %s\n", bzImage)
+	}
+
+	if img := os.Getenv("UROOT_TEST_UPLFIT"); len(img) == 0 {
+		t.Skipf("UROOT_TEST_UPLFIT not set!!")
+	} else {
+		upl = img
+	}
+
+	if _, err := os.Stat(upl); err != nil && os.IsNotExist(err) {
+		t.Skipf("UniversalPaylad image is not found: %s\n", upl)
+	}
+
+	vm := scriptvm.Start(t, "upl-vm", "",
+		scriptvm.WithUimage(
+			uimage.WithBusyboxCommands(
+				"github.com/u-root/u-root/cmds/core/init",
+				"github.com/u-root/u-root/cmds/core/kexec",
+				"github.com/u-root/u-root/cmds/core/gosh",
+			),
+			uimage.WithFiles(fmt.Sprintf("%s:/ext/upl", upl)),
+			uimage.WithUinitCommand("/bbin/kexec /ext/upl"),
+		),
+		scriptvm.WithQEMUFn(
+			qemu.WithVMTimeout(5*time.Minute),
+			qemu.ArbitraryArgs("-machine", "q35"),
+			qemu.ArbitraryArgs("-m", "4096"),
+			qemu.ArbitraryArgs("-bios", ovmf),
+			qemu.ArbitraryArgs("-kernel", bzImage),
+		),
+	)
+
+	if _, err := vm.Console.Expect(expect.All(
+		// Boot target prompted from BDS
+		expect.String("[Bds]Booting UEFI Shell"),
+		// Last code before booting to UEFI Shell
+		expect.String("PROGRESS CODE: V03058001 I0"),
+	)); err != nil {
+		t.Errorf("VM output did not match expectations: %v", err)
+	}
+
+	if err := vm.Kill(); err != nil {
+		fmt.Printf("Wait for VM process to be killed: %v\n", err)
+		t.Errorf("Wait for VM process to be killed: %v", err)
+	}
+
+	vm.Wait()
+}

--- a/integration/generic-tests/universalpayload_arm64_test.go
+++ b/integration/generic-tests/universalpayload_arm64_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build arm64 && !race
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/Netflix/go-expect"
+	"github.com/hugelgupf/vmtest/qemu"
+	"github.com/hugelgupf/vmtest/scriptvm"
+	"github.com/u-root/gobusybox/src/pkg/golang"
+	"github.com/u-root/mkuimage/uimage"
+)
+
+// TestUPLBootArm64 tests '/bbin/kexec UplFitARM64.fit' boot to UEFI Shell.
+func TestUPLBootArm64(t *testing.T) {
+	// CAUTION: Before running this VM test, environment variable must be set:
+	//     "VMTEST_ARCH=arm64"
+	// Since "github.com/hugelgupf/vmtest/qemu" package parses .vmtest.yaml
+	// with $VMTEST_ARCH to get $VMTEST_QEMU.
+
+	qemu.SkipIfNotArch(t, qemu.ArchArm64)
+
+	// Check required images, including:
+	//   QEMU_EFI.fd		-- UEFI OVMF binary
+	//   Image 				-- Linuxboot kernel Image
+	//   UplFitARM64.fit	-- UPL Arm64 image with FDT enabled
+
+	var ovmf string
+	var image string
+	var upl string
+
+	if img := os.Getenv("VMTEST_OVMF"); len(img) == 0 {
+		t.Skipf("VMTEST_OVMF not set!!")
+	} else {
+		ovmf = img
+	}
+
+	if _, err := os.Stat(ovmf); err != nil && os.IsNotExist(err) {
+		t.Skipf("OVMF.fd image is not found: %s\n", ovmf)
+	}
+
+	if img := os.Getenv("VMTEST_KERNEL"); len(img) == 0 {
+		t.Skipf("VMTEST_KERNEL not set!!")
+	} else {
+		image = img
+	}
+
+	if _, err := os.Stat(image); err != nil && os.IsNotExist(err) {
+		t.Skipf("Linux kernel image image is not found: %s\n", image)
+	}
+
+	if img := os.Getenv("UROOT_TEST_UPLFIT"); len(img) == 0 {
+		t.Skipf("UROOT_TEST_UPLFIT not set!!")
+	} else {
+		upl = img
+	}
+
+	if _, err := os.Stat(upl); err != nil && os.IsNotExist(err) {
+		t.Skipf("UniversalPaylad image is not found: %s\n", upl)
+	}
+
+	vm := scriptvm.Start(t, "upl-vm", "",
+		scriptvm.WithUimage(
+			uimage.WithEnv(golang.WithGOARCH("arm64")),
+			uimage.WithBusyboxCommands(
+				"github.com/u-root/u-root/cmds/core/init",
+				"github.com/u-root/u-root/cmds/core/kexec",
+				"github.com/u-root/u-root/cmds/core/gosh",
+			),
+			uimage.WithFiles(fmt.Sprintf("%s:/ext/upl", upl)),
+			uimage.WithUinitCommand("/bbin/kexec /ext/upl"),
+		),
+		scriptvm.WithQEMUFn(
+			qemu.WithVMTimeout(5*time.Minute),
+			qemu.ArbitraryArgs("-machine", "virt,gic-version=3"),
+			qemu.ArbitraryArgs("-m", "4096"),
+			qemu.ArbitraryArgs("-bios", ovmf),
+			qemu.ArbitraryArgs("-kernel", image),
+		),
+	)
+
+	if _, err := vm.Console.Expect(expect.All(
+		// Boot target prompted from BDS
+		expect.String("[Bds]Booting UEFI Shell"),
+		// Last code before booting to UEFI Shell
+		expect.String("PROGRESS CODE: V03058001 I0"),
+	)); err != nil {
+		t.Errorf("VM output did not match expectations: %v", err)
+	}
+
+	if err := vm.Kill(); err != nil {
+		fmt.Printf("Wait for VM process to be killed: %v\n", err)
+		t.Errorf("Wait for VM process to be killed: %v", err)
+	}
+
+	vm.Wait()
+}


### PR DESCRIPTION
The boot flow of UniversalPayload solution for real production should be:
EDK2 UEFI -> Linuxboot (kernel) -> UniversalPayload (integrated in u-root) -> Target OS

In order to cover whole boot flow of UniversalPayload, we need to switch to following boot flow:
EDK2 OVMF ->  Linuxboot (kernel) -> UniversalPayload (integrated in u-root) -> UEFI shell

The differences between github CI to real production is:
1. OVMF vs. UEFI : OVMF is used to launch EDK2 UEFI for virtual platform, and its mature and widely used in Linux distribution to provide UEFI support on top of QEMU env.
2. UEFI shell vs. Target OS: We need to figure out a way to store a QEMU QCOW2 image which installed with target OS, for instance Ubuntu or Debian. Due to above limitation, I used UEFI SHELL for current stage.
