### PR TITLE
cmds/core/mv: move file if it's missing

### DIFF
--- a/cmds/core/mv/mv.go
+++ b/cmds/core/mv/mv.go
@@ -50,10 +50,12 @@ func moveFile(source string, dest string, update bool, noClobber bool) error {
 		}
 
 		destInfo, err := os.Lstat(dest)
+		if errors.Is(err, os.ErrNotExist) {
+			return os.Rename(source, dest)
+		}
 		if err != nil {
 			return err
 		}
-
 		// Check if the destination already exists and was touched later than the source
 		if destInfo.ModTime().After(sourceInfo.ModTime()) {
 			// Source is older and we don't want to "downgrade"

--- a/cmds/core/mv/mv_test.go
+++ b/cmds/core/mv/mv_test.go
@@ -74,11 +74,10 @@ func TestMove(t *testing.T) {
 			name:  "mv logFatalf err",
 			files: []string{filepath.Join(d, "hi1.txt"), filepath.Join(d, "hi3.txt")},
 			args:  []string{"-u"},
-			err:   os.ErrNotExist,
 		},
 		{
 			name:  "no flags no error",
-			files: []string{filepath.Join(d, "hi1.txt"), filepath.Join(d, "hi1_new.txt")},
+			files: []string{filepath.Join(d, "hi3.txt"), filepath.Join(d, "hi1_new.txt")},
 		},
 		{
 			name:  "not enough args",
@@ -151,10 +150,9 @@ func TestMoveFile(t *testing.T) {
 			err:  os.ErrNotExist,
 		},
 		{
-			name: "second file in update path does not exist",
+			name: "second file in update path does not exist, -u should work",
 			src:  filepath.Join(d, "hi2.txt"),
 			dst:  filepath.Join(d, "hi3.txt"),
-			err:  os.ErrNotExist,
 		},
 	}
 


### PR DESCRIPTION
move only when the SOURCE file is newer than the destination file or when the destination file is missing