### PR TITLE
Packages and utilities for ssh and 9P

### DIFF
--- a/cmds/core/mount9p/mount9p.go
+++ b/cmds/core/mount9p/mount9p.go
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Google LLC
+//
+// Mount9p mounts a 9P server with the transport=fd method, optionally using SSH
+// for the transport.
+//
+//	mount9p -ssh -private_key ~/.ssh/id_rsa /path/to/mount [::1]:1234
+
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"github.com/u-root/u-root/pkg/ssh9p"
+	"github.com/u-root/u-root/pkg/sshstream"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	onto        string // Where to mount onto.
+	addr        string // Address:port to dial.
+	useSSH      = flag.Bool("ssh", false, "Use ssh for transport")
+	privateKey  = flag.String("private_key", "id_rsa", "Path to your private key")
+	fastTimeout = flag.Bool("fast_timeout", false, "Quickly timeout server connections")
+)
+
+// Run does the mount and blocks if necessary.  Cancel the context to unblock
+// it and kill the client side of the mount server.
+func run(ctx context.Context) error {
+	var cfg *ssh.ClientConfig
+	if *useSSH {
+		ncfg, err := sshstream.NewClientConfig(*privateKey, ssh.InsecureIgnoreHostKey())
+		if err != nil {
+			return err
+		}
+		cfg = ncfg
+	}
+
+	c, err := net.Dial("tcp", addr)
+	if err != nil {
+		return err
+	}
+	defer c.Close()
+
+	ready := make(chan bool)
+	go func() {
+		if <-ready {
+			fmt.Println("Mount ready at", onto)
+		}
+	}()
+	// If we blocked for ssh, err will be non-nil.
+	return ssh9p.Mount9P(ctx, ready, c, onto, ssh9p.WithSSHClient(cfg), ssh9p.WithUnixFlags(unix.MS_NOSUID|unix.MS_NODEV), ssh9p.WithFastTCPTimeout(*fastTimeout))
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	flag.Parse()
+	if flag.NArg() != 2 {
+		fmt.Printf("Usage: %s [options] <onto> <addr>\n\n", os.Args[0])
+		flag.Usage()
+		return
+	}
+	onto = flag.Arg(0)
+	addr = flag.Arg(1)
+
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmds/core/ufs/ufs.go
+++ b/cmds/core/ufs/ufs.go
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Google LLC
+//
+// Ufs runs a 9p server.
+//
+// Start the server:
+//
+//	ufs :3333 -root /path/to/share
+//
+// Then, connect using the Linux 9P filesystem:
+//
+//	mount -t 9p -o trans=tcp,port=3333 127.0.0.1 /mnt
+//
+// IPv6 mounts either require a fairly recent Linux, containing a22a29655c42
+// ("net/9p/fd: support ipv6 for trans=tcp"), or the use of a helper program
+// using 9p_fd, e.g. mount9p.
+//
+// To serve using ssh:
+//
+//	ufs :3333 -ssh \
+//		-authorized_keys ~/.ssh/authorized_keys \
+//		-hostkey ~/.ssh/id_rsa
+//
+// You'll need to use the mount9p client to connect to the ssh-enabled server.
+
+//go:build linux
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"github.com/hugelgupf/p9/p9"
+	"github.com/u-root/cpu/client"
+	"github.com/u-root/u-root/pkg/p9dev"
+	"github.com/u-root/u-root/pkg/ssh9p"
+	"github.com/u-root/u-root/pkg/sshstream"
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	addr           string // IP address:port to listen on.
+	root           = flag.String("root", "/", "Root of file system to serve")
+	useSSH         = flag.Bool("ssh", false, "Use ssh for transport")
+	authorizedKeys = flag.String("authorized_keys", "authorized_keys", "Path to the authorized_keys file")
+	hostkey        = flag.String("hostkey", "id_rsa", "Path to the host's private key")
+	// Flag is nodevmap, just like in 9p2000.u.
+	noDevMap = flag.Bool("nodevmap", false, "Pretend special device files are regular files")
+)
+
+func run(ctx context.Context) error {
+	var cfg *ssh.ServerConfig
+	if *useSSH {
+		_cfg, err := sshstream.NewServerConfig(*authorizedKeys, *hostkey)
+		if err != nil {
+			return fmt.Errorf("cfg: %w", err)
+		}
+		cfg = _cfg
+	}
+
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return fmt.Errorf("bind: %w", err)
+	}
+	defer l.Close()
+
+	var attacher p9.Attacher
+	attacher = client.NewCPU9P(*root)
+	if *noDevMap {
+		attacher = p9dev.New(attacher)
+	}
+
+	server := ssh9p.NewServer(p9.NewServer(attacher), ssh9p.WithSSHServer(cfg))
+	if err := server.Serve(ctx, l); err != nil {
+		return fmt.Errorf("serve: %w", err)
+	}
+	return nil
+}
+
+func main() {
+	log.SetFlags(log.LstdFlags | log.Lshortfile)
+	flag.Parse()
+	if flag.NArg() != 1 {
+		fmt.Printf("Usage: %s [options] <addr>\n\n", os.Args[0])
+		flag.Usage()
+		return
+	}
+	addr = flag.Arg(0)
+
+	if err := run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/google/go-containerregistry v0.20.6 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/hugelgupf/p9 v0.3.0 // indirect
+	github.com/hugelgupf/p9 v0.4.1 // indirect
 	github.com/jaypipes/pcidb v1.0.0 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 )
 
 require (
+	github.com/hugelgupf/p9 v0.4.1
 	github.com/jaypipes/ghw v0.12.0
 	github.com/pkg/sftp v1.13.9
 	github.com/sirupsen/logrus v1.9.3
@@ -77,7 +78,6 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/google/go-containerregistry v0.20.6 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
-	github.com/hugelgupf/p9 v0.4.1 // indirect
 	github.com/jaypipes/pcidb v1.0.0 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,10 +127,10 @@ github.com/hexdigest/gowrap v1.1.7/go.mod h1:Z+nBFUDLa01iaNM+/jzoOA1JJ7sm51rnYFa
 github.com/hexdigest/gowrap v1.1.8/go.mod h1:H/JiFmQMp//tedlV8qt2xBdGzmne6bpbaSuiHmygnMw=
 github.com/hugelgupf/go-shlex v0.0.0-20200702092117-c80c9d0918fa h1:s3KPo0nThtvjEamF/aElD4k5jSsBHew3/sgNTnth+2M=
 github.com/hugelgupf/go-shlex v0.0.0-20200702092117-c80c9d0918fa/go.mod h1:I1uW6ymzwsy5TlQgD1bFAghdMgBYqH1qtCeHoZgHMqs=
-github.com/hugelgupf/p9 v0.3.0 h1:cjn7I237wQ8DN7OTXKRWieaSILW2M8H8hoXnFy5mwgk=
-github.com/hugelgupf/p9 v0.3.0/go.mod h1:QFmcCPNn66imQcu1wUqJ8sHKxYjs00Gq60QLjt9E+VI=
-github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 h1:/jC7qQFrv8CrSJVmaolDVOxTfS9kc36uB6H40kdbQq8=
-github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714/go.mod h1:2Goc3h8EklBH5mspfHFxBnEoURQCGzQQH1ga9Myjvis=
+github.com/hugelgupf/p9 v0.4.1 h1:04RUBWSYlvP38QX8At5VXnMTg9qNEnbP/548aMLtfsk=
+github.com/hugelgupf/p9 v0.4.1/go.mod h1:LoNwfBWP+QlCkjS1GFNylCthRIk/TkMZd6ICTbC+hrI=
+github.com/hugelgupf/socketpair v0.0.0-20230822150718-707395b1939a h1:Nq7wDsqsVBUBfGn8yB1M028ShWTKTtZBcafaTJ35N0s=
+github.com/hugelgupf/socketpair v0.0.0-20230822150718-707395b1939a/go.mod h1:71Bqb5Fh9zPHF8jwdmMEmJObzr25Mx5pWLbDBMMEn6E=
 github.com/hugelgupf/vmtest v0.0.0-20240307030256-5d9f3d34a58d h1:nP8SfQJqruIVSWYJTuYc37jLHEY1Z0fF+zKSrs3K/C8=
 github.com/hugelgupf/vmtest v0.0.0-20240307030256-5d9f3d34a58d/go.mod h1:B63hDJMhTupLWCHwopAyEo7wRFowx9kOc8m8j1sfOqE=
 github.com/insomniacslk/dhcp v0.0.0-20231206064809-8c70d406f6d2 h1:9K06NfxkBh25x56yVhWWlKFE8YpicaSfHwoV8SFbueA=
@@ -515,8 +515,6 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.56.3 h1:8I4C0Yq1EjstUzUJzpcRVbuYA2mODtEmpWiQoN/b2nc=
-google.golang.org/grpc v1.56.3/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/p9dev/p9dev.go
+++ b/pkg/p9dev/p9dev.go
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Google LLC
+//
+// Package p9dev wraps a p9 Attacher such that devices can be accessed as
+// regular files.
+//
+// Linux is a pain when it comes to accessing special files, e.g. character or
+// block devices, across a mount point.  When you open a special file, you'll
+// get the file on the *client*, not the server.  Which can be surprising.
+//
+// Specifically, Linux's 9p client code (fs/9p/*) calls init_special_inode() on
+// special files, and the VFS will override the f_ops with the ops for the
+// client's OS's file, based on the major/minor number.
+//
+// This behavior is fine for something like a locally mounted disk.  Say you
+// have an ext4 filesystem on your local HDD and it has some /dev/ files, e.g.
+// /dev/console (a character device).  The intent there is that you have a
+// /dev/console that points to the console of the machine that is doing the
+// mount.  i.e. your root filesystem has these statically made device files
+// installed - they gotta come from somewhere!  (at least in Linux).
+//
+// In this sense, those special files are almost like symlinks.  Open
+// /dev/console?  That really means "open your magic local file 5-1".  Some
+// systems have /dev/ populated with all sorts of devices too; some that don't
+// even exist, but could!  e.g. /dev/sd*.  I've got "sdb15" (a blockdev), but
+// certainly don't have that 15 partitions on sdb.  If you try to open it,
+// you'll get something like ENXIO.
+//
+// A similar thing happens across a mount point.  e.g. the 9p server might have
+// 100 cpus in /dev/cpu/, but you only have 10.  If you ls /mnt/dev/cpu, you'll
+// see 100 cpus!  If you access /mnt/dev/cpu/0/cpuid, you're getting your *own*
+// /dev/cpu/0 (since they are both "quasi symlinks" to the magic chardev file).
+// If you try to access /mnt/dev/cpu/99/cpuid, you'll get ENXIO, just like with
+// /dev/sdb15.  Since the "link" points to a non-existent device.
+//
+// But when you access a 9P server, the server could intend to offer one of two
+// things:
+//
+//  1. Just like with ext4, it's trying to serve a root filesystem to you.
+//     e.g.  you're on a diskless machine and need some sort of /dev/.  Like a
+//     distro provided to you over 9p.  In this case, you want the chardevs of
+//     the client's OS.
+//
+//  2. It really wants you to access its character devices, just like in
+//     Plan 9.  It's all just reads and writes, and no file is special.  e.g.
+//     it wants you to read its cpuid file.  In this case, you don't want the
+//     Linux client (kernel module) to do anything special.
+//
+// To make things more confusing, Linux's mount has the 'nodev' option, which
+// prevents accessing special devices over a mount.  This is the client's way of
+// saying "i don't want to trust any random nodes on this filesystem".  But
+// there isn't really a way to say "i want to access character devices, but i
+// want it to be *their* devices".  At least not with the 9p client.  9p2000.u
+// has the "nodevmap" option which does that, but we're using 9p2000.L, which
+// does not.
+//
+// We could change the kernel code to add some form of "let me access the
+// server's special devices if it exposed them".  And just skip the
+// init_special_inode() call in v9fs_init_inode().  Your client would need to
+// know that you intend to serve special files, and then mount accordingly.
+// (Not a big deal.)  In this case, I think the device would still appear to be
+// a chardev, but the f_ops would still be v9fs's.  i.e. ls -l would say
+// chardev, I think.  Not sure if you'd need the nodev mount option here to
+// access the file.
+//
+// Alternatively, the server can rewrite the file mode for any special device
+// such that the client thinks it's a regular file and just does its reads and
+// writes.  Which is what this package does.  In this case, there's no special
+// mount option.  The server is explicitly giving access to its special files.
+// (By virtue of using this package).  It's in the best position to know whether
+// or not it needs this service.  The client can still do nodev (which is a good
+// idea in the scenario #2), though not a big deal.  The 'downside' is that the
+// client will see all special files as regular, which may be a little confusing
+// if you were expecting to ls /dev/console as see a chardev instead of a
+// regular file.  (But if you did that, I judge you somewhat).
+//
+// Finally, note that we explicitly do not allow mknod below.  The server is
+// giving access to a set of its device files.  It is not saying "and go ahead
+// and make and access *any* device file on my machine!  That's a benefit of the
+// server-side approach to this.  Though in general, no 9p server should let you
+// mknod on their machine.  It's like being able to make a symlink outside of
+// the root of the exported directory.  (And of the p9 servers I looked at, none
+// of them let you use mknod).  Also, mknod (with no caching) is the one path in
+// the v9fs code that doesn't do a stat before making an inode.  So if you
+// really wanted to mknod on the server in this #2 world, you'd need to unmount
+// (to destroy the dentry) or wait an unknown amount of time for the dentry to
+// die, then walk/open again.
+package p9dev
+
+import (
+	"syscall"
+
+	"github.com/hugelgupf/p9/p9"
+)
+
+type attacher struct {
+	p9.Attacher
+}
+
+// New wraps a p9.Attacher.
+func New(a p9.Attacher) p9.Attacher {
+	return &attacher{Attacher: a}
+}
+
+// Attach implements p9.Attach.
+func (a *attacher) Attach() (p9.File, error) {
+	f, err := a.Attacher.Attach()
+	if err != nil {
+		return nil, err
+	}
+	return &File{File: f}, nil
+}
+
+// File wraps a p9.File such that we can override stat (GetAttr) calls.
+// Note we need to override any p9.File interface functions that return a File.
+//
+// For example, Walk() walks from a directory to a child.  We want to ensure the
+// child is a p9Dev.File too, since the child is who we do the GetAttr call on.
+// If we just called the underlying p9.File's walk, e.g. func (l *Local) Walk(),
+// we'd get a p9.File that was e.g. &Local{path: l.path}.
+type File struct {
+	p9.File
+	// Can't implicitly embed, since p9.File and DefaultWalkGetAttr both
+	// implement WalkGetAttr.
+	defaultWalker p9.DefaultWalkGetAttr
+}
+
+// GetAttr tells the client that special files (S_IFIFO, S_IFBLK, S_IFCHR) are
+// regular files, allowing the Linux client to issue regular reads and writes.
+func (f *File) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+	qid, mask, attr, err := f.File.GetAttr(req)
+	if err != nil {
+		return qid, mask, attr, err
+	}
+	switch {
+	case attr.Mode.IsCharacterDevice(), attr.Mode.IsBlockDevice(), attr.Mode.IsNamedPipe():
+		attr.Mode = (attr.Mode & ^p9.FileModeMask) | p9.ModeRegular
+	}
+	return qid, mask, attr, err
+}
+
+// Mknod always fails, even if the underlying Attacher implements it (none of
+// them do btw...).
+//
+// We explicitly do not want to let the client make arbitrary nodes (chardev,
+// blockdev) on our filesystem.  It's one thing for us to export some special
+// devices of our machine to the client.  But if we let them mknod, they can
+// access any device we can access.
+func (f *File) Mknod(name string, mode p9.FileMode, major uint32, minor uint32, _ p9.UID, _ p9.GID) (p9.QID, error) {
+	return p9.QID{}, syscall.ENOSYS
+}
+
+// Walk wraps the underlying Walk, returning a p9dev.File.
+func (f *File) Walk(names []string) ([]p9.QID, p9.File, error) {
+	qids, newFile, err := f.File.Walk(names)
+	if err != nil {
+		return nil, nil, err
+	}
+	return qids, &File{File: newFile}, nil
+}
+
+// Create wraps the underlying Create, returning a p9dev.File.
+func (f *File) Create(name string, mode p9.OpenFlags, perms p9.FileMode, uid p9.UID, gid p9.GID) (p9.File, p9.QID, uint32, error) {
+	newFile, qid, i, err := f.File.Create(name, mode, perms, uid, gid)
+	if err != nil {
+		return nil, p9.QID{}, 0, err
+	}
+	return &File{File: newFile}, qid, i, nil
+}
+
+// WalkGetAttr calls the DefaultWalkGetAttr, i.e. return ENOSYS.  The p9 FS's
+// we're wrapping don't implement this, so no need for us to either.
+func (f *File) WalkGetAttr(names []string) ([]p9.QID, p9.File, p9.AttrMask, p9.Attr, error) {
+	return f.defaultWalker.WalkGetAttr(names)
+}

