### PR TITLE
tar: preserve relative names with working directory

### DIFF
--- a/pkg/core/tar/tar.go
+++ b/pkg/core/tar/tar.go
@@ -117,6 +117,9 @@ func (t *Tar) execute(args []string) error {
 	if t.verbose {
 		opts.Filters = []tarutil.Filter{tarutil.VerboseFilter}
 	}
+	if t.WorkingDir != "" {
+		opts.ChangeDirectory = t.WorkingDir
+	}
 
 	// Resolve file path relative to working directory
 	filePath := t.ResolvePath(t.file)
@@ -128,13 +131,7 @@ func (t *Tar) execute(args []string) error {
 			return err
 		}
 
-		// Resolve all input paths relative to working directory
-		resolvedArgs := make([]string, len(args))
-		for i, arg := range args {
-			resolvedArgs[i] = t.ResolvePath(arg)
-		}
-
-		if err := tarutil.CreateTar(f, resolvedArgs, opts); err != nil {
+		if err := tarutil.CreateTar(f, args, opts); err != nil {
 			f.Close()
 			return err
 		}

--- a/pkg/core/tar/tar.go
+++ b/pkg/core/tar/tar.go
@@ -117,9 +117,7 @@ func (t *Tar) execute(args []string) error {
 	if t.verbose {
 		opts.Filters = []tarutil.Filter{tarutil.VerboseFilter}
 	}
-	if t.WorkingDir != "" {
-		opts.ChangeDirectory = t.WorkingDir
-	}
+	opts.ChangeDirectory = t.WorkingDir
 
 	// Resolve file path relative to working directory
 	filePath := t.ResolvePath(t.file)

--- a/pkg/core/tar/tar.go
+++ b/pkg/core/tar/tar.go
@@ -143,9 +143,7 @@ func (t *Tar) execute(args []string) error {
 		}
 		defer f.Close()
 
-		// Resolve extract directory path
-		extractDir := t.ResolvePath(args[0])
-		if err := tarutil.ExtractDir(f, extractDir, opts); err != nil {
+		if err := tarutil.ExtractDir(f, args[0], opts); err != nil {
 			return err
 		}
 	case t.list:

--- a/pkg/core/tar/tar_test.go
+++ b/pkg/core/tar/tar_test.go
@@ -7,6 +7,8 @@ package tar
 import (
 	"bytes"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -95,6 +97,31 @@ func TestTarWithAbsolutePaths(t *testing.T) {
 	// Skip this test as it's not working correctly with absolute paths
 	// This would need more investigation into how tarutil handles absolute paths
 	t.Skip("Skipping test with absolute paths")
+}
+
+func TestCreateWithWorkingDirKeepsRelativeArchiveNames(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "file"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tar := New().(*Tar)
+	tar.SetWorkingDir(tmpDir)
+	if err := tar.Run("-cf", "file.tar", "file"); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout bytes.Buffer
+	tar = New().(*Tar)
+	tar.SetWorkingDir(tmpDir)
+	tar.SetIO(nil, &stdout, nil)
+	if err := tar.Run("-tf", "file.tar"); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := strings.TrimSpace(stdout.String()); got != "file" {
+		t.Errorf(`Tar("-tf", "file.tar") = %q; want "file"`, got)
+	}
 }
 
 func TestValidateErrors(t *testing.T) {


### PR DESCRIPTION
## Summary
- pass the command working directory to tarutil when creating archives
- keep create inputs relative so archive entries remain relative to the working directory
- add regression coverage for creating and listing a tar archive with `SetWorkingDir`

Fixes #3481

## AI assistance
OpenAI GPT-5 helped draft this patch and verification notes; I reviewed the diff and ran the checks listed below.

## Verification
Red test before the fix:
- `GOTOOLCHAIN=go1.25.7 go test ./pkg/core/tar -run TestCreateWithWorkingDirKeepsRelativeArchiveNames -count=1` failed with `Rel: can't make .../file relative to`

After the fix:
- `GOTOOLCHAIN=go1.25.7 go test ./pkg/core/tar -run TestCreateWithWorkingDirKeepsRelativeArchiveNames -count=1`
- `GOTOOLCHAIN=go1.25.7 go test ./pkg/core/tar ./cmds/core/tar -count=1`
- `GOTOOLCHAIN=go1.25.7 go test -race ./pkg/core/tar ./cmds/core/tar -count=1`
- `GOTOOLCHAIN=go1.25.7 go run honnef.co/go/tools/cmd/staticcheck@latest ./pkg/core/tar ./cmds/core/tar`
- `git diff --check`
