### PR TITLE
dhclient: reject line breaks in DHCP domain and search options

### DIFF
--- a/pkg/dhclient/dhclient.go
+++ b/pkg/dhclient/dhclient.go
@@ -105,6 +105,19 @@ func IfUp(ifname string, linkUpTimeout time.Duration) (netlink.Link, error) {
 
 // WriteDNSSettings writes the given nameservers, search list, and domain to the resolv.conf at the specified path.
 func WriteDNSSettings(ns []net.IP, sl []string, domain, resolvConfPath string) error {
+	// domain and the search labels come straight from DHCP options 15 and
+	// 119, which are raw byte strings under the server's control. A line
+	// break in either one would be written verbatim and inject extra
+	// resolv.conf directives, so refuse it before touching the file.
+	if strings.ContainsAny(domain, "\r\n") {
+		return fmt.Errorf("invalid domain name %q: contains a line break", domain)
+	}
+	for _, s := range sl {
+		if strings.ContainsAny(s, "\r\n") {
+			return fmt.Errorf("invalid search domain %q: contains a line break", s)
+		}
+	}
+
 	rc := &bytes.Buffer{}
 	if domain != "" {
 		rc.WriteString(fmt.Sprintf("domain %s\n", domain))

--- a/pkg/dhclient/dhclient_test.go
+++ b/pkg/dhclient/dhclient_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dhclient
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteDNSSettings(t *testing.T) {
+	ns := []net.IP{net.ParseIP("10.0.0.1")}
+
+	for _, tt := range []struct {
+		name    string
+		domain  string
+		search  []string
+		wantErr bool
+	}{
+		{
+			name:   "clean",
+			domain: "corp.example",
+			search: []string{"corp.example", "example.com"},
+		},
+		{
+			name:    "newline in domain",
+			domain:  "corp.example\nnameserver 6.6.6.6",
+			wantErr: true,
+		},
+		{
+			name:    "carriage return in domain",
+			domain:  "corp.example\rnameserver 6.6.6.6",
+			wantErr: true,
+		},
+		{
+			name:    "newline in search label",
+			search:  []string{"a.example\noptions ndots:0"},
+			wantErr: true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "resolv.conf")
+			err := WriteDNSSettings(ns, tt.search, tt.domain, path)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("WriteDNSSettings(%q, %q) = nil, want error", tt.domain, tt.search)
+				}
+				// The malformed field must never reach the file.
+				if b, rerr := os.ReadFile(path); rerr == nil {
+					if strings.Contains(string(b), "6.6.6.6") || strings.Contains(string(b), "ndots") {
+						t.Fatalf("injected directive written to resolv.conf:\n%s", b)
+					}
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("WriteDNSSettings() = %v, want nil", err)
+			}
+			b, rerr := os.ReadFile(path)
+			if rerr != nil {
+				t.Fatalf("ReadFile: %v", rerr)
+			}
+			if got := string(b); !strings.Contains(got, "nameserver 10.0.0.1\n") {
+				t.Fatalf("resolv.conf missing nameserver line:\n%s", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
1. `WriteDNSSettings` writes the DHCP `domain` (option 15) and `search` labels (option 119) into `resolv.conf` as-is.
2. `insomniacslk/dhcp` hands those options back as raw bytes, so a `\n` in either field is written verbatim and injects extra `resolv.conf` directives below the intended line.

Repro: a lease with `domain` = `corp.example\nnameserver 6.6.6.6` produces a `resolv.conf` carrying a rogue `nameserver` line of its own; a `search` label `a.example\noptions ndots:0` does the same.
Expected: the malformed value is rejected.
Actual: it is written verbatim.
Fix: reject a `domain`/`search` value containing `\r`/`\n` in `WriteDNSSettings`; both `dhcp4` and `dhcp6` funnel through it. Regression test added.