### PR TITLE
README: update Slack invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Conduct](https://github.com/u-root/u-root/wiki/Code-of-Conduct).
 ## Communication
 
 - [Open Source Firmware Slack team](https://osfw.slack.com),
-  channel `#u-root`, sign up [here](https://slack.osfw.dev/)
+  channel `#u-root`, sign up [here](https://slack.osfw.foundation/)
 - [Join the mailing list](https://groups.google.com/forum/#!forum/u-root)
 
 ## Bugs

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/u-root/u-root)](https://goreportcard.com/report/github.com/u-root/u-root)
 [![CodeQL](https://github.com/u-root/u-root/workflows/CodeQL/badge.svg)](https://github.com/u-root/u-root/actions?query=workflow%3ACodeQL)
 [![GoDoc](https://godoc.org/github.com/u-root/u-root?status.svg)](https://godoc.org/github.com/u-root/u-root)
-[![Slack](https://slack.osfw.dev/badge.svg)](https://slack.osfw.dev)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://github.com/u-root/u-root/blob/main/LICENSE)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8160/badge)](https://www.bestpractices.dev/projects/8160)
 
+Community: see [CONTRIBUTING.md](CONTRIBUTING.md#communication)
 
 # Description
 

--- a/docs/src/_includes/partials/site-foot.html
+++ b/docs/src/_includes/partials/site-foot.html
@@ -29,7 +29,7 @@
         </li> #}
 
         <li>
-          <a href="https://slack.osfw.dev/">
+          <a href="https://slack.osfw.foundation/">
             <span class="sr-only">Slack</span>
             {%- icon
               icon = "slack",

--- a/docs/src/_includes/partials/site-head.html
+++ b/docs/src/_includes/partials/site-head.html
@@ -49,7 +49,7 @@
     </li> #}
 
       <li>
-        <a href="https://slack.osfw.dev/">
+        <a href="https://slack.osfw.foundation/">
           <span class="sr-only">Slack</span>
           {%- icon
           icon = "slack",

--- a/docs/src/index.njk
+++ b/docs/src/index.njk
@@ -258,7 +258,7 @@ scripts: 'homeHeroAnimation.js'
           Contribute on GitHub
         </a>
 
-        <a href="https://slack.osfw.dev/" target="blank" class="btn btn--secondary">
+        <a href="https://slack.osfw.foundation/" target="blank" class="btn btn--secondary">
           {%- icon
             icon = "slack",
             width = "1.25em"


### PR DESCRIPTION
There is no longer a badge, so move it down as inline text.