### PR TITLE
pkg/core/cp: respect working dir for multi-source target

### DIFF
--- a/pkg/core/cp/cp.go
+++ b/pkg/core/cp/cp.go
@@ -284,7 +284,7 @@ func (c *command) RunContext(ctx context.Context, args ...string) error {
 	todir := false
 	from, to := fs.Args()[:fs.NArg()-1], fs.Args()[fs.NArg()-1]
 
-	toStat, err := os.Stat(to)
+	toStat, err := os.Stat(c.ResolvePath(to))
 	if err == nil {
 		todir = toStat.IsDir()
 	}

--- a/pkg/core/cp/cp_test.go
+++ b/pkg/core/cp/cp_test.go
@@ -135,3 +135,31 @@ func TestCopySimple(t *testing.T) {
 		}
 	}
 }
+
+func TestRunMultipleSourcesWithWorkingDirDestination(t *testing.T) {
+	workingDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workingDir, "out"), 0755); err != nil {
+		t.Fatalf(`Mkdir("out") = %v, want nil`, err)
+	}
+	for _, name := range []string{"file1", "file2"} {
+		if err := os.WriteFile(filepath.Join(workingDir, name), []byte(name), 0644); err != nil {
+			t.Fatalf(`WriteFile(%q) = %v, want nil`, name, err)
+		}
+	}
+
+	cmd := New()
+	cmd.SetWorkingDir(workingDir)
+	if err := cmd.Run("file1", "file2", "out"); err != nil {
+		t.Fatalf(`Run("file1", "file2", "out") = %v, want nil`, err)
+	}
+
+	for _, name := range []string{"file1", "file2"} {
+		got, err := os.ReadFile(filepath.Join(workingDir, "out", name))
+		if err != nil {
+			t.Fatalf(`ReadFile("out/%s") = %v, want nil`, name, err)
+		}
+		if string(got) != name {
+			t.Errorf(`ReadFile("out/%s") = %q, want %q`, name, string(got), name)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3593.

## Summary
- resolve the final `cp` destination through the command working directory before checking whether a multi-source target is a directory
- add a regression test for `cp file1 file2 out` with `SetWorkingDir`, where `out` exists under the command working directory

## Verification
- `GOTOOLCHAIN=go1.25.7 go test ./pkg/core/cp -run TestRunMultipleSourcesWithWorkingDirDestination -count=1`
- `GOTOOLCHAIN=go1.25.7 go test ./pkg/core/cp -count=1`
- `GOTOOLCHAIN=go1.25.7 go test ./cmds/core/cp -count=1`
- `GOTOOLCHAIN=go1.25.7 go test ./pkg/core/cp ./cmds/core/cp -count=1`
- `GOTOOLCHAIN=go1.25.7 go test -race ./pkg/core/cp ./cmds/core/cp -count=1`
- `GOTOOLCHAIN=go1.25.7 go run honnef.co/go/tools/cmd/staticcheck@latest ./pkg/core/cp ./cmds/core/cp`
- `git diff HEAD^ --check`

## AI usage
OpenAI GPT-5 assisted with test drafting, implementation, and local verification. I reviewed the change and verified the commands above locally.
