### PR TITLE
pkg/smbios: Add ReplaceUsbRedfishHostInterface override option to smbios modifier

### DIFF
--- a/pkg/smbios/smbios_modifier.go
+++ b/pkg/smbios/smbios_modifier.go
@@ -6,6 +6,7 @@ package smbios
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"slices"
 )
@@ -256,6 +257,125 @@ func RemoveSystemSlotInfo(slotDesignation string) OverrideOpt {
 				continue
 			}
 			result = append(result, t)
+		}
+		return result, nil
+	}
+}
+
+// ReplaceRedfishHostInterface overrides Type 42 SMBIOS tables in system memory with dynamic Redfish details.
+func ReplaceUsbRedfishHostInterface(cfg *RedfishHostInterfaceConfig) OverrideOpt {
+	return func(tables []*Table) ([]*Table, error) {
+		var result []*Table
+		for _, t := range tables {
+			if t.Type != TableTypeManagementControllerHostInterface {
+				result = append(result, t)
+				continue
+			}
+			mc, err := ParseManagementControllerHostInterface(t)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse Type 42: %w", err)
+			}
+
+			if cfg.InterfaceType != 0 {
+				mc.InterfaceType = cfg.InterfaceType
+			}
+			if cfg.USBDeviceType != 0 {
+				mc.DeviceType = cfg.USBDeviceType
+			}
+			if cfg.VendorID != 0 {
+				mc.VendorID = cfg.VendorID
+			}
+			if cfg.ProductID != 0 {
+				mc.ProductID = cfg.ProductID
+			}
+			if cfg.UsbLength != 0 {
+				mc.UsbLength = cfg.UsbLength
+			}
+			if cfg.UsbDescriptorType != 0 {
+				mc.UsbDescriptorType = cfg.UsbDescriptorType
+			}
+			if cfg.SerialNumber != "" {
+				mc.SerialNumber = cfg.SerialNumber
+			}
+
+			if len(cfg.ServiceUUID) == 16 {
+				mc.ServiceUUID = cfg.ServiceUUID
+			}
+			if cfg.HostIPAssignmentType != 0 {
+				mc.HostIPAssignmentType = cfg.HostIPAssignmentType
+			}
+			if len(cfg.HostIP) > 0 {
+				if ip4 := cfg.HostIP.To4(); ip4 != nil {
+					mc.HostIPAddressFormat = 1 // IPv4
+					mc.HostIPAddress = [16]byte{}
+					copy(mc.HostIPAddress[:4], ip4)
+					// Set Host IPv4 subnet mask. Default to /24 if not provided
+					if len(cfg.HostMask) > 0 {
+						mc.HostIPMask = [16]byte{}
+						copy(mc.HostIPMask[:4], cfg.HostMask)
+					} else {
+						mc.HostIPMask = [16]byte{}
+						copy(mc.HostIPMask[:4], net.CIDRMask(24, 32))
+					}
+				} else {
+					mc.HostIPAddressFormat = 2 // IPv6
+					mc.HostIPAddress = [16]byte{}
+					copy(mc.HostIPAddress[:], cfg.HostIP.To16())
+					// Set Host IPv6 subnet mask. Default to /64 if not provided
+					if len(cfg.HostMask) > 0 {
+						mc.HostIPMask = [16]byte{}
+						copy(mc.HostIPMask[:], cfg.HostMask)
+					} else {
+						mc.HostIPMask = [16]byte{}
+						copy(mc.HostIPMask[:], net.CIDRMask(64, 128))
+					}
+				}
+			}
+			if cfg.BmcIPDiscoveryType != 0 {
+				mc.BmcIPDiscoveryType = cfg.BmcIPDiscoveryType
+			}
+			if len(cfg.BmcIP) > 0 {
+				if ip4 := cfg.BmcIP.To4(); ip4 != nil {
+					mc.BmcIPAddressFormat = 1 // IPv4
+					mc.BmcIPAddress = [16]byte{}
+					copy(mc.BmcIPAddress[:4], ip4)
+					// Set BMC IPv4 subnet mask. Default to /24 if not provided
+					if len(cfg.BmcMask) > 0 {
+						mc.BmcIPMask = [16]byte{}
+						copy(mc.BmcIPMask[:4], cfg.BmcMask)
+					} else {
+						mc.BmcIPMask = [16]byte{}
+						copy(mc.BmcIPMask[:4], net.CIDRMask(24, 32))
+					}
+				} else {
+					mc.BmcIPAddressFormat = 2 // IPv6
+					mc.BmcIPAddress = [16]byte{}
+					copy(mc.BmcIPAddress[:], cfg.BmcIP.To16())
+					// Set BMC IPv6 subnet mask. Default to /64 if not provided
+					if len(cfg.BmcMask) > 0 {
+						mc.BmcIPMask = [16]byte{}
+						copy(mc.BmcIPMask[:], cfg.BmcMask)
+					} else {
+						mc.BmcIPMask = [16]byte{}
+						copy(mc.BmcIPMask[:], net.CIDRMask(64, 128))
+					}
+				}
+			}
+			if cfg.RedfishPort != 0 {
+				mc.RedfishPort = cfg.RedfishPort
+			}
+			if cfg.VlanID != 0 {
+				mc.VlanID = cfg.VlanID
+			}
+			if cfg.Hostname != "" {
+				mc.Hostname = cfg.Hostname
+			}
+
+			mct, err := mc.toTable()
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, mct)
 		}
 		return result, nil
 	}

