### PR TITLE
dd: cover notrunc writes to the same file

### DIFF
--- a/cmds/core/dd/dd_test.go
+++ b/cmds/core/dd/dd_test.go
@@ -523,6 +523,34 @@ func TestFiles(t *testing.T) {
 	}
 }
 
+func TestFilesSameInputOutputNotrunc(t *testing.T) {
+	tmpDir := t.TempDir()
+	dataFile := filepath.Join(tmpDir, "dataFile")
+	if err := os.WriteFile(dataFile, []byte("abbbbbbbbbb"), 0o666); err != nil {
+		t.Fatal(err)
+	}
+
+	args := []string{
+		"if=" + dataFile,
+		"of=" + dataFile,
+		"conv=notrunc",
+		"seek=1",
+		"bs=1",
+		"count=10",
+	}
+	if err := run(&bytes.Buffer{}, &ws{Writer: io.Discard}, &ws{Writer: io.Discard}, "dd", args); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(dataFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []byte("aaaaaaaaaaa"); !reflect.DeepEqual(want, got) {
+		t.Errorf("run(if=of conv=notrunc seek=1 bs=1 count=10) = %q; want %q", got, want)
+	}
+}
+
 type testBS struct {
 	name string
 	dat  *bytes.Buffer

--- a/cmds/core/dd/dd_test.go
+++ b/cmds/core/dd/dd_test.go
@@ -432,6 +432,7 @@ func TestFiles(t *testing.T) {
 		flags    []string
 		inFile   []byte
 		outFile  []byte
+		sameFile bool
 		expected []byte
 	}{
 		{
@@ -473,6 +474,13 @@ func TestFiles(t *testing.T) {
 			expected: []byte("1234e"),
 		},
 		{
+			name:     "no truncate with same input and output",
+			flags:    []string{"conv=notrunc", "seek=1", "bs=1", "count=10"},
+			inFile:   []byte("abbbbbbbbbb"),
+			sameFile: true,
+			expected: []byte("aaaaaaaaaaa"),
+		},
+		{
 			// Fully testing the file is synchronous would require something more.
 			name:     "sync",
 			flags:    []string{"oflag=sync"},
@@ -504,15 +512,19 @@ func TestFiles(t *testing.T) {
 			if err := os.WriteFile(inFile, tt.inFile, 0o666); err != nil {
 				t.Error(err)
 			}
-			if err := os.WriteFile(outFile, tt.outFile, 0o666); err != nil {
-				t.Error(err)
+			if tt.sameFile {
+				outFile = inFile
+			} else {
+				if err := os.WriteFile(outFile, tt.outFile, 0o666); err != nil {
+					t.Error(err)
+				}
 			}
 
 			args := append(tt.flags, "if="+inFile, "of="+outFile)
 			if err := run(&bytes.Buffer{}, &ws{Writer: io.Discard}, &ws{Writer: io.Discard}, tt.name, args); err != nil {
 				t.Error(err)
 			}
-			got, err := os.ReadFile(filepath.Join(tmpDir, "outFile"))
+			got, err := os.ReadFile(outFile)
 			if err != nil {
 				t.Error(err)
 			}
@@ -520,34 +532,6 @@ func TestFiles(t *testing.T) {
 				t.Errorf("expected %q, got %q", tt.expected, got)
 			}
 		})
-	}
-}
-
-func TestFilesSameInputOutputNotrunc(t *testing.T) {
-	tmpDir := t.TempDir()
-	dataFile := filepath.Join(tmpDir, "dataFile")
-	if err := os.WriteFile(dataFile, []byte("abbbbbbbbbb"), 0o666); err != nil {
-		t.Fatal(err)
-	}
-
-	args := []string{
-		"if=" + dataFile,
-		"of=" + dataFile,
-		"conv=notrunc",
-		"seek=1",
-		"bs=1",
-		"count=10",
-	}
-	if err := run(&bytes.Buffer{}, &ws{Writer: io.Discard}, &ws{Writer: io.Discard}, "dd", args); err != nil {
-		t.Fatal(err)
-	}
-
-	got, err := os.ReadFile(dataFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := []byte("aaaaaaaaaaa"); !reflect.DeepEqual(want, got) {
-		t.Errorf("run(if=of conv=notrunc seek=1 bs=1 count=10) = %q; want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fold the same-file `conv=notrunc` regression case into the existing `TestFiles` table.
- Cover `dd if=file of=file conv=notrunc seek=1 bs=1 count=10` through the command `run` path with real temp files.
- Current `main` already produces the GNU-style cascading overwrite on the toolchains I tested, so this keeps that behavior covered without changing production code.

Refs #878

## Validation

- `GOTOOLCHAIN=go1.25.7 go test ./cmds/core/dd -run 'TestFiles/no_truncate_with_same_input_and_output' -count=1`
- `GOTOOLCHAIN=go1.25.7 go test ./cmds/core/dd -count=1`
- `GOTOOLCHAIN=go1.25.7 go run honnef.co/go/tools/cmd/staticcheck@latest ./cmds/core/dd`
- `git diff --check`
- `GOTOOLCHAIN=go1.25.7 go test ./cmds/core/... -count=1` fails on this Darwin machine outside `cmds/core/dd` due existing Linux-specific build/test assumptions; `cmds/core/dd` passed in that broader run.

## AI Usage

Tool: OpenAI GPT-5

Extent: issue triage, regression-test drafting, validation review, and PR text. I reviewed the diff and ran the validation commands above locally before submission.
