### PR TITLE
cmds/core/mktemp: suppress errors with quiet is true

### DIFF
--- a/cmds/core/mktemp/mktemp.go
+++ b/cmds/core/mktemp/mktemp.go
@@ -67,16 +67,21 @@ func (c *cmd) mktemp() (string, error) {
 	}
 
 	if c.flags.d {
-		d, err := os.MkdirTemp(c.flags.dir, c.flags.prefix)
-		return d, err
+		return os.MkdirTemp(c.flags.dir, c.flags.prefix)
 	}
 	f, err := os.CreateTemp(c.flags.dir, c.flags.prefix)
-	return f.Name(), err
+	if err != nil {
+		return "", err
+	}
+	return f.Name(), nil
 }
 
 func (c *cmd) run() error {
 	fileName, err := c.mktemp()
-	if err != nil && !c.flags.q {
+	if err != nil {
+		if c.flags.q {
+			return nil
+		}
 		return err
 	}
 

--- a/cmds/core/mktemp/mktemp_test.go
+++ b/cmds/core/mktemp/mktemp_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"os"
 	"path/filepath"
@@ -47,6 +48,15 @@ func TestMkTemp(t *testing.T) {
 			out:     "",
 			err:     nil,
 		},
+		{
+			cmdline: []string{"mktemp", "-p", "/notexists"},
+			out:     "",
+			err:     os.ErrNotExist,
+		},
+		{
+			cmdline: []string{"mktemp", "-q", "-p", "/notexists"},
+			out:     "",
+		},
 	}
 
 	// Table-driven testing
@@ -54,7 +64,7 @@ func TestMkTemp(t *testing.T) {
 		var stdout bytes.Buffer
 		cmd := command(&stdout, tt.cmdline)
 		err := cmd.run()
-		if err != tt.err {
+		if !errors.Is(err, tt.err) {
 			t.Errorf("expected %v, got %v", tt.err, err)
 		}
 


### PR DESCRIPTION
fix an error when mktemp -p nonexistent will end in a nil pointer