### PR TITLE
pkg/boot/universalpayload: Update logic reserved memory region

### DIFF
--- a/pkg/boot/universalpayload/handoffblock.go
+++ b/pkg/boot/universalpayload/handoffblock.go
@@ -165,6 +165,23 @@ const (
 
 type EFIMemoryMapHOB []EFIHOBResourceDescriptor
 
+// convertResourceType determines the EFI resource type based on the memory type string.
+// It returns EFIResourceMemoryReserved for reserved memory types, IOAPIC, and HPET regions.
+// All other types are treated as memory-mapped I/O.
+func convertResourceType(memType string) EFIResourceType {
+	if memType == kexec.RangeReserved.String() {
+		return EFIResourceMemoryReserved
+	}
+	if strings.Contains(memType, "IOAPIC") {
+		return EFIResourceMemoryReserved
+	}
+	if strings.Contains(memType, "HPET") {
+		return EFIResourceMemoryReserved
+	}
+	// Treat all other types to be mapped device MMIO address
+	return EFIResourceMemoryMappedIO
+}
+
 // Translate System Map with "System RAM" type to Resource code HOBs.
 func hobFromMemMap(memMap kexec.MemoryMap) (EFIMemoryMapHOB, uint64) {
 	var memMapHOB EFIMemoryMapHOB
@@ -184,12 +201,9 @@ func hobFromMemMap(memMap kexec.MemoryMap) (EFIMemoryMapHOB, uint64) {
 		if memType == kexec.RangeRAM.String() {
 			// Skip system memory since they have been constructed at DTB
 			continue
-		} else if memType == kexec.RangeReserved.String() {
-			resourceType = EFIResourceMemoryReserved
-		} else {
-			// Treat all other types to be mapped device MMIO address
-			resourceType = EFIResourceMemoryMappedIO
 		}
+
+		resourceType = convertResourceType(memType)
 
 		memMapHOB = append(memMapHOB, EFIHOBResourceDescriptor{
 			Header: EFIHOBGenericHeader{


### PR DESCRIPTION
Due to changes TianoCore EDK2 in UefiPayloadPkg, need to update reserved memory region logic for 'HPET' and 'IOAPIC'.