### PR TITLE
wget: write stdout output directly

### DIFF
--- a/cmds/core/wget/wget.go
+++ b/cmds/core/wget/wget.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -120,9 +121,6 @@ func (c *cmd) run() error {
 	if c.outputPath == "" {
 		c.outputPath = defaultOutputPath(parsedURL.Path)
 	}
-	if c.outputPath == "-" {
-		c.outputPath = "/dev/stdout"
-	}
 
 	schemes := curl.Schemes{
 		"tftp": curl.DefaultTFTPClient,
@@ -136,6 +134,11 @@ func (c *cmd) run() error {
 	reader, err := schemes.FetchWithoutCache(context.Background(), parsedURL)
 	if err != nil {
 		return fmt.Errorf("failed to download %v: %w", c.url, err)
+	}
+
+	if c.outputPath == "-" {
+		_, err := io.Copy(os.Stdout, reader)
+		return err
 	}
 
 	if err := uio.ReadIntoFile(reader, c.outputPath); err != nil {

--- a/cmds/core/wget/wget_test.go
+++ b/cmds/core/wget/wget_test.go
@@ -12,6 +12,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -226,12 +227,33 @@ func TestStdout(t *testing.T) {
 	srv := httptest.NewServer(handler{})
 	defer srv.Close()
 
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldStdout := os.Stdout
+	os.Stdout = w
+	t.Cleanup(func() {
+		os.Stdout = oldStdout
+		r.Close()
+		w.Close()
+	})
+
 	c, err := command([]string{"wget", "-O", "-", fmt.Sprintf("%s/200", srv.URL)}...)
 	if err != nil {
 		t.Errorf("expected nil got %v", err)
 	}
-	err = c.run()
-	if err != nil {
+	if err := c.run(); err != nil {
 		t.Errorf("expected nil got %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != content {
+		t.Errorf("stdout = %q; want %q", string(got), content)
 	}
 }


### PR DESCRIPTION
## Summary
- write `wget -O -` responses directly to `os.Stdout` instead of `/dev/stdout`
- avoid platform-specific device-file open behavior for stdout output
- update the stdout regression test to capture and verify the downloaded body

Follow-up to #2387.

## AI assistance
OpenAI GPT-5 helped draft this patch and run verification. This disclosure is included per `AI_POLICY.md`.

## Verification
Red test before the fix:
- `GOTOOLCHAIN=go1.25.7 go test ./cmds/core/wget -run TestStdout -count=1 -v` failed with `open /dev/stdout: permission denied`; after strengthening the test it also showed `stdout = ""; want "Very simple web server"`

After the fix:
- `GOTOOLCHAIN=go1.25.7 go test ./cmds/core/wget -run TestStdout -count=1 -v`
- `GOTOOLCHAIN=go1.25.7 go test ./cmds/core/wget -count=1`
- `GOTOOLCHAIN=go1.25.7 go test -race ./cmds/core/wget -count=1`
- `GOTOOLCHAIN=go1.25.7 go run honnef.co/go/tools/cmd/staticcheck@latest ./cmds/core/wget`
- `git diff --check`
