### PR TITLE
cmds/core/kill: return 1 on error

### DIFF
--- a/cmds/core/kill/kill.go
+++ b/cmds/core/kill/kill.go
@@ -22,22 +22,22 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
 	"os"
 )
 
-const eUsage = "Usage: kill -l | kill [<-s | --signal | -> <signame|signum>] pid [pid...]"
-
-func usage(w io.Writer) {
-	fmt.Fprintf(w, "%s\n", eUsage)
-}
+var (
+	errUsage         = errors.New("usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]")
+	errCannotKill    = errors.New("some processes could not be killed")
+	errInvalidSignal = errors.New("invalid signal")
+)
 
 func killProcess(w io.Writer, args ...string) error {
 	if len(args) < 2 {
-		usage(w)
-		return nil
+		return errUsage
 	}
 	op := args[1]
 	pids := args[2:]
@@ -57,8 +57,7 @@ func killProcess(w io.Writer, args ...string) error {
 
 	if op[0:2] == "-l" {
 		if len(args) > 2 {
-			usage(w)
-			return nil
+			return errUsage
 		}
 		fmt.Fprintf(w, "%s\n", siglist())
 		return nil
@@ -70,8 +69,7 @@ func killProcess(w io.Writer, args ...string) error {
 
 	if op == "-s" || op == "--signal" {
 		if len(args) < 3 {
-			usage(w)
-			return nil
+			return errUsage
 		}
 		op = args[2]
 		pids = args[3:]
@@ -81,15 +79,14 @@ func killProcess(w io.Writer, args ...string) error {
 
 	s, ok := signums[op]
 	if !ok {
-		return fmt.Errorf("%v is not a valid signal", op)
+		return fmt.Errorf("%v: %w", op, errInvalidSignal)
 	}
 
 	if len(pids) < 1 {
-		usage(w)
-		return nil
+		return errUsage
 	}
 	if err := kill(s, pids...); err != nil {
-		return fmt.Errorf("some processes could not be killed: %w", err)
+		return fmt.Errorf("%w: %w", errCannotKill, err)
 	}
 	return nil
 }

--- a/cmds/core/kill/kill_test.go
+++ b/cmds/core/kill/kill_test.go
@@ -6,9 +6,9 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os/exec"
-	"strings"
 	"testing"
 )
 
@@ -25,16 +25,17 @@ func TestKillProcess(t *testing.T) {
 		name string
 		args []string
 		want string
+		err  error
 	}{
 		{
 			name: "not enough args",
 			args: []string{"kill"},
-			want: fmt.Sprintf("%s\n", eUsage),
+			err:  errUsage,
 		},
 		{
 			name: "list signal names with too much args",
 			args: []string{"kill", "-l", "10"},
-			want: fmt.Sprintf("%s\n", eUsage),
+			err:  errUsage,
 		},
 		{
 			name: "list signal names",
@@ -42,46 +43,36 @@ func TestKillProcess(t *testing.T) {
 			want: fmt.Sprintf("%s\n", siglist()),
 		},
 		{
-			name: "kill pid 2",
-			args: []string{"kill", "2"},
-			want: "",
-		},
-		{
 			name: "kill signal without signal and pid",
 			args: []string{"kill", "-s"},
-			want: fmt.Sprintf("%s\n", eUsage),
+			err:  errUsage,
 		},
 		{
 			name: "kill signal with signal but without pid",
 			args: []string{"kill", "--signal", "9"},
-			want: fmt.Sprintf("%s\n", eUsage),
-		},
-		{
-			name: "kill signal with signal and pid",
-			args: []string{"kill", "--signal", "50", "2"},
-			want: "",
+			err:  errUsage,
 		},
 		{
 			name: "kill signal with signal and wrong pid",
 			args: []string{"kill", "--signal", "9", getUnusedPID()},
-			want: "some processes could not be killed",
+			err:  errCannotKill,
 		},
 		{
 			name: "signal is invalid",
 			args: []string{"kill", "--signal", "a"},
-			want: "is not a valid signal",
+			err:  errInvalidSignal,
 		},
 		{
 			name: "signal is invalid",
 			args: []string{"kill", "-1", "a"},
-			want: "some processes could not be killed: a: arguments must be process or job IDS",
+			err:  errCannotKill,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			buf := &bytes.Buffer{}
 			if err := killProcess(buf, tt.args...); err != nil {
-				if !strings.Contains(err.Error(), tt.want) {
-					t.Errorf("killProcess() = %q, want to contain: %q", err.Error(), tt.want)
+				if !errors.Is(err, tt.err) {
+					t.Errorf("killProcess() = %v, want %v", err, tt.err)
 				}
 			} else {
 				if buf.String() != tt.want {


### PR DESCRIPTION
update tests with errors.Is,
removed two tests that are trying to kill pid 2, I don't think
they are worked as intended, without root they will just
return an error and print nothing to stdout without deleting anything