--- a/pkg/p9dev/p9dev_test.go
+++ b/pkg/p9dev/p9dev_test.go
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Google LLC
+package p9dev
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/hugelgupf/p9/p9"
+)
+
+type mockFile struct {
+	p9.File
+	attr p9.Attr
+}
+
+func (m *mockFile) GetAttr(req p9.AttrMask) (p9.QID, p9.AttrMask, p9.Attr, error) {
+	return p9.QID{}, req, m.attr, nil
+}
+
+func (m *mockFile) Walk(names []string) ([]p9.QID, p9.File, error) {
+	return nil, &mockFile{}, nil
+}
+
+func (m *mockFile) Create(name string, flags p9.OpenFlags, permissions p9.FileMode, uid p9.UID, gid p9.GID) (p9.File, p9.QID, uint32, error) {
+	return &mockFile{}, p9.QID{}, 0, nil
+}
+
+type mockAttacher struct {
+	p9.Attacher
+}
+
+func (m *mockAttacher) Attach() (p9.File, error) {
+	return &mockFile{}, nil
+}
+
+func TestGetAttr(t *testing.T) {
+	tests := []struct {
+		name     string
+		mode     p9.FileMode
+		wantMode p9.FileMode
+	}{
+		{
+			name:     "regular_file",
+			mode:     p9.ModeRegular,
+			wantMode: p9.ModeRegular,
+		},
+		{
+			name:     "directory",
+			mode:     p9.ModeDirectory,
+			wantMode: p9.ModeDirectory,
+		},
+		{
+			name:     "char_device",
+			mode:     p9.ModeCharacterDevice,
+			wantMode: p9.ModeRegular,
+		},
+		{
+			name:     "block_device",
+			mode:     p9.ModeBlockDevice,
+			wantMode: p9.ModeRegular,
+		},
+		{
+			name:     "fifo",
+			mode:     p9.ModeNamedPipe,
+			wantMode: p9.ModeRegular,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mf := &mockFile{attr: p9.Attr{Mode: tt.mode}}
+			f := &File{File: mf}
+			_, _, attr, err := f.GetAttr(p9.AttrMaskAll)
+			if err != nil {
+				t.Fatalf("GetAttr failed: %v", err)
+			}
+			if attr.Mode != tt.wantMode {
+				t.Errorf("GetAttr() mode = %v, want %v", attr.Mode, tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestMknod(t *testing.T) {
+	f := &File{File: &mockFile{}}
+	_, err := f.Mknod("foo", p9.ModeRegular, 0, 0, 0, 0)
+	if err != syscall.ENOSYS {
+		t.Errorf("Mknod() error = %v, want %v", err, syscall.ENOSYS)
+	}
+}
+
+func TestWalk(t *testing.T) {
+	f := &File{File: &mockFile{}}
+	_, newFile, err := f.Walk(nil)
+	if err != nil {
+		t.Fatalf("Walk failed: %v", err)
+	}
+	if _, ok := newFile.(*File); !ok {
+		t.Errorf("Walk() returned %T, want *File", newFile)
+	}
+}
+
+func TestCreate(t *testing.T) {
+	f := &File{File: &mockFile{}}
+	newFile, _, _, err := f.Create("foo", p9.ReadOnly, p9.ModeRegular, 0, 0)
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	if _, ok := newFile.(*File); !ok {
+		t.Errorf("Create() returned %T, want *File", newFile)
+	}
+}
+
+func TestWalkGetAttr(t *testing.T) {
+	f := &File{File: &mockFile{}}
+	_, _, _, _, err := f.WalkGetAttr(nil)
+	_, _, _, _, wantErr := f.defaultWalker.WalkGetAttr(nil)
+	if err != wantErr {
+		t.Errorf("WalkGetAttr() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestNew(t *testing.T) {
+	a := New(&mockAttacher{})
+	f, err := a.Attach()
+	if err != nil {
+		t.Fatalf("Attach failed: %v", err)
+	}
+	if _, ok := f.(*File); !ok {
+		t.Errorf("Attach() returned %T, want *File", f)
+	}
+}

--- a/pkg/ssh9p/ssh9p.go
+++ b/pkg/ssh9p/ssh9p.go
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Google LLC
+//
+// Package ssh9p provides functions to serve and mount 9P servers over SSH.
+
+//go:build linux
+
+package ssh9p
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"os"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/hugelgupf/p9/p9"
+	"github.com/u-root/u-root/pkg/sshstream"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
+)
+
+// Server wraps a p9 Server with optional SSH support.
+type Server struct {
+	*p9.Server
+	cfg *ssh.ServerConfig
+}
+
+// ServerOpt is an option function.
+type ServerOpt func(s *Server)
+
+// WithSSHServer uses SSH for the 9P server's transport.
+func WithSSHServer(cfg *ssh.ServerConfig) ServerOpt {
+	return func(s *Server) {
+		s.cfg = cfg
+	}
+}
+
+// NewServer wraps a p9.Server.
+func NewServer(p9s *p9.Server, opts ...ServerOpt) *Server {
+	s := &Server{Server: p9s}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+	return s
+}
+
+// Serve handles requests from the listener.  Will close the listener when the
+// context is done.
+func (s *Server) Serve(ctx context.Context, l net.Listener) error {
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	stopf := context.AfterFunc(ctx, func() {
+		l.Close()
+	})
+	defer stopf()
+
+	for {
+		c, err := l.Accept()
+		if err != nil {
+			return fmt.Errorf("accept: %w", err)
+		}
+
+		wg.Go(func() {
+			// The func is a closure, so c will be whatever the
+			// current version of c is, i.e. it could be nc from
+			// below.
+			stopf := context.AfterFunc(ctx, func() {
+				c.Close()
+			})
+			defer func() {
+				// Abort the AfterFunc (which might never run)
+				// and close it ourselves.
+				if stopf() {
+					c.Close()
+				}
+			}()
+			if s.cfg != nil {
+				nc, err := sshstream.NewServer(c, s.cfg)
+				if err != nil {
+					log.Printf("ssh9p NewServer: %v", err)
+					return
+
+				}
+				c = nc
+			}
+			if err := s.Handle(c, c); err != nil {
+				log.Printf("ssh9p Handle: %v", err)
+			}
+		})
+	}
+}
+
+type mountOpts struct {
+	unixFlags      int
+	msize          int
+	fastTCPTimeout bool
+	cfg            *ssh.ClientConfig
+}
+
+// MountOpt is an option function.
+type MountOpt func(*mountOpts)
+
+// WithUnixFlags sets mount flags, e.g. unix.MS_NOSUID.
+func WithUnixFlags(flags int) MountOpt {
+	return func(m *mountOpts) {
+		m.unixFlags = flags
+	}
+}
+
+// WithMsize sets the 9P msize (max message size in bytes) parameter.
+func WithMsize(msize int) MountOpt {
+	return func(m *mountOpts) {
+		m.msize = msize
+	}
+}
+
+// WithFastTCPTimeout tells the kernel to quickly kill the underlying TCP
+// connection, such that Mount9P() quickly tears down if the remote machine is
+// unresponsive.
+func WithFastTCPTimeout(enable bool) MountOpt {
+	return func(m *mountOpts) {
+		m.fastTCPTimeout = enable
+	}
+}
+
+// WithSSHClient uses ssh for the net.Conn.  In this case, the caller must keep
+// the io.Closer open to maintain the mount.
+func WithSSHClient(cfg *ssh.ClientConfig) MountOpt {
+	return func(m *mountOpts) {
+		m.cfg = cfg
+	}
+}
+
+// fdFor9PTransportMount will take a conn and return an FD that can be passed to
+// the kernel for a 9P transport mount.  Cancel the context when the mount is
+// done.
+//
+// The kernel takes FDs that it can do raw reads and writes on, expecting those
+// FDs to speak 9P.  If we're using a TCP socket, we can just hand the socket FD
+// to the kernel.
+//
+// But if we're using ssh (or more broadly, not a net.Conn on a raw socket with
+// a File() method), we need to translate ssh to 9P in userspace and hand the
+// plaintext end of the pipe to the kernel.  This is why Mount9P needs something
+// kept alive in userspace.
+func fdFor9PTransportMount(ctx context.Context, eg *errgroup.Group, c net.Conn) (*os.File, error) {
+	if tcpConn, ok := c.(*net.TCPConn); ok {
+		tcpFile, err := tcpConn.File()
+		if err == nil {
+			return tcpFile, nil
+		}
+	}
+	fds, err := unix.Socketpair(unix.AF_UNIX, syscall.SOCK_STREAM, 0)
+	if err != nil {
+		return nil, fmt.Errorf("socketpair: %w", err)
+	}
+	userside := os.NewFile(uintptr(fds[0]), "userside")
+	kernelside := os.NewFile(uintptr(fds[1]), "kernelside")
+
+	copyError := func(who string, w io.Writer, r io.Reader) error {
+		_, err := io.Copy(w, r)
+		// eg.Wait() returns the first err returned from its
+		// goroutines.  If the ctx was cancelled from higher, we want
+		// that error, not the error we get from being torn down.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		// Return some error to trigger the end of the eg.
+		return errors.New("closed 9p " + who)
+	}
+	eg.Go(func() error { return copyError("write to conn", c, userside) })
+	eg.Go(func() error { return copyError("write to userside", userside, c) })
+
+	eg.Go(func() error {
+		<-ctx.Done()
+		// The ctx can be canelled from higher up for from one of the
+		// copy goroutines erroring out.  Either way, our job is to make
+		// sure the goroutines (if any remain) exit, and we do that by
+		// making their io.Copy exit.  And the main thing to do there is
+		// to make their Reads return.  (Also want the writes to return,
+		// but the reads is where they are often blocked).
+		//
+		// Closing c (a net.Conn) will unblock any pending reads and
+		// writes.  However, closing userside will *not* unblock any
+		// reads.  It will unblock reads on the *other* side of the
+		// socketpair (aka, kernelside), but not any reads of userside.
+		// To handle that, we need to shutdown(2).
+		if err := syscall.Shutdown(int(userside.Fd()), syscall.SHUT_RDWR); err != nil {
+
+			log.Println("Failed to shutdown userside:", err)
+		}
+		userside.Close()
+		c.Close()
+
+		return ctx.Err()
+	})
+
+	return kernelside, nil
+}
+
+// Mount9P mounts a 9p server connection at mountPoint.
+//
+// If necessary (e.g. using ssh), this will block to maintain the mount.  If so:
+// - You can tear it down by cancelling the context.
+// - It will always return a non-nil error.
+// - It will unmount the mountpoint when its done.  (Since we know the mount is
+// inoperable).
+func Mount9P(ctx context.Context, mntReady chan<- bool, c net.Conn, mountPoint string, opts ...MountOpt) error {
+	// We're responsible for closing the mntReady chan, even on error.
+	defer close(mntReady)
+
+	m := &mountOpts{
+		msize: 64 * 1024,
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+
+	if m.fastTCPTimeout {
+		// Could consider setting something for retrans too.
+		if tcpConn, ok := c.(*net.TCPConn); ok {
+			if err := tcpConn.SetKeepAliveConfig(net.KeepAliveConfig{
+				Enable:   true,
+				Idle:     5 * time.Second,
+				Interval: 1 * time.Second,
+				Count:    5,
+			}); err != nil {
+				log.Println("Failed to set TCP KeepAlive, continuing:", err)
+			}
+		}
+	}
+
+	if m.cfg != nil {
+		nc, err := sshstream.NewClient(c, m.cfg)
+		if err != nil {
+			return err
+		}
+		c = nc
+	}
+
+	// If any goroutine of the eg errors, that ctx will be cancelled.  But
+	// we could also error out on our own, for example the unix.Mount()
+	// command.  That's why we set up the defer cancel() first.  (Note the
+	// cancellable context is a parent to the eg's ctx, and cancellations
+	// propagate downward).
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	eg, ctx := errgroup.WithContext(ctx)
+
+	tfd, err := fdFor9PTransportMount(ctx, eg, c)
+	if err != nil {
+		return err
+	}
+	// We can close the FD after we give it to the kernel.  (internal dup).
+	defer tfd.Close()
+
+	mntstr := fmt.Sprintf("version=9p2000.L,noxattr,trans=fd,rfdno=%d,wfdno=%d,debug=0,msize=%d", tfd.Fd(), tfd.Fd(), m.msize)
+	if err := unix.Mount("ssh9p", mountPoint, "9p", uintptr(m.unixFlags), mntstr); err != nil {
+		return fmt.Errorf("9P mount: %w", err)
+	}
+
+	mntReady <- true
+
+	// If we didn't spawn any goroutines in the eg, perhaps due to being a
+	// raw TCP connection, eg.Wait() will just return immediately.  If there
+	// are any post-mount errors, e.g. the remote server shut down, we'll
+	// exit with an error.  Similarly if our original context is cancelled,
+	// we'll return with whatever error came with that cancellation.
+	err = eg.Wait()
+	if err != nil {
+		// Since we had goroutines maintaining the mount (e.g. for SSH),
+		// and they are gone, we might as well tear down the mount too.
+		if err := unix.Unmount(mountPoint, unix.MNT_FORCE|unix.MNT_DETACH); err != nil {
+			log.Println("Could not unmount, continuing:", err)
+		}
+	}
+	return err
+}

--- a/pkg/ssh9p/ssh9p_test.go
+++ b/pkg/ssh9p/ssh9p_test.go
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Google LLC
+
+//go:build linux
+
+package ssh9p
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hugelgupf/p9/p9"
+	"github.com/u-root/cpu/client"
+	"github.com/u-root/u-root/pkg/sshstream"
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
+)
+
+func generateTestKeys(t *testing.T, tmpDir string) (string, string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	privPath := filepath.Join(tmpDir, "id_rsa")
+	privFile, err := os.Create(privPath)
+	if err != nil {
+		t.Fatalf("Failed to create private key file: %v", err)
+	}
+	defer privFile.Close()
+
+	privPEM := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	}
+	if err := pem.Encode(privFile, privPEM); err != nil {
+		t.Fatalf("Failed to write private key: %v", err)
+	}
+
+	pub, err := ssh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("Failed to create SSH public key: %v", err)
+	}
+
+	pubPath := filepath.Join(tmpDir, "id_rsa.pub")
+	if err := os.WriteFile(pubPath, ssh.MarshalAuthorizedKey(pub), 0644); err != nil {
+		t.Fatalf("Failed to write public key file: %v", err)
+	}
+
+	return privPath, pubPath
+}
+
+func TestFDFor9PTransportMount(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Test TCP connection.
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer ln.Close()
+
+	done := make(chan bool)
+	go func() {
+		c, _ := ln.Accept()
+		if c != nil {
+			c.Close()
+		}
+		done <- true
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	eg := &errgroup.Group{}
+	file, err := fdFor9PTransportMount(ctx, eg, conn)
+	if err != nil {
+		t.Fatalf("fdFor9PTransportMount failed for TCP: %v", err)
+	}
+	if file == nil {
+		t.Errorf("file should not be nil for TCP")
+	} else {
+		file.Close()
+	}
+	<-done
+
+	// Test non-TCP connection (using net.Pipe).
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	eg2 := &errgroup.Group{}
+	file2, err := fdFor9PTransportMount(ctx, eg2, c1)
+	if err != nil {
+		t.Fatalf("fdFor9PTransportMount failed for Pipe: %v", err)
+	}
+	if file2 == nil {
+		t.Errorf("file should not be nil for Pipe")
+	} else {
+		file2.Close()
+	}
+
+	// Test context cancellation in fdFor9PTransportMount.
+	ctx3, cancel3 := context.WithCancel(t.Context())
+	c13, c23 := net.Pipe()
+	defer c23.Close()
+
+	eg3 := &errgroup.Group{}
+	_, err = fdFor9PTransportMount(ctx3, eg3, c13)
+	if err != nil {
+		t.Fatalf("fdFor9PTransportMount failed for cancellation test: %v", err)
+	}
+
+	cancel3()
+	// No easy way to verify userside is closed without more inspection,
+	// but we've at least exercised the path.
+}
+
+func TestServerServe(t *testing.T) {
+	tmpDir := t.TempDir()
+	attacher := client.NewCPU9P(tmpDir)
+	p9s := p9.NewServer(attacher)
+	s := NewServer(p9s)
+
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer ln.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- s.Serve(ctx, ln)
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	client, err := p9.NewClient(conn)
+	if err != nil {
+		t.Fatalf("p9.NewClient failed: %v", err)
+	}
+	defer client.Close()
+
+	// Try to p9.Client.Attach.
+	_, err = client.Attach("")
+	if err != nil {
+		t.Errorf("Attach failed: %v", err)
+	}
+
+	cancel()
+	err = <-serveErr
+	if err != nil && !errors.Is(err, net.ErrClosed) {
+		t.Errorf("Serve returned error: %v", err)
+	}
+}
+
+func TestServerServeSSH(t *testing.T) {
+	tmpDir := t.TempDir()
+	privPath, pubPath := generateTestKeys(t, tmpDir)
+
+	serverCfg, err := sshstream.NewServerConfig(pubPath, privPath)
+	if err != nil {
+		t.Fatalf("NewServerConfig failed: %v", err)
+	}
+
+	clientCfg, err := sshstream.NewClientConfig(privPath, ssh.InsecureIgnoreHostKey())
+	if err != nil {
+		t.Fatalf("NewClientConfig failed: %v", err)
+	}
+
+	attacher := client.NewCPU9P(tmpDir)
+	p9s := p9.NewServer(attacher)
+	s := NewServer(p9s, WithSSHServer(serverCfg))
+
+	ln, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer ln.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- s.Serve(ctx, ln)
+	}()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer conn.Close()
+
+	// Wrap client side in SSH.
+	nc, err := sshstream.NewClient(conn, clientCfg)
+	if err != nil {
+		t.Fatalf("sshstream.NewClient failed: %v", err)
+	}
+	defer nc.Close()
+
+	client, err := p9.NewClient(nc)
+	if err != nil {
+		t.Fatalf("p9.NewClient failed: %v", err)
+	}
+	defer client.Close()
+
+	// Try to p9.Client.Attach.
+	_, err = client.Attach("")
+	if err != nil {
+		t.Errorf("Attach failed: %v", err)
+	}
+
+	cancel()
+	err = <-serveErr
+	if err != nil && !errors.Is(err, net.ErrClosed) {
+		t.Errorf("Serve returned error: %v", err)
+	}
+}

--- a/pkg/sshstream/sshstream.go
+++ b/pkg/sshstream/sshstream.go
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Google LLC
+//
+// Package sshstream provides a byte stream wrapped with SSH over a net.Conn.
+// Think of it as TLS, but with SSH as the mechanism for authentication and
+// encryption.
+//
+// Both sides of a net.Conn must participate.  One side acts as the ssh server
+// and the other is the client.  Either side of a net.Conn can perform either
+// role, but it makes the most sense for whoever Dials to be the client.
+package sshstream
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"golang.org/x/crypto/ssh"
+)
+
+var (
+	sshStreamName = "stream@u-root.org"
+)
+
+// Stream implements net.Conn.  It is an ssh.Channel that sits on top of the
+// net.Conn, providing io.ReadWriter.
+type Stream struct {
+	channel ssh.Channel
+	sshConn ssh.Conn
+	net.Conn
+}
+
+// Read implements io.Read().
+func (s *Stream) Read(data []byte) (int, error) {
+	return s.channel.Read(data)
+}
+
+// Write implements io.Write().
+func (s *Stream) Write(data []byte) (int, error) {
+	return s.channel.Write(data)
+}
+
+// Close closes the stream.  Any blocked Read or Write operations will be
+// unblocked and return errors.
+func (s *Stream) Close() error {
+	return errors.Join(s.channel.Close(), s.sshConn.Close(), s.Conn.Close())
+}
+
+// NewClient acts as an ssh client and creates an ssh channel on the underlying
+// net.Conn c.  The returned net.Conn is a byte stream corresponding to the
+// NewServer() on the remote side of c.
+func NewClient(c net.Conn, cfg *ssh.ClientConfig) (net.Conn, error) {
+	// c, chans, and reqs are all handled by ssh.NewClient(); don't worry
+	// about them.
+	cIGN, chansIGN, reqsIGN, err := ssh.NewClientConn(c, c.RemoteAddr().String(), cfg)
+	if err != nil {
+		return nil, fmt.Errorf("new clientconn: %w", err)
+	}
+	client := ssh.NewClient(cIGN, chansIGN, reqsIGN)
+
+	channel, reqs, err := client.OpenChannel(sshStreamName, []byte{})
+	if err != nil {
+		return nil, fmt.Errorf("open channel: %w", err)
+	}
+
+	go ssh.DiscardRequests(reqs)
+
+	return &Stream{channel: channel, sshConn: client, Conn: c}, nil
+}
+
+// Dial is a helper to dial a server and create a NewClient.
+func Dial(network, address string, cfg *ssh.ClientConfig) (net.Conn, error) {
+	c, err := net.Dial(network, address)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(c, cfg)
+}
+
+// NewServer acts as an ssh server on the underlying net.Conn c.  The returned
+// net.Conn is a byte stream corresponding to the ssh.Channel created by the
+// client on the remote side of c.
+func NewServer(c net.Conn, cfg *ssh.ServerConfig) (net.Conn, error) {
+	server, chans, reqs, err := ssh.NewServerConn(c, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("new serverconn: %w", err)
+	}
+
+	go ssh.DiscardRequests(reqs)
+
+	sockChan := make(chan ssh.Channel)
+
+	go func() {
+		defer close(sockChan)
+		madeChannel := false
+		// Yes, 'chans' is a go chan of ssh.Channels, enjoy!
+		for nc := range chans {
+			if nc.ChannelType() != sshStreamName {
+				nc.Reject(ssh.UnknownChannelType, "must be "+sshStreamName)
+				continue
+			}
+			if madeChannel {
+				nc.Reject(ssh.ResourceShortage, "already have a "+sshStreamName)
+				continue
+			}
+			channel, reqs, err := nc.Accept()
+			if err != nil {
+				log.Printf("sshwrap: channel accept: %v", err)
+				continue
+			}
+			madeChannel = true
+			go ssh.DiscardRequests(reqs)
+			sockChan <- channel
+		}
+	}()
+
+	channel := <-sockChan
+	if channel == nil {
+		return nil, errors.New("sockChan closed early")
+	}
+	return &Stream{channel: channel, sshConn: server, Conn: c}, nil
+}
+
+// NewClientConfig is a helper to make an ssh.ClientConfig.
+func NewClientConfig(privateKey string, hkcb ssh.HostKeyCallback) (*ssh.ClientConfig, error) {
+	keyBytes, err := os.ReadFile(privateKey)
+	if err != nil {
+		return nil, fmt.Errorf("key read: %w", err)
+	}
+	keyParse, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("key parse: %w", err)
+	}
+
+	cfg := &ssh.ClientConfig{
+		HostKeyCallback: hkcb,
+	}
+	cfg.Auth = []ssh.AuthMethod{ssh.PublicKeys(keyParse)}
+	return cfg, nil
+}
+
+// NewServerConfig is a helper to make an ssh.ServerConfig.
+func NewServerConfig(authorizedKeys, hostKey string) (*ssh.ServerConfig, error) {
+	authBytes, err := os.ReadFile(authorizedKeys)
+	if err != nil {
+		return nil, fmt.Errorf("authkey read: %w", err)
+	}
+	authKeys := map[string]bool{}
+	for len(authBytes) > 0 {
+		k, _, _, rest, err := ssh.ParseAuthorizedKey(authBytes)
+		if err != nil {
+			return nil, fmt.Errorf("authkey parse: %w", err)
+		}
+
+		authKeys[string(k.Marshal())] = true
+		authBytes = rest
+	}
+	cfg := &ssh.ServerConfig{
+		PublicKeyCallback: func(cm ssh.ConnMetadata, k ssh.PublicKey) (*ssh.Permissions, error) {
+			if authKeys[string(k.Marshal())] {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, fmt.Errorf("unknown key for user %q", cm.User())
+		},
+	}
+	keyBytes, err := os.ReadFile(hostKey)
+	if err != nil {
+		return nil, fmt.Errorf("key read: %w", err)
+	}
+	keyParse, err := ssh.ParsePrivateKey(keyBytes)
+	if err != nil {
+		return nil, fmt.Errorf("key parse: %w", err)
+	}
+	cfg.AddHostKey(keyParse)
+	return cfg, nil
+}

--- a/pkg/sshstream/sshstream_test.go
+++ b/pkg/sshstream/sshstream_test.go
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: MIT
+// Copyright 2026 Google LLC
+package sshstream
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+)
+
+func generateTestKeys(t *testing.T, tmpDir string) (string, string) {
+	t.Helper()
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("Failed to generate RSA key: %v", err)
+	}
+
+	privPath := filepath.Join(tmpDir, "id_rsa")
+	privFile, err := os.Create(privPath)
+	if err != nil {
+		t.Fatalf("Failed to create private key file: %v", err)
+	}
+	defer privFile.Close()
+
+	privPEM := &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(priv),
+	}
+	if err := pem.Encode(privFile, privPEM); err != nil {
+		t.Fatalf("Failed to write private key: %v", err)
+	}
+
+	pub, err := ssh.NewPublicKey(&priv.PublicKey)
+	if err != nil {
+		t.Fatalf("Failed to create SSH public key: %v", err)
+	}
+
+	pubPath := filepath.Join(tmpDir, "id_rsa.pub")
+	if err := os.WriteFile(pubPath, ssh.MarshalAuthorizedKey(pub), 0644); err != nil {
+		t.Fatalf("Failed to write public key file: %v", err)
+	}
+
+	return privPath, pubPath
+}
+
+func TestSSHStream(t *testing.T) {
+	tmpDir := t.TempDir()
+	privPath, pubPath := generateTestKeys(t, tmpDir)
+
+	serverCfg, err := NewServerConfig(pubPath, privPath)
+	if err != nil {
+		t.Fatalf("NewServerConfig failed: %v", err)
+	}
+
+	clientCfg, err := NewClientConfig(privPath, ssh.InsecureIgnoreHostKey())
+	if err != nil {
+		t.Fatalf("NewClientConfig failed: %v", err)
+	}
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer listener.Close()
+
+	errChan := make(chan error, 2)
+	dataChan := make(chan []byte, 1)
+
+	// Start server
+	go func() {
+		serverConn, err := listener.Accept()
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer serverConn.Close()
+
+		stream, err := NewServer(serverConn, serverCfg)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer stream.Close()
+
+		buf := make([]byte, 1024)
+		n, err := stream.Read(buf)
+		if err != nil && err != io.EOF {
+			errChan <- err
+			return
+		}
+		dataChan <- buf[:n]
+	}()
+
+	// Start client
+	go func() {
+		clientConn, err := net.Dial("tcp", listener.Addr().String())
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer clientConn.Close()
+
+		clientStream, err := NewClient(clientConn, clientCfg)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		defer clientStream.Close()
+
+		_, err = clientStream.Write([]byte("hello world"))
+		if err != nil {
+			errChan <- err
+			return
+		}
+	}()
+
+	select {
+	case err := <-errChan:
+		t.Fatalf("Error in goroutine: %v", err)
+	case data := <-dataChan:
+		// Assumes the server's read grabbed the entire string.
+		if !bytes.Equal(data, []byte("hello world")) {
+			t.Errorf("Got %q, want %q", string(data), "hello world")
+		}
+	}
+}
+
+func TestSSHStreamRejection(t *testing.T) {
+	tmpDir := t.TempDir()
+	privPath, pubPath := generateTestKeys(t, tmpDir)
+
+	serverCfg, _ := NewServerConfig(pubPath, privPath)
+
+	otherDir := t.TempDir()
+	otherPriv, _ := generateTestKeys(t, otherDir)
+	clientCfg, _ := NewClientConfig(otherPriv, ssh.InsecureIgnoreHostKey())
+
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Listen failed: %v", err)
+	}
+	defer listener.Close()
+
+	go func() {
+		serverConn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer serverConn.Close()
+		_, _ = NewServer(serverConn, serverCfg)
+	}()
+
+	clientConn, err := net.Dial("tcp", listener.Addr().String())
+	if err != nil {
+		t.Fatalf("Dial failed: %v", err)
+	}
+	defer clientConn.Close()
+
+	_, err = NewClient(clientConn, clientCfg)
+	if err == nil {
+		t.Fatal("Client should have failed to connect with unauthorized key")
+	}
+}

