### PR TITLE
pkg/boot: add arm kexec support

### DIFF
--- a/pkg/boot/linux/load_linux_arm.go
+++ b/pkg/boot/linux/load_linux_arm.go
@@ -1,0 +1,30 @@
+// Copyright 2026 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package linux
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/u-root/u-root/pkg/boot/kexec"
+)
+
+// KexecLoad loads an arm zImage, with the given ramfs and kernel cmdline.
+//
+// reservedRanges are additional pieces of physical memory that are not used
+// for kexec segment allocation. They are not transmitted to the next kernel to
+// be considered reserved.
+func KexecLoad(kernel, ramfs *os.File, cmdline string, dtb io.ReaderAt, reservedRanges kexec.Ranges) error {
+	img, err := kexecLoadZImage(kernel, ramfs, cmdline, dtb, reservedRanges)
+	if err != nil {
+		return err
+	}
+	defer img.clean()
+	if err := kexec.Load(img.entry, img.segments, 0); err != nil {
+		return fmt.Errorf("kexec Load(%v, %v, %d) = %w", img.entry, img.segments, 0, err)
+	}
+	return nil
+}

--- a/pkg/boot/linux/load_linux_zimage.go
+++ b/pkg/boot/linux/load_linux_zimage.go
@@ -1,0 +1,187 @@
+// Copyright 2026 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package linux
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"os"
+
+	"github.com/u-root/u-root/pkg/boot/kexec"
+	"github.com/u-root/u-root/pkg/boot/zimage"
+	"github.com/u-root/u-root/pkg/dt"
+)
+
+const (
+	// zImageTextOffset is where the kernel is placed relative to the start
+	// of the region found for it. (arch/arm/boot/compressed/vmlinux.lds.S
+	// exports it as TEXT_OFFSET.)
+	zImageTextOffset = 0x8000
+
+	// zImageExtraSpace is the stack (4K) and malloc space (64K) the zImage
+	// uses while decompressing, which its own length does not cover.
+	zImageExtraSpace = 0x11000
+
+	// zImageAlignSize is the alignment for the region the kernel is placed
+	// in. A page is enough; the decompressor relocates itself as needed.
+	zImageAlignSize = 0x1000
+)
+
+// zImageMemSize returns the amount of memory to reserve for a zImage.
+//
+// A zImage is self-extracting and its header does not say how large the kernel
+// becomes, so the space that must be kept free is derived from the kernel size
+// entry in its extension table: the decompressed kernel is edata_size +
+// bss_size, and while decompressing, the compressed image sits past _edata of
+// the decompressed kernel, so at least edata_size + the compressed length is
+// needed as well.
+//
+// If the entry is absent -- it is optional, and older kernels do not carry one
+// -- fall back to five times the compressed length, as kexec-tools does,
+// assuming a compression ratio of at most four plus room for the image itself.
+func zImageMemSize(kernelBuf []byte) (uint, error) {
+	z, err := zimage.Parse(bytes.NewReader(kernelBuf))
+	if err != nil {
+		return 0, fmt.Errorf("parse zImage: %w", err)
+	}
+
+	// The zImage needs its stack and malloc space on top of its own length.
+	compressed := uint(len(kernelBuf)) + zImageExtraSpace
+
+	sizeAddr, bssSize, err := z.GetKernelSizes()
+	if err != nil {
+		Debug("zImage has no usable kernel size entry (%v), assuming a compression ratio of 4", err)
+		return uint(len(kernelBuf)) * 5, nil
+	}
+
+	// sizeAddr is an offset into the image at which the size of the
+	// decompressed kernel up to _edata is stored.
+	if uint64(sizeAddr)+4 > uint64(len(kernelBuf)) {
+		return 0, fmt.Errorf("zImage kernel size is at %#x, past the end of the %#x byte image", sizeAddr, len(kernelBuf))
+	}
+	edataSize := uint(binary.LittleEndian.Uint32(kernelBuf[sizeAddr:]))
+
+	size := max(edataSize+uint(bssSize), edataSize+compressed)
+	Debug("zImage decompresses to %#x bytes (text+data %#x, bss %#x), reserving %#x", edataSize+uint(bssSize), edataSize, bssSize, size)
+	return size, nil
+}
+
+func kexecLoadZImage(kernel, ramfs *os.File, cmdline string, dtb io.ReaderAt, reservedRanges kexec.Ranges) (*kimage, error) {
+	var fdt *dt.FDT
+	var err error
+	// We want to fail when a user-supplied FDT is not parseable, not
+	// implicitly fall back to some other FDT. Avoid the dt.LoadFDT API.
+	if dtb != nil {
+		fdt, err = dt.ReadFDT(io.NewSectionReader(dtb, 0, math.MaxInt64))
+	} else {
+		fdt, err = dt.ReadFile("/sys/firmware/fdt")
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read FDT = %w", err)
+	}
+	Debug("Loaded FDT: %s", fdt)
+
+	Debug("Try parsing memory map...")
+	mm, err := kexec.MemoryMapFromFDT(fdt)
+	if err != nil {
+		return nil, fmt.Errorf("memoryMapFromFDT(%v): %w", fdt, err)
+	}
+	Debug("Mem map: \n%+v", mm)
+	if len(mm.RAM()) == 0 {
+		return nil, ErrMemmapEmpty
+	}
+	for _, r := range reservedRanges {
+		mm.Insert(kexec.TypedRange{Range: r, Type: kexec.RangeReserved})
+	}
+	return kexecLoadZImageMM(mm, kernel, ramfs, fdt, cmdline)
+}
+
+func kexecLoadZImageMM(mm kexec.MemoryMap, kernel, ramfs *os.File, fdt *dt.FDT, cmdline string) (*kimage, error) {
+	kmem := &kexec.Memory{
+		Phys: mm,
+	}
+
+	img := &kimage{}
+
+	kernelBuf, cleanup, err := getFile(kernel)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get kernel contents: %w", err)
+	}
+	img.cleanup = append(img.cleanup, cleanup)
+
+	memSize, err := zImageMemSize(kernelBuf)
+	if err != nil {
+		return nil, err
+	}
+
+	// The kernel is placed TEXT_OFFSET into the region, and memSize must
+	// stay free so that the decompressed kernel and its BSS do not land on
+	// the initrd or the device tree.
+	kernelRange, err := kmem.AddKexecSegmentExplicit(kernelBuf, memSize, zImageTextOffset, zImageAlignSize)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errKernelSegmentFailed, err)
+	}
+	Debug("Added %#x byte (size %#x) kernel at %s with offset %#x", len(kernelBuf), memSize, kernelRange, zImageTextOffset)
+
+	chosen, err := sanitizeFDT(fdt)
+	if err != nil {
+		return nil, fmt.Errorf("sanitizeFDT(%v) = %w", fdt, err)
+	}
+	Debug("FDT after sanitization: %s", fdt)
+
+	if ramfs != nil {
+		ramfsBuf, cleanup, err := getFile(ramfs)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get initramfs contents: %w", err)
+		}
+		img.cleanup = append(img.cleanup, cleanup)
+
+		ramfsRange, err := kmem.AddKexecSegment(ramfsBuf)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", errInitramfsSegmentFailed, err)
+		}
+		Debug("Added %d byte initramfs at %s", len(ramfsBuf), ramfsRange)
+
+		ramfsStart := make([]byte, 8)
+		binary.BigEndian.PutUint64(ramfsStart, uint64(ramfsRange.Start))
+		chosen.UpdateProperty("linux,initrd-start", ramfsStart)
+		ramfsEnd := make([]byte, 8)
+		binary.BigEndian.PutUint64(ramfsEnd, uint64(ramfsRange.Start)+uint64(ramfsRange.Size))
+		chosen.UpdateProperty("linux,initrd-end", ramfsEnd)
+	}
+
+	Debug("Kernel cmdline to append: %s", cmdline)
+	if len(cmdline) > 0 {
+		cmdlineBuf := append([]byte(cmdline), byte(0))
+		chosen.UpdateProperty("bootargs", cmdlineBuf)
+	} else {
+		chosen.RemoveProperty("bootargs")
+	}
+
+	var dtbBuffer bytes.Buffer
+	if _, err := fdt.Write(&dtbBuffer); err != nil {
+		return nil, fmt.Errorf("flattening device tree: %w", err)
+	}
+	dtbBuf := dtbBuffer.Bytes()
+	dtbRange, err := kmem.AddKexecSegment(dtbBuf)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errDTBSegmentFailed, err)
+	}
+	Debug("Added %d byte device tree at %s", len(dtbBuf), dtbRange)
+
+	// As on riscv64, no trampoline is needed. The arm kernel expects r0=0,
+	// r1=machine type and r2=the device tree, and none of those can be set
+	// from here. The running kernel does it instead: machine_kexec_prepare()
+	// scans the loaded segments for a device tree header to find r2, and
+	// relocate_kernel.S sets all three before jumping. So the kernel itself
+	// is the entry point, as it also is in kexec-tools.
+	img.entry = kernelRange.Start
+	img.segments = kmem.Segments
+	Debug("Entry: %#x", img.entry)
+	return img, nil
+}

