### PR TITLE
pkg/ls: read the stat fields TinyGo does provide on js/wasm

### DIFF
--- a/pkg/ls/fileinfo_tinygo.go
+++ b/pkg/ls/fileinfo_tinygo.go
@@ -9,11 +9,16 @@ package ls
 import (
 	"math"
 	"os"
+	"syscall"
 	"time"
 )
 
-// FileInfo holds file metadata (tinygo js variant: no syscall.Stat_t
-// access — virtual filesystems return nil from Sys anyway).
+// FileInfo holds file metadata.
+//
+// Since `os.FileInfo` is an interface, it is difficult to tweak some of its
+// internal values. For example, replacing the starting directory with a dot.
+// `extractImportantParts` populates our own struct which we can modify at will
+// before printing.
 type FileInfo struct {
 	Name          string
 	Mode          os.FileMode
@@ -31,9 +36,31 @@ type FileInfo struct {
 	NLink         uint64
 }
 
-// FromOSFileInfo converts os.FileInfo to an ls.FileInfo.
+// FromOSFileInfo converts os.FileInfo to an ls.FileInfo (TinyGo js/wasm
+// variant).
+//
+// It differs from the js variant only in how the timestamps are spelled:
+// TinyGo's syscall.Stat_t carries Atim and Ctim as a Timespec, where Go's
+// js implementation has whole-second and nanosecond fields. Every other
+// field is read the same way.
 func FromOSFileInfo(path string, fi os.FileInfo) FileInfo {
 	var link string
+
+	uID, gID, rdev := uint32(math.MaxUint32), uint32(math.MaxUint32), uint64(math.MaxUint64)
+	var aTime, cTime time.Time
+	var dev, ino, nLink uint64
+	var blkSize, blocks int64
+	if s, ok := fi.Sys().(*syscall.Stat_t); ok {
+		uID, gID, rdev = uint32(s.Uid), uint32(s.Gid), uint64(s.Rdev)
+		aTime = time.Unix(int64(s.Atim.Sec), s.Atim.Nsec)
+		cTime = time.Unix(int64(s.Ctim.Sec), s.Ctim.Nsec)
+		dev = uint64(s.Dev)
+		ino = s.Ino
+		nLink = uint64(s.Nlink)
+		blkSize = int64(s.Blksize)
+		blocks = int64(s.Blocks)
+	}
+
 	if fi.Mode()&os.ModeType == os.ModeSymlink {
 		if l, err := os.Readlink(path); err != nil {
 			link = err.Error()
@@ -41,14 +68,22 @@ func FromOSFileInfo(path string, fi os.FileInfo) FileInfo {
 			link = l
 		}
 	}
+
 	return FileInfo{
 		Name:          fi.Name(),
 		Mode:          fi.Mode(),
-		Rdev:          uint64(math.MaxUint64),
-		UID:           math.MaxUint32,
-		GID:           math.MaxUint32,
+		Rdev:          rdev,
+		UID:           uID,
+		GID:           gID,
 		Size:          fi.Size(),
+		BlkSize:       blkSize,
+		Blocks:        blocks,
 		MTime:         fi.ModTime(),
+		ATime:         aTime,
+		CTime:         cTime,
 		SymlinkTarget: link,
+		Dev:           dev,
+		Ino:           ino,
+		NLink:         nLink,
 	}
 }


### PR DESCRIPTION
Follow-up to #3709, correcting a mistake of mine in it.

That PR added a TinyGo js variant which zeroed every field it could not read from `syscall.Stat_t`, and both the PR description and the code comment justified this by saying TinyGo's js target has no `Stat_t` to read. **That is not true.**

TinyGo's js/wasm `syscall.Stat_t` exists and carries `Dev`, `Ino`, `Nlink`, `Mode`, `Uid`, `Gid`, `Rdev`, `Size`, `Blksize` and `Blocks`. The only real difference is how the timestamps are spelled:

| | timestamps |
|---|---|
| Go, `GOOS=js` | `Atime` / `AtimeNsec` — whole seconds plus nsec |
| TinyGo, `-target wasm` | `Atim` / `Mtim` / `Ctim` — a `Timespec` |

Nothing else differs. So the variant was discarding eight fields it could have read, for no reason beyond my misreading.

This reads them: `uid`, `gid`, `rdev`, `dev`, `ino`, `nlink`, `blksize` and `blocks` are populated exactly as in the js variant, and `ATime`/`CTime` come from `Atim`/`Ctim` instead of staying at the zero time. The comment now states the actual difference rather than the imagined one.

### Verification

The only toolchain that compiles this file is TinyGo, so that is where it was checked: `tinygo build -target wasm` against TinyGo 0.41, via a program calling `ls.FromOSFileInfo` and `FileString`.

Worth noting explicitly, since I leaned on it in #3709 and it no longer holds: `GOOS=js GOARCH=wasm go vet -tags tinygo ./pkg/ls/` is **not** a valid check for this file any more. It would compile it against Go's `Stat_t`, which has no `Atim`, so it now fails by design. Selection is still confirmable with `go list -tags tinygo`, which picks `fileinfo_tinygo.go` and `filestring_js.go`.

Untouched paths re-verified: `go build ./pkg/ls/` and `go test ./pkg/ls/` on linux, and `GOOS=js GOARCH=wasm go build ./pkg/ls/` for the standard-Go js variant.

@rminnich — this also sharpens the `fs.FileInfo` question you raised on #3709. The fields here are only ever populated when `Sys()` returns a `*syscall.Stat_t`; in the browser case that prompted this work the filesystem is an in-memory/IndexedDB one via `spf13/afero`, where `Sys()` is nil and every one of these stays at its zero value regardless. So for that consumer the struct genuinely does carry fields nothing fills — which is an argument for your point, not against it.