### PR TITLE
pkg/tarutil: fix file descriptor leak in CreateTar

### DIFF
--- a/pkg/tarutil/tar.go
+++ b/pkg/tarutil/tar.go
@@ -167,6 +167,7 @@ func CreateTar(tarFile io.Writer, files []string, opts *Opts) error {
 				if err != nil {
 					return err
 				}
+				defer f.Close()
 
 				var r io.Reader = f
 				if hdr.Size == 0 {
@@ -175,10 +176,8 @@ func CreateTar(tarFile io.Writer, files []string, opts *Opts) error {
 					// buffer to determine size.
 					b := &bytes.Buffer{}
 					if _, err := io.Copy(b, f); err != nil {
-						f.Close()
 						return err
 					}
-					f.Close()
 					hdr.Size = int64(b.Len())
 					r = b
 				}

--- a/pkg/tarutil/tar_linux_test.go
+++ b/pkg/tarutil/tar_linux_test.go
@@ -1,0 +1,48 @@
+// Copyright 2026 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package tarutil
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+// TestCreateTarManyFiles archives more files than the file descriptor limit
+// allows to be open at once. It is a regression test for CreateTar leaking
+// one descriptor per archived file.
+func TestCreateTarManyFiles(t *testing.T) {
+	dir := t.TempDir()
+	for i := range 80 {
+		if err := os.WriteFile(filepath.Join(dir, fmt.Sprintf("file-%03d", i)), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var old unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &old); err != nil {
+		t.Fatal(err)
+	}
+	limit := old
+	limit.Cur = min(limit.Cur, 64)
+	if err := unix.Setrlimit(unix.RLIMIT_NOFILE, &limit); err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Setrlimit(unix.RLIMIT_NOFILE, &old)
+
+	// CreateTar only derives in-archive names for paths relative to
+	// ChangeDirectory, so archive the temporary directory like
+	// "tar -C / DIR".
+	var archive bytes.Buffer
+	relDir := strings.TrimPrefix(dir, string(filepath.Separator))
+	if err := CreateTar(&archive, []string{relDir}, &Opts{ChangeDirectory: string(filepath.Separator)}); err != nil {
+		t.Fatalf("CreateTar(%q) = %v, want nil", relDir, err)
+	}
+}


### PR DESCRIPTION
`CreateTar` opened each regular file but only closed it in the `hdr.Size == 0` buffering path. Every non-empty regular file left its descriptor open until process exit (on the success path as well as the `WriteHeader` and `io.Copy` error paths), so archiving a large tree could exhaust the file descriptor limit.

Close the file with a `defer` in the per-file walk callback, which also covers the early error returns, and drop the now-redundant explicit closes in the zero-size branch.

Add a regression test that archives more files than the descriptor limit allows open at once.