--- a/vendor/github.com/hugelgupf/p9/fsimpl/xattr/xattr_other.go
+++ b/vendor/github.com/hugelgupf/p9/fsimpl/xattr/xattr_other.go
@@ -1,3 +1,5 @@
+//go:build (windows || plan9) && !unix
+
 package xattr
 
 import "github.com/hugelgupf/p9/linux"

--- a/vendor/github.com/hugelgupf/p9/internal/stat_bsd.go
+++ b/vendor/github.com/hugelgupf/p9/internal/stat_bsd.go
@@ -1,5 +1,4 @@
 //go:build freebsd || darwin || netbsd
-// +build freebsd darwin netbsd
 
 package internal
 

--- a/vendor/github.com/hugelgupf/p9/internal/stat_plan9.go
+++ b/vendor/github.com/hugelgupf/p9/internal/stat_plan9.go
@@ -1,0 +1,48 @@
+package internal
+
+import (
+	"os"
+)
+
+// NOTE: taken from amd64 Linux
+type Timespec struct {
+	Sec  int64
+	Nsec int64
+}
+
+type Stat_t struct {
+	Dev     uint64
+	Ino     uint64
+	Nlink   uint64
+	Mode    uint32
+	Uid     uint32
+	Gid     uint32
+	Rdev    uint64
+	Size    int64
+	Blksize int64
+	Blocks  int64
+	Atim    Timespec
+	Mtim    Timespec
+	Ctim    Timespec
+}
+
+// InfoToStat takes a platform native FileInfo and converts it into a 9P2000.L compatible Stat_t
+func InfoToStat(fi os.FileInfo) *Stat_t {
+	const blockSize = 8192
+	t := Timespec{Sec: fi.ModTime().Unix()}
+	return &Stat_t{
+		Dev:     0,
+		Ino:     0,
+		Nlink:   1,
+		Mode:    uint32(fi.Mode()),
+		Uid:     0,
+		Gid:     0,
+		Rdev:    0,
+		Size:    fi.Size(),
+		Blksize: blockSize,
+		Blocks:  fi.Size() / blockSize,
+		Atim:    t,
+		Mtim:    t,
+		Ctim:    t,
+	}
+}

