### PR TITLE
pkg/acpi: fix unsafe memory access on ARM64

### DIFF
--- a/pkg/acpi/rsdp_linux.go
+++ b/pkg/acpi/rsdp_linux.go
@@ -54,4 +54,3 @@ func GetRSDPEFI() (*RSDP, error) {
 }
 
 // You can change the getters if you wish for testing.
-var rsdpgetters = []func() (*RSDP, error){GetRSDPEBDA, GetRSDPMem, GetRSDPEFI}

--- a/pkg/acpi/rsdpgetters_linux_arm64.go
+++ b/pkg/acpi/rsdpgetters_linux_arm64.go
@@ -1,0 +1,10 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//go:build linux && arm64
+package acpi
+
+// On non-x86 architectures, there are no legacy PC BIOS memory locations (e.g. EBDA, 0xe0000).
+// Attempting to read these unbacked physical addresses via /dev/mem can cause fatal hardware faults.
+// Thus, we only query the EFI system table.
+var rsdpgetters = []func() (*RSDP, error){GetRSDPEFI}

--- a/pkg/acpi/rsdpgetters_linux_x86.go
+++ b/pkg/acpi/rsdpgetters_linux_x86.go
@@ -1,0 +1,11 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && (amd64 || 386)
+
+package acpi
+
+// On x86 architectures, we probe legacy PC BIOS memory locations first, then EFI.
+// You can change the getters if you wish for testing.
+var rsdpgetters = []func() (*RSDP, error){GetRSDPEBDA, GetRSDPMem, GetRSDPEFI}


### PR DESCRIPTION
Separate RSDP getters by architecture to prevent ARM64 from scanning legacy PC BIOS memory regions (e.g. EBDA) via /dev/mem, which can cause synchronous external aborts or hardware faults. ARM64 now safely relies exclusively on the EFI System Table to find the RSDP.