### PR TITLE
cmds/core/uniq: fix bug where duplicates were being printed

### DIFF
--- a/cmds/core/uniq/uniq.go
+++ b/cmds/core/uniq/uniq.go
@@ -53,61 +53,62 @@ var (
 // var fnum = flag.Int("f", 0, "ignore num fields from beginning of line")
 // var cnum = flag.Int("cn", 0, "ignore num characters from beginning of line")
 
-func uniq(r io.Reader, w io.Writer, unique, duplicates, count bool, equal func(a, b []byte) bool) {
-	br := bufio.NewReader(r)
+func shouldPrint(unique, duplicates bool, cnt int) bool {
+	if unique && cnt > 1 {
+		return false
+	}
+	if duplicates && cnt == 1 {
+		return false
+	}
+	return true
+}
 
-	var err error
-	var oline, line []byte
-	cnt := 1
-	isLast := false
-	for {
-		line, err = br.ReadBytes('\n')
-		line = bytes.TrimSuffix(line, []byte{'\n'})
-		if err == io.EOF {
-			isLast = true
-		} else if err != nil {
-			log.Printf("Can't read the %v line of %v file: %v", line, r, err)
-		}
-		if oline == nil {
-			oline = line
-			continue
-		}
-		if !equal(line, oline) {
-			if count {
-				fmt.Fprintf(w, "%d\t%s\n", cnt, oline)
-				goto skip
-			}
-			if cnt > 1 && unique {
-				goto skip
-			}
-			if cnt == 1 && duplicates {
-				goto skip
-			}
-			fmt.Fprintf(w, "%s\n", oline)
-		skip:
-			oline = line
-			cnt = 1
-		} else {
-			cnt++
-		}
-		if isLast {
-			break
-		}
-	}
-	if cnt == 1 && duplicates {
-		return
-	}
-	if len(line) == 0 && cnt == 1 {
-		return
-	}
+func printLine(w io.Writer, line []byte, count bool, cnt int) {
 	if count {
-		if len(line) == 0 {
-			cnt--
-		}
-		fmt.Fprintf(w, "%d\t%s\n", cnt, line)
-		return
+		_, _ = fmt.Fprintf(w, "%d\t%s\n", cnt, line)
+	} else {
+		_, _ = fmt.Fprintf(w, "%s\n", line)
 	}
-	fmt.Fprintf(w, "%s\n", line)
+}
+
+func uniq(r io.Reader, w io.Writer, unique, duplicates, count bool, equal func(a, b []byte) bool) error {
+	bs := bufio.NewScanner(r)
+
+	if !bs.Scan() {
+		return bs.Err()
+	}
+	prevLine := bytes.Clone(bs.Bytes())
+	cnt := 1
+
+	for bs.Scan() {
+		line := bytes.Clone(bs.Bytes())
+		if equal(line, prevLine) {
+			cnt++
+		} else {
+			if shouldPrint(unique, duplicates, cnt) {
+				printLine(w, prevLine, count, cnt)
+			}
+			cnt = 1
+			prevLine = line
+		}
+	}
+	if err := bs.Err(); err != nil {
+		return err
+	}
+
+	if shouldPrint(unique, duplicates, cnt) {
+		printLine(w, prevLine, count, cnt)
+	}
+	return nil
+}
+
+func runOnFile(fn string, stdout io.Writer, unique bool, duplicates bool, count bool, eq func(a []byte, b []byte) bool) error {
+	f, err := os.Open(fn)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return uniq(f, stdout, unique, duplicates, count, eq)
 }
 
 func run(stdin io.Reader, stdout io.Writer, unique, duplicates, count, ignoreCase bool, args []string) error {
@@ -118,17 +119,13 @@ func run(stdin io.Reader, stdout io.Writer, unique, duplicates, count, ignoreCas
 		eq = bytes.Equal
 	}
 	if len(args) == 0 {
-		uniq(stdin, stdout, unique, duplicates, count, eq)
-		return nil
+		return uniq(stdin, stdout, unique, duplicates, count, eq)
 	}
 	for _, fn := range args {
-		f, err := os.Open(fn)
+		err := runOnFile(fn, stdout, unique, duplicates, count, eq)
 		if err != nil {
-			log.Printf("open %s: %v\n", fn, err)
 			return err
 		}
-		uniq(f, stdout, unique, duplicates, count, eq)
-		f.Close()
 	}
 	return nil
 }

--- a/cmds/core/uniq/uniq.go
+++ b/cmds/core/uniq/uniq.go
@@ -22,12 +22,14 @@
 //	–c:      Prefix a repetition count and a tab to each output line.
 //	         Implies –u and –d.
 //	-i:      Case insensitive comparison of lines.
+package main
+
+// TODO: implement these flags:
 //	–f num:  The first num fields together with any blanks before each are
 //	         ignored. A field is defined as a string of non–space, non–tab
 //	         characters separated by tabs and spaces from its neighbors.
-//	-cn num: The first num characters are ignored. Fields are skipped before
+//	-s num: The first num characters are ignored. Fields are skipped before
 //	         characters.
-package main
 
 // TODO(aam): -num and +num are not implemented. they're easy to do, just not exactly the
 // way that the plan9 uniq does them as we want to avoid polluting the flag parsing libs with
@@ -54,10 +56,7 @@ var (
 // var cnum = flag.Int("cn", 0, "ignore num characters from beginning of line")
 
 func shouldPrint(unique, duplicates bool, cnt int) bool {
-	if unique && cnt > 1 {
-		return false
-	}
-	if duplicates && cnt == 1 {
+	if unique && cnt > 1 || duplicates && cnt == 1 {
 		return false
 	}
 	return true
@@ -102,30 +101,23 @@ func uniq(r io.Reader, w io.Writer, unique, duplicates, count bool, equal func(a
 	return nil
 }
 
-func runOnFile(fn string, stdout io.Writer, unique bool, duplicates bool, count bool, eq func(a []byte, b []byte) bool) error {
-	f, err := os.Open(fn)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-	return uniq(f, stdout, unique, duplicates, count, eq)
-}
-
 func run(stdin io.Reader, stdout io.Writer, unique, duplicates, count, ignoreCase bool, args []string) error {
-	var eq func(a, b []byte) bool
+	eq := bytes.Equal
 	if ignoreCase {
 		eq = bytes.EqualFold
-	} else {
-		eq = bytes.Equal
 	}
 	if len(args) == 0 {
 		return uniq(stdin, stdout, unique, duplicates, count, eq)
 	}
 	for _, fn := range args {
-		err := runOnFile(fn, stdout, unique, duplicates, count, eq)
+		f, err := os.Open(fn)
 		if err != nil {
 			return err
 		}
+		if err := uniq(f, stdout, unique, duplicates, count, eq); err != nil {
+			return err
+		}
+		_ = f.Close()
 	}
 	return nil
 }

--- a/cmds/core/uniq/uniq_test.go
+++ b/cmds/core/uniq/uniq_test.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"strings"
 	"testing"
+	"testing/iotest"
 )
 
 func TestUniq(t *testing.T) {
@@ -67,7 +68,7 @@ func TestUniq(t *testing.T) {
 			name:   "file 2 uniques == true",
 			args:   []string{"testdata/file2.txt"},
 			unique: true,
-			want:   "u-root\nuniq\nteam\nbinaries\ntest\nTest\n\n",
+			want:   "u-root\nuniq\nteam\nbinaries\ntest\nTest\n",
 		},
 		{
 			name:       "file 2 duplicates == true",
@@ -82,7 +83,37 @@ func TestUniq(t *testing.T) {
 			want:       "u-root\nuniq\nron\nteam\nbinaries\ntest\n\n",
 		},
 		{
-			name:   "no args given use stdin",
+			name:    "error reading from stdin 1",
+			args:    nil,
+			wantErr: iotest.ErrTimeout.Error(),
+			stdin:   iotest.ErrReader(iotest.ErrTimeout),
+		},
+		{
+			name:    "error reading from stdin 2",
+			args:    nil,
+			wantErr: iotest.ErrTimeout.Error(),
+			stdin:   io.MultiReader(strings.NewReader("go\n"), iotest.ErrReader(iotest.ErrTimeout)),
+		},
+		{
+			name:  "stdin empty input",
+			args:  nil,
+			want:  "",
+			stdin: strings.NewReader(""),
+		},
+		{
+			name:  "stdin one string",
+			args:  nil,
+			want:  "go\n",
+			stdin: strings.NewReader("go\n"),
+		},
+		{
+			name:  "stdin three identical strings",
+			args:  nil,
+			want:  "go\n",
+			stdin: strings.NewReader("go\ngo\ngo\n"),
+		},
+		{
+			name:   "stdin and unique",
 			args:   nil,
 			unique: true,
 			stdin:  strings.NewReader("go\nu-root\ngo\ngo\ngo\n"),
@@ -103,6 +134,9 @@ func TestUniq(t *testing.T) {
 					t.Errorf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
 				}
 			} else {
+				if len(tt.wantErr) > 0 {
+					t.Errorf("runUniq() = <nil>, want %q", tt.wantErr)
+				}
 				if buf.String() != tt.want {
 					t.Errorf("runUniq() = %q, want %q", buf.String(), tt.want)
 				}

--- a/cmds/core/uniq/uniq_test.go
+++ b/cmds/core/uniq/uniq_test.go
@@ -6,9 +6,12 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"log"
+	"os"
 	"strings"
+	"syscall"
 	"testing"
 	"testing/iotest"
 )
@@ -22,13 +25,17 @@ func TestUniq(t *testing.T) {
 		count      bool
 		ignoreCase bool
 		want       string
-		wantErr    string
+		wantErr    error
 		stdin      io.Reader
 	}{
 		{
-			name:    "file 1 with wrong file",
-			args:    []string{"filedoesnotexist"},
-			wantErr: "open filedoesnotexist: no such file or directory",
+			name: "file 1 with wrong file",
+			args: []string{"filedoesnotexist"},
+			wantErr: &os.PathError{
+				Op:   "open",
+				Path: "filedoesnotexist",
+				Err:  syscall.Errno(2),
+			},
 		},
 		{
 			name: "file 1 without any flag",
@@ -85,13 +92,13 @@ func TestUniq(t *testing.T) {
 		{
 			name:    "error reading from stdin 1",
 			args:    nil,
-			wantErr: iotest.ErrTimeout.Error(),
+			wantErr: iotest.ErrTimeout,
 			stdin:   iotest.ErrReader(iotest.ErrTimeout),
 		},
 		{
 			name:    "error reading from stdin 2",
 			args:    nil,
-			wantErr: iotest.ErrTimeout.Error(),
+			wantErr: iotest.ErrTimeout,
 			stdin:   io.MultiReader(strings.NewReader("go\n"), iotest.ErrReader(iotest.ErrTimeout)),
 		},
 		{
@@ -130,12 +137,24 @@ func TestUniq(t *testing.T) {
 		log.SetOutput(buf)
 		t.Run(tt.name, func(t *testing.T) {
 			if got := run(tt.stdin, buf, tt.unique, tt.duplicates, tt.count, tt.ignoreCase, tt.args); got != nil {
-				if got.Error() != tt.wantErr {
-					t.Errorf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
+				var gotPathErr *os.PathError
+				var wantPathErr *os.PathError
+				if errors.As(got, &gotPathErr) && errors.As(tt.wantErr, &wantPathErr) {
+					if gotPathErr.Op != wantPathErr.Op {
+						t.Fatalf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
+					}
+					if gotPathErr.Path != wantPathErr.Path {
+						t.Fatalf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
+					}
+					if !errors.Is(gotPathErr.Err, wantPathErr.Err) {
+						t.Fatalf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
+					}
+				} else if !errors.Is(got, tt.wantErr) {
+					t.Fatalf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
 				}
 			} else {
-				if len(tt.wantErr) > 0 {
-					t.Errorf("runUniq() = <nil>, want %q", tt.wantErr)
+				if tt.wantErr != nil {
+					t.Fatalf("runUniq() = <nil>, want %q", tt.wantErr)
 				}
 				if buf.String() != tt.want {
 					t.Errorf("runUniq() = %q, want %q", buf.String(), tt.want)

--- a/cmds/core/uniq/uniq_test.go
+++ b/cmds/core/uniq/uniq_test.go
@@ -11,7 +11,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"syscall"
 	"testing"
 	"testing/iotest"
 )
@@ -29,13 +28,9 @@ func TestUniq(t *testing.T) {
 		stdin      io.Reader
 	}{
 		{
-			name: "file 1 with wrong file",
-			args: []string{"filedoesnotexist"},
-			wantErr: &os.PathError{
-				Op:   "open",
-				Path: "filedoesnotexist",
-				Err:  syscall.Errno(2),
-			},
+			name:    "file 1 with wrong file",
+			args:    []string{"filedoesnotexist"},
+			wantErr: os.ErrNotExist,
 		},
 		{
 			name: "file 1 without any flag",
@@ -137,19 +132,7 @@ func TestUniq(t *testing.T) {
 		log.SetOutput(buf)
 		t.Run(tt.name, func(t *testing.T) {
 			if got := run(tt.stdin, buf, tt.unique, tt.duplicates, tt.count, tt.ignoreCase, tt.args); got != nil {
-				var gotPathErr *os.PathError
-				var wantPathErr *os.PathError
-				if errors.As(got, &gotPathErr) && errors.As(tt.wantErr, &wantPathErr) {
-					if gotPathErr.Op != wantPathErr.Op {
-						t.Fatalf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
-					}
-					if gotPathErr.Path != wantPathErr.Path {
-						t.Fatalf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
-					}
-					if !errors.Is(gotPathErr.Err, wantPathErr.Err) {
-						t.Fatalf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
-					}
-				} else if !errors.Is(got, tt.wantErr) {
+				if !errors.Is(got, tt.wantErr) {
 					t.Fatalf("runUniq() = %q, want %q", got.Error(), tt.wantErr)
 				}
 			} else {


### PR DESCRIPTION
With the help of the LLM OpenCode Zen Big Pickle, I discovered the following bug in `uniq`:

```bash
$ printf "foo\nfoo\nbar\nbaz\nbaz" | uniq -u # using GNU uniq
# fine
bar

$ printf "foo\nfoo\nbar\nbaz\nbaz" | go run ./cmds/core/uniq -u
# oops!
bar
baz
```

The current implementation falls over when the input ends with two or more duplicate strings but no `\n` character at the end.

After brainstorming ways forward with the LLM, I decided to rewrite the implementation with TDD.

Also, it turns out I didn't need to add a new test case, as the pre-existing test "file 2 uniques == true" was already encoding the bug by accident.