### PR TITLE
create extracted files with the record mode, not 0666

### DIFF
--- a/pkg/cpio/fs_plan9.go
+++ b/pkg/cpio/fs_plan9.go
@@ -95,7 +95,7 @@ func CreateFileInRoot(f Record, rootDir string, forcePriv bool) error {
 
 	switch m {
 	case os.FileMode(0):
-		nf, err := os.Create(f.Name)
+		nf, err := os.OpenFile(f.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, toFileMode(f).Perm())
 		if err != nil {
 			return err
 		}

--- a/pkg/cpio/fs_unix.go
+++ b/pkg/cpio/fs_unix.go
@@ -139,7 +139,7 @@ func CreateFileInRoot(f Record, rootDir string, forcePriv bool) error {
 		return os.Symlink(string(content), f.Name)
 
 	case os.FileMode(0):
-		nf, err := os.Create(f.Name)
+		nf, err := os.OpenFile(f.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, toFileMode(f).Perm())
 		if err != nil {
 			return err
 		}

--- a/pkg/cpio/fs_unix_test.go
+++ b/pkg/cpio/fs_unix_test.go
@@ -7,8 +7,11 @@
 package cpio
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"sync"
+	"syscall"
 	"testing"
 )
 
@@ -29,5 +32,63 @@ func TestCreateFileInRoot(t *testing.T) {
 
 	if string(b) != content {
 		t.Errorf("expected %q got %q", content, string(b))
+	}
+}
+
+// modeSpyReaderAt records the on-disk mode of statPath the first time the
+// record content is read, i.e. while CreateFileInRoot is still copying into
+// the freshly created file and before it applies the final mode.
+type modeSpyReaderAt struct {
+	data     []byte
+	statPath string
+	once     sync.Once
+	mode     os.FileMode
+}
+
+func (s *modeSpyReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	s.once.Do(func() {
+		if fi, err := os.Stat(s.statPath); err == nil {
+			s.mode = fi.Mode()
+		}
+	})
+	if off >= int64(len(s.data)) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.data[off:])
+	if off+int64(n) >= int64(len(s.data)) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func TestCreateFileInRootMode(t *testing.T) {
+	// Pin umask so the observed create mode is deterministic.
+	old := syscall.Umask(0)
+	defer syscall.Umask(old)
+
+	tmp := t.TempDir()
+	name := "secret"
+	spy := &modeSpyReaderAt{
+		data:     []byte("topsecret"),
+		statPath: filepath.Join(tmp, name),
+	}
+	rec := Record{
+		ReaderAt: spy,
+		Info: Info{
+			Name:     name,
+			Mode:     S_IFREG | 0o600,
+			FileSize: uint64(len(spy.data)),
+		},
+	}
+
+	if err := CreateFileInRoot(rec, tmp, false); err != nil {
+		t.Fatalf("CreateFileInRoot: %v", err)
+	}
+
+	if spy.mode&0o077 != 0 {
+		t.Errorf("file group/world accessible while being written: mode %#o", spy.mode.Perm())
+	}
+	if got := spy.mode.Perm(); got != 0o600 {
+		t.Errorf("create mode = %#o, want 0o600", got)
 	}
 }

--- a/pkg/cpio/fs_windows.go
+++ b/pkg/cpio/fs_windows.go
@@ -92,7 +92,7 @@ func CreateFileInRoot(f Record, rootDir string, forcePriv bool) error {
 
 	switch m {
 	case os.FileMode(0):
-		nf, err := os.Create(f.Name)
+		nf, err := os.OpenFile(f.Name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, toFileMode(f).Perm())
 		if err != nil {
 			return err
 		}

--- a/pkg/tarutil/tar.go
+++ b/pkg/tarutil/tar.go
@@ -215,7 +215,7 @@ func createFileInRoot(hdr *tar.Header, r io.Reader, rootDir string) error {
 		return fmt.Errorf("symlinks not yet supported: %q", path)
 
 	case os.FileMode(0):
-		f, err := os.Create(path)
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, fi.Mode().Perm())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Repro: extract a `cpio` or `tar` whose regular-file record has mode `0600` while the process `umask` is `0`.
Cause: `CreateFileInRoot`/`createFileInRoot` create the file with `os.Create` (mode `0666`) and only `chmod` to the record mode after the content copy finishes, so the file is group/world readable, and world writable under a zero `umask`, for the whole write window.
Fix: open with `os.OpenFile` using the record permission bits, the way `uzip.FromZip` already does. The trailing mode set is kept so the final bits stay exact.