### PR TITLE
Add the builtin package, with a forth example

### DIFF
--- a/pkg/builtin/builtin.go
+++ b/pkg/builtin/builtin.go
@@ -1,0 +1,47 @@
+// Copyright 2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package builtin
+
+import (
+	"bytes"
+	"io"
+)
+
+// The Cmd struct is modelled on os/exec.Cmd, with only
+// those items need to run a function. Stdin/Stdout/Stderr
+// are ReadWriter, to allow functions or returns to be provided with
+// data.
+type Cmd struct {
+	// Path is the BuiltIn's name
+	Path string
+
+	// Args holds command line arguments, including the command as Args[0].
+	// In typical use, both Path and Args are set by calling Command.
+	Args []string
+
+	// Stdin specifies the process's standard input.
+	Stdin io.ReadWriter
+
+	// Stdout and Stderr specify the process's standard output and error.
+	Stdout io.ReadWriter
+	Stderr io.ReadWriter
+}
+
+// Command provides a BuiltIn struct with defaults that will behave properly.
+// It is recommended that you call this to set up your package builtin,
+// but it is not required.
+// Stdin has its own bytes.Buffer; Stdout and Stderr share one.
+// You can make them separate if you wish.
+func Command(path string, args ...string) *Cmd {
+	r := &bytes.Buffer{}
+	w := &bytes.Buffer{}
+	c := &Cmd{Path: path, Args: append([]string{path}, args...), Stdin: r, Stdout: w, Stderr: w}
+	return c
+}
+
+// Runner is the interface packages must implement.
+type Runner interface {
+	Run() error
+}

--- a/pkg/builtin/builtin_test.go
+++ b/pkg/builtin/builtin_test.go
@@ -1,0 +1,26 @@
+// Copyright 2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package builtin
+
+import (
+	"testing"
+)
+
+func TestBuiltIn(t *testing.T) {
+	c := Command("hi", "there")
+
+	if c.Path != "hi" {
+		t.Errorf("c.Path: got %v, want hi", c.Path)
+	}
+	if len(c.Args) != 2 {
+		t.Fatalf("c.Args: got %d elements, want 2", len(c.Args))
+	}
+	if c.Args[0] != "hi" {
+		t.Errorf("c.Args[0]: got %v, want hi", c.Args[0])
+	}
+	if c.Args[1] != "there" {
+		t.Errorf("c.Args[1]: got %v, want there", c.Args[1])
+	}
+}

--- a/pkg/builtin/doc.go
+++ b/pkg/builtin/doc.go
@@ -1,0 +1,49 @@
+// Copyright 2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package builtin defines how packages can be used
+// as command builtins in bare metal or other embedded environments.
+//
+// The common mechanism for using a command as a package is to use
+// the gobusybox tool. That said, we have occasional requests to make
+// individual commands available as packages; the gobusybox
+// model, in some cases, brings in more than people want.
+// In tightly space-constrained environments, such as the Pico2,
+// every byte counts.
+//
+// This package defines a type, Cmd, and an interface,
+// Runner. Packages must define their own Cmd type
+// which may be as simple as:
+//
+//	type Cmd struct {
+//	  *builtin.Cmd
+//	  ...
+//	  }
+//
+// If a package defines builtin.Cmd, it should make an
+// assertion:
+// var _ builtin.Runner = &Cmd{}
+// For this assertion to work, a package must satisfy the
+// builtin.Runner interface:
+// func (c *Cmd) Run() error
+//
+// Packages must define a Command function, e.g.
+// func Command(path string, args ...string) *Cmd
+// The non-optional path arg should be thought of as the
+// arg0 provided by the kernel to a process on exec(2).
+// Among other things, this provides consistency with
+// os/exec. That may seem a foolish consistency, but
+// we have already had to fix one bug that
+// resulted from a Command method which was not consistent
+// with os/exec.Command().
+//
+// The most common pattern for a user is to call a function,
+// Command, which returns a package defined type which
+// must implement the Runner interface.
+//
+// With the returned struct, users can call the Run method.
+//
+// To see a usage, look at builtin_test.go in the forth package.
+// It uses the forth package to run simple forth scripts.
+package builtin

--- a/pkg/forth/builtin.go
+++ b/pkg/forth/builtin.go
@@ -1,0 +1,51 @@
+// Copyright 2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package forth
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/u-root/u-root/pkg/builtin"
+)
+
+// Cmd supports using the forth package as a builtin.
+type Cmd struct {
+	*builtin.Cmd
+	f     Forth
+	cells []Cell
+}
+
+// Command returns a new Command, with a forth interpreter attached.
+func Command(path string, args ...string) *Cmd {
+	var cells []Cell
+	for _, s := range args {
+		cells = append(cells, Cell(s))
+	}
+
+	return &Cmd{
+		Cmd:   builtin.Command(path, args...),
+		f:     New(),
+		cells: cells,
+	}
+}
+
+var _ builtin.Runner = (*Cmd)(nil)
+
+// Run implements builtin.Run. For forth, it takes the args
+// and runs them, returning results c.Stdout (which, by default,
+// is a bytes.Buffer)
+func (c *Cmd) Run() error {
+	evalErr := Eval(c.f, c.cells...)
+	s := c.f.Stack()
+	Debug("stack:%v", s)
+	if len(s) == 0 {
+		return errors.Join(evalErr, ErrEmptyStack)
+	}
+
+	_, err := fmt.Fprintf(c.Stdout, "%s", s[0])
+
+	return errors.Join(evalErr, err)
+}

--- a/pkg/forth/builtin_test.go
+++ b/pkg/forth/builtin_test.go
@@ -1,0 +1,23 @@
+// Copyright 2025 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package forth
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBuiltIn(t *testing.T) {
+	c := Command("forth", "2", "2", "+")
+	Debug = t.Logf
+	if err := c.Run(); err != nil {
+		t.Fatalf("2 2 +: got %v, want nil", err)
+	}
+	s := c.Stdout.(*bytes.Buffer).String()
+	t.Logf("output %v", s)
+	if s != "4/1" {
+		t.Errorf("eval: got %s, want 4/1", s)
+	}
+}


### PR DESCRIPTION
The builtin package is an proposal to
implementing command builtins. The core idea is
that a package can be used as a builtin, without
using the gobusybox.

It is only for special circumstances where use of the gobusybox is not practical.

Gobusybox remains the preferred approach, since it can incorporate arbitrary Go programs outside u-root.