### PR TITLE
cpio: avoid comparing directory sizes in test

### DIFF
--- a/cmds/core/cpio/cpio_posix_test.go
+++ b/cmds/core/cpio/cpio_posix_test.go
@@ -18,9 +18,11 @@ func checkFileInfo(t *testing.T, ent *dirEnt, newFileInfo os.FileInfo) {
 
 	newStatT := newFileInfo.Sys().(*syscall.Stat_t)
 	statT := ent.FileInfo.Sys().(*syscall.Stat_t)
+	// Directory sizes are filesystem-specific and are not portable archive content.
+	sizeMatches := ent.FileInfo.IsDir() || ent.FileInfo.Size() == newFileInfo.Size()
 	t.Logf("Entry %v statT %v old ino %d new Ino %d", ent, newFileInfo, statT.Ino, newStatT.Ino)
 	if ent.FileInfo.Name() != newFileInfo.Name() ||
-		ent.FileInfo.Size() != newFileInfo.Size() ||
+		!sizeMatches ||
 		ent.FileInfo.Mode() != newFileInfo.Mode() ||
 		ent.FileInfo.IsDir() != newFileInfo.IsDir() ||
 		statT.Mode != newStatT.Mode ||


### PR DESCRIPTION
## Summary
- stop requiring extracted directories to report the same size as their source directories
- keep file-size checks for non-directories and leave the other POSIX metadata checks in place

This addresses the CircleCI `race` failure seen on #3605, where `TestCpio` failed because Linux reported different sizes for the source and extracted `directory1`.

## Testing
- `GOCACHE=/private/tmp/u-root-cpio-race-gocache GOMODCACHE=/private/tmp/u-root-cpio-race-gomod GOTOOLCHAIN=go1.25.7 go test -count=1 ./cmds/core/cpio`
- `GOCACHE=/private/tmp/u-root-cpio-race-gocache GOMODCACHE=/private/tmp/u-root-cpio-race-gomod GOTOOLCHAIN=go1.25.7 go test -race -count=1 ./cmds/core/cpio`