### PR TITLE
dhclient: preserve resolv.conf entries across lease updates

### DIFF
--- a/pkg/dhclient/dhclient.go
+++ b/pkg/dhclient/dhclient.go
@@ -103,7 +103,8 @@ func IfUp(ifname string, linkUpTimeout time.Duration) (netlink.Link, error) {
 	return nil, fmt.Errorf("link %q still down after %v seconds", ifname, linkUpTimeout.Seconds())
 }
 
-// WriteDNSSettings writes the given nameservers, search list, and domain to the resolv.conf at the specified path.
+// WriteDNSSettings appends the given nameservers, search list, and domain to
+// the resolv.conf at the specified path, preserving existing settings.
 func WriteDNSSettings(ns []net.IP, sl []string, domain, resolvConfPath string) error {
 	rc := &bytes.Buffer{}
 	if domain != "" {
@@ -117,7 +118,16 @@ func WriteDNSSettings(ns []net.IP, sl []string, domain, resolvConfPath string) e
 		rc.WriteString(strings.Join(sl, " "))
 		rc.WriteString("\n")
 	}
-	return os.WriteFile(resolvConfPath, rc.Bytes(), 0o644)
+	f, err := os.OpenFile(resolvConfPath, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o644)
+	if err != nil {
+		return err
+	}
+	_, writeErr := f.Write(rc.Bytes())
+	closeErr := f.Close()
+	if writeErr != nil {
+		return writeErr
+	}
+	return closeErr
 }
 
 // Lease is a network configuration obtained by DHCP.

--- a/pkg/dhclient/dhclient_test.go
+++ b/pkg/dhclient/dhclient_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package dhclient
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteDNSSettingsPreservesExistingSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolv.conf")
+	initial := "# managed by another service\nnameserver 192.0.2.1\n"
+	if err := os.WriteFile(path, []byte(initial), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := WriteDNSSettings([]net.IP{net.ParseIP("192.0.2.2")}, nil, "", path); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteDNSSettings([]net.IP{net.ParseIP("192.0.2.3")}, nil, "", path); err != nil {
+		t.Fatal(err)
+	}
+
+	want := initial + "nameserver 192.0.2.2\nnameserver 192.0.2.3\n"
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("resolv.conf = %q, want %q", got, want)
+	}
+}
+
+func TestWriteDNSSettingsCreatesFileAndPreservesEmptyUpdate(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "resolv.conf")
+
+	if err := WriteDNSSettings(nil, nil, "", path); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteDNSSettings(nil, []string{"example.test", "internal.example.test"}, "example.test", path); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteDNSSettings(nil, nil, "", path); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "domain example.test\nsearch example.test internal.example.test\n"
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != want {
+		t.Fatalf("resolv.conf = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
`WriteDNSSettings` now preserves existing resolver configuration and appends subsequent DHCP DNS settings instead of truncating the target file on every lease configuration. This prevents the last DHCP response from replacing DNS servers supplied by earlier responses.

Added regression coverage for successive updates, existing content, empty updates, file creation, and domain/search formatting.

Tested with:
- `go test ./pkg/dhclient`
- `go test ./cmds/core/dhclient ./cmds/boot/pxeboot ./pkg/dhclient`
- `go test ./pkg/...`
- `go test -race ./pkg/dhclient -run 'TestWriteDNSSettings' -count=1`
- `go vet` on the affected packages

The pinned-base regression reproduced the last-response overwrite and passed with this change.

Fixes #1837