### PR TITLE
cmds/core/ip: fix ip6tnl mode name

### DIFF
--- a/cmds/core/ip/link_linux.go
+++ b/cmds/core/ip/link_linux.go
@@ -400,7 +400,7 @@ func (cmd *cmd) linkAdd() error {
 		return cmd.handle.LinkAdd(&netlink.Gretap{LinkAttrs: attrs})
 	case "ipip":
 		return cmd.handle.LinkAdd(&netlink.Iptun{LinkAttrs: attrs})
-	case "ip6tln":
+	case "ip6tnl":
 		return cmd.handle.LinkAdd(&netlink.Ip6tnl{LinkAttrs: attrs})
 	case "sit":
 		return cmd.handle.LinkAdd(&netlink.Sittun{LinkAttrs: attrs})

--- a/cmds/core/ip/tunnel_linux.go
+++ b/cmds/core/ip/tunnel_linux.go
@@ -35,8 +35,8 @@ Where: NAME := STRING
 )
 
 var (
-	filterMap      = map[string][]string{"gre": {"gre", "ip6gre"}, "ip6gre": {"ip6gre"}, "ipip": {"ipip", "ip6tln"}, "ip6tln": {"ip6tln"}, "vti": {"vti", "vti6"}, "vti6": {"vti6"}, "sit": {"sit"}}
-	allTunnelTypes = []string{"gre", "ipip", "ip6tln", "ip6gre", "vti", "vti6", "sit"}
+	filterMap      = map[string][]string{"gre": {"gre", "ip6gre"}, "ip6gre": {"ip6gre"}, "ipip": {"ipip", "ip6tnl"}, "ip6tnl": {"ip6tnl"}, "vti": {"vti", "vti6"}, "vti6": {"vti6"}, "sit": {"sit"}}
+	allTunnelTypes = []string{"gre", "ipip", "ip6tnl", "ip6gre", "vti", "vti6", "sit"}
 )
 
 func (cmd *cmd) tunnel() error {
@@ -100,9 +100,9 @@ func (cmd *cmd) parseTunnel() (*options, error) {
 	for cmd.tokenRemains() {
 		switch cmd.nextToken("name", "mode", "remote", "local", "ttl", "tos", "ikey", "okey", "dev") {
 		case "mode":
-			token := cmd.nextToken("gre", "ip6gre", "ipip", "ip6tln", "vti", "vti6", "sit")
+			token := cmd.nextToken("gre", "ip6gre", "ipip", "ip6tnl", "vti", "vti6", "sit")
 			switch token {
-			case "gre", "ip6gre", "ipip", "ip6tln", "vti", "vti6", "sit":
+			case "gre", "ip6gre", "ipip", "ip6tnl", "vti", "vti6", "sit":
 				options.mode = token
 				options.modes = append(options.modes, filterMap[token]...)
 			default:
@@ -289,7 +289,7 @@ func (cmd *cmd) printTunnels(tunnels []netlink.Link) error {
 		case *netlink.Ip6tnl:
 			tunnel.Remote = v.Remote.String()
 			tunnel.Local = v.Local.String()
-			tunnel.Mode = "ip6tln"
+			tunnel.Mode = "ip6tnl"
 			tunnel.TTL = fmt.Sprintf("%d", v.Ttl)
 			tunnel.TOS = v.Tos
 		case *netlink.Vti:
@@ -493,7 +493,7 @@ func normalizeOptsForAddingTunnel(op *options) error {
 			op.name = "gre0"
 		case "ipip":
 			op.name = "tuln0"
-		case "ip6tln":
+		case "ip6tnl":
 			op.name = "ip6tnl0"
 		case "vti", "vti6":
 			op.name = "ip_vti0"
@@ -551,7 +551,7 @@ func (cmd *cmd) tunnelAdd(op *options) error {
 			Ttl:    uint8(op.ttl),
 			Tos:    uint8(op.tos),
 		}
-	case "ip6tln":
+	case "ip6tnl":
 		link = &netlink.Ip6tnl{
 			LinkAttrs: netlink.LinkAttrs{
 				Name: op.name,

--- a/cmds/core/ip/tunnel_linux_test.go
+++ b/cmds/core/ip/tunnel_linux_test.go
@@ -767,10 +767,10 @@ func TestNormalizeOptsForAddingTunnel(t *testing.T) {
 			err: nil,
 		},
 		{
-			name: "ip6tln",
-			op:   &options{mode: "ip6tln", name: "", iKey: 123, oKey: 456, ttl: 64, tos: 16},
+			name: "ip6tnl",
+			op:   &options{mode: "ip6tnl", name: "", iKey: 123, oKey: 456, ttl: 64, tos: 16},
 			expected: &options{
-				mode: "ip6tln",
+				mode: "ip6tnl",
 				name: "ip6tnl0",
 				iKey: 123,
 				oKey: 456,
@@ -852,7 +852,7 @@ func TestPrintTunnels(t *testing.T) {
 				},
 			},
 			json: false,
-			want: "ipv60: ip6tln/ip remote ::2 local ::1 ttl 64\n",
+			want: "ipv60: ip6tnl/ip remote ::2 local ::1 ttl 64\n",
 		},
 		{
 			name: "Single VTI tunnel",


### PR DESCRIPTION
The tunnel mode parser uses ip6tln everywhere, but the actual netlink type is named ip6tnl. Replace all references to ip6tln with ip6tnl.