### PR TITLE
cmds/core/touch: fix touch_test.go

### DIFF
--- a/cmds/core/touch/touch_test.go
+++ b/cmds/core/touch/touch_test.go
@@ -65,8 +65,7 @@ func TestTouchEmptyDir(t *testing.T) {
 	for _, test := range tests {
 		temp := t.TempDir()
 		var args []string
-		args = append(args, test.args[0]) // "touch"
-		for i := 1; i < len(test.args); i++ {
+		for i := 0; i < len(test.args); i++ {
 			arg := test.args[i]
 			if !strings.HasPrefix(arg, "-") {
 				args = append(args, filepath.Join(temp, arg))
@@ -82,17 +81,17 @@ func TestTouchEmptyDir(t *testing.T) {
 		err := cmd.Run(args...)
 		if test.err != nil {
 			if !errors.Is(err, test.err) {
-				t.Fatalf("Run() expected %v, got %v", test.err, err)
+				t.Fatalf("%s: Run() expected %v, got %v", test.name, test.err, err)
 			}
 			continue
 		}
 
 		if err != nil {
-			t.Fatalf("Run() expected no error, got %v", err)
+			t.Fatalf("%s: Run() expected no error, got %v", test.name, err)
 		}
 
 		// Check if files were created (only for non-error cases)
-		for i := 1; i < len(test.args); i++ {
+		for i := 0; i < len(test.args); i++ {
 			arg := test.args[i]
 			if !strings.HasPrefix(arg, "-") {
 				fullPath := filepath.Join(temp, arg)


### PR DESCRIPTION
It was failing with the error below when it was run from an unwritable current directory:

```
=== RUN   TestTouchEmptyDir
    third_party/golang/uroot/cmds/core/touch/touch_test.go:91: create is false, files should be created: Run() expected no error, got open a1: permission denied
```

With `strace` I saw that the first argument ("a1") was a relative path, while the second was an absolute path:

```
=== RUN   TestTouchEmptyDir
[pid 3723760] openat(AT_FDCWD, "a1", O_RDWR|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = -1 EACCES (Permission denied)
[pid 3723760] openat(AT_FDCWD, "/tmp/TestTouchEmptyDir1858418718/002/a2", O_RDWR|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 7
    third_party/golang/uroot/cmds/core/touch/touch_test.go:91: create is false, files should be created: Run() expected no error, got open a1: permission denied
```

The test logic incorrectly assumed that the first value in `args` would be the executable name.