### PR TITLE
cmds/core/mount9p: add cache options

### DIFF
--- a/cmds/core/mount9p/mount9p.go
+++ b/cmds/core/mount9p/mount9p.go
@@ -30,6 +30,7 @@ var (
 	useSSH      = flag.Bool("ssh", false, "Use ssh for transport")
 	privateKey  = flag.String("private_key", "id_rsa", "Path to your private key")
 	fastTimeout = flag.Bool("fast_timeout", false, "Quickly timeout server connections")
+	cache       = flag.String("cache", "none", "Cache mode")
 )
 
 // Run does the mount and blocks if necessary.  Cancel the context to unblock
@@ -57,7 +58,7 @@ func run(ctx context.Context) error {
 		}
 	}()
 	// If we blocked for ssh, err will be non-nil.
-	return ssh9p.Mount9P(ctx, ready, c, onto, ssh9p.WithSSHClient(cfg), ssh9p.WithUnixFlags(unix.MS_NOSUID|unix.MS_NODEV), ssh9p.WithFastTCPTimeout(*fastTimeout))
+	return ssh9p.Mount9P(ctx, ready, c, onto, ssh9p.WithSSHClient(cfg), ssh9p.WithUnixFlags(unix.MS_NOSUID|unix.MS_NODEV), ssh9p.WithFastTCPTimeout(*fastTimeout), ssh9p.WithCache(*cache))
 }
 
 func main() {

--- a/pkg/ssh9p/ssh9p.go
+++ b/pkg/ssh9p/ssh9p.go
@@ -103,6 +103,7 @@ type mountOpts struct {
 	unixFlags      int
 	msize          int
 	fastTCPTimeout bool
+	cache          string
 	cfg            *ssh.ClientConfig
 }
 
@@ -137,6 +138,14 @@ func WithFastTCPTimeout(enable bool) MountOpt {
 func WithSSHClient(cfg *ssh.ClientConfig) MountOpt {
 	return func(m *mountOpts) {
 		m.cfg = cfg
+	}
+}
+
+// WithCache sets the cache option.  See
+// https://docs.kernel.org/filesystems/9p.html for valid values.
+func WithCache(cache string) MountOpt {
+	return func(m *mountOpts) {
+		m.cache = cache
 	}
 }
 
@@ -223,6 +232,7 @@ func Mount9P(ctx context.Context, mntReady chan<- bool, c net.Conn, mountPoint s
 
 	m := &mountOpts{
 		msize: 64 * 1024,
+		cache: "none",
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -266,7 +276,7 @@ func Mount9P(ctx context.Context, mntReady chan<- bool, c net.Conn, mountPoint s
 	// We can close the FD after we give it to the kernel.  (internal dup).
 	defer tfd.Close()
 
-	mntstr := fmt.Sprintf("version=9p2000.L,noxattr,trans=fd,rfdno=%d,wfdno=%d,debug=0,msize=%d", tfd.Fd(), tfd.Fd(), m.msize)
+	mntstr := fmt.Sprintf("version=9p2000.L,noxattr,cache=%s,trans=fd,rfdno=%d,wfdno=%d,debug=0,msize=%d", m.cache, tfd.Fd(), tfd.Fd(), m.msize)
 	if err := unix.Mount("ssh9p", mountPoint, "9p", uintptr(m.unixFlags), mntstr); err != nil {
 		return fmt.Errorf("9P mount: %w", err)
 	}


### PR DESCRIPTION
Tested: manually mounted with various cache options, including none, loose, 0b00000010 (which should fail) and 2.