### PR TITLE
pkg/acpi: fix unsafe memory access on ARM architectures

### DIFF
--- a/pkg/acpi/rsdp_linux.go
+++ b/pkg/acpi/rsdp_linux.go
@@ -52,6 +52,3 @@ func GetRSDPEFI() (*RSDP, error) {
 	}
 	return nil, fmt.Errorf("invalid /sys/firmware/efi/systab file")
 }
-
-// You can change the getters if you wish for testing.
-var rsdpgetters = []func() (*RSDP, error){GetRSDPEBDA, GetRSDPMem, GetRSDPEFI}

--- a/pkg/acpi/rsdpgetters_linux_other.go
+++ b/pkg/acpi/rsdpgetters_linux_other.go
@@ -1,0 +1,12 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && !amd64 && !386
+
+package acpi
+
+// On non-x86 architectures, there are no legacy PC BIOS memory locations (e.g. EBDA, 0xe0000).
+// Attempting to read these unbacked physical addresses via /dev/mem can cause fatal hardware faults.
+// Thus, we only query the EFI system table.
+var rsdpgetters = []func() (*RSDP, error){GetRSDPEFI}

--- a/pkg/acpi/rsdpgetters_linux_other_test.go
+++ b/pkg/acpi/rsdpgetters_linux_other_test.go
@@ -1,0 +1,17 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && !amd64 && !386
+
+package acpi
+
+import (
+	"testing"
+)
+
+func TestRSDPGetters(t *testing.T) {
+	if len(rsdpgetters) != 1 {
+		t.Fatalf("expected exactly 1 RSDP getter on non-x86 architectures, got %d", len(rsdpgetters))
+	}
+}

--- a/pkg/acpi/rsdpgetters_linux_x86.go
+++ b/pkg/acpi/rsdpgetters_linux_x86.go
@@ -1,0 +1,11 @@
+// Copyright 2024 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && (amd64 || 386)
+
+package acpi
+
+// On x86 architectures, we probe legacy PC BIOS memory locations first, then EFI.
+// You can change the getters if you wish for testing.
+var rsdpgetters = []func() (*RSDP, error){GetRSDPEBDA, GetRSDPMem, GetRSDPEFI}


### PR DESCRIPTION
On ARM64, `acpi.GetRSDP()` was crashing by attempting to scan x86 memory regions that ARM is unaware of (RSDPEBDA, RSDPMem), which can trigger hardware faults on these architectures. 

This tries resolve that by separating the list of regions to scan over by building based on architectur.