--- a/pkg/boot/linux/load_linux_zimage_test.go
+++ b/pkg/boot/linux/load_linux_zimage_test.go
@@ -1,0 +1,256 @@
+// Copyright 2026 the u-root Authors. All rights reserved
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package linux
+
+import (
+	"bytes"
+	"encoding/binary"
+	"os"
+	"testing"
+
+	"github.com/u-root/u-root/pkg/boot/kexec"
+	"github.com/u-root/u-root/pkg/dt"
+)
+
+func zImageFDT() *dt.FDT {
+	return &dt.FDT{
+		RootNode: dt.NewNode("/", dt.WithChildren(
+			dt.NewNode("chosen"),
+			dt.NewNode("test memory", dt.WithProperty(
+				dt.PropertyString("device_type", "memory"),
+				dt.PropertyRegion("reg", 0x80000000, 0x10000000),
+			)),
+		)),
+	}
+}
+
+func zImageMM(t *testing.T) kexec.MemoryMap {
+	t.Helper()
+	mm, err := kexec.MemoryMapFromFDT(zImageFDT())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mm
+}
+
+// A zImage is self-extracting, so the space reserved for it has to cover the
+// decompressed kernel and its BSS rather than the size of the file.
+func TestZImageMemSize(t *testing.T) {
+	Debug = t.Logf
+
+	kernelBuf, err := os.ReadFile("../zimage/testdata/zImage")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := zImageMemSize(kernelBuf)
+	if err != nil {
+		t.Fatalf("zImageMemSize = %v, want nil", err)
+	}
+	if got <= uint(len(kernelBuf)) {
+		t.Errorf("reserved %#x for a %#x byte image, want more than the file itself", got, len(kernelBuf))
+	}
+	// The compressed image sits past _edata while unpacking, so at minimum
+	// _edata plus the image and its scratch space must be free.
+	if want := uint(len(kernelBuf)) + zImageExtraSpace; got < want {
+		t.Errorf("reserved %#x, want at least %#x", got, want)
+	}
+}
+
+// Without a kernel size entry there is nothing to compute from, so fall back
+// to a guess rather than refusing the image.
+func TestZImageMemSizeNoEntry(t *testing.T) {
+	Debug = t.Logf
+
+	kernelBuf, err := os.ReadFile("../zimage/testdata/zImage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Break the table magic so the entry is not found.
+	buf := append([]byte(nil), kernelBuf...)
+	binary.LittleEndian.PutUint32(buf[0x24+16:], 0)
+
+	got, err := zImageMemSize(buf)
+	if err != nil {
+		t.Fatalf("zImageMemSize = %v, want nil", err)
+	}
+	if want := uint(len(buf)) * 5; got != want {
+		t.Errorf("fallback reserved %#x, want %#x", got, want)
+	}
+}
+
+func TestZImageMemSizeNotAZImage(t *testing.T) {
+	if _, err := zImageMemSize([]byte("this is not a zImage")); err == nil {
+		t.Error("zImageMemSize(garbage) = nil, want error")
+	}
+}
+
+// The kernel is entered directly: r0/r1/r2 are set by the running kernel, so
+// there is no trampoline to place in front of it.
+func TestKexecLoadZImageEntryIsKernel(t *testing.T) {
+	Debug = t.Logf
+
+	kernel := openFile(t, "../zimage/testdata/zImage")
+	defer kernel.Close()
+
+	img, err := kexecLoadZImageMM(zImageMM(t), kernel, nil, zImageFDT(), "")
+	if err != nil {
+		t.Fatalf("kexecLoadZImageMM = %v, want nil", err)
+	}
+	defer img.clean()
+
+	var kernelSeg *kexec.Segment
+	for i := range img.segments {
+		if img.segments[i].Phys.Start == img.entry {
+			kernelSeg = &img.segments[i]
+		}
+	}
+	if kernelSeg == nil {
+		t.Fatalf("no segment starts at entry %#x: %v", img.entry, img.segments)
+	}
+
+	// The kernel goes TEXT_OFFSET into an aligned region.
+	if got := (img.entry - zImageTextOffset) % zImageAlignSize; got != 0 {
+		t.Errorf("entry %#x is not TEXT_OFFSET into an aligned region (remainder %#x)", img.entry, got)
+	}
+}
+
+// The reserved space must exceed the file, or the decompressed kernel would
+// land on whatever was placed after it.
+func TestKexecLoadZImageReservesDecompressedSize(t *testing.T) {
+	Debug = t.Logf
+
+	kernel := openFile(t, "../zimage/testdata/zImage")
+	defer kernel.Close()
+
+	fi, err := kernel.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	img, err := kexecLoadZImageMM(zImageMM(t), kernel, nil, zImageFDT(), "")
+	if err != nil {
+		t.Fatalf("kexecLoadZImageMM = %v, want nil", err)
+	}
+	defer img.clean()
+
+	kernelBuf, err := os.ReadFile("../zimage/testdata/zImage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := zImageMemSize(kernelBuf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var found bool
+	for _, s := range img.segments {
+		if s.Phys.Start == img.entry {
+			found = true
+			if int64(s.Phys.Size) <= fi.Size() {
+				t.Errorf("kernel segment size %#x should exceed the file size %#x", s.Phys.Size, fi.Size())
+			}
+			if uint(s.Phys.Size) < want {
+				t.Errorf("kernel segment reserves %#x, want at least the decompressed size %#x", s.Phys.Size, want)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no segment starts at entry %#x", img.entry)
+	}
+}
+
+func TestKexecLoadZImageCmdlineAndInitramfs(t *testing.T) {
+	Debug = t.Logf
+
+	kernel := openFile(t, "../zimage/testdata/zImage")
+	defer kernel.Close()
+	ramfs := createFile(t, []byte("ramfs"))
+	defer ramfs.Close()
+
+	fdt := zImageFDT()
+	img, err := kexecLoadZImageMM(zImageMM(t), kernel, ramfs, fdt, "console=ttyO0")
+	if err != nil {
+		t.Fatalf("kexecLoadZImageMM = %v, want nil", err)
+	}
+	defer img.clean()
+
+	chosen, _ := fdt.NodeByName("chosen")
+	if chosen == nil {
+		t.Fatal("no chosen node")
+	}
+	for _, want := range []string{"bootargs", "linux,initrd-start", "linux,initrd-end"} {
+		if _, found := chosen.LookProperty(want); !found {
+			t.Errorf("chosen is missing %q", want)
+		}
+	}
+}
+
+func TestKexecLoadZImageNoMemory(t *testing.T) {
+	Debug = t.Logf
+
+	kernel := openFile(t, "../zimage/testdata/zImage")
+	defer kernel.Close()
+
+	if _, err := kexecLoadZImageMM(kexec.MemoryMap{}, kernel, nil, zImageFDT(), ""); err == nil {
+		t.Error("kexecLoadZImageMM(empty mm) = nil, want error")
+	}
+}
+
+// Exercise the outer entry point, which reads and parses the FDT before
+// handing off. Passing a dtb keeps it off /sys/firmware/fdt.
+func TestKexecLoadZImageWithDTB(t *testing.T) {
+	Debug = t.Logf
+
+	kernel := openFile(t, "../zimage/testdata/zImage")
+	defer kernel.Close()
+
+	img, err := kexecLoadZImage(kernel, nil, "console=ttyO0", fdtReader(t, zImageFDT()), nil)
+	if err != nil {
+		t.Fatalf("kexecLoadZImage = %v, want nil", err)
+	}
+	defer img.clean()
+
+	if img.entry == 0 {
+		t.Error("entry is 0")
+	}
+	if len(img.segments) == 0 {
+		t.Error("no segments")
+	}
+}
+
+func TestKexecLoadZImageBadDTB(t *testing.T) {
+	Debug = t.Logf
+
+	kernel := openFile(t, "../zimage/testdata/zImage")
+	defer kernel.Close()
+
+	if _, err := kexecLoadZImage(kernel, nil, "", bytes.NewReader([]byte("not an fdt")), nil); err == nil {
+		t.Error("kexecLoadZImage(bad dtb) = nil, want error")
+	}
+}
+
+// Reserved ranges must be kept away from the segments we allocate.
+func TestKexecLoadZImageReservations(t *testing.T) {
+	Debug = t.Logf
+
+	kernel := openFile(t, "../zimage/testdata/zImage")
+	defer kernel.Close()
+
+	reserved := kexec.Ranges{{Start: 0x80000000, Size: 0x1000000}}
+	img, err := kexecLoadZImage(kernel, nil, "", fdtReader(t, zImageFDT()), reserved)
+	if err != nil {
+		t.Fatalf("kexecLoadZImage = %v, want nil", err)
+	}
+	defer img.clean()
+
+	for _, s := range img.segments {
+		for _, r := range reserved {
+			if s.Phys.Start < r.Start+uintptr(r.Size) && r.Start < s.Phys.Start+uintptr(s.Phys.Size) {
+				t.Errorf("segment %v overlaps reserved range %v", s.Phys, r)
+			}
+		}
+	}
+}

--- a/pkg/boot/linux/load_other_linux.go
+++ b/pkg/boot/linux/load_other_linux.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:build !amd64 && !arm64
+//go:build !amd64 && !arm && !arm64
 
 package linux
 
@@ -14,7 +14,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// KexecLoad is not implemented for platforms other than amd64 and arm64.
+// KexecLoad is not implemented for platforms other than amd64, arm and arm64.
 func KexecLoad(kernel, ramfs *os.File, cmdline string, dtb io.ReaderAt, reservations kexec.Ranges) error {
 	return unix.ENOSYS
 }

--- a/pkg/boot/zimage/zimage.go
+++ b/pkg/boot/zimage/zimage.go
@@ -125,13 +125,18 @@ func (z *ZImage) GetEntry(t Tag) (*TableEntry, error) {
 }
 
 // GetKernelSizes returns two kernel sizes relevant for kexec.
+//
+// The entry has grown over time: it held two words when this was written, and
+// Linux has since appended TEXT_OFFSET and MALLOC_SIZE to it. Only the first
+// two are read here, and any that follow are ignored, so that a kernel built
+// with a longer entry still parses.
 func (z *ZImage) GetKernelSizes() (piggySizeAddr uint32, kernelBSSSize uint32, err error) {
 	e, err := z.GetEntry(TagKernelSize)
 	if err != nil {
 		return 0, 0, err
 	}
-	if len(e.Data) != 2 {
-		return 0, 0, fmt.Errorf("zImage tag %#08x has incorrect size %d, expected 2",
+	if len(e.Data) < 2 {
+		return 0, 0, fmt.Errorf("zImage tag %#08x has incorrect size %d, expected at least 2",
 			TagKernelSize, len(e.Data))
 	}
 	return e.Data[0], e.Data[1], nil

--- a/pkg/boot/zimage/zimage_test.go
+++ b/pkg/boot/zimage/zimage_test.go
@@ -56,3 +56,49 @@ func TestKernelSizes(t *testing.T) {
 		t.Errorf("want kernelBSSSize=0x2b83c, got kernelBSSSize=%#x", kernelBSSSize)
 	}
 }
+
+// Linux has appended TEXT_OFFSET and MALLOC_SIZE to the kernel size entry
+// since this parser was written, so the entry is now six words rather than
+// two. Read the first two and ignore the rest, as kexec-tools does.
+//
+// The values are from a real 6.12.45-bone34 zImage on a BeagleBone Black.
+func TestKernelSizesLongEntry(t *testing.T) {
+	z := &ZImage{
+		Table: []TableEntry{
+			{
+				Tag: TagKernelSize,
+				Data: []uint32{
+					0x875534, // __piggy_size_addr - _start
+					0x8c9a0,  // _kernel_bss_size
+					0x8000,   // TEXT_OFFSET
+					0x10000,  // MALLOC_SIZE
+					0,
+					0x5b1c1ca1,
+				},
+			},
+		},
+	}
+
+	piggySizeAddr, kernelBSSSize, err := z.GetKernelSizes()
+	if err != nil {
+		t.Fatalf("GetKernelSizes() = %v, want nil", err)
+	}
+	if piggySizeAddr != 0x875534 {
+		t.Errorf("want piggySizeAddr=0x875534, got %#x", piggySizeAddr)
+	}
+	if kernelBSSSize != 0x8c9a0 {
+		t.Errorf("want kernelBSSSize=0x8c9a0, got %#x", kernelBSSSize)
+	}
+}
+
+func TestKernelSizesShortEntry(t *testing.T) {
+	z := &ZImage{
+		Table: []TableEntry{
+			{Tag: TagKernelSize, Data: []uint32{0x875534}},
+		},
+	}
+
+	if _, _, err := z.GetKernelSizes(); err == nil {
+		t.Error("GetKernelSizes() on a one-word entry = nil, want error")
+	}
+}


### PR DESCRIPTION
`KexecLoad` returned ENOSYS on 32-bit arm, so Linux could not be kexec'd
there. The reasoning — how the memory a zImage needs is derived, and why no
trampoline is built — is in the commit message.

**This is stacked on #3735** and contains that commit as well. `GetKernelSizes`
rejects any recent zImage without it, which this needs to size the kernel
segment. Happy to rebase once that lands, or to fold them together if you'd
rather have one PR.

I have a BeagleBone Black (6.12.45-bone34) but its Debian kernel ships with
`# CONFIG_KEXEC is not set`, so `kexec_load` does not exist there and I could
not do the jump on the board. I also had no way to recover it if a rebuilt
kernel failed to boot. What the board did give me is the kernel size entry the
sizing depends on, which is where the values in #3735 came from.

So this is not hardware-tested end to end, unlike #3733 where I could complete
a kexec under QEMU. I did not find an equivalent shortcut here: the zImage in
testdata is mostly zeroed and won't run, and I don't have a bootable armv7
kernel with KEXEC to hand. The unit tests cover the sizing and the entry
placement, which are the parts specific to this format; the segment layout is
shared with the existing code. If you'd rather wait for a real boot before
taking this, that's fair, and I'll come back to it once I can rebuild the
board's kernel.