--- a/vendor/github.com/hugelgupf/p9/internal/stat_standard.go
+++ b/vendor/github.com/hugelgupf/p9/internal/stat_standard.go
@@ -1,5 +1,4 @@
 //go:build linux || dragonfly || solaris
-// +build linux dragonfly solaris
 
 package internal
 

--- a/vendor/github.com/hugelgupf/p9/internal/stat_unix.go
+++ b/vendor/github.com/hugelgupf/p9/internal/stat_unix.go
@@ -1,5 +1,4 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !plan9
 
 package internal
 

--- a/vendor/github.com/hugelgupf/p9/linux/errors_linux.go
+++ b/vendor/github.com/hugelgupf/p9/linux/errors_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package linux
 

--- a/vendor/github.com/hugelgupf/p9/linux/errors_plan9.go
+++ b/vendor/github.com/hugelgupf/p9/linux/errors_plan9.go
@@ -1,0 +1,23 @@
+package linux
+
+import (
+	"errors"
+	"io/fs"
+)
+
+func sysErrno(err error) Errno {
+	for _, pair := range []struct {
+		error
+		Errno
+	}{
+		{fs.ErrNotExist, ENOENT},
+		{fs.ErrPermission, EACCES},
+		{fs.ErrExist, EEXIST},
+	} {
+		if errors.Is(err, pair.error) {
+			return pair.Errno
+		}
+	}
+	// No clue what to do with others.
+	return 0
+}

