### PR TITLE
cmds/core/sluinit: prevent sluinit from exiting on extra uinitargs

### DIFF
--- a/cmds/core/sluinit/uinit_linux.go
+++ b/cmds/core/sluinit/uinit_linux.go
@@ -99,13 +99,7 @@ func checkDebugFlag() {
 
 	flag.Parse()
 
-	if flag.NArg() > 1 {
-		// Log with Printf instead of Fatal to prevent sluinit from exiting early and
-		// bypassing the securelaunch chain. Ignore extra positional args and continue.
-		log.Printf("Incorrect number of arguments")
-	}
-
-	if *slDebug {
+	if slDebug != nil && *slDebug {
 		slaunch.Debug = log.Printf
 		slaunch.Debug("debug flag is set. Logging Enabled.")
 	}

--- a/cmds/core/sluinit/uinit_linux.go
+++ b/cmds/core/sluinit/uinit_linux.go
@@ -100,7 +100,9 @@ func checkDebugFlag() {
 	flag.Parse()
 
 	if flag.NArg() > 1 {
-		log.Fatal("Incorrect number of arguments")
+		// Log with Printf instead of Fatal to prevent sluinit from exiting early and
+		// bypassing the securelaunch chain. Ignore extra positional args and continue.
+		log.Printf("Incorrect number of arguments")
 	}
 
 	if *slDebug {

--- a/integration/generic-tests/uinit_test.go
+++ b/integration/generic-tests/uinit_test.go
@@ -61,3 +61,28 @@ func TestHelloWorldNegative(t *testing.T) {
 		t.Errorf("Wait: %v", err)
 	}
 }
+
+// TestSluinitWithUnexpectedUinitArgs tests that sluinit does not fall into a kernel panic.
+func TestSluinitWithUnexpectedUinitArgs(t *testing.T) {
+	vm := qemu.StartT(t, "vm", qemu.ArchUseEnvv,
+		quimage.WithUimageT(t,
+			uimage.WithInit("init"),
+			uimage.WithUinit("sluinit"),
+			uimage.WithBusyboxCommands(
+				"github.com/u-root/u-root/cmds/core/sluinit",
+				"github.com/u-root/u-root/cmds/core/init",
+			),
+		),
+		qemu.WithAppendKernel("uroot.uinitargs=\"x y\""),
+		qemu.WithVMTimeout(time.Minute),
+		qcoverage.CollectKernelCoverage(t),
+	)
+
+	// Expect that it does NOT panic.
+	if _, err := vm.Console.ExpectString("Kernel panic"); err == nil {
+		t.Error(`unexpected kernel panic found`)
+	}
+
+	// Since no shell is configured, vm will fall into a reboot loop and eventually time out.
+	vm.Wait()
+}


### PR DESCRIPTION
The use of `log.Fatal` within `sluinit` when encountering extra `uinitargs` creates a security vulnerability that is easily exploited. By simply adding an extra token to the kernel command line, an attacker can the entire measured-boot and securelaunch trust chain.

### Trigger
Append `uroot.uinitargs="x y"` to the kernel command line:

### Reproduction (verified in production initramfs under QEMU)
```
runvmtest -- go test -run TestSluinitWithUnexpectedUinitArgs ./integration/generic-tests/
```
Observed in the `.vmtest.yaml`-pinned QEMU/kernel with the `cmds/core/{sluinit, init}` busybox build:
* `Incorrect number of arguments` — sluinit `log.Fatal`'d
* With `shell: gosh` configured, the VM then blocks at an interactive gosh prompt instead of kernel-panicking (control returned to init's command loop and `/bin/defaultsh` was exec'd).
* Without a shell configured, init logs `All commands exited → Kernel panic - not syncing: Attempted to kill init!` (bypasses sluinit's intended reboot-loop).

Tested: `runvmtest -- go test -run TestSluinitWithUnexpectedUinitArgs ./integration/generic-tests/` : OK