--- a/pkg/smbios/smbios_modifier_test.go
+++ b/pkg/smbios/smbios_modifier_test.go
@@ -6,6 +6,7 @@ package smbios
 
 import (
 	"io"
+	"net"
 	"os"
 	"reflect"
 	"testing"
@@ -635,5 +636,114 @@ func TestRemoveSystemSlotInfo(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestReplaceUsbRedfishHostInterface(t *testing.T) {
+	headerAndInterfaceBytes := []byte{
+		42, 108, 0x01, 0x00, // Type=42, Length=108, Handle=0x0001
+		0x40,       // InterfaceType Network Host
+		8,          // InterfaceTypeSpecificDataLength
+		2,          // DeviceType USB
+		0x12, 0x34, // VendorID
+		0x01, 0x00, // ProductID
+		2, // UsbLength
+		3, // UsbDescriptorType
+		1, // SerialNumber string index 1
+	}
+
+	uuidVal := []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	hostIP := net.ParseIP("fe80::211:32ff:fe54:8801").To16()
+	hostMask := net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff::").To16())
+	bmcIP := net.ParseIP("fe80::1").To16()
+	bmcMask := net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff::").To16())
+
+	protoData := []byte{}
+	protoData = append(protoData, uuidVal...)
+	protoData = append(protoData, 1) // HostIPAssignmentType Static
+	protoData = append(protoData, 2) // HostIPAddressFormat IPv6
+	protoData = append(protoData, hostIP...)
+	protoData = append(protoData, hostMask...)
+	protoData = append(protoData, 1) // BmcIPDiscoveryType Static
+	protoData = append(protoData, 2) // BmcIPAddressFormat IPv6
+	protoData = append(protoData, bmcIP...)
+	protoData = append(protoData, bmcMask...)
+	protoData = append(protoData, 0xB6, 0x27) // RedfishPort 10166
+	protoData = append(protoData, 0, 0, 0, 0) // VlanID 0
+	protoData = append(protoData, 2)          // Hostname string index 2
+
+	payload := []byte{}
+	payload = append(payload, 1)  // ProtocolCount 1
+	payload = append(payload, 4)  // ProtocolIdentifier Redfish
+	payload = append(payload, 91) // ProtocolLength 91 (includes 1-byte Hostname index)
+	payload = append(payload, protoData...)
+
+	rawTableData := append([]byte(nil), headerAndInterfaceBytes...)
+	rawTableData = append(rawTableData, payload...)
+
+	strings := []string{"SerialNumber123", "bmc-hostname"}
+
+	tObj := &Table{
+		Header: Header{
+			Type:   42,
+			Length: uint8(len(rawTableData)),
+			Handle: 0x0001,
+		},
+		data:    rawTableData,
+		strings: strings,
+	}
+
+	var uuid UUID
+	copy(uuid[:], uuidVal)
+
+	opt := ReplaceUsbRedfishHostInterface(&RedfishHostInterfaceConfig{
+		ServiceUUID:          uuid,
+		HostIP:               net.ParseIP("192.168.1.2"),
+		HostMask:             net.CIDRMask(24, 32),
+		BmcIP:                net.ParseIP("192.168.1.1"),
+		BmcMask:              net.CIDRMask(24, 32),
+		RedfishPort:          8080,
+		VlanID:               10,
+		VendorID:             0xABCD,
+		ProductID:            0x1234,
+		SerialNumber:         "NewSerialNumber",
+		Hostname:             "new-hostname",
+		InterfaceType:        0x40,
+		USBDeviceType:        2,
+		UsbLength:            2,
+		UsbDescriptorType:    3,
+		HostIPAssignmentType: uint8(IPAssignmentTypeStatic),
+		BmcIPDiscoveryType:   uint8(BmcIPDiscoveryTypeStatic),
+	})
+
+	tables := []*Table{tObj}
+	modifiedTables, err := opt(tables)
+	if err != nil {
+		t.Fatalf("Modifier failed: %v", err)
+	}
+
+	mc, err := ParseManagementControllerHostInterface(modifiedTables[0])
+	if err != nil {
+		t.Fatalf("Failed to parse modified table: %v", err)
+	}
+
+	if mc.VendorID != 0xABCD || mc.ProductID != 0x1234 {
+		t.Errorf("Expected modified Vendor/Product IDs")
+	}
+
+	if mc.SerialNumber != "NewSerialNumber" || mc.Hostname != "new-hostname" {
+		t.Errorf("Expected modified strings")
+	}
+
+	if mc.HostIPAddressFormat != 1 || mc.BmcIPAddressFormat != 1 {
+		t.Errorf("Expected modified IPv4 formats (1)")
+	}
+
+	if !net.IP(mc.HostIPAddress[:4]).Equal(net.ParseIP("192.168.1.2")) {
+		t.Errorf("Expected modified Host IP")
+	}
+
+	if mc.RedfishPort != 8080 || mc.VlanID != 10 {
+		t.Errorf("Expected modified Port and VlanID")
 	}
 }

--- a/pkg/smbios/type42_management_controller_host_interface.go
+++ b/pkg/smbios/type42_management_controller_host_interface.go
@@ -1,0 +1,271 @@
+// Copyright 2016-2026 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package smbios
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+)
+
+// TableTypeManagementControllerHostInterface is the SMBIOS Type 42
+const TableTypeManagementControllerHostInterface TableType = 42
+
+// IP is a 16-byte SMBIOS representation of an IP address
+type IP [16]byte
+
+// IPAddressFormat represents the format of an IP address.
+type IPAddressFormat uint8
+
+const (
+	IPAddressFormatUnknown IPAddressFormat = 0
+	IPAddressFormatIPv4    IPAddressFormat = 1
+	IPAddressFormatIPv6    IPAddressFormat = 2
+)
+
+// IPAssignmentType represents the assignment method of an IP address.
+type IPAssignmentType uint8
+
+const (
+	IPAssignmentTypeUnknown       IPAssignmentType = 0
+	IPAssignmentTypeStatic        IPAssignmentType = 1
+	IPAssignmentTypeDHCP          IPAssignmentType = 2
+	IPAssignmentTypeAutoConfigure IPAssignmentType = 3
+	IPAssignmentTypeHostSelected  IPAssignmentType = 4
+)
+
+// BmcIPDiscoveryType represents the BMC IP address discovery method.
+type BmcIPDiscoveryType uint8
+
+const (
+	BmcIPDiscoveryTypeUnknown       BmcIPDiscoveryType = 0
+	BmcIPDiscoveryTypeStatic        BmcIPDiscoveryType = 1
+	BmcIPDiscoveryTypeDHCP          BmcIPDiscoveryType = 2
+	BmcIPDiscoveryTypeAutoConfigure BmcIPDiscoveryType = 3
+	BmcIPDiscoveryTypeHostSelected  BmcIPDiscoveryType = 4
+)
+
+// NetIP converts the SMBIOS IP representation to Go's standard net.IP
+func (ip IP) NetIP() net.IP {
+	return net.IP(ip[:])
+}
+
+// ParseField parses an IP field within a table.
+func (ip *IP) ParseField(t *Table, off int) (int, error) {
+	b, err := t.GetBytesAt(off, 16)
+	if err != nil {
+		return off, err
+	}
+	copy(ip[:], b)
+	return off + 16, nil
+}
+
+// RedfishHostInterfaceConfig holds all parameters needed to configure a Redfish Host Interface over USB(Type 42).
+type RedfishHostInterfaceConfig struct {
+	InterfaceType        uint8
+	USBDeviceType        uint8
+	VendorID             uint16
+	ProductID            uint16
+	UsbLength            uint8
+	UsbDescriptorType    uint8
+	SerialNumber         string
+	HostIPAssignmentType uint8
+	BmcIPDiscoveryType   uint8
+	ServiceUUID          UUID
+	HostIP               net.IP
+	HostMask             net.IPMask
+	BmcIP                net.IP
+	BmcMask              net.IPMask
+	RedfishPort          uint16
+	VlanID               uint32
+	Hostname             string
+}
+
+// ManagementControllerHostInterface is defined in DSP0134 7.43.
+// This layout specifically models the USB physical interface carrying the Redfish-over-IP protocol.
+type ManagementControllerHostInterface struct {
+	Header
+	InterfaceType                   uint8  // 04h physical interface type (e.g. 40h Network Host)
+	InterfaceTypeSpecificDataLength uint8  // 05h size of interface specific data (8 bytes)
+	DeviceType                      uint8  // 06h USB Network Interface device type (e.g. 02h)
+	VendorID                        uint16 // 07h USB Vendor ID (idVendor)
+	ProductID                       uint16 // 09h USB Product ID (idProduct)
+	UsbLength                       uint8  // 0Bh USB descriptor bLength (2)
+	UsbDescriptorType               uint8  // 0Ch USB descriptor bDescriptorType (3)
+	SerialNumber                    string // 0Dh USB SerialNumber string index (resolves to trailing string)
+	ProtocolCount                   uint8  // 0Eh number of supported protocols (1)
+	ProtocolIdentifier              uint8  // 0Fh protocol identifier (e.g. 04h Redfish over IP)
+	ProtocolLength                  uint8  // 10h size of Redfish protocol data block
+	ServiceUUID                     UUID   // 11h Redfish service UUID
+	HostIPAssignmentType            uint8  // 21h
+	HostIPAddressFormat             uint8  // 22h
+	HostIPAddress                   IP     // 23h
+	HostIPMask                      IP     // 33h
+	BmcIPDiscoveryType              uint8  // 43h
+	BmcIPAddressFormat              uint8  // 44h
+	BmcIPAddress                    IP     // 45h
+	BmcIPMask                       IP     // 55h
+	RedfishPort                     uint16 // 65h
+	VlanID                          uint32 // 67h
+	Hostname                        string // 6Bh
+}
+
+// ParseManagementControllerHostInterface parses a generic Table into ManagementControllerHostInterface.
+func ParseManagementControllerHostInterface(t *Table) (*ManagementControllerHostInterface, error) {
+	return parseManagementControllerHostInterface(parseStruct, t)
+}
+
+func parseManagementControllerHostInterface(parseFn parseStructure, t *Table) (*ManagementControllerHostInterface, error) {
+	if t.Type != TableTypeManagementControllerHostInterface {
+		return nil, fmt.Errorf("invalid table type %d", t.Type)
+	}
+	if t.Len() < 11 {
+		return nil, errors.New("required fields missing")
+	}
+
+	mc := &ManagementControllerHostInterface{Header: t.Header}
+	if _, err := parseFn(t, 0 /* off */, false /* complete */, mc); err != nil {
+		return nil, err
+	}
+
+	// If the ProtocolLength is larger than 91, it means the hostname
+	// is stored in-line (DSP0270 V1.0.0) rather than as a trailing string index.
+	if mc.ProtocolLength > 91 {
+		hLen, err := t.GetByteAt(107) // X+90 is offset 107 (since X starts at 17)
+		if err == nil && hLen > 0 {
+			if hBytes, err := t.GetBytesAt(108, int(hLen)); err == nil {
+				mc.Hostname = string(hBytes)
+			}
+		}
+	}
+
+	return mc, nil
+}
+
+// MarshalBinary encodes the ManagementControllerHostInterface content into binary format.
+func (mc *ManagementControllerHostInterface) MarshalBinary() ([]byte, error) {
+	t, err := mc.toTable()
+	if err != nil {
+		return nil, err
+	}
+	return t.MarshalBinary()
+}
+
+func (mc *ManagementControllerHostInterface) toTable() (*Table, error) {
+	var payload []byte
+	var tableStr []string
+	idx := byte(1)
+
+	payload = append(payload, mc.InterfaceType)
+	payload = append(payload, mc.InterfaceTypeSpecificDataLength)
+	payload = append(payload, mc.DeviceType)
+
+	vid := make([]byte, 2)
+	binary.LittleEndian.PutUint16(vid, mc.VendorID)
+	payload = append(payload, vid...)
+
+	pid := make([]byte, 2)
+	binary.LittleEndian.PutUint16(pid, mc.ProductID)
+	payload = append(payload, pid...)
+
+	payload = append(payload, mc.UsbLength)
+	payload = append(payload, mc.UsbDescriptorType)
+
+	if mc.SerialNumber != "" {
+		payload = append(payload, idx)
+		idx++
+		tableStr = append(tableStr, mc.SerialNumber)
+	} else {
+		payload = append(payload, 0)
+	}
+
+	if mc.Hostname != "" && mc.ProtocolLength > 91 {
+		mc.ProtocolLength = uint8(90 + 1 + len(mc.Hostname))
+	}
+
+	payload = append(payload, mc.ProtocolCount)
+	payload = append(payload, mc.ProtocolIdentifier)
+	payload = append(payload, mc.ProtocolLength)
+	payload = append(payload, mc.ServiceUUID[:]...)
+	payload = append(payload, mc.HostIPAssignmentType)
+	payload = append(payload, mc.HostIPAddressFormat)
+	payload = append(payload, mc.HostIPAddress[:]...)
+	payload = append(payload, mc.HostIPMask[:]...)
+	payload = append(payload, mc.BmcIPDiscoveryType)
+	payload = append(payload, mc.BmcIPAddressFormat)
+	payload = append(payload, mc.BmcIPAddress[:]...)
+	payload = append(payload, mc.BmcIPMask[:]...)
+
+	port := make([]byte, 2)
+	binary.LittleEndian.PutUint16(port, mc.RedfishPort)
+	payload = append(payload, port...)
+
+	vlan := make([]byte, 4)
+	binary.LittleEndian.PutUint32(vlan, mc.VlanID)
+	payload = append(payload, vlan...)
+
+	if mc.Hostname != "" {
+		if mc.ProtocolLength > 91 {
+			payload = append(payload, byte(len(mc.Hostname)))
+			payload = append(payload, []byte(mc.Hostname)...)
+		} else {
+			payload = append(payload, idx)
+			tableStr = append(tableStr, mc.Hostname)
+		}
+	} else {
+		payload = append(payload, 0)
+	}
+
+	// Update header length to match payload size + 4-byte header
+	mc.Header.Length = uint8(len(payload) + 4)
+
+	h, err := mc.Header.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+
+	var d []byte
+	d = append(d, h...)
+	d = append(d, payload...)
+
+	t := &Table{
+		Header:  mc.Header,
+		data:    d,
+		strings: tableStr,
+	}
+	return t, nil
+}
+
+func (mc *ManagementControllerHostInterface) String() string {
+	lines := []string{
+		mc.Header.String(),
+		fmt.Sprintf("Interface Type: 0x%02X", mc.InterfaceType),
+		fmt.Sprintf("Interface Specific Data Length: %d", mc.InterfaceTypeSpecificDataLength),
+		fmt.Sprintf("Device Type: 0x%02X", mc.DeviceType),
+		fmt.Sprintf("Vendor ID: 0x%04X", mc.VendorID),
+		fmt.Sprintf("Product ID: 0x%04X", mc.ProductID),
+		fmt.Sprintf("USB bLength: %d", mc.UsbLength),
+		fmt.Sprintf("USB bDescriptorType: %d", mc.UsbDescriptorType),
+		fmt.Sprintf("Serial Number: %s", mc.SerialNumber),
+		fmt.Sprintf("Protocol Count: %d", mc.ProtocolCount),
+		fmt.Sprintf("Protocol Identifier: 0x%02X", mc.ProtocolIdentifier),
+		fmt.Sprintf("Protocol Length: %d", mc.ProtocolLength),
+		fmt.Sprintf("Service UUID: %s", mc.ServiceUUID),
+		fmt.Sprintf("Host IP Assignment Type: 0x%02X", mc.HostIPAssignmentType),
+		fmt.Sprintf("Host IP Address Format: 0x%02X", mc.HostIPAddressFormat),
+		fmt.Sprintf("Host IP Address: %s", mc.HostIPAddress.NetIP()),
+		fmt.Sprintf("Host IP Mask: %s", net.IP(mc.HostIPMask[:])),
+		fmt.Sprintf("BMC IP Discovery Type: 0x%02X", mc.BmcIPDiscoveryType),
+		fmt.Sprintf("BMC IP Address Format: 0x%02X", mc.BmcIPAddressFormat),
+		fmt.Sprintf("BMC IP Address: %s", mc.BmcIPAddress.NetIP()),
+		fmt.Sprintf("BMC IP Mask: %s", net.IP(mc.BmcIPMask[:])),
+		fmt.Sprintf("Redfish Port: %d", mc.RedfishPort),
+		fmt.Sprintf("VLAN ID: %d", mc.VlanID),
+		fmt.Sprintf("Hostname: %s", mc.Hostname),
+	}
+	return strings.Join(lines, "\n\t")
+}

--- a/pkg/smbios/type42_management_controller_host_interface_test.go
+++ b/pkg/smbios/type42_management_controller_host_interface_test.go
@@ -1,0 +1,216 @@
+// Copyright 2016-2026 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package smbios
+
+import (
+	"bytes"
+	"net"
+	"testing"
+)
+
+func TestType42RedfishWithTrailingStringHostname(t *testing.T) {
+	// Header (4 bytes) + physical & USB data (10 bytes)
+	headerAndInterfaceBytes := []byte{
+		42, 108, 0x01, 0x00, // Type=42, Length=108, Handle=0x0001
+		0x40,       // InterfaceType Network Host
+		8,          // InterfaceTypeSpecificDataLength
+		2,          // DeviceType USB
+		0x12, 0x34, // VendorID
+		0x01, 0x00, // ProductID
+		2, // UsbLength
+		3, // UsbDescriptorType
+		1, // SerialNumber string index 1
+	}
+
+	uuidVal := []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	hostIP := net.ParseIP("fe80::211:32ff:fe54:8801").To16()
+	hostMask := net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff::").To16())
+	bmcIP := net.ParseIP("fe80::1").To16()
+	bmcMask := net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff::").To16())
+
+	protoData := []byte{}
+	protoData = append(protoData, uuidVal...)
+	protoData = append(protoData, 1) // HostIPAssignmentType Static
+	protoData = append(protoData, 2) // HostIPAddressFormat IPv6
+	protoData = append(protoData, hostIP...)
+	protoData = append(protoData, hostMask...)
+	protoData = append(protoData, 1) // BmcIPDiscoveryType Static
+	protoData = append(protoData, 2) // BmcIPAddressFormat IPv6
+	protoData = append(protoData, bmcIP...)
+	protoData = append(protoData, bmcMask...)
+	protoData = append(protoData, 0xB6, 0x27) // RedfishPort 10166
+	protoData = append(protoData, 0, 0, 0, 0) // VlanID 0
+	protoData = append(protoData, 2)          // Hostname string index 2
+
+	payload := []byte{}
+	payload = append(payload, 1)  // ProtocolCount 1
+	payload = append(payload, 4)  // ProtocolIdentifier Redfish
+	payload = append(payload, 91) // ProtocolLength 91 (includes 1-byte Hostname index)
+	payload = append(payload, protoData...)
+
+	rawTableData := append([]byte(nil), headerAndInterfaceBytes...)
+	rawTableData = append(rawTableData, payload...)
+
+	strings := []string{"SerialNumber123", "bmc-hostname"}
+
+	tObj := &Table{
+		Header: Header{
+			Type:   42,
+			Length: uint8(len(rawTableData)),
+			Handle: 0x0001,
+		},
+		data:    rawTableData,
+		strings: strings,
+	}
+
+	// 1. Parse and verify
+	mc, err := ParseManagementControllerHostInterface(tObj)
+	if err != nil {
+		t.Fatalf("Failed to parse Type 42 IPv6 with string index hostname: %v", err)
+	}
+
+	if mc.Hostname != "bmc-hostname" {
+		t.Errorf("Expected resolved hostname 'bmc-hostname', got '%s'", mc.Hostname)
+	}
+
+	// 2. Marshal and verify
+	tableMarshaled, err := mc.toTable()
+	if err != nil {
+		t.Fatalf("Failed to marshal back: %v", err)
+	}
+
+	if !bytes.Equal(tableMarshaled.data, tObj.data) {
+		t.Errorf("Marshaled data mismatch")
+	}
+}
+
+func TestType42RedfishWithInLineHostname(t *testing.T) {
+	headerAndInterfaceBytes := []byte{
+		42, 123, 0x01, 0x00, // Type=42, Length=123, Handle=0x0001
+		0x40,       // InterfaceType Network Host
+		8,          // InterfaceTypeSpecificDataLength
+		2,          // DeviceType USB
+		0x12, 0x34, // VendorID
+		0x01, 0x00, // ProductID
+		2, // UsbLength
+		3, // UsbDescriptorType
+		1, // SerialNumber string index 1
+	}
+
+	uuidVal := []byte{0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}
+	hostIP := net.ParseIP("fe80::211:32ff:fe54:8801").To16()
+	hostMask := net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff::").To16())
+	bmcIP := net.ParseIP("fe80::1").To16()
+	bmcMask := net.IPMask(net.ParseIP("ffff:ffff:ffff:ffff::").To16())
+
+	protoData := []byte{}
+	protoData = append(protoData, uuidVal...)
+	protoData = append(protoData, 1) // HostIPAssignmentType Static
+	protoData = append(protoData, 2) // HostIPAddressFormat IPv6
+	protoData = append(protoData, hostIP...)
+	protoData = append(protoData, hostMask...)
+	protoData = append(protoData, 1) // BmcIPDiscoveryType Static
+	protoData = append(protoData, 2) // BmcIPAddressFormat IPv6
+	protoData = append(protoData, bmcIP...)
+	protoData = append(protoData, bmcMask...)
+	protoData = append(protoData, 0xB6, 0x27) // RedfishPort 10166
+	protoData = append(protoData, 0, 0, 0, 0) // VlanID 0
+	protoData = append(protoData, 15)         // Hostname string Length (15)
+	protoData = append(protoData, []byte("inline-bmc-host")...)
+
+	payload := []byte{}
+	payload = append(payload, 1)   // ProtocolCount 1
+	payload = append(payload, 4)   // ProtocolIdentifier Redfish
+	payload = append(payload, 106) // ProtocolLength 106 (90 + 1 + 15 in-line bytes)
+	payload = append(payload, protoData...)
+
+	rawTableData := append([]byte(nil), headerAndInterfaceBytes...)
+	rawTableData = append(rawTableData, payload...)
+
+	strings := []string{"SerialNumber123"} // SerialNumber string section
+
+	tObj := &Table{
+		Header: Header{
+			Type:   42,
+			Length: uint8(len(rawTableData)),
+			Handle: 0x0001,
+		},
+		data:    rawTableData,
+		strings: strings,
+	}
+
+	// 1. Parse and verify
+	mc, err := ParseManagementControllerHostInterface(tObj)
+	if err != nil {
+		t.Fatalf("Failed to parse Type 42 with in-line hostname: %v", err)
+	}
+
+	if mc.Hostname != "inline-bmc-host" {
+		t.Errorf("Expected parsed in-line hostname 'inline-bmc-host', got '%s'", mc.Hostname)
+	}
+
+	// 2. Marshal and verify
+	tableMarshaled, err := mc.toTable()
+	if err != nil {
+		t.Fatalf("Failed to marshal back: %v", err)
+	}
+
+	if !bytes.Equal(tableMarshaled.data, tObj.data) {
+		t.Errorf("Marshaled data mismatch")
+	}
+}
+
+func TestType42ErrorCases(t *testing.T) {
+	// 1. Invalid table type (e.g., Type 1 System Info)
+	tObjInvalidType := &Table{
+		Header: Header{
+			Type:   TableTypeSystemInfo,
+			Length: 8,
+			Handle: 0x0001,
+		},
+		data: []byte{1, 8, 0x01, 0x00, 0, 0, 0, 0},
+	}
+	if _, err := ParseManagementControllerHostInterface(tObjInvalidType); err == nil {
+		t.Error("Expected error parsing non-Type 42 table, got nil")
+	}
+
+	// 2. Truncated data (shorter than 11 bytes)
+	tObjTruncated := &Table{
+		Header: Header{
+			Type:   42,
+			Length: 8,
+			Handle: 0x0001,
+		},
+		data: []byte{42, 8, 0x01, 0x00, 0x40, 8, 2, 0},
+	}
+	if _, err := ParseManagementControllerHostInterface(tObjTruncated); err == nil {
+		t.Error("Expected error parsing truncated Type 42 table, got nil")
+	}
+}
+
+func TestType42String(t *testing.T) {
+	tObj := &Table{
+		Header: Header{
+			Type:   42,
+			Length: 108,
+			Handle: 0x0001,
+		},
+		data: make([]byte, 108),
+	}
+	tObj.data[0] = 42
+	tObj.data[1] = 108
+	tObj.data[4] = 0x40
+	tObj.data[5] = 8
+
+	mc, err := ParseManagementControllerHostInterface(tObj)
+	if err != nil {
+		t.Fatalf("Failed to parse: %v", err)
+	}
+
+	str := mc.String()
+	if str == "" {
+		t.Error("String representation is empty")
+	}
+}


### PR DESCRIPTION
This allows dynamically modifying USB Redfish host interface configurations in system memory, and adds parsing and serialization support for Type 42 Management Controller Host Interface tables.