--- a/vendor/github.com/hugelgupf/p9/linux/errors_unix.go
+++ b/vendor/github.com/hugelgupf/p9/linux/errors_unix.go
@@ -1,5 +1,4 @@
-//go:build !windows && !linux
-// +build !windows,!linux
+//go:build !windows && !linux && !plan9
 
 package linux
 

--- a/vendor/github.com/hugelgupf/p9/linux/errors_windows.go
+++ b/vendor/github.com/hugelgupf/p9/linux/errors_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package linux
 

--- a/vendor/github.com/hugelgupf/p9/p9/fuzz.go
+++ b/vendor/github.com/hugelgupf/p9/p9/fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package p9
 

--- a/vendor/github.com/hugelgupf/p9/p9/handlers.go
+++ b/vendor/github.com/hugelgupf/p9/p9/handlers.go
@@ -182,7 +182,7 @@ func (t *tremove) handle(cs *connState) message {
 	// Tunlinkat. All p9 clients will use Tunlinkat.
 	err := ref.safelyGlobal(func() error {
 		// Is this a root? Can't remove that.
-		if ref.isRoot() {
+		if ref.hasParent() {
 			return linux.EINVAL
 		}
 
@@ -627,7 +627,7 @@ func (t *trename) handle(cs *connState) message {
 
 	if err := ref.safelyGlobal(func() (err error) {
 		// Don't allow a root rename.
-		if ref.isRoot() {
+		if ref.hasParent() {
 			return linux.EINVAL
 		}
 
@@ -997,7 +997,6 @@ func (t *txattrwalk) handle(cs *connState) message {
 				buf:  buf,
 			},
 			pathNode: ref.pathNode,
-			parent:   ref.parent,
 		}
 		cs.InsertFID(t.newFID, newRef)
 		return nil
@@ -1204,7 +1203,7 @@ func doWalk(cs *connState, ref *fidRef, names []string, getattr bool) (qids []QI
 				mode:     ref.mode,
 				pathNode: ref.pathNode,
 			}
-			if !ref.isRoot() {
+			if !ref.hasParent() {
 				if !newRef.isDeleted() {
 					// Add only if a non-root node; the same node.
 					ref.parent.pathNode.addChild(newRef, ref.parent.pathNode.nameFor(ref))

--- a/vendor/github.com/hugelgupf/p9/p9/server.go
+++ b/vendor/github.com/hugelgupf/p9/p9/server.go
@@ -209,10 +209,10 @@ type fidRef struct {
 	// fidRef. Holding either of these locks is sufficient to examine
 	// parent safely.
 	//
-	// The parent will be nil for root fidRefs, and non-nil otherwise. The
-	// method maybeParent can be used to return a cyclical reference, and
-	// isRoot should be used to check for root over looking at parent
-	// directly.
+	// The parent will be nil for root fidRefs and pending xattrwalk/create
+	// fidRefs, and non-nil otherwise. The method maybeParent can be used
+	// to return a cyclical reference, and hasParent should be used to
+	// check for root over looking at parent directly.
 	parent *fidRef
 }
 
@@ -274,8 +274,8 @@ func (f *fidRef) isDeleted() bool {
 	return atomic.LoadUint32(&f.pathNode.deleted) != 0
 }
 
-// isRoot indicates whether this is a root fid.
-func (f *fidRef) isRoot() bool {
+// hasParent indicates whether this is a root fid.
+func (f *fidRef) hasParent() bool {
 	return f.parent == nil
 }
 
@@ -505,7 +505,11 @@ func (cs *connState) handleRequest() bool {
 
 	// Ensure that another goroutine is available to receive from cs.t.
 	if atomic.LoadInt32(&cs.recvIdle) == 0 {
-		go cs.handleRequests() // S/R-SAFE: Irrelevant.
+		cs.pendingWg.Add(1)
+		go func() {
+			defer cs.pendingWg.Done()
+			cs.handleRequests() // S/R-SAFE: Irrelevant.
+		}()
 	}
 	cs.recvMu.Unlock()
 

--- a/vendor/github.com/hugelgupf/p9/vecnet/iov32_linux.go
+++ b/vendor/github.com/hugelgupf/p9/vecnet/iov32_linux.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build 386 || mips || arm || mipsle
-// +build 386 mips arm mipsle
 
 package vecnet
 

--- a/vendor/github.com/hugelgupf/p9/vecnet/iov_linux.go
+++ b/vendor/github.com/hugelgupf/p9/vecnet/iov_linux.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !386 && !arm && !mips && !mipsle
-// +build !386,!arm,!mips,!mipsle
 
 package vecnet
 

--- a/vendor/github.com/hugelgupf/p9/vecnet/vecnet_linux.go
+++ b/vendor/github.com/hugelgupf/p9/vecnet/vecnet_linux.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !386
-// +build !386
 
 package vecnet
 

--- a/vendor/github.com/hugelgupf/p9/vecnet/vecnet_other.go
+++ b/vendor/github.com/hugelgupf/p9/vecnet/vecnet_other.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build !linux || (linux && 386)
-// +build !linux linux,386
 
 package vecnet
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -208,8 +208,8 @@ github.com/hashicorp/golang-lru/v2/simplelru
 # github.com/hugelgupf/go-shlex v0.0.0-20200702092117-c80c9d0918fa
 ## explicit; go 1.14
 github.com/hugelgupf/go-shlex
-# github.com/hugelgupf/p9 v0.3.0
-## explicit; go 1.20
+# github.com/hugelgupf/p9 v0.4.1
+## explicit; go 1.21
 github.com/hugelgupf/p9/fsimpl/templatefs
 github.com/hugelgupf/p9/fsimpl/xattr
 github.com/hugelgupf/p9/internal


### PR DESCRIPTION
Main parts:

- sshstream: let's you wrap a net.Conn with ssh, such that you can use ssh for your authentication.  Essentially an ssh channel that looks like a net.Conn.
- ssh9p: package for mounting 9p, in particular with the "transport=fd" methods, over ssh.
- p9dev: package so you can export character devices over 9p.  arguably this should be a 9p client option, which would be a linux kernel change / addition to 9p2000.L to implement the "nodevmap" option from 9p2000.u.  but that seems like a mess.  see the comments in p9dev.go for lots of details.
- ufs and mount9p: commands to export over 9p and mount, respectively.