### PR TITLE
fix up Slack invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Conduct](https://github.com/u-root/u-root/wiki/Code-of-Conduct).
 ## Communication
 
 - [Open Source Firmware Slack team](https://osfw.slack.com),
-  channel `#u-root`, sign up [here](https://slack.osfw.foundation/)
+  channel `#u-root`, sign up [here](http://slack.osfw.foundation/)
 - [Join the mailing list](https://groups.google.com/forum/#!forum/u-root)
 
 ## Bugs

--- a/website/src/_includes/partials/site-foot.html
+++ b/website/src/_includes/partials/site-foot.html
@@ -29,7 +29,7 @@
         </li> #}
 
         <li>
-          <a href="https://slack.osfw.foundation/">
+          <a href="http://slack.osfw.foundation/">
             <span class="sr-only">Slack</span>
             {%- icon
               icon = "slack",

--- a/website/src/_includes/partials/site-head.html
+++ b/website/src/_includes/partials/site-head.html
@@ -49,7 +49,7 @@
     </li> #}
 
       <li>
-        <a href="https://slack.osfw.foundation/">
+        <a href="http://slack.osfw.foundation/">
           <span class="sr-only">Slack</span>
           {%- icon
           icon = "slack",

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -258,7 +258,7 @@ scripts: 'homeHeroAnimation.js'
           Contribute on GitHub
         </a>
 
-        <a href="https://slack.osfw.foundation/" target="blank" class="btn btn--secondary">
+        <a href="http://slack.osfw.foundation/" target="blank" class="btn btn--secondary">
           {%- icon
             icon = "slack",
             width = "1.25em"


### PR DESCRIPTION
The URL is only set up to redirect and does not handle HTTPS. Sorry, my bad!

On the plus side, we can now verify that the website deployment finally works. :sweat_smile: 