### PR TITLE
pkg/boot/zimage: accept a longer kernel size entry

### DIFF
--- a/pkg/boot/zimage/zimage.go
+++ b/pkg/boot/zimage/zimage.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"os"
 )
 
 // Magic values used in the zImage header and table.
@@ -125,14 +126,18 @@ func (z *ZImage) GetEntry(t Tag) (*TableEntry, error) {
 }
 
 // GetKernelSizes returns two kernel sizes relevant for kexec.
+//
+// The entry has grown over time: it held two words when this was written, and
+// Linux has since appended TEXT_OFFSET and MALLOC_SIZE to it. Only the first
+// two are read here, and any that follow are ignored, so that a kernel built
+// with a longer entry still parses.
 func (z *ZImage) GetKernelSizes() (piggySizeAddr uint32, kernelBSSSize uint32, err error) {
 	e, err := z.GetEntry(TagKernelSize)
 	if err != nil {
 		return 0, 0, err
 	}
-	if len(e.Data) != 2 {
-		return 0, 0, fmt.Errorf("zImage tag %#08x has incorrect size %d, expected 2",
-			TagKernelSize, len(e.Data))
+	if len(e.Data) < 2 {
+		return 0, 0, fmt.Errorf("zImage tag %#08x has size %d, expected at least 2: %w", TagKernelSize, len(e.Data), os.ErrInvalid)
 	}
 	return e.Data[0], e.Data[1], nil
 }

--- a/pkg/boot/zimage/zimage_test.go
+++ b/pkg/boot/zimage/zimage_test.go
@@ -5,6 +5,7 @@
 package zimage
 
 import (
+	"errors"
 	"os"
 	"reflect"
 	"testing"
@@ -54,5 +55,51 @@ func TestKernelSizes(t *testing.T) {
 	}
 	if kernelBSSSize != 0x2b83c {
 		t.Errorf("want kernelBSSSize=0x2b83c, got kernelBSSSize=%#x", kernelBSSSize)
+	}
+}
+
+// Linux has appended TEXT_OFFSET and MALLOC_SIZE to the kernel size entry
+// since this parser was written, so the entry is now six words rather than
+// two. Read the first two and ignore the rest, as kexec-tools does.
+//
+// The values are from a real 6.12.45-bone34 zImage on a BeagleBone Black.
+func TestKernelSizesLongEntry(t *testing.T) {
+	z := &ZImage{
+		Table: []TableEntry{
+			{
+				Tag: TagKernelSize,
+				Data: []uint32{
+					0x875534, // __piggy_size_addr - _start
+					0x8c9a0,  // _kernel_bss_size
+					0x8000,   // TEXT_OFFSET
+					0x10000,  // MALLOC_SIZE
+					0,
+					0x5b1c1ca1,
+				},
+			},
+		},
+	}
+
+	piggySizeAddr, kernelBSSSize, err := z.GetKernelSizes()
+	if err != nil {
+		t.Fatalf("GetKernelSizes() = %v, want nil", err)
+	}
+	if piggySizeAddr != 0x875534 {
+		t.Errorf("want piggySizeAddr=0x875534, got %#x", piggySizeAddr)
+	}
+	if kernelBSSSize != 0x8c9a0 {
+		t.Errorf("want kernelBSSSize=0x8c9a0, got %#x", kernelBSSSize)
+	}
+}
+
+func TestKernelSizesShortEntry(t *testing.T) {
+	z := &ZImage{
+		Table: []TableEntry{
+			{Tag: TagKernelSize, Data: []uint32{0x875534}},
+		},
+	}
+
+	if _, _, err := z.GetKernelSizes(); !errors.Is(err, os.ErrInvalid) {
+		t.Errorf("GetKernelSizes() on a one-word entry = %v, want %v", err, os.ErrInvalid)
 	}
 }


### PR DESCRIPTION
Found while looking at what it would take to support arm32 in
`pkg/boot/linux`, on a BeagleBone Black running 6.12.45-bone34. `Parse`
handles that zImage fine, but `GetKernelSizes` refuses it:

```
zImage tag 0x5a534c4b has incorrect size 6, expected 2
```

The entry really is six words now — Linux appended TEXT_OFFSET and
MALLOC_SIZE to it — so the exact comparison rejects any reasonably recent
kernel. kexec-tools reads only the first two words and ignores the rest,
which is why the same zImage works there; this does the same.

The zImage in testdata still has a two word entry, so the existing test
passes either way. The new tests construct the entry in memory rather than
adding another large binary to testdata; the values are the real ones from
the board.
