### PR TITLE
reject weak digests in fit signature verification

### DIFF
--- a/pkg/boot/fit/fit_test.go
+++ b/pkg/boot/fit/fit_test.go
@@ -6,7 +6,6 @@ package fit
 
 import (
 	"bytes"
-	"crypto"
 	"errors"
 	"fmt"
 	"io"
@@ -17,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/u-root/u-root/pkg/boot"
-	"github.com/u-root/u-root/pkg/dt"
 	"github.com/u-root/u-root/pkg/vfile"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -365,67 +363,5 @@ func TestRank(t *testing.T) {
 	l := img.Rank()
 	if l != testRank {
 		t.Fatalf("Expected Image rank %d, got %d", testRank, l)
-	}
-}
-
-func TestParseHash(t *testing.T) {
-	for _, tt := range []struct {
-		algo string
-		want crypto.Hash
-		ok   bool
-	}{
-		{algo: "sha256,rsa4096", want: crypto.SHA256, ok: true},
-		{algo: "sha512,rsa2048", want: crypto.SHA512, ok: true},
-		{algo: "sha384", want: crypto.SHA384, ok: true},
-		// Broken/weak digests must be rejected rather than silently
-		// downgrading signature strength.
-		{algo: "md5,rsa2048", ok: false},
-		{algo: "md4", ok: false},
-		{algo: "sha1,rsa4096", ok: false},
-		{algo: "ripemd160,rsa2048", ok: false},
-	} {
-		t.Run(tt.algo, func(t *testing.T) {
-			got, err := parseHash(tt.algo)
-			if tt.ok {
-				if err != nil {
-					t.Fatalf("parseHash(%q) returned error %v, want %v", tt.algo, err, tt.want)
-				}
-				if got != tt.want {
-					t.Fatalf("parseHash(%q) = %v, want %v", tt.algo, got, tt.want)
-				}
-				return
-			}
-			if err == nil {
-				t.Fatalf("parseHash(%q) = %v, want rejection", tt.algo, got)
-			}
-		})
-	}
-}
-
-func TestParseSignaturesRejectsWeakRSAHash(t *testing.T) {
-	weak := &dt.Node{
-		Name: "signature@1",
-		Properties: []dt.Property{
-			{Name: "value", Value: []byte{1, 2, 3, 4}},
-			{Name: "algo", Value: []byte("sha1,rsa2048")},
-		},
-	}
-	if sigs, err := parseSignatures(weak); err == nil {
-		t.Fatalf("parseSignatures with sha1,rsa2048 = %v, want error", sigs)
-	}
-
-	strong := &dt.Node{
-		Name: "signature@1",
-		Properties: []dt.Property{
-			{Name: "value", Value: []byte{1, 2, 3, 4}},
-			{Name: "algo", Value: []byte("sha256,rsa2048")},
-		},
-	}
-	sigs, err := parseSignatures(strong)
-	if err != nil {
-		t.Fatalf("parseSignatures with sha256,rsa2048 = %v, want a signature", err)
-	}
-	if len(sigs) != 1 {
-		t.Fatalf("parseSignatures with sha256,rsa2048 gave %d signatures, want 1", len(sigs))
 	}
 }

--- a/pkg/boot/fit/fit_test.go
+++ b/pkg/boot/fit/fit_test.go
@@ -6,6 +6,7 @@ package fit
 
 import (
 	"bytes"
+	"crypto"
 	"errors"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/u-root/u-root/pkg/boot"
+	"github.com/u-root/u-root/pkg/dt"
 	"github.com/u-root/u-root/pkg/vfile"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
@@ -363,5 +365,67 @@ func TestRank(t *testing.T) {
 	l := img.Rank()
 	if l != testRank {
 		t.Fatalf("Expected Image rank %d, got %d", testRank, l)
+	}
+}
+
+func TestParseHash(t *testing.T) {
+	for _, tt := range []struct {
+		algo string
+		want crypto.Hash
+		ok   bool
+	}{
+		{algo: "sha256,rsa4096", want: crypto.SHA256, ok: true},
+		{algo: "sha512,rsa2048", want: crypto.SHA512, ok: true},
+		{algo: "sha384", want: crypto.SHA384, ok: true},
+		// Broken/weak digests must be rejected rather than silently
+		// downgrading signature strength.
+		{algo: "md5,rsa2048", ok: false},
+		{algo: "md4", ok: false},
+		{algo: "sha1,rsa4096", ok: false},
+		{algo: "ripemd160,rsa2048", ok: false},
+	} {
+		t.Run(tt.algo, func(t *testing.T) {
+			got, err := parseHash(tt.algo)
+			if tt.ok {
+				if err != nil {
+					t.Fatalf("parseHash(%q) returned error %v, want %v", tt.algo, err, tt.want)
+				}
+				if got != tt.want {
+					t.Fatalf("parseHash(%q) = %v, want %v", tt.algo, got, tt.want)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("parseHash(%q) = %v, want rejection", tt.algo, got)
+			}
+		})
+	}
+}
+
+func TestParseSignaturesRejectsWeakRSAHash(t *testing.T) {
+	weak := &dt.Node{
+		Name: "signature@1",
+		Properties: []dt.Property{
+			{Name: "value", Value: []byte{1, 2, 3, 4}},
+			{Name: "algo", Value: []byte("sha1,rsa2048")},
+		},
+	}
+	if sigs, err := parseSignatures(weak); err == nil {
+		t.Fatalf("parseSignatures with sha1,rsa2048 = %v, want error", sigs)
+	}
+
+	strong := &dt.Node{
+		Name: "signature@1",
+		Properties: []dt.Property{
+			{Name: "value", Value: []byte{1, 2, 3, 4}},
+			{Name: "algo", Value: []byte("sha256,rsa2048")},
+		},
+	}
+	sigs, err := parseSignatures(strong)
+	if err != nil {
+		t.Fatalf("parseSignatures with sha256,rsa2048 = %v, want a signature", err)
+	}
+	if len(sigs) != 1 {
+		t.Fatalf("parseSignatures with sha256,rsa2048 gave %d signatures, want 1", len(sigs))
 	}
 }

--- a/pkg/boot/fit/vfit.go
+++ b/pkg/boot/fit/vfit.go
@@ -30,10 +30,7 @@ import (
 	"github.com/u-root/u-root/pkg/vfile"
 )
 
-// algs maps the digest names accepted in a signature node's algo property to
-// their crypto.Hash. MD4, MD5, SHA1 and RIPEMD160 are deliberately absent: they
-// offer at most 80-bit collision resistance (fully broken for the MD family and
-// SHA1), so a signature over such a digest can be lifted onto a colliding image.
+// algs must only contain currently secure hash functions.
 var algs = map[string]crypto.Hash{
 	"SHA224":   crypto.SHA224,
 	"SHA256":   crypto.SHA256,

--- a/pkg/boot/fit/vfit.go
+++ b/pkg/boot/fit/vfit.go
@@ -30,19 +30,19 @@ import (
 	"github.com/u-root/u-root/pkg/vfile"
 )
 
+// algs maps the digest names accepted in a signature node's algo property to
+// their crypto.Hash. MD4, MD5, SHA1 and RIPEMD160 are deliberately absent: they
+// offer at most 80-bit collision resistance (fully broken for the MD family and
+// SHA1), so a signature over such a digest can be lifted onto a colliding image.
 var algs = map[string]crypto.Hash{
-	"MD4":       crypto.MD4,
-	"MD5":       crypto.MD5,
-	"SHA1":      crypto.SHA1,
-	"SHA224":    crypto.SHA224,
-	"SHA256":    crypto.SHA256,
-	"SHA384":    crypto.SHA384,
-	"SHA512":    crypto.SHA512,
-	"RIPEMD160": crypto.RIPEMD160,
-	"SHA3_224":  crypto.SHA3_224,
-	"SHA3_256":  crypto.SHA3_256,
-	"SHA3_384":  crypto.SHA3_384,
-	"SHA3_512":  crypto.SHA3_512,
+	"SHA224":   crypto.SHA224,
+	"SHA256":   crypto.SHA256,
+	"SHA384":   crypto.SHA384,
+	"SHA512":   crypto.SHA512,
+	"SHA3_224": crypto.SHA3_224,
+	"SHA3_256": crypto.SHA3_256,
+	"SHA3_384": crypto.SHA3_384,
+	"SHA3_512": crypto.SHA3_512,
 }
 
 // Signature defines an extendable interface for verifying images using
@@ -121,7 +121,7 @@ func (s RSASignature) String() string {
 }
 
 // parseHash cleans and maps the first detected hash string into a crypto.Hash.
-// Expected format: "sha256,rsa4096" or "sha1"
+// Expected format: "sha256,rsa4096" or "sha512"
 func parseHash(algo string) (crypto.Hash, error) {
 	cleaned := strings.TrimFunc(algo, func(r rune) bool {
 		return !unicode.IsGraphic(r)


### PR DESCRIPTION
Repro: build a FIT whose `signature` node has `algo = "md5,rsa2048"` (or `sha1`, `md4`, `ripemd160`) and sign the image `data` with that digest; `ReadSignedImage` verifies it and returns the image with no error.
Cause: the `algs` allowlist behind `parseHash` maps `MD4`/`MD5`/`SHA1`/`RIPEMD160` to their `crypto.Hash`, so `RSASignature.Verify` will validate a signature made over a broken digest. Each gives at most 80-bit collision resistance, so a signature over a legitimately signed image can be lifted onto a colliding image and still verify.
Fix: drop those four from the allowlist in `pkg/boot/fit/vfit.go`, so `parseHash` rejects them and the signature is treated as unparsable and the image refused. `sha224` and up (SHA-2/SHA-3) continue to verify.