### PR TITLE
pkg/dhclient: propagate IPv6 AddrReplace errors

### DIFF
--- a/pkg/dhclient/dhcp6.go
+++ b/pkg/dhclient/dhcp6.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 
 	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv6"
@@ -78,9 +77,7 @@ func (p *Packet6) Configure() error {
 	}
 
 	if err := netlink.AddrReplace(p.iface, dst); err != nil {
-		if os.IsExist(err) {
-			return fmt.Errorf("add/replace %s to %v: %w", dst, p.iface, err)
-		}
+		return fmt.Errorf("add/replace %s to %v: %w", dst, p.iface, err)
 	}
 
 	if ips := p.DNS(); ips != nil {


### PR DESCRIPTION
`Packet6.Configure` returned an error only when `netlink.AddrReplace` failed with `EEXIST`. `AddrReplace` should never return that error since it sends `RTM_NEWADDR` with `NLM_F_CREATE|NLM_F_REPLACE`, which handles the address replacement case. Real failures were silently ignored, and `dhclient` would write `resolv.conf` without an address configured.

The `os.IsExist` check was dropped from the IPv4 `Configure` function in 090b13509. 92aa8ab99 was intended to update the IPv6 configuration call to be consistent with IPv4, but preserved the `os.IsExist` check. Match the IPv4 behavior and return all errors.