### PR TITLE
codecov: allow 1% threshold on component project status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -10,6 +10,9 @@ component_management:
     statuses:
       - type: project
         target: auto
+        # `target: auto` with no threshold fails on any drop at all, including
+        # run-to-run noise on diffs that touch no covered lines.
+        threshold: 1%
       - type: patch
   individual_components:
     - component_id: nonexp


### PR DESCRIPTION
`target: auto` with no threshold fails on any drop at all, including run-to-run
noise: #3699, #3707 and #3710 each report an identical -0.06% and fail on it.
1% absorbs that; dependabot's -4.71% stays red. `patch` is left strict.

Config validated against https://codecov.io/validate.

AI disclosure: diagnosed and drafted with Claude Code; reviewed by me before submitting.
