### PR TITLE
pkg/smbios: Update ProtocolLength on Hostname override

### DIFF
--- a/pkg/smbios/smbios_modifier.go
+++ b/pkg/smbios/smbios_modifier.go
@@ -369,6 +369,7 @@ func ReplaceUsbRedfishHostInterface(cfg *RedfishHostInterfaceConfig) OverrideOpt
 			}
 			if cfg.Hostname != "" {
 				mc.Hostname = cfg.Hostname
+				mc.ProtocolLength = uint8(90 + 1 + len(cfg.Hostname))
 			}
 
 			mct, err := mc.toTable()

--- a/pkg/smbios/smbios_modifier_test.go
+++ b/pkg/smbios/smbios_modifier_test.go
@@ -746,4 +746,8 @@ func TestReplaceUsbRedfishHostInterface(t *testing.T) {
 	if mc.RedfishPort != 8080 || mc.VlanID != 10 {
 		t.Errorf("Expected modified Port and VlanID")
 	}
+
+	if mc.ProtocolLength != 103 {
+		t.Errorf("Expected ProtocolLength to be 103, got %d", mc.ProtocolLength)
+	}
 }


### PR DESCRIPTION
This updates the ProtocolLength field in the ManagementControllerHostInterface structure when overriding the Hostname dynamically in ReplaceUsbRedfishHostInterface. According to the DSP0270 Redfish Host Interface Specification, the ProtocolLength for an inline hostname is calculated as 90 + 1 + len(Hostname). Updating this field ensures the table remains valid and matches the dynamically generated payload length.